### PR TITLE
chore: use rustls for reqwest

### DIFF
--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -10,15 +10,15 @@ categories = ["authentication", "web-programming"]
 edition = "2021"
 
 [dependencies]
+async-trait = "0.1"
+backoff = { version="0.4", features = ["tokio"] }
 base64 = "0.13"
 chrono = { version = "0.4", features = ["serde"] }
-reqwest = {version = "0.11", features = ["json"] }
+http = "0.2"
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 rustls = "0.20"
 rustls-pemfile = "0.2"
-serde = {version="1", features = ["derive"]}
+serde = { version="1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
 tokio = { version = "1.12", features = ["full", "macros"] }
-async-trait = "0.1"
-http = "0.2"
-backoff = {version="0.4", features = ["tokio"]}


### PR DESCRIPTION
This commit changes the auth library to use the rustls feature of
reqwest instead of native-tls. This is done because rustls is already
included as a dependency of google-cloud-auth anyway. There is no point
in including multiple TLS libraries.

By extension this removes the dependency on OpenSSL.

This reduces the Cargo.lock file form 1217 lines to 1070 lines :-)

