### PR TITLE
chore: move package to internal/language

### DIFF
--- a/generator/internal/language/symbol_names_test.go
+++ b/generator/internal/language/symbol_names_test.go
@@ -1,4 +1,4 @@
-package internal
+package language
 
 import (
 	"testing"


### PR DESCRIPTION
Go packages typically live in the `internal/` directory, unless the code needs to be exported (as opposed to the other way around).