### PR TITLE
ci: rename the generator build

### DIFF
--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -7,7 +7,7 @@ permissions:
 
 
 jobs:
-  build:
+  generator-build:
     runs-on: ubuntu-24.04
     strategy:
       matrix:


### PR DESCRIPTION
Makes it easier to grok what the branch protections are doing.
