### PR TITLE
doc: populate "Code of Conduct" placeholders

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -69,13 +69,13 @@ dispute. If you are unable to resolve the matter for any reason, or if the
 behavior is threatening or harassing, report it. We are dedicated to providing
 an environment where participants feel welcome and safe.
 
-Reports should be directed to *[PROJECT STEWARD NAME(s) AND EMAIL(s)]*, the
-Project Steward(s) for *[PROJECT NAME]*. It is the Project Steward’s duty to
-receive and address reported violations of the code of conduct. They will then
-work with a committee consisting of representatives from the Open Source
-Programs Office and the Google Open Source Strategy team. If for any reason you
-are uncomfortable reaching out to the Project Steward, please email
-opensource@google.com.
+Reports should be directed to *Carlos O'Ryan (coryan@google.com)*, the
+Project Steward(s) for *Google Cloud API Client Libraries for Rust*. It is the
+Project Steward’s duty to receive and address reported violations of the code of
+conduct. They will then work with a committee consisting of representatives from
+the Open Source Programs Office and the Google Open Source Strategy team. If for
+any reason you are uncomfortable reaching out to the Project Steward, please
+email opensource@google.com.
 
 We will investigate every complaint, but you may not receive a direct response.
 We will use our discretion in determining when and how to follow up on reported


### PR DESCRIPTION
The project is using version 1.4 of the contributor-covenant.org code of
conduct. That version includes two placeholders that I just filled out.

If anybody else would prefer to act as the project steward I am happy to pass on the role.  I just feel bad that we only had a placeholder in this document, I don't feel like I am particularly qualified for the role.
