### PR TITLE
ci: enforce copyright boilerplate

### DIFF
--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Client Generator
 
 on: [push, pull_request]

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,17 @@ jobs:
         cargo install typos-cli --version 1.26.8
     - run:
         typos
-    - run: |
-        git ls-files -z -- '*.yaml' '*.' '*.rs' ':!:**/testdata/**.rs' ':!:**.md' ':!:**.mustache' | \
-          xargs -0 cargo run --release --bin check-copyright
 
+  misc-formatting:
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo
+        key: ${{ github.job }}-${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+    - run: |
+        git ls-files -z -- '*.yaml' '*.toml' '*.go' '*.rs' ':!:**/testdata/**' ':!:**.md' ':!:**.mustache' | \
+          xargs -0 cargo run --release --bin check-copyright

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,5 +44,5 @@ jobs:
           ~/.cargo
         key: ${{ github.job }}-${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
     - run: |
-        git ls-files -z -- '*.yaml' '*.toml' '*.go' '*.rs' ':!:**/testdata/**' ':!:**.md' ':!:**.mustache' | \
+        git ls-files -z -- '*.yaml$' '*.toml$' '*.go$' '*.rs$' ':!:**/testdata/**' ':!:**.md' ':!:**.mustache' | \
           xargs -0 cargo run --release --bin check-copyright

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Lint
 
 on: [push, pull_request]
@@ -18,3 +32,7 @@ jobs:
         cargo install typos-cli --version 1.26.8
     - run:
         typos
+    - run: |
+        git ls-files -z -- '*.yaml' '*.' '*.rs' ':!:**/testdata/**.rs' ':!:**.md' ':!:**.mustache' | \
+          xargs -0 cargo run --release --bin check-copyright
+

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Rust SDK
 
 on: [push, pull_request]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +149,13 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "check-copyright"
+version = "0.1.0"
+dependencies = [
+ "regex",
+]
 
 [[package]]
 name = "chrono"
@@ -827,6 +843,35 @@ checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,18 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 [workspace]
+resolver = "2"
 
-members = ["auth", "types"]
+members = ["auth", "tools/check-copyright", "types"]

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [package]
 name = "google-cloud-auth"
 version = "0.1.0"

--- a/generator/all_test.go
+++ b/generator/all_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/tools/check-copyright/Cargo.toml
+++ b/tools/check-copyright/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "check-copyright"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+regex = "1.11.1"

--- a/tools/check-copyright/Cargo.toml
+++ b/tools/check-copyright/Cargo.toml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [package]
 name = "check-copyright"
 version = "0.1.0"

--- a/tools/check-copyright/src/main.rs
+++ b/tools/check-copyright/src/main.rs
@@ -1,0 +1,123 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use regex::Regex;
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let checker = Checker::new()?;
+
+    let (_success, errors): (Vec<_>, Vec<_>) = std::env::args()
+        .skip(1)
+        .map(|filename| {
+            let r = checker.verify(&filename);
+            (filename, r)
+        })
+        .partition(|(_, b)| b.is_ok());
+
+    for (filename, result) in errors.iter() {
+        eprintln!("Error searching for copyright boiler plate in {filename}: {result:?}");
+    }
+    let _ = errors
+        .into_iter()
+        .map(|(_, b)| b)
+        .collect::<Result<Vec<()>, _>>()?;
+    Ok(())
+}
+
+struct Checker {
+    copyright: Regex,
+    boilerplate: Vec<String>,
+}
+
+impl Checker {
+    fn new() -> Result<Checker, Box<dyn Error>> {
+        const COPYRIGHT_RE: &str = "^ Copyright [0-9]{4} Google LLC$";
+
+        let boilerplate = Self::load_boilerplate(file!())?;
+        // Just panic on failures to compile the RE.
+        let copyright = Regex::new(COPYRIGHT_RE).unwrap();
+        Ok(Self {
+            boilerplate,
+            copyright,
+        })
+    }
+
+    fn verify(&self, filename: &str) -> Result<(), Box<dyn Error>> {
+        let found = Self::load_boilerplate(filename)?;
+        let mut lines = found.into_iter();
+        if let Some(first) = lines.next() {
+            if !self.copyright.is_match(&first) {
+                return Err(format!("Missing copyright in first line, found={first}"))?;
+            }
+        } else {
+            return Err("Could not read any boilerplate lines".to_string())?;
+        }
+
+        let first_mismatch = lines
+            .zip(self.boilerplate[1..].iter())
+            // Humans prefer "line 1" vs. "line 0", and we already consumed the first line.
+            .zip(2..)
+            .filter_map(|((found, expected), lineno)| {
+                if &found == expected {
+                    None
+                } else {
+                    Some((lineno, found, expected))
+                }
+            })
+            .map(|(lineno, found, expected)| {
+                format!(
+                    "Mismatched boilerplate in line {lineno}, found={found}, expected={expected}"
+                )
+            })
+            .nth(0);
+        if let Some(msg) = first_mismatch {
+            return Err(msg)?;
+        }
+
+        Ok(())
+    }
+
+    fn load_boilerplate(filename: &str) -> Result<Vec<String>, Box<dyn Error>> {
+        let prefix = Self::comment_prefix(&filename);
+        use std::io::BufRead;
+        let file = std::fs::File::open(filename)?;
+        let lines = std::io::BufReader::new(file)
+            .lines()
+            .take(13)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(lines
+            .iter()
+            .map(|line| line.strip_prefix(&prefix).unwrap_or(""))
+            .map(str::to_string)
+            .collect::<Vec<_>>())
+    }
+
+    fn comment_prefix(filename: &str) -> String {
+        const KNOWN_EXTENSIONS: &[(&str, &str); 5] = &[
+            (".rs", "//"),
+            (".go", "//"),
+            (".yaml", "#"),
+            (".yml", "#"),
+            (".toml", "#"),
+        ];
+
+        for &(extension, prefix) in KNOWN_EXTENSIONS {
+            if filename.ends_with(extension) {
+                return prefix.to_string();
+            }
+        }
+        return String::new();
+    }
+}

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/types/src/timestamp.rs
+++ b/types/src/timestamp.rs
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This includes a number of fixes for existing files and a new build to enforce the copyright boilerplate.

This is easy to run locally (unlike robots), and handles golang, Rust, TOM, and YAML files.

I wonder if the rules about what files get ignored should be (a) in the build script (as done here), (b) in the code itself (we would need to navigate the directories and ignore .`git/` directories and anything listed in .`gitignore` files), or (c) in yet another `.toml` file.
