### PR TITLE
impl: better name conversions

### DIFF
--- a/generator/cmd/protoc-gen-gclient/testdata/rust/golden/model.rs
+++ b/generator/cmd/protoc-gen-gclient/testdata/rust/golden/model.rs
@@ -457,7 +457,7 @@ pub struct SecretPayload {
     ///  The CRC32C value is encoded as a Int64 for compatibility, and can be
     ///  safely downconverted to uint32 in languages that support this type.
     ///  https://cloud.google.com/apis/design/design_patterns#integer_types
-    pub data_crc_32_c: i64,
+    pub data_crc32c: i64,
 }
 
 /// Request message for

--- a/generator/internal/genclient/genclient.go
+++ b/generator/internal/genclient/genclient.go
@@ -60,7 +60,7 @@ type LanguageCodec interface {
 	// An example return value might be
 	// `&Pair{Key: "secretId", Value: "req.SecretId()"}`
 	QueryParams(m *Method, state *APIState) []*Pair
-	// ToSnake converts a symbol name to `snake_case``, applying any mangling
+	// ToSnake converts a symbol name to `snake_case`, applying any mangling
 	// required by the language, e.g., to avoid clashes with reserved words.
 	ToSnake(string) string
 	// ToPascal converts a symbol name to `PascalCase`, applying any mangling

--- a/generator/internal/genclient/genclient.go
+++ b/generator/internal/genclient/genclient.go
@@ -60,6 +60,16 @@ type LanguageCodec interface {
 	// An example return value might be
 	// `&Pair{Key: "secretId", Value: "req.SecretId()"}`
 	QueryParams(m *Method, state *APIState) []*Pair
+	// ToSnake converts a symbol name to `snake_case``, applying any mangling
+	// required by the language, e.g., to avoid clashes with reserved words.
+	ToSnake(string) string
+	// ToPascal converts a symbol name to `PascalCase`, applying any mangling
+	// required by the language, e.g., to avoid clashes with reserved words.
+	ToPascal(string) string
+	// ToCamel converts a symbol name to `camelCase` (sometimes called
+	// "lowercase CamelCase"), applying any mangling required by the language,
+	// e.g., to avoid clashes with reserved words.
+	ToCamel(string) string
 }
 
 // GenerateRequest used to generate clients.

--- a/generator/internal/genclient/language/internal/golang/golang.go
+++ b/generator/internal/genclient/language/internal/golang/golang.go
@@ -160,3 +160,56 @@ func (c *Codec) QueryParams(m *genclient.Method, state *genclient.APIState) []*g
 	}
 	return queryParams
 }
+
+func (*Codec) ToSnake(symbol string) string {
+	if strings.ToLower(symbol) == symbol {
+		return EscapeKeyword(symbol)
+	}
+	return EscapeKeyword(strcase.ToSnake(symbol))
+}
+
+func (*Codec) ToPascal(symbol string) string {
+	return EscapeKeyword(strcase.ToCamel(symbol))
+}
+
+func (*Codec) ToCamel(symbol string) string {
+	return strcase.ToLowerCamel(symbol)
+}
+
+// The list of Golang keywords and reserved words can be found at:
+//
+// https://go.dev/ref/spec#Keywords
+func EscapeKeyword(symbol string) string {
+	keywords := map[string]bool{
+		"break":       true,
+		"default":     true,
+		"func":        true,
+		"interface":   true,
+		"select":      true,
+		"case":        true,
+		"defer":       true,
+		"go":          true,
+		"map":         true,
+		"struct":      true,
+		"chan":        true,
+		"else":        true,
+		"goto":        true,
+		"package":     true,
+		"switch":      true,
+		"const":       true,
+		"fallthrough": true,
+		"if":          true,
+		"range":       true,
+		"type":        true,
+		"continue":    true,
+		"for":         true,
+		"import":      true,
+		"return":      true,
+		"var":         true,
+	}
+	_, ok := keywords[symbol]
+	if !ok {
+		return symbol
+	}
+	return symbol + "_"
+}

--- a/generator/internal/genclient/language/internal/golang/golang_test.go
+++ b/generator/internal/genclient/language/internal/golang/golang_test.go
@@ -12,38 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rust
+package golang
 
 import (
 	"testing"
-
-	"github.com/googleapis/google-cloud-rust/generator/internal/genclient"
 )
-
-type ScalarFieldTest struct {
-	Typez    genclient.Typez
-	Optional bool
-	Expected string
-}
-
-var scalarFieldTests = []ScalarFieldTest{
-	{genclient.INT32_TYPE, false, "i32"},
-	{genclient.INT64_TYPE, false, "i64"},
-	{genclient.UINT32_TYPE, true, "Option<u32>"},
-	{genclient.UINT64_TYPE, true, "Option<u64>"},
-	{genclient.BOOL_TYPE, true, "Option<bool>"},
-	{genclient.STRING_TYPE, true, "Option<String>"},
-	{genclient.BYTES_TYPE, true, "Option<bytes::Bytes>"},
-}
-
-func TestScalarFields(t *testing.T) {
-	for _, test := range scalarFieldTests {
-		field := genclient.Field{Typez: test.Typez, Optional: test.Optional}
-		if output := ScalarFieldType(&field); output != test.Expected {
-			t.Errorf("Output %q not equal to expected %q", output, test.Expected)
-		}
-	}
-}
 
 type CaseConvertTest struct {
 	Input    string
@@ -56,16 +29,12 @@ func TestToSnake(t *testing.T) {
 		{"FooBar", "foo_bar"},
 		{"foo_bar", "foo_bar"},
 		{"data_crc32c", "data_crc32c"},
-		{"True", "r#true"},
-		{"Static", "r#static"},
-		{"Trait", "r#trait"},
-		{"Self", "r#self"},
-		{"self", "r#self"},
-		{"yield", "r#yield"},
+		{"Map", "map_"},
+		{"switch", "switch_"},
 	}
 	for _, test := range snakeConvertTests {
 		if output := c.ToSnake(test.Input); output != test.Expected {
-			t.Errorf("Output %q not equal to expected %q, input=%s", output, test.Expected, test.Input)
+			t.Errorf("Output %s not equal to expected %s, input=%s", output, test.Expected, test.Input)
 		}
 	}
 }
@@ -76,13 +45,11 @@ func TestToPascal(t *testing.T) {
 		{"foo_bar", "FooBar"},
 		{"FooBar", "FooBar"},
 		{"True", "True"},
-		{"Self", "r#Self"},
-		{"self", "r#Self"},
-		{"yield", "Yield"},
+		{"return", "Return"},
 	}
 	for _, test := range pascalConvertTests {
 		if output := c.ToPascal(test.Input); output != test.Expected {
-			t.Errorf("Output %q not equal to expected %q", output, test.Expected)
+			t.Errorf("Output %s not equal to expected %s, input=%s", output, test.Expected, test.Input)
 		}
 	}
 }

--- a/generator/internal/genclient/templatedata.go
+++ b/generator/internal/genclient/templatedata.go
@@ -82,22 +82,22 @@ func (s *service) Methods() []*method {
 
 // NameToSnake converts Name to snake_case.
 func (s *service) NameToSnake() string {
-	return strcase.ToSnake(s.s.Name)
+	return s.c.ToSnake(s.s.Name)
 }
 
-// NameToCamel converts a Name to CamelCase.
+// NameToPascanl converts a Name to PascalCase.
+func (s *service) NameToPascal() string {
+	return s.ServiceNameToPascal()
+}
+
+// NameToPascal converts a Name to PascalCase.
+func (s *service) ServiceNameToPascal() string {
+	return s.c.ToPascal(s.s.Name)
+}
+
+// NameToCamel coverts Name to camelCase
 func (s *service) NameToCamel() string {
-	return s.ServiceNameToCamel()
-}
-
-// NameToCamel converts a Name to CamelCase.
-func (s *service) ServiceNameToCamel() string {
-	return strcase.ToCamel(s.s.Name)
-}
-
-// NameToLowerCamel coverts Name to camelCase
-func (s *service) NameToLowerCamel() string {
-	return strcase.ToLowerCamel(s.s.Name)
+	return s.c.ToCamel(s.s.Name)
 }
 
 func (s *service) DocLines() []string {
@@ -120,7 +120,7 @@ func (m *method) NameToSnake() string {
 	return strcase.ToSnake(m.s.Name)
 }
 
-// NameToCamel converts a Name to CamelCase.
+// NameToCamel converts a Name to camelCase.
 func (m *method) NameToCamel() string {
 	return strcase.ToCamel(m.s.Name)
 }
@@ -285,12 +285,12 @@ type field struct {
 
 // NameToSnake converts a Name to snake_case.
 func (f *field) NameToSnake() string {
-	return strcase.ToSnake(f.s.Name)
+	return f.c.ToSnake(f.s.Name)
 }
 
 // NameToCamel converts a Name to camelCase.
 func (f *field) NameToCamel() string {
-	return strcase.ToCamel(f.s.Name)
+	return f.c.ToCamel(f.s.Name)
 }
 
 func (f *field) DocLines() []string {

--- a/generator/templates/rust/lib.rs.mustache
+++ b/generator/templates/rust/lib.rs.mustache
@@ -29,8 +29,8 @@ impl Client {
     {{#DocLines}}
     /// {{{.}}}
     {{/DocLines}}
-    pub fn {{NameToSnake}}(&self) -> {{NameToCamel}} {
-        {{NameToCamel}} {
+    pub fn {{NameToSnake}}(&self) -> {{NameToPascal}} {
+        {{NameToPascal}} {
             client: self.clone(),
             base_path: "https://{{DefaultHost}}/".to_string(),
         }
@@ -43,12 +43,12 @@ impl Client {
 /// {{{.}}}
 {{/DocLines}}
 #[derive(Debug)]
-pub struct {{NameToCamel}} {
+pub struct {{NameToPascal}} {
     client: Client,
     base_path: String,
 }
 
-impl {{NameToCamel}} {
+impl {{NameToPascal}} {
     {{#Methods}}
 
     {{#DocLines}}


### PR DESCRIPTION
This PR always uses the per-language Codec to perform any "case conversion". We
need to involve the Codec because each language has a different number of
reserved words that must be escaped, and the escaping is also language
specific.

I also fixed a number of places where we used "camel case" when we meant
`PascalCase` (note the starting upper case, as opposed to `camelCase`).

Almost incidentally, I fixed the conversion for `data_crc32c` (and other names
already in `snake_case` form). Previously that got converted to
`data_crc_32_c`.

Fixes #35 and fixes #36.
