### PR TITLE
impl(generator): handle nested messages and enums in Rust

### DIFF
--- a/generator/internal/genclient/language/internal/golang/golang.go
+++ b/generator/internal/genclient/language/internal/golang/golang.go
@@ -108,6 +108,10 @@ func (c *Codec) MessageName(m *genclient.Message, state *genclient.APIState) str
 	return strcase.ToCamel(m.Name)
 }
 
+func (c *Codec) FQMessageName(m *genclient.Message, state *genclient.APIState) string {
+	return c.MessageName(m, state)
+}
+
 func (c *Codec) EnumName(e *genclient.Enum, state *genclient.APIState) string {
 	if e.Parent != nil {
 		return c.MessageName(e.Parent, state) + "_" + strcase.ToCamel(e.Name)
@@ -115,11 +119,19 @@ func (c *Codec) EnumName(e *genclient.Enum, state *genclient.APIState) string {
 	return strcase.ToCamel(e.Name)
 }
 
+func (c *Codec) FQEnumName(e *genclient.Enum, state *genclient.APIState) string {
+	return c.EnumName(e, state)
+}
+
 func (c *Codec) EnumValueName(e *genclient.EnumValue, state *genclient.APIState) string {
 	if e.Parent.Parent != nil {
 		return c.MessageName(e.Parent.Parent, state) + "_" + strings.ToUpper(e.Name)
 	}
 	return strings.ToUpper(e.Name)
+}
+
+func (c *Codec) FQEnumValueName(v *genclient.EnumValue, state *genclient.APIState) string {
+	return c.EnumValueName(v, state)
 }
 
 func (c *Codec) BodyAccessor(m *genclient.Method, state *genclient.APIState) string {

--- a/generator/internal/genclient/language/internal/golang/golang_test.go
+++ b/generator/internal/genclient/language/internal/golang/golang_test.go
@@ -16,6 +16,8 @@ package golang
 
 import (
 	"testing"
+
+	"github.com/googleapis/google-cloud-rust/generator/internal/genclient"
 )
 
 type CaseConvertTest struct {
@@ -51,5 +53,72 @@ func TestToPascal(t *testing.T) {
 		if output := c.ToPascal(test.Input); output != test.Expected {
 			t.Errorf("Output %s not equal to expected %s, input=%s", output, test.Expected, test.Input)
 		}
+	}
+}
+
+func TestMessageNames(t *testing.T) {
+	message := &genclient.Message{
+		Name: "Replication",
+		ID:   "..Replication",
+		Fields: []*genclient.Field{
+			{
+				Name:     "automatic",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  "..Automatic",
+				Optional: true,
+				Repeated: false,
+			},
+		},
+	}
+	nested := &genclient.Message{
+		Name: "Automatic",
+		ID:   "..Replication.Automatic",
+	}
+
+	api := genclient.NewTestAPI([]*genclient.Message{message, nested}, []*genclient.Enum{}, []*genclient.Service{})
+
+	c := &Codec{}
+	if got := c.MessageName(message, api.State); got != "Replication" {
+		t.Errorf("mismatched message name, want=Replication, got=%s", got)
+	}
+	if got := c.FQMessageName(message, api.State); got != "Replication" {
+		t.Errorf("mismatched message name, want=Replication, got=%s", got)
+	}
+
+	if got := c.MessageName(nested, api.State); got != "Replication_Automatic" {
+		t.Errorf("mismatched message name, want=SecretVersion_Automatic, got=%s", got)
+	}
+	if got := c.FQMessageName(nested, api.State); got != "Replication_Automatic" {
+		t.Errorf("mismatched message name, want=Replication_Automatic, got=%s", got)
+	}
+}
+
+func TestEnumNames(t *testing.T) {
+	message := &genclient.Message{
+		Name: "SecretVersion",
+		ID:   "..SecretVersion",
+		Fields: []*genclient.Field{
+			{
+				Name:     "automatic",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  "..Automatic",
+				Optional: true,
+				Repeated: false,
+			},
+		},
+	}
+	nested := &genclient.Enum{
+		Name: "State",
+		ID:   "..SecretVersion.State",
+	}
+
+	api := genclient.NewTestAPI([]*genclient.Message{message}, []*genclient.Enum{nested}, []*genclient.Service{})
+
+	c := &Codec{}
+	if got := c.EnumName(nested, api.State); got != "SecretVersion_State" {
+		t.Errorf("mismatched message name, want=SecretVersion_Automatic, got=%s", got)
+	}
+	if got := c.FQEnumName(nested, api.State); got != "SecretVersion_State" {
+		t.Errorf("mismatched message name, want=SecretVersion_State, got=%s", got)
 	}
 }

--- a/generator/internal/genclient/language/internal/rust/rust_test.go
+++ b/generator/internal/genclient/language/internal/rust/rust_test.go
@@ -86,3 +86,70 @@ func TestToPascal(t *testing.T) {
 		}
 	}
 }
+
+func TestMessageNames(t *testing.T) {
+	message := &genclient.Message{
+		Name: "Replication",
+		ID:   "..Replication",
+		Fields: []*genclient.Field{
+			{
+				Name:     "automatic",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  "..Automatic",
+				Optional: true,
+				Repeated: false,
+			},
+		},
+	}
+	nested := &genclient.Message{
+		Name: "Automatic",
+		ID:   "..Replication.Automatic",
+	}
+
+	api := genclient.NewTestAPI([]*genclient.Message{message, nested}, []*genclient.Enum{}, []*genclient.Service{})
+
+	c := &Codec{}
+	if got := c.MessageName(message, api.State); got != "Replication" {
+		t.Errorf("mismatched message name, want=Replication, got=%s", got)
+	}
+	if got := c.FQMessageName(message, api.State); got != "crate::Replication" {
+		t.Errorf("mismatched message name, want=crate::Replication, got=%s", got)
+	}
+
+	if got := c.MessageName(nested, api.State); got != "Automatic" {
+		t.Errorf("mismatched message name, want=Automatic, got=%s", got)
+	}
+	if got := c.FQMessageName(nested, api.State); got != "crate::replication::Automatic" {
+		t.Errorf("mismatched message name, want=crate::replication::Automatic, got=%s", got)
+	}
+}
+
+func TestEnumNames(t *testing.T) {
+	message := &genclient.Message{
+		Name: "SecretVersion",
+		ID:   "..SecretVersion",
+		Fields: []*genclient.Field{
+			{
+				Name:     "automatic",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  "..Automatic",
+				Optional: true,
+				Repeated: false,
+			},
+		},
+	}
+	nested := &genclient.Enum{
+		Name: "State",
+		ID:   "..SecretVersion.State",
+	}
+
+	api := genclient.NewTestAPI([]*genclient.Message{message}, []*genclient.Enum{nested}, []*genclient.Service{})
+
+	c := &Codec{}
+	if got := c.EnumName(nested, api.State); got != "State" {
+		t.Errorf("mismatched message name, want=Automatic, got=%s", got)
+	}
+	if got := c.FQEnumName(nested, api.State); got != "crate::secret_version::State" {
+		t.Errorf("mismatched message name, want=crate::secret_version::State, got=%s", got)
+	}
+}

--- a/generator/internal/genclient/language/internal/rust/rust_test.go
+++ b/generator/internal/genclient/language/internal/rust/rust_test.go
@@ -110,17 +110,17 @@ func TestMessageNames(t *testing.T) {
 
 	c := &Codec{}
 	if got := c.MessageName(message, api.State); got != "Replication" {
-		t.Errorf("mismatched message name, want=Replication, got=%s", got)
+		t.Errorf("mismatched message name, got=%s, want=Replication", got)
 	}
 	if got := c.FQMessageName(message, api.State); got != "crate::Replication" {
-		t.Errorf("mismatched message name, want=crate::Replication, got=%s", got)
+		t.Errorf("mismatched message name, got=%s, want=crate::Replication", got)
 	}
 
 	if got := c.MessageName(nested, api.State); got != "Automatic" {
-		t.Errorf("mismatched message name, want=Automatic, got=%s", got)
+		t.Errorf("mismatched message name, got=%s, want=Automatic", got)
 	}
 	if got := c.FQMessageName(nested, api.State); got != "crate::replication::Automatic" {
-		t.Errorf("mismatched message name, want=crate::replication::Automatic, got=%s", got)
+		t.Errorf("mismatched message name, got=%s, want=crate::replication::Automatic", got)
 	}
 }
 
@@ -147,9 +147,9 @@ func TestEnumNames(t *testing.T) {
 
 	c := &Codec{}
 	if got := c.EnumName(nested, api.State); got != "State" {
-		t.Errorf("mismatched message name, want=Automatic, got=%s", got)
+		t.Errorf("mismatched message name, got=%s, want=Automatic", got)
 	}
 	if got := c.FQEnumName(nested, api.State); got != "crate::secret_version::State" {
-		t.Errorf("mismatched message name, want=crate::secret_version::State, got=%s", got)
+		t.Errorf("mismatched message name, got=%s, want=crate::secret_version::State", got)
 	}
 }

--- a/generator/internal/genclient/templatedata.go
+++ b/generator/internal/genclient/templatedata.go
@@ -202,9 +202,28 @@ func (m *message) Enums() []*enum {
 	})
 }
 
-// NameToCamel converts a Name to CamelCase.
 func (m *message) Name() string {
 	return m.c.MessageName(m.s, m.state)
+}
+
+func (m *message) QualifiedName() string {
+	return m.c.FQMessageName(m.s, m.state)
+}
+
+func (m *message) NameSnakeCase() string {
+	return m.c.ToSnake(m.s.Name)
+}
+
+func (m *message) HasNestedTypes() bool {
+	if len(m.s.Enums) > 0 {
+		return true
+	}
+	for _, child := range m.s.Messages {
+		if !child.IsMap {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *message) DocLines() []string {

--- a/generator/templates/rust/model.mustache
+++ b/generator/templates/rust/model.mustache
@@ -15,11 +15,18 @@ pub struct {{Name}} {
     pub {{NameToSnake}}: {{{FieldType}}},
     {{/Fields}}
 }
-{{#NestedMessages}}
-{{! TODO(codyoss) https://github.com/googleapis/google-cloud-rust/issues/40 }}
-{{> model}}
-{{/NestedMessages}}
-{{#Enums}}
-{{> enum}}
-{{/Enums}}
+{{#HasNestedTypes}}
+
+/// Defines additional types related to {{Name}}
+pub mod {{NameSnakeCase}} {
+{{/HasNestedTypes}}
+    {{#NestedMessages}}
+    {{> model}}
+    {{/NestedMessages}}
+    {{#Enums}}
+    {{> enum}}
+    {{/Enums}}
+{{#HasNestedTypes}}
+}
+{{/HasNestedTypes}}
 {{/IsMap}}

--- a/generator/testdata/rust/gclient/golden/model.rs
+++ b/generator/testdata/rust/gclient/golden/model.rs
@@ -23,11 +23,11 @@ pub struct Secret {
     ///  the [Secret][google.cloud.secretmanager.v1.Secret].
     /// 
     ///  The replication policy cannot be changed after the Secret has been created.
-    pub replication: Option<Replication>,
+    pub replication: Option<crate::Replication>,
 
     /// Output only. The time at which the
     ///  [Secret][google.cloud.secretmanager.v1.Secret] was created.
-    pub create_time: Option<String>,
+    pub create_time: Option<String> /* TODO(#77) - handle .google.protobuf.Timestamp */,
 
     /// The labels assigned to this Secret.
     /// 
@@ -44,16 +44,16 @@ pub struct Secret {
 
     /// Optional. A list of up to 10 Pub/Sub topics to which messages are published
     ///  when control plane operations are called on the secret or its versions.
-    pub topics: Option<Topic>,
+    pub topics: Option<crate::Topic>,
 
     /// Optional. Timestamp in UTC when the
     ///  [Secret][google.cloud.secretmanager.v1.Secret] is scheduled to expire.
     ///  This is always provided on output, regardless of what was sent on input.
-    pub expire_time: Option<String>,
+    pub expire_time: Option<String> /* TODO(#77) - handle .google.protobuf.Timestamp */,
 
     /// Input only. The TTL for the
     ///  [Secret][google.cloud.secretmanager.v1.Secret].
-    pub ttl: Option<String>,
+    pub ttl: Option<String> /* TODO(#77) - handle .google.protobuf.Duration */,
 
     /// Optional. Etag of the currently stored
     ///  [Secret][google.cloud.secretmanager.v1.Secret].
@@ -62,7 +62,7 @@ pub struct Secret {
     /// Optional. Rotation policy attached to the
     ///  [Secret][google.cloud.secretmanager.v1.Secret]. May be excluded if there is
     ///  no rotation policy.
-    pub rotation: Option<Rotation>,
+    pub rotation: Option<crate::Rotation>,
 
     /// Optional. Mapping from version alias to version name.
     /// 
@@ -97,7 +97,7 @@ pub struct Secret {
     ///  For secret with TTL>0, version destruction doesn't happen immediately
     ///  on calling destroy instead the version goes to a disabled state and
     ///  destruction happens after the TTL expires.
-    pub version_destroy_ttl: Option<String>,
+    pub version_destroy_ttl: Option<String> /* TODO(#77) - handle .google.protobuf.Duration */,
 
     /// Optional. The customer-managed encryption configuration of the Regionalised
     ///  Secrets. If no configuration is provided, Google-managed default encryption
@@ -108,7 +108,7 @@ pub struct Secret {
     ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] added
     ///  afterwards. They do not apply retroactively to existing
     ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
-    pub customer_managed_encryption: Option<CustomerManagedEncryption>,
+    pub customer_managed_encryption: Option<crate::CustomerManagedEncryption>,
 }
 
 /// A secret version resource in the Secret Manager API.
@@ -128,22 +128,22 @@ pub struct SecretVersion {
 
     /// Output only. The time at which the
     ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] was created.
-    pub create_time: Option<String>,
+    pub create_time: Option<String> /* TODO(#77) - handle .google.protobuf.Timestamp */,
 
     /// Output only. The time this
     ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] was destroyed.
     ///  Only present if [state][google.cloud.secretmanager.v1.SecretVersion.state]
     ///  is
     ///  [DESTROYED][google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED].
-    pub destroy_time: Option<String>,
+    pub destroy_time: Option<String> /* TODO(#77) - handle .google.protobuf.Timestamp */,
 
     /// Output only. The current state of the
     ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-    pub state: SecretVersion_State,
+    pub state: crate::secret_version::State,
 
     /// The replication status of the
     ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-    pub replication_status: Option<ReplicationStatus>,
+    pub replication_status: Option<crate::ReplicationStatus>,
 
     /// Output only. Etag of the currently stored
     ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -163,39 +163,43 @@ pub struct SecretVersion {
     ///  destroyed, the version is moved to disabled state and it is scheduled for
     ///  destruction. The version is destroyed only after the
     ///  `scheduled_destroy_time`.
-    pub scheduled_destroy_time: Option<String>,
+    pub scheduled_destroy_time: Option<String> /* TODO(#77) - handle .google.protobuf.Timestamp */,
 
     /// Output only. The customer-managed encryption status of the
     ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. Only
     ///  populated if customer-managed encryption is used and
     ///  [Secret][google.cloud.secretmanager.v1.Secret] is a Regionalised Secret.
-    pub customer_managed_encryption: Option<CustomerManagedEncryptionStatus>,
+    pub customer_managed_encryption: Option<crate::CustomerManagedEncryptionStatus>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct SecretVersion_State(i32);
+/// Defines additional types related to SecretVersion
+pub mod secret_version {
 
-impl SecretVersion_State {
+    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+    pub struct State(i32);
 
-    // Not specified. This value is unused and invalid.
-    pub const SecretVersion_StateUnspecified: SecretVersion_State = SecretVersion_State(0);
+    impl State {
 
-    // The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] may be
-    // accessed.
-    pub const SecretVersion_Enabled: SecretVersion_State = SecretVersion_State(1);
+        // Not specified. This value is unused and invalid.
+        pub const SecretVersion_StateUnspecified: State = State(0);
 
-    // The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] may not
-    // be accessed, but the secret data is still available and can be placed
-    // back into the
-    // [ENABLED][google.cloud.secretmanager.v1.SecretVersion.State.ENABLED]
-    // state.
-    pub const SecretVersion_Disabled: SecretVersion_State = SecretVersion_State(2);
+        // The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] may be
+        // accessed.
+        pub const SecretVersion_Enabled: State = State(1);
 
-    // The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] is
-    // destroyed and the secret data is no longer stored. A version may not
-    // leave this state once entered.
-    pub const SecretVersion_Destroyed: SecretVersion_State = SecretVersion_State(3);
-}
+        // The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] may not
+        // be accessed, but the secret data is still available and can be placed
+        // back into the
+        // [ENABLED][google.cloud.secretmanager.v1.SecretVersion.State.ENABLED]
+        // state.
+        pub const SecretVersion_Disabled: State = State(2);
+
+        // The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] is
+        // destroyed and the secret data is no longer stored. A version may not
+        // leave this state once entered.
+        pub const SecretVersion_Destroyed: State = State(3);
+    }}
+
 /// A policy that defines the replication and encryption configuration of data.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -204,69 +208,77 @@ pub struct Replication {
 
     /// The [Secret][google.cloud.secretmanager.v1.Secret] will automatically be
     ///  replicated without any restrictions.
-    pub automatic: Option<Replication_Automatic>,
+    pub automatic: Option<crate::replication::Automatic>,
 
     /// The [Secret][google.cloud.secretmanager.v1.Secret] will only be
     ///  replicated into the locations specified.
-    pub user_managed: Option<Replication_UserManaged>,
+    pub user_managed: Option<crate::replication::UserManaged>,
 }
 
-/// A replication policy that replicates the
-/// [Secret][google.cloud.secretmanager.v1.Secret] payload without any
-/// restrictions.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub struct Replication_Automatic {
+/// Defines additional types related to Replication
+pub mod replication {
 
-    /// Optional. The customer-managed encryption configuration of the
-    ///  [Secret][google.cloud.secretmanager.v1.Secret]. If no configuration is
-    ///  provided, Google-managed default encryption is used.
-    /// 
-    ///  Updates to the [Secret][google.cloud.secretmanager.v1.Secret] encryption
-    ///  configuration only apply to
-    ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] added
-    ///  afterwards. They do not apply retroactively to existing
-    ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
-    pub customer_managed_encryption: Option<CustomerManagedEncryption>,
-}
+    /// A replication policy that replicates the
+    /// [Secret][google.cloud.secretmanager.v1.Secret] payload without any
+    /// restrictions.
+    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    #[non_exhaustive]
+    pub struct Automatic {
 
-/// A replication policy that replicates the
-/// [Secret][google.cloud.secretmanager.v1.Secret] payload into the locations
-/// specified in [Secret.replication.user_managed.replicas][]
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub struct Replication_UserManaged {
+        /// Optional. The customer-managed encryption configuration of the
+        ///  [Secret][google.cloud.secretmanager.v1.Secret]. If no configuration is
+        ///  provided, Google-managed default encryption is used.
+        /// 
+        ///  Updates to the [Secret][google.cloud.secretmanager.v1.Secret] encryption
+        ///  configuration only apply to
+        ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] added
+        ///  afterwards. They do not apply retroactively to existing
+        ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
+        pub customer_managed_encryption: Option<crate::CustomerManagedEncryption>,
+    }
 
-    /// Required. The list of Replicas for this
-    ///  [Secret][google.cloud.secretmanager.v1.Secret].
-    /// 
-    ///  Cannot be empty.
-    pub replicas: Option<Replication_UserManaged_Replica>,
-}
+    /// A replication policy that replicates the
+    /// [Secret][google.cloud.secretmanager.v1.Secret] payload into the locations
+    /// specified in [Secret.replication.user_managed.replicas][]
+    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    #[non_exhaustive]
+    pub struct UserManaged {
 
-/// Represents a Replica for this
-/// [Secret][google.cloud.secretmanager.v1.Secret].
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub struct Replication_UserManaged_Replica {
+        /// Required. The list of Replicas for this
+        ///  [Secret][google.cloud.secretmanager.v1.Secret].
+        /// 
+        ///  Cannot be empty.
+        pub replicas: Option<crate::replication::user_managed::Replica>,
+    }
 
-    /// The canonical IDs of the location to replicate data.
-    ///  For example: `"us-east1"`.
-    pub location: String,
+    /// Defines additional types related to UserManaged
+    pub mod user_managed {
 
-    /// Optional. The customer-managed encryption configuration of the
-    ///  [User-Managed Replica][Replication.UserManaged.Replica]. If no
-    ///  configuration is provided, Google-managed default encryption is used.
-    /// 
-    ///  Updates to the [Secret][google.cloud.secretmanager.v1.Secret]
-    ///  encryption configuration only apply to
-    ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] added
-    ///  afterwards. They do not apply retroactively to existing
-    ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
-    pub customer_managed_encryption: Option<CustomerManagedEncryption>,
+        /// Represents a Replica for this
+        /// [Secret][google.cloud.secretmanager.v1.Secret].
+        #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+        #[serde(rename_all = "camelCase")]
+        #[non_exhaustive]
+        pub struct Replica {
+
+            /// The canonical IDs of the location to replicate data.
+            ///  For example: `"us-east1"`.
+            pub location: String,
+
+            /// Optional. The customer-managed encryption configuration of the
+            ///  [User-Managed Replica][Replication.UserManaged.Replica]. If no
+            ///  configuration is provided, Google-managed default encryption is used.
+            /// 
+            ///  Updates to the [Secret][google.cloud.secretmanager.v1.Secret]
+            ///  encryption configuration only apply to
+            ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] added
+            ///  afterwards. They do not apply retroactively to existing
+            ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
+            pub customer_managed_encryption: Option<crate::CustomerManagedEncryption>,
+        }
+    }
 }
 
 /// Configuration for encrypting secret payloads using customer-managed
@@ -306,7 +318,7 @@ pub struct ReplicationStatus {
     ///  Only populated if the parent
     ///  [Secret][google.cloud.secretmanager.v1.Secret] has an automatic
     ///  replication policy.
-    pub automatic: Option<ReplicationStatus_AutomaticStatus>,
+    pub automatic: Option<crate::replication_status::AutomaticStatus>,
 
     /// Describes the replication status of a
     ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] with
@@ -315,57 +327,65 @@ pub struct ReplicationStatus {
     ///  Only populated if the parent
     ///  [Secret][google.cloud.secretmanager.v1.Secret] has a user-managed
     ///  replication policy.
-    pub user_managed: Option<ReplicationStatus_UserManagedStatus>,
+    pub user_managed: Option<crate::replication_status::UserManagedStatus>,
 }
 
-/// The replication status of a
-/// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] using
-/// automatic replication.
-/// 
-/// Only populated if the parent [Secret][google.cloud.secretmanager.v1.Secret]
-/// has an automatic replication policy.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub struct ReplicationStatus_AutomaticStatus {
+/// Defines additional types related to ReplicationStatus
+pub mod replication_status {
 
-    /// Output only. The customer-managed encryption status of the
-    ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. Only
-    ///  populated if customer-managed encryption is used.
-    pub customer_managed_encryption: Option<CustomerManagedEncryptionStatus>,
-}
+    /// The replication status of a
+    /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] using
+    /// automatic replication.
+    /// 
+    /// Only populated if the parent [Secret][google.cloud.secretmanager.v1.Secret]
+    /// has an automatic replication policy.
+    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    #[non_exhaustive]
+    pub struct AutomaticStatus {
 
-/// The replication status of a
-/// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] using
-/// user-managed replication.
-/// 
-/// Only populated if the parent [Secret][google.cloud.secretmanager.v1.Secret]
-/// has a user-managed replication policy.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub struct ReplicationStatus_UserManagedStatus {
+        /// Output only. The customer-managed encryption status of the
+        ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. Only
+        ///  populated if customer-managed encryption is used.
+        pub customer_managed_encryption: Option<crate::CustomerManagedEncryptionStatus>,
+    }
 
-    /// Output only. The list of replica statuses for the
-    ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-    pub replicas: Option<ReplicationStatus_UserManagedStatus_ReplicaStatus>,
-}
+    /// The replication status of a
+    /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] using
+    /// user-managed replication.
+    /// 
+    /// Only populated if the parent [Secret][google.cloud.secretmanager.v1.Secret]
+    /// has a user-managed replication policy.
+    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    #[non_exhaustive]
+    pub struct UserManagedStatus {
 
-/// Describes the status of a user-managed replica for the
-/// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub struct ReplicationStatus_UserManagedStatus_ReplicaStatus {
+        /// Output only. The list of replica statuses for the
+        ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+        pub replicas: Option<crate::replication_status::user_managed_status::ReplicaStatus>,
+    }
 
-    /// Output only. The canonical ID of the replica location.
-    ///  For example: `"us-east1"`.
-    pub location: String,
+    /// Defines additional types related to UserManagedStatus
+    pub mod user_managed_status {
 
-    /// Output only. The customer-managed encryption status of the
-    ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. Only
-    ///  populated if customer-managed encryption is used.
-    pub customer_managed_encryption: Option<CustomerManagedEncryptionStatus>,
+        /// Describes the status of a user-managed replica for the
+        /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+        #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+        #[serde(rename_all = "camelCase")]
+        #[non_exhaustive]
+        pub struct ReplicaStatus {
+
+            /// Output only. The canonical ID of the replica location.
+            ///  For example: `"us-east1"`.
+            pub location: String,
+
+            /// Output only. The customer-managed encryption status of the
+            ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. Only
+            ///  populated if customer-managed encryption is used.
+            pub customer_managed_encryption: Option<crate::CustomerManagedEncryptionStatus>,
+        }
+    }
 }
 
 /// Describes the status of customer-managed encryption.
@@ -414,7 +434,7 @@ pub struct Rotation {
     ///  MUST  be set if
     ///  [rotation_period][google.cloud.secretmanager.v1.Rotation.rotation_period]
     ///  is set.
-    pub next_rotation_time: Option<String>,
+    pub next_rotation_time: Option<String> /* TODO(#77) - handle .google.protobuf.Timestamp */,
 
     /// Input only. The Duration between rotation notifications. Must be in seconds
     ///  and at least 3600s (1h) and at most 3153600000s (100 years).
@@ -427,7 +447,7 @@ pub struct Rotation {
     ///  [next_rotation_time][google.cloud.secretmanager.v1.Rotation.next_rotation_time]
     ///  will be advanced by this period when the service automatically sends
     ///  rotation notifications.
-    pub rotation_period: Option<String>,
+    pub rotation_period: Option<String> /* TODO(#77) - handle .google.protobuf.Duration */,
 }
 
 /// A secret payload resource in the Secret Manager API. This contains the
@@ -481,7 +501,7 @@ pub struct CreateSecretRequest {
 
     /// Required. A [Secret][google.cloud.secretmanager.v1.Secret] with initial
     ///  field values.
-    pub secret: Option<Secret>,
+    pub secret: Option<crate::Secret>,
 }
 
 /// Request message for

--- a/generator/testdata/rust/openapi/golden/model.rs
+++ b/generator/testdata/rust/openapi/golden/model.rs
@@ -78,7 +78,7 @@ pub struct Secret {
     /// Optional. Immutable. The replication policy of the secret data attached to the Secret.
     /// 
     /// The replication policy cannot be changed after the Secret has been created.
-    pub replication: Option<Replication>,
+    pub replication: Option<crate::Replication>,
 
     /// Output only. The time at which the Secret was created.
     pub create_time: Option<String> /* TODO(#77) - handle .google.protobuf.Timestamp */,
@@ -112,7 +112,7 @@ pub struct Secret {
 
     /// Optional. Rotation policy attached to the Secret. May be excluded if there is no
     /// rotation policy.
-    pub rotation: Option<Rotation>,
+    pub rotation: Option<crate::Rotation>,
 
     /// Optional. Mapping from version alias to version name.
     /// 
@@ -155,7 +155,7 @@ pub struct Secret {
     /// Updates to the Secret encryption configuration only apply to
     /// SecretVersions added afterwards. They do not apply
     /// retroactively to existing SecretVersions.
-    pub customer_managed_encryption: Option<CustomerManagedEncryption>,
+    pub customer_managed_encryption: Option<crate::CustomerManagedEncryption>,
 }
 
 /// A policy that defines the replication and encryption configuration of data.
@@ -165,10 +165,10 @@ pub struct Secret {
 pub struct Replication {
 
     /// The Secret will automatically be replicated without any restrictions.
-    pub automatic: Option<Automatic>,
+    pub automatic: Option<crate::Automatic>,
 
     /// The Secret will only be replicated into the locations specified.
-    pub user_managed: Option<UserManaged>,
+    pub user_managed: Option<crate::UserManaged>,
 }
 
 /// A replication policy that replicates the Secret payload without any
@@ -184,7 +184,7 @@ pub struct Automatic {
     /// Updates to the Secret encryption configuration only apply to
     /// SecretVersions added afterwards. They do not apply
     /// retroactively to existing SecretVersions.
-    pub customer_managed_encryption: Option<CustomerManagedEncryption>,
+    pub customer_managed_encryption: Option<crate::CustomerManagedEncryption>,
 }
 
 /// Configuration for encrypting secret payloads using customer-managed
@@ -238,7 +238,7 @@ pub struct Replica {
     /// Updates to the Secret encryption configuration only apply to
     /// SecretVersions added afterwards. They do not apply
     /// retroactively to existing SecretVersions.
-    pub customer_managed_encryption: Option<CustomerManagedEncryption>,
+    pub customer_managed_encryption: Option<crate::CustomerManagedEncryption>,
 }
 
 /// A Pub/Sub topic which Secret Manager will publish to when control plane
@@ -287,7 +287,7 @@ pub struct Rotation {
 pub struct AddSecretVersionRequest {
 
     /// Required. The secret payload of the SecretVersion.
-    pub payload: Option<SecretPayload>,
+    pub payload: Option<crate::SecretPayload>,
 }
 
 /// A secret payload resource in the Secret Manager API. This contains the
@@ -338,7 +338,7 @@ pub struct SecretVersion {
     pub state: Option<String>,
 
     /// The replication status of the SecretVersion.
-    pub replication_status: Option<ReplicationStatus>,
+    pub replication_status: Option<crate::ReplicationStatus>,
 
     /// Output only. Etag of the currently stored SecretVersion.
     pub etag: Option<String>,
@@ -358,7 +358,7 @@ pub struct SecretVersion {
     /// Output only. The customer-managed encryption status of the SecretVersion. Only
     /// populated if customer-managed encryption is used and Secret is
     /// a Regionalised Secret.
-    pub customer_managed_encryption: Option<CustomerManagedEncryptionStatus>,
+    pub customer_managed_encryption: Option<crate::CustomerManagedEncryptionStatus>,
 }
 
 /// The replication status of a SecretVersion.
@@ -372,14 +372,14 @@ pub struct ReplicationStatus {
     /// 
     /// Only populated if the parent Secret has an automatic replication
     /// policy.
-    pub automatic: Option<AutomaticStatus>,
+    pub automatic: Option<crate::AutomaticStatus>,
 
     /// Describes the replication status of a SecretVersion with
     /// user-managed replication.
     /// 
     /// Only populated if the parent Secret has a user-managed replication
     /// policy.
-    pub user_managed: Option<UserManagedStatus>,
+    pub user_managed: Option<crate::UserManagedStatus>,
 }
 
 /// The replication status of a SecretVersion using automatic replication.
@@ -393,7 +393,7 @@ pub struct AutomaticStatus {
 
     /// Output only. The customer-managed encryption status of the SecretVersion. Only
     /// populated if customer-managed encryption is used.
-    pub customer_managed_encryption: Option<CustomerManagedEncryptionStatus>,
+    pub customer_managed_encryption: Option<crate::CustomerManagedEncryptionStatus>,
 }
 
 /// Describes the status of customer-managed encryption.
@@ -434,7 +434,7 @@ pub struct ReplicaStatus {
 
     /// Output only. The customer-managed encryption status of the SecretVersion. Only
     /// populated if customer-managed encryption is used.
-    pub customer_managed_encryption: Option<CustomerManagedEncryptionStatus>,
+    pub customer_managed_encryption: Option<crate::CustomerManagedEncryptionStatus>,
 }
 
 /// A generic empty message that you can re-use to avoid defining duplicated
@@ -481,7 +481,7 @@ pub struct AccessSecretVersionResponse {
     pub name: Option<String>,
 
     /// Secret payload
-    pub payload: Option<SecretPayload>,
+    pub payload: Option<crate::SecretPayload>,
 }
 
 /// Request message for SecretManagerService.DisableSecretVersion.
@@ -530,7 +530,7 @@ pub struct SetIamPolicyRequest {
     /// the policy is limited to a few 10s of KB. An empty policy is a
     /// valid policy but certain Google Cloud services (such as Projects)
     /// might reject them.
-    pub policy: Option<Policy>,
+    pub policy: Option<crate::Policy>,
 
     /// OPTIONAL: A FieldMask specifying which fields of the policy to modify. Only
     /// the fields in the mask will be modified. If no mask is provided, the
@@ -783,7 +783,7 @@ pub struct Binding {
     /// To learn which resources support conditions in their IAM policies, see the
     /// [IAM
     /// documentation](https://cloud.google.com/iam/help/conditions/resource-policies).
-    pub condition: Option<Expr>,
+    pub condition: Option<crate::Expr>,
 }
 
 /// Represents a textual expression in the Common Expression Language (CEL)

--- a/generator/testdata/rust/openapi/golden/model.rs
+++ b/generator/testdata/rust/openapi/golden/model.rs
@@ -81,7 +81,7 @@ pub struct Secret {
     pub replication: Option<Replication>,
 
     /// Output only. The time at which the Secret was created.
-    pub create_time: Option<String>,
+    pub create_time: Option<String> /* TODO(#77) - handle .google.protobuf.Timestamp */,
 
     /// The labels assigned to this Secret.
     /// 
@@ -102,10 +102,10 @@ pub struct Secret {
 
     /// Optional. Timestamp in UTC when the Secret is scheduled to expire. This is
     /// always provided on output, regardless of what was sent on input.
-    pub expire_time: Option<String>,
+    pub expire_time: Option<String> /* TODO(#77) - handle .google.protobuf.Timestamp */,
 
     /// Input only. The TTL for the Secret.
-    pub ttl: Option<String>,
+    pub ttl: Option<String> /* TODO(#77) - handle .google.protobuf.Duration */,
 
     /// Optional. Etag of the currently stored Secret.
     pub etag: Option<String>,
@@ -147,7 +147,7 @@ pub struct Secret {
     /// For secret with TTL>0, version destruction doesn't happen immediately
     /// on calling destroy instead the version goes to a disabled state and
     /// destruction happens after the TTL expires.
-    pub version_destroy_ttl: Option<String>,
+    pub version_destroy_ttl: Option<String> /* TODO(#77) - handle .google.protobuf.Duration */,
 
     /// Optional. The customer-managed encryption configuration of the Regionalised Secrets.
     /// If no configuration is provided, Google-managed default encryption is used.
@@ -269,7 +269,7 @@ pub struct Rotation {
     /// years).
     /// 
     /// next_rotation_time MUST  be set if rotation_period is set.
-    pub next_rotation_time: Option<String>,
+    pub next_rotation_time: Option<String> /* TODO(#77) - handle .google.protobuf.Timestamp */,
 
     /// Input only. The Duration between rotation notifications. Must be in seconds
     /// and at least 3600s (1h) and at most 3153600000s (100 years).
@@ -277,7 +277,7 @@ pub struct Rotation {
     /// If rotation_period is set, next_rotation_time must be set.
     /// next_rotation_time will be advanced by this period when the service
     /// automatically sends rotation notifications.
-    pub rotation_period: Option<String>,
+    pub rotation_period: Option<String> /* TODO(#77) - handle .google.protobuf.Duration */,
 }
 
 /// Request message for SecretManagerService.AddSecretVersion.
@@ -327,12 +327,12 @@ pub struct SecretVersion {
     pub name: Option<String>,
 
     /// Output only. The time at which the SecretVersion was created.
-    pub create_time: Option<String>,
+    pub create_time: Option<String> /* TODO(#77) - handle .google.protobuf.Timestamp */,
 
     /// Output only. The time this SecretVersion was destroyed.
     /// Only present if state is
     /// DESTROYED.
-    pub destroy_time: Option<String>,
+    pub destroy_time: Option<String> /* TODO(#77) - handle .google.protobuf.Timestamp */,
 
     /// Output only. The current state of the SecretVersion.
     pub state: Option<String>,
@@ -353,7 +353,7 @@ pub struct SecretVersion {
     /// Secret with a valid version destroy TTL, when a secert version is
     /// destroyed, version is moved to disabled state and it is scheduled for
     /// destruction Version is destroyed only after the scheduled_destroy_time.
-    pub scheduled_destroy_time: Option<String>,
+    pub scheduled_destroy_time: Option<String> /* TODO(#77) - handle .google.protobuf.Timestamp */,
 
     /// Output only. The customer-managed encryption status of the SecretVersion. Only
     /// populated if customer-managed encryption is used and Secret is


### PR DESCRIPTION
The mapping nested messages and enums uses a public module within the crate.
That requires a new "snake case" accessor for the message name, as Rust uses
snake case for modules.

We also need a boolean to find out if the module is needed at all.

And we need to get a different attribute for the fully qualified name of each
message and enum, as we must refer to the qualified name of the generated
struct when using the type.

Fixes #40. This PR is more bulky than I like, it snowballed on me. Let me know if you want me to break it into smaller PRs.
