### PR TITLE
impl(generator/protobuf): fix comment cleanup

### DIFF
--- a/generator/testdata/rust/gclient/golden/lib.rs
+++ b/generator/testdata/rust/gclient/golden/lib.rs
@@ -27,11 +27,11 @@ impl Client {
 
     /// Secret Manager Service
     /// 
-    ///  Manages secrets and operations using those secrets. Implements a REST
-    ///  model with the following objects:
+    /// Manages secrets and operations using those secrets. Implements a REST
+    /// model with the following objects:
     /// 
-    ///  * [Secret][google.cloud.secretmanager.v1.Secret]
-    ///  * [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
+    /// * [Secret][google.cloud.secretmanager.v1.Secret]
+    /// * [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
     pub fn secret_manager_service(&self) -> SecretManagerService {
         SecretManagerService {
             client: self.clone(),
@@ -42,11 +42,11 @@ impl Client {
 
 /// Secret Manager Service
 /// 
-///  Manages secrets and operations using those secrets. Implements a REST
-///  model with the following objects:
+/// Manages secrets and operations using those secrets. Implements a REST
+/// model with the following objects:
 /// 
-///  * [Secret][google.cloud.secretmanager.v1.Secret]
-///  * [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
+/// * [Secret][google.cloud.secretmanager.v1.Secret]
+/// * [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
 #[derive(Debug)]
 pub struct SecretManagerService {
     client: Client,
@@ -56,7 +56,7 @@ pub struct SecretManagerService {
 impl SecretManagerService {
 
     /// Creates a new [Secret][google.cloud.secretmanager.v1.Secret] containing no
-    ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
+    /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
     pub async fn create_secret(&self, req: model::CreateSecretRequest) -> Result<model::Secret, Box<dyn std::error::Error>> {
         let client = self.client.inner.clone();
         let res = client.http_client

--- a/generator/testdata/rust/gclient/golden/model.rs
+++ b/generator/testdata/rust/gclient/golden/model.rs
@@ -15,99 +15,99 @@ use serde::{Deserialize, Serialize};
 pub struct Secret {
 
     /// Output only. The resource name of the
-    ///  [Secret][google.cloud.secretmanager.v1.Secret] in the format
-    ///  `projects/*/secrets/*`.
+    /// [Secret][google.cloud.secretmanager.v1.Secret] in the format
+    /// `projects/*/secrets/*`.
     pub name: String,
 
     /// Optional. Immutable. The replication policy of the secret data attached to
-    ///  the [Secret][google.cloud.secretmanager.v1.Secret].
+    /// the [Secret][google.cloud.secretmanager.v1.Secret].
     /// 
-    ///  The replication policy cannot be changed after the Secret has been created.
+    /// The replication policy cannot be changed after the Secret has been created.
     pub replication: Option<crate::Replication>,
 
     /// Output only. The time at which the
-    ///  [Secret][google.cloud.secretmanager.v1.Secret] was created.
+    /// [Secret][google.cloud.secretmanager.v1.Secret] was created.
     pub create_time: Option<String> /* TODO(#77) - handle .google.protobuf.Timestamp */,
 
     /// The labels assigned to this Secret.
     /// 
-    ///  Label keys must be between 1 and 63 characters long, have a UTF-8 encoding
-    ///  of maximum 128 bytes, and must conform to the following PCRE regular
-    ///  expression: `[\p{Ll}\p{Lo}][\p{Ll}\p{Lo}\p{N}_-]{0,62}`
+    /// Label keys must be between 1 and 63 characters long, have a UTF-8 encoding
+    /// of maximum 128 bytes, and must conform to the following PCRE regular
+    /// expression: `[\p{Ll}\p{Lo}][\p{Ll}\p{Lo}\p{N}_-]{0,62}`
     /// 
-    ///  Label values must be between 0 and 63 characters long, have a UTF-8
-    ///  encoding of maximum 128 bytes, and must conform to the following PCRE
-    ///  regular expression: `[\p{Ll}\p{Lo}\p{N}_-]{0,63}`
+    /// Label values must be between 0 and 63 characters long, have a UTF-8
+    /// encoding of maximum 128 bytes, and must conform to the following PCRE
+    /// regular expression: `[\p{Ll}\p{Lo}\p{N}_-]{0,63}`
     /// 
-    ///  No more than 64 labels can be assigned to a given resource.
+    /// No more than 64 labels can be assigned to a given resource.
     pub labels: Option<std::collections::HashMap<String,String>>,
 
     /// Optional. A list of up to 10 Pub/Sub topics to which messages are published
-    ///  when control plane operations are called on the secret or its versions.
+    /// when control plane operations are called on the secret or its versions.
     pub topics: Option<crate::Topic>,
 
     /// Optional. Timestamp in UTC when the
-    ///  [Secret][google.cloud.secretmanager.v1.Secret] is scheduled to expire.
-    ///  This is always provided on output, regardless of what was sent on input.
+    /// [Secret][google.cloud.secretmanager.v1.Secret] is scheduled to expire.
+    /// This is always provided on output, regardless of what was sent on input.
     pub expire_time: Option<String> /* TODO(#77) - handle .google.protobuf.Timestamp */,
 
     /// Input only. The TTL for the
-    ///  [Secret][google.cloud.secretmanager.v1.Secret].
+    /// [Secret][google.cloud.secretmanager.v1.Secret].
     pub ttl: Option<String> /* TODO(#77) - handle .google.protobuf.Duration */,
 
     /// Optional. Etag of the currently stored
-    ///  [Secret][google.cloud.secretmanager.v1.Secret].
+    /// [Secret][google.cloud.secretmanager.v1.Secret].
     pub etag: String,
 
     /// Optional. Rotation policy attached to the
-    ///  [Secret][google.cloud.secretmanager.v1.Secret]. May be excluded if there is
-    ///  no rotation policy.
+    /// [Secret][google.cloud.secretmanager.v1.Secret]. May be excluded if there is
+    /// no rotation policy.
     pub rotation: Option<crate::Rotation>,
 
     /// Optional. Mapping from version alias to version name.
     /// 
-    ///  A version alias is a string with a maximum length of 63 characters and can
-    ///  contain uppercase and lowercase letters, numerals, and the hyphen (`-`)
-    ///  and underscore ('_') characters. An alias string must start with a
-    ///  letter and cannot be the string 'latest' or 'NEW'.
-    ///  No more than 50 aliases can be assigned to a given secret.
+    /// A version alias is a string with a maximum length of 63 characters and can
+    /// contain uppercase and lowercase letters, numerals, and the hyphen (`-`)
+    /// and underscore ('_') characters. An alias string must start with a
+    /// letter and cannot be the string 'latest' or 'NEW'.
+    /// No more than 50 aliases can be assigned to a given secret.
     /// 
-    ///  Version-Alias pairs will be viewable via GetSecret and modifiable via
-    ///  UpdateSecret. Access by alias is only be supported on
-    ///  GetSecretVersion and AccessSecretVersion.
+    /// Version-Alias pairs will be viewable via GetSecret and modifiable via
+    /// UpdateSecret. Access by alias is only be supported on
+    /// GetSecretVersion and AccessSecretVersion.
     pub version_aliases: Option<std::collections::HashMap<String,i64>>,
 
     /// Optional. Custom metadata about the secret.
     /// 
-    ///  Annotations are distinct from various forms of labels.
-    ///  Annotations exist to allow client tools to store their own state
-    ///  information without requiring a database.
+    /// Annotations are distinct from various forms of labels.
+    /// Annotations exist to allow client tools to store their own state
+    /// information without requiring a database.
     /// 
-    ///  Annotation keys must be between 1 and 63 characters long, have a UTF-8
-    ///  encoding of maximum 128 bytes, begin and end with an alphanumeric character
-    ///  ([a-z0-9A-Z]), and may have dashes (-), underscores (_), dots (.), and
-    ///  alphanumerics in between these symbols.
+    /// Annotation keys must be between 1 and 63 characters long, have a UTF-8
+    /// encoding of maximum 128 bytes, begin and end with an alphanumeric character
+    /// ([a-z0-9A-Z]), and may have dashes (-), underscores (_), dots (.), and
+    /// alphanumerics in between these symbols.
     /// 
-    ///  The total size of annotation keys and values must be less than 16KiB.
+    /// The total size of annotation keys and values must be less than 16KiB.
     pub annotations: Option<std::collections::HashMap<String,String>>,
 
     /// Optional. Secret Version TTL after destruction request
     /// 
-    ///  This is a part of the Delayed secret version destroy feature.
-    ///  For secret with TTL>0, version destruction doesn't happen immediately
-    ///  on calling destroy instead the version goes to a disabled state and
-    ///  destruction happens after the TTL expires.
+    /// This is a part of the Delayed secret version destroy feature.
+    /// For secret with TTL>0, version destruction doesn't happen immediately
+    /// on calling destroy instead the version goes to a disabled state and
+    /// destruction happens after the TTL expires.
     pub version_destroy_ttl: Option<String> /* TODO(#77) - handle .google.protobuf.Duration */,
 
     /// Optional. The customer-managed encryption configuration of the Regionalised
-    ///  Secrets. If no configuration is provided, Google-managed default encryption
-    ///  is used.
+    /// Secrets. If no configuration is provided, Google-managed default encryption
+    /// is used.
     /// 
-    ///  Updates to the [Secret][google.cloud.secretmanager.v1.Secret] encryption
-    ///  configuration only apply to
-    ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] added
-    ///  afterwards. They do not apply retroactively to existing
-    ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
+    /// Updates to the [Secret][google.cloud.secretmanager.v1.Secret] encryption
+    /// configuration only apply to
+    /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] added
+    /// afterwards. They do not apply retroactively to existing
+    /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
     pub customer_managed_encryption: Option<crate::CustomerManagedEncryption>,
 }
 
@@ -118,57 +118,57 @@ pub struct Secret {
 pub struct SecretVersion {
 
     /// Output only. The resource name of the
-    ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format
-    ///  `projects/*/secrets/*/versions/*`.
+    /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format
+    /// `projects/*/secrets/*/versions/*`.
     /// 
-    ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] IDs in a
-    ///  [Secret][google.cloud.secretmanager.v1.Secret] start at 1 and are
-    ///  incremented for each subsequent version of the secret.
+    /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] IDs in a
+    /// [Secret][google.cloud.secretmanager.v1.Secret] start at 1 and are
+    /// incremented for each subsequent version of the secret.
     pub name: String,
 
     /// Output only. The time at which the
-    ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] was created.
+    /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] was created.
     pub create_time: Option<String> /* TODO(#77) - handle .google.protobuf.Timestamp */,
 
     /// Output only. The time this
-    ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] was destroyed.
-    ///  Only present if [state][google.cloud.secretmanager.v1.SecretVersion.state]
-    ///  is
-    ///  [DESTROYED][google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED].
+    /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] was destroyed.
+    /// Only present if [state][google.cloud.secretmanager.v1.SecretVersion.state]
+    /// is
+    /// [DESTROYED][google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED].
     pub destroy_time: Option<String> /* TODO(#77) - handle .google.protobuf.Timestamp */,
 
     /// Output only. The current state of the
-    ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+    /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
     pub state: crate::secret_version::State,
 
     /// The replication status of the
-    ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+    /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
     pub replication_status: Option<crate::ReplicationStatus>,
 
     /// Output only. Etag of the currently stored
-    ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+    /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
     pub etag: String,
 
     /// Output only. True if payload checksum specified in
-    ///  [SecretPayload][google.cloud.secretmanager.v1.SecretPayload] object has
-    ///  been received by
-    ///  [SecretManagerService][google.cloud.secretmanager.v1.SecretManagerService]
-    ///  on
-    ///  [SecretManagerService.AddSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion].
+    /// [SecretPayload][google.cloud.secretmanager.v1.SecretPayload] object has
+    /// been received by
+    /// [SecretManagerService][google.cloud.secretmanager.v1.SecretManagerService]
+    /// on
+    /// [SecretManagerService.AddSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion].
     pub client_specified_payload_checksum: bool,
 
     /// Optional. Output only. Scheduled destroy time for secret version.
-    ///  This is a part of the Delayed secret version destroy feature. For a
-    ///  Secret with a valid version destroy TTL, when a secert version is
-    ///  destroyed, the version is moved to disabled state and it is scheduled for
-    ///  destruction. The version is destroyed only after the
-    ///  `scheduled_destroy_time`.
+    /// This is a part of the Delayed secret version destroy feature. For a
+    /// Secret with a valid version destroy TTL, when a secert version is
+    /// destroyed, the version is moved to disabled state and it is scheduled for
+    /// destruction. The version is destroyed only after the
+    /// `scheduled_destroy_time`.
     pub scheduled_destroy_time: Option<String> /* TODO(#77) - handle .google.protobuf.Timestamp */,
 
     /// Output only. The customer-managed encryption status of the
-    ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. Only
-    ///  populated if customer-managed encryption is used and
-    ///  [Secret][google.cloud.secretmanager.v1.Secret] is a Regionalised Secret.
+    /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. Only
+    /// populated if customer-managed encryption is used and
+    /// [Secret][google.cloud.secretmanager.v1.Secret] is a Regionalised Secret.
     pub customer_managed_encryption: Option<crate::CustomerManagedEncryptionStatus>,
 }
 
@@ -207,11 +207,11 @@ pub mod secret_version {
 pub struct Replication {
 
     /// The [Secret][google.cloud.secretmanager.v1.Secret] will automatically be
-    ///  replicated without any restrictions.
+    /// replicated without any restrictions.
     pub automatic: Option<crate::replication::Automatic>,
 
     /// The [Secret][google.cloud.secretmanager.v1.Secret] will only be
-    ///  replicated into the locations specified.
+    /// replicated into the locations specified.
     pub user_managed: Option<crate::replication::UserManaged>,
 }
 
@@ -227,14 +227,14 @@ pub mod replication {
     pub struct Automatic {
 
         /// Optional. The customer-managed encryption configuration of the
-        ///  [Secret][google.cloud.secretmanager.v1.Secret]. If no configuration is
-        ///  provided, Google-managed default encryption is used.
+        /// [Secret][google.cloud.secretmanager.v1.Secret]. If no configuration is
+        /// provided, Google-managed default encryption is used.
         /// 
-        ///  Updates to the [Secret][google.cloud.secretmanager.v1.Secret] encryption
-        ///  configuration only apply to
-        ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] added
-        ///  afterwards. They do not apply retroactively to existing
-        ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
+        /// Updates to the [Secret][google.cloud.secretmanager.v1.Secret] encryption
+        /// configuration only apply to
+        /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] added
+        /// afterwards. They do not apply retroactively to existing
+        /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
         pub customer_managed_encryption: Option<crate::CustomerManagedEncryption>,
     }
 
@@ -247,9 +247,9 @@ pub mod replication {
     pub struct UserManaged {
 
         /// Required. The list of Replicas for this
-        ///  [Secret][google.cloud.secretmanager.v1.Secret].
+        /// [Secret][google.cloud.secretmanager.v1.Secret].
         /// 
-        ///  Cannot be empty.
+        /// Cannot be empty.
         pub replicas: Option<crate::replication::user_managed::Replica>,
     }
 
@@ -264,18 +264,18 @@ pub mod replication {
         pub struct Replica {
 
             /// The canonical IDs of the location to replicate data.
-            ///  For example: `"us-east1"`.
+            /// For example: `"us-east1"`.
             pub location: String,
 
             /// Optional. The customer-managed encryption configuration of the
-            ///  [User-Managed Replica][Replication.UserManaged.Replica]. If no
-            ///  configuration is provided, Google-managed default encryption is used.
+            /// [User-Managed Replica][Replication.UserManaged.Replica]. If no
+            /// configuration is provided, Google-managed default encryption is used.
             /// 
-            ///  Updates to the [Secret][google.cloud.secretmanager.v1.Secret]
-            ///  encryption configuration only apply to
-            ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] added
-            ///  afterwards. They do not apply retroactively to existing
-            ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
+            /// Updates to the [Secret][google.cloud.secretmanager.v1.Secret]
+            /// encryption configuration only apply to
+            /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] added
+            /// afterwards. They do not apply retroactively to existing
+            /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
             pub customer_managed_encryption: Option<crate::CustomerManagedEncryption>,
         }
     }
@@ -289,18 +289,18 @@ pub mod replication {
 pub struct CustomerManagedEncryption {
 
     /// Required. The resource name of the Cloud KMS CryptoKey used to encrypt
-    ///  secret payloads.
+    /// secret payloads.
     /// 
-    ///  For secrets using the
-    ///  [UserManaged][google.cloud.secretmanager.v1.Replication.UserManaged]
-    ///  replication policy type, Cloud KMS CryptoKeys must reside in the same
-    ///  location as the [replica location][Secret.UserManaged.Replica.location].
+    /// For secrets using the
+    /// [UserManaged][google.cloud.secretmanager.v1.Replication.UserManaged]
+    /// replication policy type, Cloud KMS CryptoKeys must reside in the same
+    /// location as the [replica location][Secret.UserManaged.Replica.location].
     /// 
-    ///  For secrets using the
-    ///  [Automatic][google.cloud.secretmanager.v1.Replication.Automatic]
-    ///  replication policy type, Cloud KMS CryptoKeys must reside in `global`.
+    /// For secrets using the
+    /// [Automatic][google.cloud.secretmanager.v1.Replication.Automatic]
+    /// replication policy type, Cloud KMS CryptoKeys must reside in `global`.
     /// 
-    ///  The expected format is `projects/*/locations/*/keyRings/*/cryptoKeys/*`.
+    /// The expected format is `projects/*/locations/*/keyRings/*/cryptoKeys/*`.
     pub kms_key_name: String,
 }
 
@@ -312,21 +312,21 @@ pub struct CustomerManagedEncryption {
 pub struct ReplicationStatus {
 
     /// Describes the replication status of a
-    ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] with
-    ///  automatic replication.
+    /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] with
+    /// automatic replication.
     /// 
-    ///  Only populated if the parent
-    ///  [Secret][google.cloud.secretmanager.v1.Secret] has an automatic
-    ///  replication policy.
+    /// Only populated if the parent
+    /// [Secret][google.cloud.secretmanager.v1.Secret] has an automatic
+    /// replication policy.
     pub automatic: Option<crate::replication_status::AutomaticStatus>,
 
     /// Describes the replication status of a
-    ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] with
-    ///  user-managed replication.
+    /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] with
+    /// user-managed replication.
     /// 
-    ///  Only populated if the parent
-    ///  [Secret][google.cloud.secretmanager.v1.Secret] has a user-managed
-    ///  replication policy.
+    /// Only populated if the parent
+    /// [Secret][google.cloud.secretmanager.v1.Secret] has a user-managed
+    /// replication policy.
     pub user_managed: Option<crate::replication_status::UserManagedStatus>,
 }
 
@@ -345,8 +345,8 @@ pub mod replication_status {
     pub struct AutomaticStatus {
 
         /// Output only. The customer-managed encryption status of the
-        ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. Only
-        ///  populated if customer-managed encryption is used.
+        /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. Only
+        /// populated if customer-managed encryption is used.
         pub customer_managed_encryption: Option<crate::CustomerManagedEncryptionStatus>,
     }
 
@@ -362,7 +362,7 @@ pub mod replication_status {
     pub struct UserManagedStatus {
 
         /// Output only. The list of replica statuses for the
-        ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+        /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
         pub replicas: Option<crate::replication_status::user_managed_status::ReplicaStatus>,
     }
 
@@ -377,12 +377,12 @@ pub mod replication_status {
         pub struct ReplicaStatus {
 
             /// Output only. The canonical ID of the replica location.
-            ///  For example: `"us-east1"`.
+            /// For example: `"us-east1"`.
             pub location: String,
 
             /// Output only. The customer-managed encryption status of the
-            ///  [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. Only
-            ///  populated if customer-managed encryption is used.
+            /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. Only
+            /// populated if customer-managed encryption is used.
             pub customer_managed_encryption: Option<crate::CustomerManagedEncryptionStatus>,
         }
     }
@@ -395,8 +395,8 @@ pub mod replication_status {
 pub struct CustomerManagedEncryptionStatus {
 
     /// Required. The resource name of the Cloud KMS CryptoKeyVersion used to
-    ///  encrypt the secret payload, in the following format:
-    ///  `projects/*/locations/*/keyRings/*/cryptoKeys/*/versions/*`.
+    /// encrypt the secret payload, in the following format:
+    /// `projects/*/locations/*/keyRings/*/cryptoKeys/*/versions/*`.
     pub kms_key_version_name: String,
 }
 
@@ -408,10 +408,10 @@ pub struct CustomerManagedEncryptionStatus {
 pub struct Topic {
 
     /// Required. The resource name of the Pub/Sub topic that will be published to,
-    ///  in the following format: `projects/*/topics/*`. For publication to succeed,
-    ///  the Secret Manager service agent must have the `pubsub.topic.publish`
-    ///  permission on the topic. The Pub/Sub Publisher role
-    ///  (`roles/pubsub.publisher`) includes this permission.
+    /// in the following format: `projects/*/topics/*`. For publication to succeed,
+    /// the Secret Manager service agent must have the `pubsub.topic.publish`
+    /// permission on the topic. The Pub/Sub Publisher role
+    /// (`roles/pubsub.publisher`) includes this permission.
     pub name: String,
 }
 
@@ -426,27 +426,27 @@ pub struct Topic {
 pub struct Rotation {
 
     /// Optional. Timestamp in UTC at which the
-    ///  [Secret][google.cloud.secretmanager.v1.Secret] is scheduled to rotate.
-    ///  Cannot be set to less than 300s (5 min) in the future and at most
-    ///  3153600000s (100 years).
+    /// [Secret][google.cloud.secretmanager.v1.Secret] is scheduled to rotate.
+    /// Cannot be set to less than 300s (5 min) in the future and at most
+    /// 3153600000s (100 years).
     /// 
-    ///  [next_rotation_time][google.cloud.secretmanager.v1.Rotation.next_rotation_time]
-    ///  MUST  be set if
-    ///  [rotation_period][google.cloud.secretmanager.v1.Rotation.rotation_period]
-    ///  is set.
+    /// [next_rotation_time][google.cloud.secretmanager.v1.Rotation.next_rotation_time]
+    /// MUST  be set if
+    /// [rotation_period][google.cloud.secretmanager.v1.Rotation.rotation_period]
+    /// is set.
     pub next_rotation_time: Option<String> /* TODO(#77) - handle .google.protobuf.Timestamp */,
 
     /// Input only. The Duration between rotation notifications. Must be in seconds
-    ///  and at least 3600s (1h) and at most 3153600000s (100 years).
+    /// and at least 3600s (1h) and at most 3153600000s (100 years).
     /// 
-    ///  If
-    ///  [rotation_period][google.cloud.secretmanager.v1.Rotation.rotation_period]
-    ///  is set,
-    ///  [next_rotation_time][google.cloud.secretmanager.v1.Rotation.next_rotation_time]
-    ///  must be set.
-    ///  [next_rotation_time][google.cloud.secretmanager.v1.Rotation.next_rotation_time]
-    ///  will be advanced by this period when the service automatically sends
-    ///  rotation notifications.
+    /// If
+    /// [rotation_period][google.cloud.secretmanager.v1.Rotation.rotation_period]
+    /// is set,
+    /// [next_rotation_time][google.cloud.secretmanager.v1.Rotation.next_rotation_time]
+    /// must be set.
+    /// [next_rotation_time][google.cloud.secretmanager.v1.Rotation.next_rotation_time]
+    /// will be advanced by this period when the service automatically sends
+    /// rotation notifications.
     pub rotation_period: Option<String> /* TODO(#77) - handle .google.protobuf.Duration */,
 }
 
@@ -462,21 +462,21 @@ pub struct SecretPayload {
     pub data: bytes::Bytes,
 
     /// Optional. If specified,
-    ///  [SecretManagerService][google.cloud.secretmanager.v1.SecretManagerService]
-    ///  will verify the integrity of the received
-    ///  [data][google.cloud.secretmanager.v1.SecretPayload.data] on
-    ///  [SecretManagerService.AddSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion]
-    ///  calls using the crc32c checksum and store it to include in future
-    ///  [SecretManagerService.AccessSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion]
-    ///  responses. If a checksum is not provided in the
-    ///  [SecretManagerService.AddSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion]
-    ///  request, the
-    ///  [SecretManagerService][google.cloud.secretmanager.v1.SecretManagerService]
-    ///  will generate and store one for you.
+    /// [SecretManagerService][google.cloud.secretmanager.v1.SecretManagerService]
+    /// will verify the integrity of the received
+    /// [data][google.cloud.secretmanager.v1.SecretPayload.data] on
+    /// [SecretManagerService.AddSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion]
+    /// calls using the crc32c checksum and store it to include in future
+    /// [SecretManagerService.AccessSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion]
+    /// responses. If a checksum is not provided in the
+    /// [SecretManagerService.AddSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion]
+    /// request, the
+    /// [SecretManagerService][google.cloud.secretmanager.v1.SecretManagerService]
+    /// will generate and store one for you.
     /// 
-    ///  The CRC32C value is encoded as a Int64 for compatibility, and can be
-    ///  safely downconverted to uint32 in languages that support this type.
-    ///  https://cloud.google.com/apis/design/design_patterns#integer_types
+    /// The CRC32C value is encoded as a Int64 for compatibility, and can be
+    /// safely downconverted to uint32 in languages that support this type.
+    /// https://cloud.google.com/apis/design/design_patterns#integer_types
     pub data_crc32c: Option<i64>,
 }
 
@@ -488,19 +488,19 @@ pub struct SecretPayload {
 pub struct CreateSecretRequest {
 
     /// Required. The resource name of the project to associate with the
-    ///  [Secret][google.cloud.secretmanager.v1.Secret], in the format `projects/*`
-    ///  or `projects/*/locations/*`.
+    /// [Secret][google.cloud.secretmanager.v1.Secret], in the format `projects/*`
+    /// or `projects/*/locations/*`.
     pub parent: String,
 
     /// Required. This must be unique within the project.
     /// 
-    ///  A secret ID is a string with a maximum length of 255 characters and can
-    ///  contain uppercase and lowercase letters, numerals, and the hyphen (`-`) and
-    ///  underscore (`_`) characters.
+    /// A secret ID is a string with a maximum length of 255 characters and can
+    /// contain uppercase and lowercase letters, numerals, and the hyphen (`-`) and
+    /// underscore (`_`) characters.
     pub secret_id: String,
 
     /// Required. A [Secret][google.cloud.secretmanager.v1.Secret] with initial
-    ///  field values.
+    /// field values.
     pub secret: Option<crate::Secret>,
 }
 
@@ -512,7 +512,7 @@ pub struct CreateSecretRequest {
 pub struct GetSecretRequest {
 
     /// Required. The resource name of the
-    ///  [Secret][google.cloud.secretmanager.v1.Secret], in the format
-    ///  `projects/*/secrets/*` or `projects/*/locations/*/secrets/*`.
+    /// [Secret][google.cloud.secretmanager.v1.Secret], in the format
+    /// `projects/*/secrets/*` or `projects/*/locations/*/secrets/*`.
     pub name: String,
 }


### PR DESCRIPTION
Protobuf introduces an extra newline at the beginning of each comment line.
OpenAPI comments do not have this extra space. I chose to normalize the
comments to the OpenAPI style because that makes the rest of the code cleaner.

Fixes #31
