### PR TITLE
impl(generator): move doc formatting to Codec

### DIFF
--- a/generator/internal/genclient/genclient.go
+++ b/generator/internal/genclient/genclient.go
@@ -82,6 +82,15 @@ type LanguageCodec interface {
 	// "lowercase CamelCase"), applying any mangling required by the language,
 	// e.g., to avoid clashes with reserved words.
 	ToCamel(string) string
+	// Reformat ${Lang}Doc comments according to the language-specific rules.
+	// For example,
+	// - The protos in googleapis include cross-references in the format
+	//   `[Foo][proto.package.name.Foo]`, this should become links to the
+	//   language entities, in the language documentation.
+	// - Rust requires a `norust` annotation in all blockquotes (```-sections).
+	//   Without this annotation Rustdoc assumes the blockquote is an Rust code
+	//   snippet and attempts to compile it.
+	FormatDocComments(string) []string
 }
 
 // GenerateRequest used to generate clients.

--- a/generator/internal/genclient/genclient.go
+++ b/generator/internal/genclient/genclient.go
@@ -84,12 +84,12 @@ type LanguageCodec interface {
 	ToCamel(string) string
 	// Reformat ${Lang}Doc comments according to the language-specific rules.
 	// For example,
-	// - The protos in googleapis include cross-references in the format
-	//   `[Foo][proto.package.name.Foo]`, this should become links to the
-	//   language entities, in the language documentation.
-	// - Rust requires a `norust` annotation in all blockquotes (```-sections).
-	//   Without this annotation Rustdoc assumes the blockquote is an Rust code
-	//   snippet and attempts to compile it.
+	//   - The protos in googleapis include cross-references in the format
+	//     `[Foo][proto.package.name.Foo]`, this should become links to the
+	//     language entities, in the language documentation.
+	//   - Rust requires a `norust` annotation in all blockquotes, that is,
+	//     any ```-sections. Without this annotation Rustdoc assumes the
+	//     blockquote is an Rust code snippet and attempts to compile it.
 	FormatDocComments(string) []string
 }
 

--- a/generator/internal/genclient/language/internal/golang/golang.go
+++ b/generator/internal/genclient/language/internal/golang/golang.go
@@ -17,6 +17,7 @@ package golang
 import (
 	"log/slog"
 	"strings"
+	"unicode"
 
 	"github.com/googleapis/google-cloud-rust/generator/internal/genclient"
 	"github.com/iancoleman/strcase"
@@ -186,6 +187,14 @@ func (*Codec) ToPascal(symbol string) string {
 
 func (*Codec) ToCamel(symbol string) string {
 	return strcase.ToLowerCamel(symbol)
+}
+
+func (*Codec) FormatDocComments(documentation string) []string {
+	ss := strings.Split(documentation, "\n")
+	for i := range ss {
+		ss[i] = strings.TrimRightFunc(ss[i], unicode.IsSpace)
+	}
+	return ss
 }
 
 // The list of Golang keywords and reserved words can be found at:

--- a/generator/internal/genclient/language/internal/golang/golang_test.go
+++ b/generator/internal/genclient/language/internal/golang/golang_test.go
@@ -17,6 +17,7 @@ package golang
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/google-cloud-rust/generator/internal/genclient"
 )
 
@@ -120,5 +121,50 @@ func TestEnumNames(t *testing.T) {
 	}
 	if got := c.FQEnumName(nested, api.State); got != "SecretVersion_State" {
 		t.Errorf("mismatched message name, want=SecretVersion_State, got=%s", got)
+	}
+}
+
+func TestFormatDocComments(t *testing.T) {
+	input := `Some comments describing the thing.
+
+The next line has some extra trailing whitespace:
+    
+We want to respect whitespace at the beginning, because it important in Markdown:
+- A thing
+  - A nested thing
+- The next thing
+
+Now for some fun with block quotes
+
+` + "```" + `
+Maybe they wanted to show some JSON:
+{
+  "foo": "bar"
+}
+` + "```"
+
+	want := []string{
+		"Some comments describing the thing.",
+		"",
+		"The next line has some extra trailing whitespace:",
+		"",
+		"We want to respect whitespace at the beginning, because it important in Markdown:",
+		"- A thing",
+		"  - A nested thing",
+		"- The next thing",
+		"",
+		"Now for some fun with block quotes",
+		"",
+		"```",
+		"Maybe they wanted to show some JSON:",
+		"{",
+		`  "foo": "bar"`,
+		"}",
+		"```",
+	}
+	c := &Codec{}
+	got := c.FormatDocComments(input)
+	if diff := cmp.Diff(want, got); len(diff) > 0 {
+		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
 }

--- a/generator/internal/genclient/language/internal/rust/rust.go
+++ b/generator/internal/genclient/language/internal/rust/rust.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"unicode"
 
 	"github.com/googleapis/google-cloud-rust/generator/internal/genclient"
 	"github.com/iancoleman/strcase"
@@ -239,6 +240,21 @@ func (*Codec) ToPascal(symbol string) string {
 
 func (*Codec) ToCamel(symbol string) string {
 	return EscapeKeyword(strcase.ToLowerCamel(symbol))
+}
+
+func (*Codec) FormatDocComments(documentation string) []string {
+	inBlockQuote := false
+	ss := strings.Split(documentation, "\n")
+	for i := range ss {
+		ss[i] = strings.TrimRightFunc(ss[i], unicode.IsSpace)
+		if strings.HasSuffix(ss[i], "```") {
+			if !inBlockQuote {
+				ss[i] = ss[i] + "norust"
+			}
+			inBlockQuote = !inBlockQuote
+		}
+	}
+	return ss
 }
 
 // The list of Rust keywords and reserved words can be found at:

--- a/generator/internal/genclient/language/internal/rust/rust_test.go
+++ b/generator/internal/genclient/language/internal/rust/rust_test.go
@@ -17,6 +17,7 @@ package rust
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/google-cloud-rust/generator/internal/genclient"
 )
 
@@ -84,6 +85,51 @@ func TestToPascal(t *testing.T) {
 		if output := c.ToPascal(test.Input); output != test.Expected {
 			t.Errorf("Output %q not equal to expected %q", output, test.Expected)
 		}
+	}
+}
+
+func TestFormatDocComments(t *testing.T) {
+	input := `Some comments describing the thing.
+
+The next line has some extra trailing whitespace:
+    
+We want to respect whitespace at the beginning, because it important in Markdown:
+- A thing
+  - A nested thing
+- The next thing
+
+Now for some fun with block quotes
+
+` + "```" + `
+Maybe they wanted to show some JSON:
+{
+  "foo": "bar"
+}
+` + "```"
+
+	want := []string{
+		"Some comments describing the thing.",
+		"",
+		"The next line has some extra trailing whitespace:",
+		"",
+		"We want to respect whitespace at the beginning, because it important in Markdown:",
+		"- A thing",
+		"  - A nested thing",
+		"- The next thing",
+		"",
+		"Now for some fun with block quotes",
+		"",
+		"```norust",
+		"Maybe they wanted to show some JSON:",
+		"{",
+		`  "foo": "bar"`,
+		"}",
+		"```",
+	}
+	c := &Codec{}
+	got := c.FormatDocComments(input)
+	if diff := cmp.Diff(want, got); len(diff) > 0 {
+		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
 }
 

--- a/generator/internal/genclient/templatedata.go
+++ b/generator/internal/genclient/templatedata.go
@@ -101,7 +101,7 @@ func (s *service) NameToCamel() string {
 }
 
 func (s *service) DocLines() []string {
-	return strings.Split(s.s.Documentation, "\n")
+	return s.c.FormatDocComments(s.s.Documentation)
 }
 
 func (s *service) DefaultHost() string {
@@ -126,7 +126,7 @@ func (m *method) NameToCamel() string {
 }
 
 func (m *method) DocLines() []string {
-	return strings.Split(m.s.Documentation, "\n")
+	return m.c.FormatDocComments(m.s.Documentation)
 }
 
 func (m *method) InputTypeName() string {
@@ -227,12 +227,7 @@ func (m *message) HasNestedTypes() bool {
 }
 
 func (m *message) DocLines() []string {
-	// TODO(codyoss): https://github.com/googleapis/google-cloud-rust/issues/33
-	ss := strings.Split(m.s.Documentation, "\n")
-	for i := range ss {
-		ss[i] = strings.TrimSpace(ss[i])
-	}
-	return ss
+	return m.c.FormatDocComments(m.s.Documentation)
 }
 
 func (m *message) IsMap() bool {
@@ -250,11 +245,7 @@ func (e *enum) Name() string {
 }
 
 func (e *enum) DocLines() []string {
-	ss := strings.Split(e.s.Documentation, "\n")
-	for i := range ss {
-		ss[i] = strings.TrimSpace(ss[i])
-	}
-	return ss
+	return e.c.FormatDocComments(e.s.Documentation)
 }
 
 func (e *enum) Values() []*enumValue {
@@ -276,11 +267,7 @@ type enumValue struct {
 }
 
 func (e *enumValue) DocLines() []string {
-	ss := strings.Split(e.s.Documentation, "\n")
-	for i := range ss {
-		ss[i] = strings.TrimSpace(ss[i])
-	}
-	return ss
+	return e.c.FormatDocComments(e.s.Documentation)
 }
 
 func (e *enumValue) Name() string {
@@ -313,7 +300,7 @@ func (f *field) NameToCamel() string {
 }
 
 func (f *field) DocLines() []string {
-	return strings.Split(f.s.Documentation, "\n")
+	return f.c.FormatDocComments(f.s.Documentation)
 }
 
 func (f *field) FieldType() string {

--- a/generator/testdata/rust/openapi/golden/model.rs
+++ b/generator/testdata/rust/openapi/golden/model.rs
@@ -441,9 +441,9 @@ pub struct ReplicaStatus {
 /// empty messages in your APIs. A typical example is to use it as the request
 /// or the response type of an API method. For instance:
 /// 
-/// service Foo {
-/// rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
-/// }
+///     service Foo {
+///       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+///     }
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
@@ -559,54 +559,54 @@ pub struct SetIamPolicyRequest {
 /// 
 /// **JSON example:**
 /// 
-/// ```
-/// {
-/// "bindings": [
-/// {
-/// "role": "roles/resourcemanager.organizationAdmin",
-/// "members": [
-/// "user:mike@example.com",
-/// "group:admins@example.com",
-/// "domain:google.com",
-/// "serviceAccount:my-project-id@appspot.gserviceaccount.com"
-/// ]
-/// },
-/// {
-/// "role": "roles/resourcemanager.organizationViewer",
-/// "members": [
-/// "user:eve@example.com"
-/// ],
-/// "condition": {
-/// "title": "expirable access",
-/// "description": "Does not grant access after Sep 2020",
-/// "expression": "request.time < timestamp('2020-10-01T00:00:00.000Z')",
-/// }
-/// }
-/// ],
-/// "etag": "BwWWja0YfJA=",
-/// "version": 3
-/// }
+/// ```norust
+///     {
+///       "bindings": [
+///         {
+///           "role": "roles/resourcemanager.organizationAdmin",
+///           "members": [
+///             "user:mike@example.com",
+///             "group:admins@example.com",
+///             "domain:google.com",
+///             "serviceAccount:my-project-id@appspot.gserviceaccount.com"
+///           ]
+///         },
+///         {
+///           "role": "roles/resourcemanager.organizationViewer",
+///           "members": [
+///             "user:eve@example.com"
+///           ],
+///           "condition": {
+///             "title": "expirable access",
+///             "description": "Does not grant access after Sep 2020",
+///             "expression": "request.time < timestamp('2020-10-01T00:00:00.000Z')",
+///           }
+///         }
+///       ],
+///       "etag": "BwWWja0YfJA=",
+///       "version": 3
+///     }
 /// ```
 /// 
 /// **YAML example:**
 /// 
-/// ```
-/// bindings:
-/// - members:
-/// - user:mike@example.com
-/// - group:admins@example.com
-/// - domain:google.com
-/// - serviceAccount:my-project-id@appspot.gserviceaccount.com
-/// role: roles/resourcemanager.organizationAdmin
-/// - members:
-/// - user:eve@example.com
-/// role: roles/resourcemanager.organizationViewer
-/// condition:
-/// title: expirable access
-/// description: Does not grant access after Sep 2020
-/// expression: request.time < timestamp('2020-10-01T00:00:00.000Z')
-/// etag: BwWWja0YfJA=
-/// version: 3
+/// ```norust
+///     bindings:
+///     - members:
+///       - user:mike@example.com
+///       - group:admins@example.com
+///       - domain:google.com
+///       - serviceAccount:my-project-id@appspot.gserviceaccount.com
+///       role: roles/resourcemanager.organizationAdmin
+///     - members:
+///       - user:eve@example.com
+///       role: roles/resourcemanager.organizationViewer
+///       condition:
+///         title: expirable access
+///         description: Does not grant access after Sep 2020
+///         expression: request.time < timestamp('2020-10-01T00:00:00.000Z')
+///     etag: BwWWja0YfJA=
+///     version: 3
 /// ```
 /// 
 /// For a description of IAM and its features, see the
@@ -792,27 +792,27 @@ pub struct Binding {
 /// 
 /// Example (Comparison):
 /// 
-/// title: "Summary size limit"
-/// description: "Determines if a summary is less than 100 chars"
-/// expression: "document.summary.size() < 100"
+///     title: "Summary size limit"
+///     description: "Determines if a summary is less than 100 chars"
+///     expression: "document.summary.size() < 100"
 /// 
 /// Example (Equality):
 /// 
-/// title: "Requestor is owner"
-/// description: "Determines if requestor is the document owner"
-/// expression: "document.owner == request.auth.claims.email"
+///     title: "Requestor is owner"
+///     description: "Determines if requestor is the document owner"
+///     expression: "document.owner == request.auth.claims.email"
 /// 
 /// Example (Logic):
 /// 
-/// title: "Public documents"
-/// description: "Determine whether the document should be publicly visible"
-/// expression: "document.type != 'private' && document.type != 'internal'"
+///     title: "Public documents"
+///     description: "Determine whether the document should be publicly visible"
+///     expression: "document.type != 'private' && document.type != 'internal'"
 /// 
 /// Example (Data Manipulation):
 /// 
-/// title: "Notification string"
-/// description: "Create a notification string with a timestamp."
-/// expression: "'New message received at ' + string(document.create_time)"
+///     title: "Notification string"
+///     description: "Create a notification string with a timestamp."
+///     expression: "'New message received at ' + string(document.create_time)"
 /// 
 /// The exact variables and functions that may be referenced within an expression
 /// are determined by the service that evaluates it. See the service
@@ -852,41 +852,41 @@ pub struct Expr {
 /// 
 /// Example Policy with multiple AuditConfigs:
 /// 
-/// {
-/// "audit_configs": [
-/// {
-/// "service": "allServices",
-/// "audit_log_configs": [
-/// {
-/// "log_type": "DATA_READ",
-/// "exempted_members": [
-/// "user:jose@example.com"
-/// ]
-/// },
-/// {
-/// "log_type": "DATA_WRITE"
-/// },
-/// {
-/// "log_type": "ADMIN_READ"
-/// }
-/// ]
-/// },
-/// {
-/// "service": "sampleservice.googleapis.com",
-/// "audit_log_configs": [
-/// {
-/// "log_type": "DATA_READ"
-/// },
-/// {
-/// "log_type": "DATA_WRITE",
-/// "exempted_members": [
-/// "user:aliya@example.com"
-/// ]
-/// }
-/// ]
-/// }
-/// ]
-/// }
+///     {
+///       "audit_configs": [
+///         {
+///           "service": "allServices",
+///           "audit_log_configs": [
+///             {
+///               "log_type": "DATA_READ",
+///               "exempted_members": [
+///                 "user:jose@example.com"
+///               ]
+///             },
+///             {
+///               "log_type": "DATA_WRITE"
+///             },
+///             {
+///               "log_type": "ADMIN_READ"
+///             }
+///           ]
+///         },
+///         {
+///           "service": "sampleservice.googleapis.com",
+///           "audit_log_configs": [
+///             {
+///               "log_type": "DATA_READ"
+///             },
+///             {
+///               "log_type": "DATA_WRITE",
+///               "exempted_members": [
+///                 "user:aliya@example.com"
+///               ]
+///             }
+///           ]
+///         }
+///       ]
+///     }
 /// 
 /// For sampleservice, this policy enables DATA_READ, DATA_WRITE and ADMIN_READ
 /// logging. It also exempts `jose@example.com` from DATA_READ logging, and
@@ -908,19 +908,19 @@ pub struct AuditConfig {
 /// Provides the configuration for logging a type of permissions.
 /// Example:
 /// 
-/// {
-/// "audit_log_configs": [
-/// {
-/// "log_type": "DATA_READ",
-/// "exempted_members": [
-/// "user:jose@example.com"
-/// ]
-/// },
-/// {
-/// "log_type": "DATA_WRITE"
-/// }
-/// ]
-/// }
+///     {
+///       "audit_log_configs": [
+///         {
+///           "log_type": "DATA_READ",
+///           "exempted_members": [
+///             "user:jose@example.com"
+///           ]
+///         },
+///         {
+///           "log_type": "DATA_WRITE"
+///         }
+///       ]
+///     }
 /// 
 /// This enables 'DATA_READ' and 'DATA_WRITE' logging, while exempting
 /// jose@example.com from DATA_READ logging.


### PR DESCRIPTION
Each language codec will need to make slightly different adjustments to the
documentation comments. This PR moves the splitting and cleanup of each line to
the Codec, and introduces some Rust specific cleanups.

Fixes #57 and fixes #33