### PR TITLE
ci: fail the build on clippy warnings

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -56,5 +56,5 @@ jobs:
       - name: Display rustc version
         run: rustc --version
       - run: cargo fmt
-      - run: cargo clippy
+      - run: cargo clippy --fix
       - run: git diff --exit-code

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -55,6 +55,6 @@ jobs:
         run: cargo version
       - name: Display rustc version
         run: rustc --version
-      - run: cargo fmt
       - run: cargo clippy --fix
+      - run: cargo fmt
       - run: git diff --exit-code

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -352,12 +352,12 @@ mod tests {
     #[tokio::main]
     #[test]
     async fn test_refresher() {
-        if vec!["GITHUB_WORKFLOW", "GITHUB_ACTION", "GITHUB_WORKSPACE"]
+        if ["GITHUB_WORKFLOW", "GITHUB_ACTION", "GITHUB_WORKSPACE"]
             .iter()
             .all(|name| std::env::var(name).is_ok())
         {
             // TODO(#21) - disabled on GitHub Actions builds
-            return ();
+            return ;
         }
         let cred = Credential::find_default(crate::CredentialConfig {
             scopes: vec!["https://www.googleapis.com/auth/cloud-platform".into()],

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -357,7 +357,7 @@ mod tests {
             .all(|name| std::env::var(name).is_ok())
         {
             // TODO(#21) - disabled on GitHub Actions builds
-            return ;
+            return;
         }
         let cred = Credential::find_default(crate::CredentialConfig {
             scopes: vec!["https://www.googleapis.com/auth/cloud-platform".into()],

--- a/tools/check-copyright/src/main.rs
+++ b/tools/check-copyright/src/main.rs
@@ -90,7 +90,7 @@ impl Checker {
     }
 
     fn load_boilerplate(filename: &str) -> Result<Vec<String>, Box<dyn Error>> {
-        let prefix = Self::comment_prefix(&filename);
+        let prefix = Self::comment_prefix(filename);
         use std::io::BufRead;
         let file = std::fs::File::open(filename)?;
         let lines = std::io::BufReader::new(file)
@@ -118,6 +118,6 @@ impl Checker {
                 return prefix.to_string();
             }
         }
-        return String::new();
+        String::new()
     }
 }

--- a/types/src/duration.rs
+++ b/types/src/duration.rs
@@ -239,8 +239,8 @@ mod test {
     #[test_case(-12, -123_456_789, "-12.123456789s"; "negative seconds and full nanos")]
     fn serialize(seconds: i64, nanos: i32, want: &str) {
         let got = serde_json::to_value(Duration {
-            seconds: seconds,
-            nanos: nanos,
+            seconds,
+            nanos,
         })
         .unwrap()
         .as_str()

--- a/types/src/duration.rs
+++ b/types/src/duration.rs
@@ -238,14 +238,11 @@ mod test {
     #[test_case(-12, -123_000_000, "-12.123000000s"; "negative seconds and millis")]
     #[test_case(-12, -123_456_789, "-12.123456789s"; "negative seconds and full nanos")]
     fn serialize(seconds: i64, nanos: i32, want: &str) {
-        let got = serde_json::to_value(Duration {
-            seconds,
-            nanos,
-        })
-        .unwrap()
-        .as_str()
-        .map(str::to_string)
-        .unwrap();
+        let got = serde_json::to_value(Duration { seconds, nanos })
+            .unwrap()
+            .as_str()
+            .map(str::to_string)
+            .unwrap();
         assert_eq!(want, got);
     }
 


### PR DESCRIPTION
TIL: without `--fix` clippy fails silently, with `--fix` at least we get failures in the `git diff` command.