### PR TITLE
impl(generator/protobuf): message fields are always optional

### DIFF
--- a/generator/internal/genclient/translator/protobuf/protobuf.go
+++ b/generator/internal/genclient/translator/protobuf/protobuf.go
@@ -179,6 +179,9 @@ func normalizeTypes(in *descriptorpb.FieldDescriptorProto, field *genclient.Fiel
 		field.TypezID = in.GetTypeName()
 	case descriptorpb.FieldDescriptorProto_TYPE_MESSAGE:
 		field.TypezID = in.GetTypeName()
+		// Repeated fields are not optional, they can be empty, but always have
+		// presence.
+		field.Optional = !field.Repeated
 	case descriptorpb.FieldDescriptorProto_TYPE_ENUM:
 		field.TypezID = in.GetTypeName()
 	default:

--- a/generator/internal/genclient/translator/protobuf/protobuf_test.go
+++ b/generator/internal/genclient/translator/protobuf/protobuf_test.go
@@ -375,6 +375,39 @@ func TestOneOfs(t *testing.T) {
 	})
 }
 
+func TestObjectFields(t *testing.T) {
+	api := makeAPI(newCodeGeneratorRequest(t, "object_fields.proto"))
+
+	message, ok := api.State.MessageByID[".test.Fake"]
+	if !ok {
+		t.Fatalf("Cannot find message %s in API State", ".test.Fake")
+	}
+	checkMessage(t, *message, genclient.Message{
+		Name: "Fake",
+		ID:   ".test.Fake",
+		Fields: []*genclient.Field{
+			{
+				Repeated: false,
+				Optional: true,
+				Name:     "singular_object",
+				JSONName: "singularObject",
+				ID:       ".test.Fake.singular_object",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  ".test.Other",
+			},
+			{
+				Repeated: true,
+				Optional: false,
+				Name:     "repeated_object",
+				JSONName: "repeatedObject",
+				ID:       ".test.Fake.repeated_object",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  ".test.Other",
+			},
+		},
+	})
+}
+
 func newCodeGeneratorRequest(t *testing.T, filename string) *pluginpb.CodeGeneratorRequest {
 	t.Helper()
 	contents, err := os.ReadFile(filepath.Join("testdata", filename))

--- a/generator/internal/genclient/translator/protobuf/testdata/object_fields.proto
+++ b/generator/internal/genclient/translator/protobuf/testdata/object_fields.proto
@@ -1,0 +1,23 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package test;
+
+message Fake {
+  Other singular_object = 1;
+  repeated Other repeated_object = 2;
+}
+
+message Other {}


### PR DESCRIPTION
Normalize message fields to always be optional. This will make other parts of
the code easier to implement: we always wrap optional fields with `Option<T>`.

Motivated by #95
