### PR TITLE
impl(generator/protobuf): cleanup map fields

### DIFF
--- a/generator/internal/genclient/translator/protobuf/protobuf.go
+++ b/generator/internal/genclient/translator/protobuf/protobuf.go
@@ -167,7 +167,7 @@ var descriptorpbToTypez = map[descriptorpb.FieldDescriptorProto_Type]genclient.T
 	descriptorpb.FieldDescriptorProto_TYPE_ENUM:     genclient.ENUM_TYPE,
 }
 
-func normalizeTypes(in *descriptorpb.FieldDescriptorProto, field *genclient.Field) {
+func normalizeTypes(state *genclient.APIState, in *descriptorpb.FieldDescriptorProto, field *genclient.Field) {
 	typ := in.GetType()
 	field.Typez = genclient.UNDEFINED_TYPE
 	if tz, ok := descriptorpbToTypez[typ]; ok {
@@ -182,11 +182,20 @@ func normalizeTypes(in *descriptorpb.FieldDescriptorProto, field *genclient.Fiel
 		// Repeated fields are not optional, they can be empty, but always have
 		// presence.
 		field.Optional = !field.Repeated
+		message, ok := state.MessageByID[field.TypezID]
+		if ok {
+			// Map fields appear as repeated in Protobuf. This is confusing,
+			// as they typically are represented by a single `map<k, v>`-like
+			// datatype. Protobuf leaks the wire-representation of maps, i.e.,
+			// repeated pairs.
+			field.Repeated = !message.IsMap
+		}
 	case descriptorpb.FieldDescriptorProto_TYPE_ENUM:
 		field.TypezID = in.GetTypeName()
 	default:
 		slog.Warn("found undefined field", "field", in.GetName())
 	}
+
 }
 
 func processMessage(state *genclient.APIState, m *descriptorpb.DescriptorProto, mFQN string, parent *genclient.Message) *genclient.Message {
@@ -228,7 +237,7 @@ func processMessage(state *genclient.APIState, m *descriptorpb.DescriptorProto, 
 			Repeated: mf.Label != nil && *mf.Label == descriptorpb.FieldDescriptorProto_LABEL_REPEATED,
 			IsOneOf:  mf.OneofIndex != nil && !isProtoOptional,
 		}
-		normalizeTypes(mf, field)
+		normalizeTypes(state, mf, field)
 		message.Fields = append(message.Fields, field)
 		if field.IsOneOf {
 			message.OneOfs[*mf.OneofIndex].Fields = append(message.OneOfs[*mf.OneofIndex].Fields, field)

--- a/generator/internal/genclient/translator/protobuf/protobuf.go
+++ b/generator/internal/genclient/translator/protobuf/protobuf.go
@@ -182,8 +182,7 @@ func normalizeTypes(state *genclient.APIState, in *descriptorpb.FieldDescriptorP
 		// Repeated fields are not optional, they can be empty, but always have
 		// presence.
 		field.Optional = !field.Repeated
-		message, ok := state.MessageByID[field.TypezID]
-		if ok {
+		if message, ok := state.MessageByID[field.TypezID]; ok {
 			// Map fields appear as repeated in Protobuf. This is confusing,
 			// as they typically are represented by a single `map<k, v>`-like
 			// datatype. Protobuf leaks the wire-representation of maps, i.e.,

--- a/generator/internal/genclient/translator/protobuf/protobuf_test.go
+++ b/generator/internal/genclient/translator/protobuf/protobuf_test.go
@@ -408,6 +408,58 @@ func TestObjectFields(t *testing.T) {
 	})
 }
 
+func TestMapFields(t *testing.T) {
+	api := makeAPI(newCodeGeneratorRequest(t, "map_fields.proto"))
+
+	message, ok := api.State.MessageByID[".test.Fake"]
+	if !ok {
+		t.Fatalf("Cannot find message %s in API State", ".test.Fake")
+	}
+	checkMessage(t, *message, genclient.Message{
+		Name: "Fake",
+		ID:   ".test.Fake",
+		Fields: []*genclient.Field{
+			{
+				Repeated: false,
+				Optional: false,
+				Name:     "singular_map",
+				JSONName: "singularMap",
+				ID:       ".test.Fake.singular_map",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  ".test.Fake.SingularMapEntry",
+			},
+		},
+	})
+
+	message, ok = api.State.MessageByID[".test.Fake.SingularMapEntry"]
+	if !ok {
+		t.Fatalf("Cannot find message %s in API State", ".test.Fake")
+	}
+	checkMessage(t, *message, genclient.Message{
+		Name:  "SingularMapEntry",
+		ID:    ".test.Fake.SingularMapEntry",
+		IsMap: true,
+		Fields: []*genclient.Field{
+			{
+				Repeated: false,
+				Optional: false,
+				Name:     "key",
+				JSONName: "key",
+				ID:       ".test.Fake.SingularMapEntry.key",
+				Typez:    genclient.STRING_TYPE,
+			},
+			{
+				Repeated: false,
+				Optional: false,
+				Name:     "value",
+				JSONName: "value",
+				ID:       ".test.Fake.SingularMapEntry.value",
+				Typez:    genclient.INT32_TYPE,
+			},
+		},
+	})
+}
+
 func newCodeGeneratorRequest(t *testing.T, filename string) *pluginpb.CodeGeneratorRequest {
 	t.Helper()
 	contents, err := os.ReadFile(filepath.Join("testdata", filename))

--- a/generator/internal/genclient/translator/protobuf/testdata/map_fields.proto
+++ b/generator/internal/genclient/translator/protobuf/testdata/map_fields.proto
@@ -1,0 +1,20 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package test;
+
+message Fake {
+  map<string, int32> singular_map = 1;
+}


### PR DESCRIPTION
Map fields are represented as repeated fields in Protobuf. I think this is
leaking their representation on the wire (a sequence of objects, with `key` and
`value` fields). For our purposes the field is not repeated, and can never be
(`repeated map<K, V> foo = 1;` is not a legal Protobuf field).

Part of the work for #95