### PR TITLE
test: verify we can handle types as desired

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,9 @@ name = "bytes"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -1415,6 +1418,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 name = "types"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "serde",
  "serde_json",
  "serde_with",

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -19,10 +19,12 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0.214", features = ["serde_derive"] }
-serde_with = "3.11.0"
+serde_with = { version = "3.11.0" }
 serde_json = "1.0.132"
 time = { version = "0.3.36", features = ["formatting", "parsing"] }
+bytes = { version = "1.8.0", features = ["serde"] }
 
 [dev-dependencies]
-serde = { version = "1.0.214", features = ["serde_derive"] }
 test-case = "3.3.1"
+bytes = { version = "1.8.0", features = ["serde"] }
+serde_with = { version = "3.11.0", features = ["base64"] }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -20,3 +20,90 @@ mod field_mask;
 pub use crate::field_mask::*;
 mod timestamp;
 pub use crate::timestamp::*;
+
+#[cfg(test)]
+mod test {
+    use serde_json::json;
+    use std::error::Error;
+
+    #[serde_with::serde_as]
+    #[serde_with::skip_serializing_none]
+    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    #[non_exhaustive]
+    pub struct Int64 {
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        pub int64: i64,
+    }
+
+    #[test]
+    fn test_serialize_large_i64() -> Result<(), Box<dyn Error>> {
+        // 1 << 60 is too large to be represented as a JSON number, those are
+        // always IEEE 754 double precision floating point numbers, which only
+        // has about 52 bits of mantissa.
+        let value = 1152921504606846976i64;
+        let msg = Int64 {
+            int64: value,
+            ..Default::default()
+        };
+        let got = serde_json::to_value(msg)?;
+        let want = json!({"int64": "1152921504606846976"});
+        assert_eq!(want, got);
+        Ok(())
+    }
+
+    #[test]
+    fn test_deserialize_large_i64() -> Result<(), Box<dyn Error>> {
+        // 1 << 60 is too large to be represented as a JSON number, those are
+        // always IEEE 754 double precision floating point numbers, which only
+        // has about 52 bits of mantissa.
+        let got = serde_json::from_value::<Int64>(json!({"int64": "1152921504606846976"}))?;
+        let want = Int64 {
+            int64: 1152921504606846976i64,
+            ..Default::default()
+        };
+        assert_eq!(want, got);
+        Ok(())
+    }
+
+    #[serde_with::serde_as]
+    #[serde_with::skip_serializing_none]
+    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    #[non_exhaustive]
+    pub struct MessageWithBytes {
+        #[serde_as(as = "serde_with::base64::Base64")]
+        pub payload: bytes::Bytes,
+    }
+
+    #[test]
+    fn test_serialize_bytes() -> Result<(), Box<dyn Error>> {
+        // 1 << 60 is too large to be represented as a JSON number, those are
+        // always IEEE 754 double precision floating point numbers, which only
+        // has about 52 bits of mantissa.
+        let b = bytes::Bytes::from("the quick brown fox jumps over the laze dog");
+        let msg = MessageWithBytes {
+            payload: b,
+            ..Default::default()
+        };
+        let got = serde_json::to_value(msg)?;
+        let want =
+            json!({"payload": "dGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXplIGRvZw=="});
+        assert_eq!(want, got);
+        Ok(())
+    }
+
+    #[test]
+    fn test_deserialize_bytes() -> Result<(), Box<dyn Error>> {
+        // 1 << 60 is too large to be represented as a JSON number, those are
+        // always IEEE 754 double precision floating point numbers, which only
+        // has about 52 bits of mantissa.
+        let got = serde_json::from_str::<Int64>(r###"{"int64":"1152921504606846976"}"###)?;
+        let want = Int64 {
+            int64: 1152921504606846976i64,
+            ..Default::default()
+        };
+        assert_eq!(want, got);
+        Ok(())
+    }
+}


### PR DESCRIPTION
We have made some decisions about the mapping for `bytes` and `int64`. We need
to make sure these are serialized to JSON as the Google APIs expect them to.

Motivated by #109
