### PR TITLE
impl(generator/rust): avoid `use serde::*`

### DIFF
--- a/generator/templates/rust/Cargo.toml.mustache
+++ b/generator/templates/rust/Cargo.toml.mustache
@@ -1,3 +1,18 @@
+{{!
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
 [package]
 name = "placeholder"
 version = "0.1.0"

--- a/generator/templates/rust/README.md.mustache
+++ b/generator/templates/rust/README.md.mustache
@@ -1,2 +1,17 @@
+{{!
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
 # Placeholder - the name of the API goes here - Rust Client Library
 

--- a/generator/templates/rust/src/enum.mustache
+++ b/generator/templates/rust/src/enum.mustache
@@ -1,7 +1,23 @@
+{{!
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+
 {{#DocLines}}
 /// {{{.}}}
 {{/DocLines}}
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 pub struct {{Name}}(String);
 
 /// Useful constants to work with [{{Name}}]({{Name}})

--- a/generator/templates/rust/src/lib.rs.mustache
+++ b/generator/templates/rust/src/lib.rs.mustache
@@ -1,3 +1,18 @@
+{{!
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
 use std::sync::Arc;
 
 pub mod model;

--- a/generator/templates/rust/src/model.mustache
+++ b/generator/templates/rust/src/model.mustache
@@ -1,9 +1,24 @@
+{{!
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
 {{^IsMap}}
 
 {{#DocLines}}
 /// {{{.}}}
 {{/DocLines}}
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct {{Name}} {

--- a/generator/templates/rust/src/model.rs.mustache
+++ b/generator/templates/rust/src/model.rs.mustache
@@ -1,6 +1,19 @@
-#![allow(dead_code)]
+{{!
+Copyright 2024 Google LLC
 
-use serde::{Deserialize, Serialize};
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+#![allow(dead_code)]
 
 {{#Messages}}
 {{> model}}

--- a/generator/templates/rust/src/oneof.mustache
+++ b/generator/templates/rust/src/oneof.mustache
@@ -1,3 +1,18 @@
+{{!
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
 
 {{#DocLines}}
 /// {{{.}}}

--- a/generator/testdata/rust/gclient/golden/src/model.rs
+++ b/generator/testdata/rust/gclient/golden/src/model.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 
-use serde::{Deserialize, Serialize};
-
 
 /// A [Secret][google.cloud.secretmanager.v1.Secret] is a logical secret whose
 /// value and versions can be accessed.
@@ -9,7 +7,7 @@ use serde::{Deserialize, Serialize};
 /// A [Secret][google.cloud.secretmanager.v1.Secret] is made up of zero or more
 /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] that represent
 /// the secret data.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Secret {
@@ -140,10 +138,11 @@ pub mod secret {
         /// Input only. The TTL for the
         /// [Secret][google.cloud.secretmanager.v1.Secret].
         Ttl(gax_placeholder::Duration),
-    }}
+    }
+}
 
 /// A secret version resource in the Secret Manager API.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct SecretVersion {
@@ -205,10 +204,11 @@ pub struct SecretVersion {
 
 /// Defines additional types related to SecretVersion
 pub mod secret_version {
+
     /// The state of a
     /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion], indicating if
     /// it can be accessed.
-    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
     pub struct State(String);
 
     /// Useful constants to work with [State](State)
@@ -236,7 +236,7 @@ pub mod secret_version {
 }
 
 /// A policy that defines the replication and encryption configuration of data.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Replication {
@@ -251,7 +251,7 @@ pub mod replication {
     /// A replication policy that replicates the
     /// [Secret][google.cloud.secretmanager.v1.Secret] payload without any
     /// restrictions.
-    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
     #[serde(rename_all = "camelCase")]
     #[non_exhaustive]
     pub struct Automatic {
@@ -271,7 +271,7 @@ pub mod replication {
     /// A replication policy that replicates the
     /// [Secret][google.cloud.secretmanager.v1.Secret] payload into the locations
     /// specified in [Secret.replication.user_managed.replicas][]
-    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
     #[serde(rename_all = "camelCase")]
     #[non_exhaustive]
     pub struct UserManaged {
@@ -288,7 +288,7 @@ pub mod replication {
 
         /// Represents a Replica for this
         /// [Secret][google.cloud.secretmanager.v1.Secret].
-        #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+        #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
         #[serde(rename_all = "camelCase")]
         #[non_exhaustive]
         pub struct Replica {
@@ -321,11 +321,12 @@ pub mod replication {
         /// The [Secret][google.cloud.secretmanager.v1.Secret] will only be
         /// replicated into the locations specified.
         UserManaged(crate::replication::UserManaged),
-    }}
+    }
+}
 
 /// Configuration for encrypting secret payloads using customer-managed
 /// encryption keys (CMEK).
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct CustomerManagedEncryption {
@@ -348,7 +349,7 @@ pub struct CustomerManagedEncryption {
 
 /// The replication status of a
 /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ReplicationStatus {
@@ -367,7 +368,7 @@ pub mod replication_status {
     /// 
     /// Only populated if the parent [Secret][google.cloud.secretmanager.v1.Secret]
     /// has an automatic replication policy.
-    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
     #[serde(rename_all = "camelCase")]
     #[non_exhaustive]
     pub struct AutomaticStatus {
@@ -384,7 +385,7 @@ pub mod replication_status {
     /// 
     /// Only populated if the parent [Secret][google.cloud.secretmanager.v1.Secret]
     /// has a user-managed replication policy.
-    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
     #[serde(rename_all = "camelCase")]
     #[non_exhaustive]
     pub struct UserManagedStatus {
@@ -399,7 +400,7 @@ pub mod replication_status {
 
         /// Describes the status of a user-managed replica for the
         /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-        #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+        #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
         #[serde(rename_all = "camelCase")]
         #[non_exhaustive]
         pub struct ReplicaStatus {
@@ -437,10 +438,11 @@ pub mod replication_status {
         /// [Secret][google.cloud.secretmanager.v1.Secret] has a user-managed
         /// replication policy.
         UserManaged(crate::replication_status::UserManagedStatus),
-    }}
+    }
+}
 
 /// Describes the status of customer-managed encryption.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct CustomerManagedEncryptionStatus {
@@ -453,7 +455,7 @@ pub struct CustomerManagedEncryptionStatus {
 
 /// A Pub/Sub topic which Secret Manager will publish to when control plane
 /// events occur on this secret.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Topic {
@@ -471,7 +473,7 @@ pub struct Topic {
 /// Manager will send a Pub/Sub notification to the topics configured on the
 /// Secret. [Secret.topics][google.cloud.secretmanager.v1.Secret.topics] must be
 /// set to configure rotation.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Rotation {
@@ -504,7 +506,7 @@ pub struct Rotation {
 /// A secret payload resource in the Secret Manager API. This contains the
 /// sensitive secret payload that is associated with a
 /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct SecretPayload {
@@ -533,7 +535,7 @@ pub struct SecretPayload {
 
 /// Request message for
 /// [SecretManagerService.CreateSecret][google.cloud.secretmanager.v1.SecretManagerService.CreateSecret].
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct CreateSecretRequest {
@@ -557,7 +559,7 @@ pub struct CreateSecretRequest {
 
 /// Request message for
 /// [SecretManagerService.GetSecret][google.cloud.secretmanager.v1.SecretManagerService.GetSecret].
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct GetSecretRequest {

--- a/generator/testdata/rust/openapi/golden/src/model.rs
+++ b/generator/testdata/rust/openapi/golden/src/model.rs
@@ -1,10 +1,8 @@
 #![allow(dead_code)]
 
-use serde::{Deserialize, Serialize};
-
 
 /// The response message for Locations.ListLocations.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ListLocationsResponse {
@@ -17,7 +15,7 @@ pub struct ListLocationsResponse {
 }
 
 /// A resource that represents a Google Cloud location.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Location {
@@ -44,7 +42,7 @@ pub struct Location {
 }
 
 /// Response message for SecretManagerService.ListSecrets.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ListSecretsResponse {
@@ -67,7 +65,7 @@ pub struct ListSecretsResponse {
 /// 
 /// A Secret is made up of zero or more SecretVersions that
 /// represent the secret data.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Secret {
@@ -159,7 +157,7 @@ pub struct Secret {
 }
 
 /// A policy that defines the replication and encryption configuration of data.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Replication {
@@ -173,7 +171,7 @@ pub struct Replication {
 
 /// A replication policy that replicates the Secret payload without any
 /// restrictions.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Automatic {
@@ -189,7 +187,7 @@ pub struct Automatic {
 
 /// Configuration for encrypting secret payloads using customer-managed
 /// encryption keys (CMEK).
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct CustomerManagedEncryption {
@@ -210,7 +208,7 @@ pub struct CustomerManagedEncryption {
 
 /// A replication policy that replicates the Secret payload into the
 /// locations specified in Secret.replication.user_managed.replicas
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct UserManaged {
@@ -222,7 +220,7 @@ pub struct UserManaged {
 }
 
 /// Represents a Replica for this Secret.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Replica {
@@ -243,7 +241,7 @@ pub struct Replica {
 
 /// A Pub/Sub topic which Secret Manager will publish to when control plane
 /// events occur on this secret.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Topic {
@@ -259,7 +257,7 @@ pub struct Topic {
 /// The rotation time and period for a Secret. At next_rotation_time, Secret
 /// Manager will send a Pub/Sub notification to the topics configured on the
 /// Secret. Secret.topics must be set to configure rotation.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Rotation {
@@ -281,7 +279,7 @@ pub struct Rotation {
 }
 
 /// Request message for SecretManagerService.AddSecretVersion.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct AddSecretVersionRequest {
@@ -292,7 +290,7 @@ pub struct AddSecretVersionRequest {
 
 /// A secret payload resource in the Secret Manager API. This contains the
 /// sensitive secret payload that is associated with a SecretVersion.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct SecretPayload {
@@ -314,7 +312,7 @@ pub struct SecretPayload {
 }
 
 /// A secret version resource in the Secret Manager API.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct SecretVersion {
@@ -362,7 +360,7 @@ pub struct SecretVersion {
 }
 
 /// The replication status of a SecretVersion.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ReplicationStatus {
@@ -386,7 +384,7 @@ pub struct ReplicationStatus {
 /// 
 /// Only populated if the parent Secret has an automatic replication
 /// policy.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct AutomaticStatus {
@@ -397,7 +395,7 @@ pub struct AutomaticStatus {
 }
 
 /// Describes the status of customer-managed encryption.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct CustomerManagedEncryptionStatus {
@@ -413,7 +411,7 @@ pub struct CustomerManagedEncryptionStatus {
 /// 
 /// Only populated if the parent Secret has a user-managed replication
 /// policy.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct UserManagedStatus {
@@ -423,7 +421,7 @@ pub struct UserManagedStatus {
 }
 
 /// Describes the status of a user-managed replica for the SecretVersion.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ReplicaStatus {
@@ -444,14 +442,14 @@ pub struct ReplicaStatus {
 ///     service Foo {
 ///       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
 ///     }
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Empty {
 }
 
 /// Response message for SecretManagerService.ListSecretVersions.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ListSecretVersionsResponse {
@@ -470,7 +468,7 @@ pub struct ListSecretVersionsResponse {
 }
 
 /// Response message for SecretManagerService.AccessSecretVersion.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct AccessSecretVersionResponse {
@@ -485,7 +483,7 @@ pub struct AccessSecretVersionResponse {
 }
 
 /// Request message for SecretManagerService.DisableSecretVersion.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct DisableSecretVersionRequest {
@@ -497,7 +495,7 @@ pub struct DisableSecretVersionRequest {
 }
 
 /// Request message for SecretManagerService.EnableSecretVersion.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct EnableSecretVersionRequest {
@@ -509,7 +507,7 @@ pub struct EnableSecretVersionRequest {
 }
 
 /// Request message for SecretManagerService.DestroySecretVersion.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct DestroySecretVersionRequest {
@@ -521,7 +519,7 @@ pub struct DestroySecretVersionRequest {
 }
 
 /// Request message for `SetIamPolicy` method.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct SetIamPolicyRequest {
@@ -611,7 +609,7 @@ pub struct SetIamPolicyRequest {
 /// 
 /// For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Policy {
@@ -673,7 +671,7 @@ pub struct Policy {
 }
 
 /// Associates `members`, or principals, with a `role`.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Binding {
@@ -817,7 +815,7 @@ pub struct Binding {
 /// The exact variables and functions that may be referenced within an expression
 /// are determined by the service that evaluates it. See the service
 /// documentation for additional information.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Expr {
@@ -891,7 +889,7 @@ pub struct Expr {
 /// For sampleservice, this policy enables DATA_READ, DATA_WRITE and ADMIN_READ
 /// logging. It also exempts `jose@example.com` from DATA_READ logging, and
 /// `aliya@example.com` from DATA_WRITE logging.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct AuditConfig {
@@ -924,7 +922,7 @@ pub struct AuditConfig {
 /// 
 /// This enables 'DATA_READ' and 'DATA_WRITE' logging, while exempting
 /// jose@example.com from DATA_READ logging.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct AuditLogConfig {
@@ -939,7 +937,7 @@ pub struct AuditLogConfig {
 }
 
 /// Request message for `TestIamPermissions` method.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct TestIamPermissionsRequest {
@@ -952,7 +950,7 @@ pub struct TestIamPermissionsRequest {
 }
 
 /// Response message for `TestIamPermissions` method.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct TestIamPermissionsResponse {


### PR DESCRIPTION
We want to avoid `use ` declarations in the generated code, because we do not
know if these can introduce any conflicts.

Took this opportunity to introduce the copyright boilerplate to the mustache templates.

Because I have not domesticated my editor w.r.t. mustache files, I finished all
the mustache files on newlines. The only side effect is that now the closing
braces for messages are indented correctly. I like that change too.