### PR TITLE
impl(generator/rust): fix client build problems

### DIFF
--- a/generator/templates/rust/Cargo.toml.mustache
+++ b/generator/templates/rust/Cargo.toml.mustache
@@ -8,5 +8,5 @@ serde = { version = "1.0.214", features = ["serde_derive"] }
 serde_with = "3.11.0"
 serde_json = "1.0.132"
 time = { version = "0.3.36", features = ["formatting", "parsing"] }
-reqwest = "0.12.9"
+reqwest = { version = "0.12.9", features = ["json"] }
 bytes = "1.8.0"

--- a/generator/templates/rust/src/lib.rs.mustache
+++ b/generator/templates/rust/src/lib.rs.mustache
@@ -76,7 +76,8 @@ impl {{NameToPascal}} {
         if !res.status().is_success() {
             return Err("sorry the api you are looking for is not available, please try again".into());
         }
-        res.json::<model::{{OutputTypeName}}>.await?
+        let response = res.json::<model::{{OutputTypeName}}>().await?;
+        Ok(response)
     }
     {{/Methods}}
 }

--- a/generator/testdata/rust/gclient/golden/Cargo.toml
+++ b/generator/testdata/rust/gclient/golden/Cargo.toml
@@ -8,5 +8,5 @@ serde = { version = "1.0.214", features = ["serde_derive"] }
 serde_with = "3.11.0"
 serde_json = "1.0.132"
 time = { version = "0.3.36", features = ["formatting", "parsing"] }
-reqwest = "0.12.9"
+reqwest = { version = "0.12.9", features = ["json"] }
 bytes = "1.8.0"

--- a/generator/testdata/rust/gclient/golden/src/lib.rs
+++ b/generator/testdata/rust/gclient/golden/src/lib.rs
@@ -73,7 +73,8 @@ impl SecretManagerService {
         if !res.status().is_success() {
             return Err("sorry the api you are looking for is not available, please try again".into());
         }
-        res.json::<model::Secret>.await?
+        let response = res.json::<model::Secret>().await?;
+        Ok(response)
     }
 
     /// Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].
@@ -92,6 +93,7 @@ impl SecretManagerService {
         if !res.status().is_success() {
             return Err("sorry the api you are looking for is not available, please try again".into());
         }
-        res.json::<model::Secret>.await?
+        let response = res.json::<model::Secret>().await?;
+        Ok(response)
     }
 }

--- a/generator/testdata/rust/openapi/golden/Cargo.toml
+++ b/generator/testdata/rust/openapi/golden/Cargo.toml
@@ -8,5 +8,5 @@ serde = { version = "1.0.214", features = ["serde_derive"] }
 serde_with = "3.11.0"
 serde_json = "1.0.132"
 time = { version = "0.3.36", features = ["formatting", "parsing"] }
-reqwest = "0.12.9"
+reqwest = { version = "0.12.9", features = ["json"] }
 bytes = "1.8.0"


### PR DESCRIPTION
We need the `json` feature in the `reqwest` package to do JSON serialization
and deserialization of the messages.

The generated code had some syntax errors (missing parens in a function call),
and needed a temporary to convert the returned error correctly.