### PR TITLE
fix(generator/rust): use right scope for model

### DIFF
--- a/generator/internal/genclient/language/internal/rust/rust.go
+++ b/generator/internal/genclient/language/internal/rust/rust.go
@@ -174,7 +174,7 @@ func (c *Codec) MessageName(m *genclient.Message, state *genclient.APIState) str
 
 func (c *Codec) messageScopeName(m *genclient.Message) string {
 	if m == nil {
-		return "crate"
+		return "crate::model"
 	}
 	return c.messageScopeName(m.Parent) + "::" + c.ToSnake(m.Name)
 }

--- a/generator/internal/genclient/language/internal/rust/rust_test.go
+++ b/generator/internal/genclient/language/internal/rust/rust_test.go
@@ -84,8 +84,8 @@ func TestFieldType(t *testing.T) {
 		"f_int32":              "i32",
 		"f_int32_optional":     "Option<i32>",
 		"f_int32_repeated":     "Vec<i32>",
-		"f_msg":                "Option<crate::Target>",
-		"f_msg_repeated":       "Vec<crate::Target>",
+		"f_msg":                "Option<crate::model::Target>",
+		"f_msg_repeated":       "Vec<crate::model::Target>",
 		"f_timestamp":          "Option<gax_placeholder::Timestamp>",
 		"f_timestamp_repeated": "Vec<gax_placeholder::Timestamp>",
 	}
@@ -215,15 +215,15 @@ func TestMessageNames(t *testing.T) {
 	if got := c.MessageName(message, api.State); got != "Replication" {
 		t.Errorf("mismatched message name, got=%s, want=Replication", got)
 	}
-	if got := c.FQMessageName(message, api.State); got != "crate::Replication" {
-		t.Errorf("mismatched message name, got=%s, want=crate::Replication", got)
+	if got := c.FQMessageName(message, api.State); got != "crate::model::Replication" {
+		t.Errorf("mismatched message name, got=%s, want=crate::model::Replication", got)
 	}
 
 	if got := c.MessageName(nested, api.State); got != "Automatic" {
 		t.Errorf("mismatched message name, got=%s, want=Automatic", got)
 	}
-	if got := c.FQMessageName(nested, api.State); got != "crate::replication::Automatic" {
-		t.Errorf("mismatched message name, got=%s, want=crate::replication::Automatic", got)
+	if got := c.FQMessageName(nested, api.State); got != "crate::model::replication::Automatic" {
+		t.Errorf("mismatched message name, got=%s, want=crate::model::replication::Automatic", got)
 	}
 }
 
@@ -252,7 +252,7 @@ func TestEnumNames(t *testing.T) {
 	if got := c.EnumName(nested, api.State); got != "State" {
 		t.Errorf("mismatched message name, got=%s, want=Automatic", got)
 	}
-	if got := c.FQEnumName(nested, api.State); got != "crate::secret_version::State" {
-		t.Errorf("mismatched message name, got=%s, want=crate::secret_version::State", got)
+	if got := c.FQEnumName(nested, api.State); got != "crate::model::secret_version::State" {
+		t.Errorf("mismatched message name, got=%s, want=crate::model::secret_version::State", got)
 	}
 }

--- a/generator/testdata/rust/gclient/golden/src/model.rs
+++ b/generator/testdata/rust/gclient/golden/src/model.rs
@@ -21,7 +21,7 @@ pub struct Secret {
     /// the [Secret][google.cloud.secretmanager.v1.Secret].
     /// 
     /// The replication policy cannot be changed after the Secret has been created.
-    pub replication: Option<crate::Replication>,
+    pub replication: Option<crate::model::Replication>,
 
     /// Output only. The time at which the
     /// [Secret][google.cloud.secretmanager.v1.Secret] was created.
@@ -42,7 +42,7 @@ pub struct Secret {
 
     /// Optional. A list of up to 10 Pub/Sub topics to which messages are published
     /// when control plane operations are called on the secret or its versions.
-    pub topics: Vec<crate::Topic>,
+    pub topics: Vec<crate::model::Topic>,
 
     /// Optional. Etag of the currently stored
     /// [Secret][google.cloud.secretmanager.v1.Secret].
@@ -51,7 +51,7 @@ pub struct Secret {
     /// Optional. Rotation policy attached to the
     /// [Secret][google.cloud.secretmanager.v1.Secret]. May be excluded if there is
     /// no rotation policy.
-    pub rotation: Option<crate::Rotation>,
+    pub rotation: Option<crate::model::Rotation>,
 
     /// Optional. Mapping from version alias to version name.
     /// 
@@ -97,7 +97,7 @@ pub struct Secret {
     /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] added
     /// afterwards. They do not apply retroactively to existing
     /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
-    pub customer_managed_encryption: Option<crate::CustomerManagedEncryption>,
+    pub customer_managed_encryption: Option<crate::model::CustomerManagedEncryption>,
 
     /// Expiration policy attached to the
     /// [Secret][google.cloud.secretmanager.v1.Secret]. If specified the
@@ -110,7 +110,7 @@ pub struct Secret {
     /// Conditions](https://cloud.google.com/secret-manager/docs/access-control#conditions)
     /// is recommended for granting time-based permissions because the operation
     /// can be reversed.
-    pub expiration: Option<crate::secret::Expiration>,
+    pub expiration: Option<crate::model::secret::Expiration>,
 }
 
 /// Defines additional types related to Secret
@@ -169,11 +169,11 @@ pub struct SecretVersion {
 
     /// Output only. The current state of the
     /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-    pub state: crate::secret_version::State,
+    pub state: crate::model::secret_version::State,
 
     /// The replication status of the
     /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-    pub replication_status: Option<crate::ReplicationStatus>,
+    pub replication_status: Option<crate::model::ReplicationStatus>,
 
     /// Output only. Etag of the currently stored
     /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -199,7 +199,7 @@ pub struct SecretVersion {
     /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. Only
     /// populated if customer-managed encryption is used and
     /// [Secret][google.cloud.secretmanager.v1.Secret] is a Regionalised Secret.
-    pub customer_managed_encryption: Option<crate::CustomerManagedEncryptionStatus>,
+    pub customer_managed_encryption: Option<crate::model::CustomerManagedEncryptionStatus>,
 }
 
 /// Defines additional types related to SecretVersion
@@ -242,7 +242,7 @@ pub mod secret_version {
 pub struct Replication {
 
     /// The replication policy for this secret.
-    pub replication: Option<crate::replication::Replication>,
+    pub replication: Option<crate::model::replication::Replication>,
 }
 
 /// Defines additional types related to Replication
@@ -265,7 +265,7 @@ pub mod replication {
         /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] added
         /// afterwards. They do not apply retroactively to existing
         /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
-        pub customer_managed_encryption: Option<crate::CustomerManagedEncryption>,
+        pub customer_managed_encryption: Option<crate::model::CustomerManagedEncryption>,
     }
 
     /// A replication policy that replicates the
@@ -280,7 +280,7 @@ pub mod replication {
         /// [Secret][google.cloud.secretmanager.v1.Secret].
         /// 
         /// Cannot be empty.
-        pub replicas: Vec<crate::replication::user_managed::Replica>,
+        pub replicas: Vec<crate::model::replication::user_managed::Replica>,
     }
 
     /// Defines additional types related to UserManaged
@@ -306,7 +306,7 @@ pub mod replication {
             /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] added
             /// afterwards. They do not apply retroactively to existing
             /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
-            pub customer_managed_encryption: Option<crate::CustomerManagedEncryption>,
+            pub customer_managed_encryption: Option<crate::model::CustomerManagedEncryption>,
         }
     }
 
@@ -317,10 +317,10 @@ pub mod replication {
     pub enum Replication {
         /// The [Secret][google.cloud.secretmanager.v1.Secret] will automatically be
         /// replicated without any restrictions.
-        Automatic(crate::replication::Automatic),
+        Automatic(crate::model::replication::Automatic),
         /// The [Secret][google.cloud.secretmanager.v1.Secret] will only be
         /// replicated into the locations specified.
-        UserManaged(crate::replication::UserManaged),
+        UserManaged(crate::model::replication::UserManaged),
     }
 }
 
@@ -356,7 +356,7 @@ pub struct ReplicationStatus {
 
     /// The replication status of the
     /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-    pub replication_status: Option<crate::replication_status::ReplicationStatus>,
+    pub replication_status: Option<crate::model::replication_status::ReplicationStatus>,
 }
 
 /// Defines additional types related to ReplicationStatus
@@ -376,7 +376,7 @@ pub mod replication_status {
         /// Output only. The customer-managed encryption status of the
         /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. Only
         /// populated if customer-managed encryption is used.
-        pub customer_managed_encryption: Option<crate::CustomerManagedEncryptionStatus>,
+        pub customer_managed_encryption: Option<crate::model::CustomerManagedEncryptionStatus>,
     }
 
     /// The replication status of a
@@ -392,7 +392,7 @@ pub mod replication_status {
 
         /// Output only. The list of replica statuses for the
         /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-        pub replicas: Vec<crate::replication_status::user_managed_status::ReplicaStatus>,
+        pub replicas: Vec<crate::model::replication_status::user_managed_status::ReplicaStatus>,
     }
 
     /// Defines additional types related to UserManagedStatus
@@ -412,7 +412,7 @@ pub mod replication_status {
             /// Output only. The customer-managed encryption status of the
             /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. Only
             /// populated if customer-managed encryption is used.
-            pub customer_managed_encryption: Option<crate::CustomerManagedEncryptionStatus>,
+            pub customer_managed_encryption: Option<crate::model::CustomerManagedEncryptionStatus>,
         }
     }
 
@@ -429,7 +429,7 @@ pub mod replication_status {
         /// Only populated if the parent
         /// [Secret][google.cloud.secretmanager.v1.Secret] has an automatic
         /// replication policy.
-        Automatic(crate::replication_status::AutomaticStatus),
+        Automatic(crate::model::replication_status::AutomaticStatus),
         /// Describes the replication status of a
         /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] with
         /// user-managed replication.
@@ -437,7 +437,7 @@ pub mod replication_status {
         /// Only populated if the parent
         /// [Secret][google.cloud.secretmanager.v1.Secret] has a user-managed
         /// replication policy.
-        UserManaged(crate::replication_status::UserManagedStatus),
+        UserManaged(crate::model::replication_status::UserManagedStatus),
     }
 }
 
@@ -554,7 +554,7 @@ pub struct CreateSecretRequest {
 
     /// Required. A [Secret][google.cloud.secretmanager.v1.Secret] with initial
     /// field values.
-    pub secret: Vec<crate::Secret>,
+    pub secret: Vec<crate::model::Secret>,
 }
 
 /// Request message for

--- a/generator/testdata/rust/openapi/golden/src/model.rs
+++ b/generator/testdata/rust/openapi/golden/src/model.rs
@@ -8,7 +8,7 @@
 pub struct ListLocationsResponse {
 
     /// A list of locations that matches the specified filter in the request.
-    pub locations: Vec<crate::Location>,
+    pub locations: Vec<crate::model::Location>,
 
     /// The standard List next-page token.
     pub next_page_token: Option<String>,
@@ -49,7 +49,7 @@ pub struct ListSecretsResponse {
 
     /// The list of Secrets sorted in reverse by create_time (newest
     /// first).
-    pub secrets: Vec<crate::Secret>,
+    pub secrets: Vec<crate::model::Secret>,
 
     /// A token to retrieve the next page of results. Pass this value in
     /// ListSecretsRequest.page_token to retrieve the next page.
@@ -76,7 +76,7 @@ pub struct Secret {
     /// Optional. Immutable. The replication policy of the secret data attached to the Secret.
     /// 
     /// The replication policy cannot be changed after the Secret has been created.
-    pub replication: Option<crate::Replication>,
+    pub replication: Option<crate::model::Replication>,
 
     /// Output only. The time at which the Secret was created.
     pub create_time: Option<gax_placeholder::Timestamp>,
@@ -96,7 +96,7 @@ pub struct Secret {
 
     /// Optional. A list of up to 10 Pub/Sub topics to which messages are published when
     /// control plane operations are called on the secret or its versions.
-    pub topics: Vec<crate::Topic>,
+    pub topics: Vec<crate::model::Topic>,
 
     /// Optional. Timestamp in UTC when the Secret is scheduled to expire. This is
     /// always provided on output, regardless of what was sent on input.
@@ -110,7 +110,7 @@ pub struct Secret {
 
     /// Optional. Rotation policy attached to the Secret. May be excluded if there is no
     /// rotation policy.
-    pub rotation: Option<crate::Rotation>,
+    pub rotation: Option<crate::model::Rotation>,
 
     /// Optional. Mapping from version alias to version name.
     /// 
@@ -153,7 +153,7 @@ pub struct Secret {
     /// Updates to the Secret encryption configuration only apply to
     /// SecretVersions added afterwards. They do not apply
     /// retroactively to existing SecretVersions.
-    pub customer_managed_encryption: Option<crate::CustomerManagedEncryption>,
+    pub customer_managed_encryption: Option<crate::model::CustomerManagedEncryption>,
 }
 
 /// A policy that defines the replication and encryption configuration of data.
@@ -163,10 +163,10 @@ pub struct Secret {
 pub struct Replication {
 
     /// The Secret will automatically be replicated without any restrictions.
-    pub automatic: Option<crate::Automatic>,
+    pub automatic: Option<crate::model::Automatic>,
 
     /// The Secret will only be replicated into the locations specified.
-    pub user_managed: Option<crate::UserManaged>,
+    pub user_managed: Option<crate::model::UserManaged>,
 }
 
 /// A replication policy that replicates the Secret payload without any
@@ -182,7 +182,7 @@ pub struct Automatic {
     /// Updates to the Secret encryption configuration only apply to
     /// SecretVersions added afterwards. They do not apply
     /// retroactively to existing SecretVersions.
-    pub customer_managed_encryption: Option<crate::CustomerManagedEncryption>,
+    pub customer_managed_encryption: Option<crate::model::CustomerManagedEncryption>,
 }
 
 /// Configuration for encrypting secret payloads using customer-managed
@@ -216,7 +216,7 @@ pub struct UserManaged {
     /// Required. The list of Replicas for this Secret.
     /// 
     /// Cannot be empty.
-    pub replicas: Vec<crate::Replica>,
+    pub replicas: Vec<crate::model::Replica>,
 }
 
 /// Represents a Replica for this Secret.
@@ -236,7 +236,7 @@ pub struct Replica {
     /// Updates to the Secret encryption configuration only apply to
     /// SecretVersions added afterwards. They do not apply
     /// retroactively to existing SecretVersions.
-    pub customer_managed_encryption: Option<crate::CustomerManagedEncryption>,
+    pub customer_managed_encryption: Option<crate::model::CustomerManagedEncryption>,
 }
 
 /// A Pub/Sub topic which Secret Manager will publish to when control plane
@@ -285,7 +285,7 @@ pub struct Rotation {
 pub struct AddSecretVersionRequest {
 
     /// Required. The secret payload of the SecretVersion.
-    pub payload: Option<crate::SecretPayload>,
+    pub payload: Option<crate::model::SecretPayload>,
 }
 
 /// A secret payload resource in the Secret Manager API. This contains the
@@ -336,7 +336,7 @@ pub struct SecretVersion {
     pub state: Option<String>,
 
     /// The replication status of the SecretVersion.
-    pub replication_status: Option<crate::ReplicationStatus>,
+    pub replication_status: Option<crate::model::ReplicationStatus>,
 
     /// Output only. Etag of the currently stored SecretVersion.
     pub etag: Option<String>,
@@ -356,7 +356,7 @@ pub struct SecretVersion {
     /// Output only. The customer-managed encryption status of the SecretVersion. Only
     /// populated if customer-managed encryption is used and Secret is
     /// a Regionalised Secret.
-    pub customer_managed_encryption: Option<crate::CustomerManagedEncryptionStatus>,
+    pub customer_managed_encryption: Option<crate::model::CustomerManagedEncryptionStatus>,
 }
 
 /// The replication status of a SecretVersion.
@@ -370,14 +370,14 @@ pub struct ReplicationStatus {
     /// 
     /// Only populated if the parent Secret has an automatic replication
     /// policy.
-    pub automatic: Option<crate::AutomaticStatus>,
+    pub automatic: Option<crate::model::AutomaticStatus>,
 
     /// Describes the replication status of a SecretVersion with
     /// user-managed replication.
     /// 
     /// Only populated if the parent Secret has a user-managed replication
     /// policy.
-    pub user_managed: Option<crate::UserManagedStatus>,
+    pub user_managed: Option<crate::model::UserManagedStatus>,
 }
 
 /// The replication status of a SecretVersion using automatic replication.
@@ -391,7 +391,7 @@ pub struct AutomaticStatus {
 
     /// Output only. The customer-managed encryption status of the SecretVersion. Only
     /// populated if customer-managed encryption is used.
-    pub customer_managed_encryption: Option<crate::CustomerManagedEncryptionStatus>,
+    pub customer_managed_encryption: Option<crate::model::CustomerManagedEncryptionStatus>,
 }
 
 /// Describes the status of customer-managed encryption.
@@ -417,7 +417,7 @@ pub struct CustomerManagedEncryptionStatus {
 pub struct UserManagedStatus {
 
     /// Output only. The list of replica statuses for the SecretVersion.
-    pub replicas: Vec<crate::ReplicaStatus>,
+    pub replicas: Vec<crate::model::ReplicaStatus>,
 }
 
 /// Describes the status of a user-managed replica for the SecretVersion.
@@ -432,7 +432,7 @@ pub struct ReplicaStatus {
 
     /// Output only. The customer-managed encryption status of the SecretVersion. Only
     /// populated if customer-managed encryption is used.
-    pub customer_managed_encryption: Option<crate::CustomerManagedEncryptionStatus>,
+    pub customer_managed_encryption: Option<crate::model::CustomerManagedEncryptionStatus>,
 }
 
 /// A generic empty message that you can re-use to avoid defining duplicated
@@ -456,7 +456,7 @@ pub struct ListSecretVersionsResponse {
 
     /// The list of SecretVersions sorted in reverse by
     /// create_time (newest first).
-    pub versions: Vec<crate::SecretVersion>,
+    pub versions: Vec<crate::model::SecretVersion>,
 
     /// A token to retrieve the next page of results. Pass this value in
     /// ListSecretVersionsRequest.page_token to retrieve the next page.
@@ -479,7 +479,7 @@ pub struct AccessSecretVersionResponse {
     pub name: Option<String>,
 
     /// Secret payload
-    pub payload: Option<crate::SecretPayload>,
+    pub payload: Option<crate::model::SecretPayload>,
 }
 
 /// Request message for SecretManagerService.DisableSecretVersion.
@@ -528,7 +528,7 @@ pub struct SetIamPolicyRequest {
     /// the policy is limited to a few 10s of KB. An empty policy is a
     /// valid policy but certain Google Cloud services (such as Projects)
     /// might reject them.
-    pub policy: Option<crate::Policy>,
+    pub policy: Option<crate::model::Policy>,
 
     /// OPTIONAL: A FieldMask specifying which fields of the policy to modify. Only
     /// the fields in the mask will be modified. If no mask is provided, the
@@ -650,10 +650,10 @@ pub struct Policy {
     /// different roles to `user:alice@example.com`, and not to any other
     /// principal, then you can add another 1,450 principals to the `bindings` in
     /// the `Policy`.
-    pub bindings: Vec<crate::Binding>,
+    pub bindings: Vec<crate::model::Binding>,
 
     /// Specifies cloud audit logging configuration for this policy.
-    pub audit_configs: Vec<crate::AuditConfig>,
+    pub audit_configs: Vec<crate::model::AuditConfig>,
 
     /// `etag` is used for optimistic concurrency control as a way to help
     /// prevent simultaneous updates of a policy from overwriting each other.
@@ -781,7 +781,7 @@ pub struct Binding {
     /// To learn which resources support conditions in their IAM policies, see the
     /// [IAM
     /// documentation](https://cloud.google.com/iam/help/conditions/resource-policies).
-    pub condition: Option<crate::Expr>,
+    pub condition: Option<crate::model::Expr>,
 }
 
 /// Represents a textual expression in the Common Expression Language (CEL)
@@ -900,7 +900,7 @@ pub struct AuditConfig {
     pub service: Option<String>,
 
     /// The configuration for logging of each type of permission.
-    pub audit_log_configs: Vec<crate::AuditLogConfig>,
+    pub audit_log_configs: Vec<crate::model::AuditLogConfig>,
 }
 
 /// Provides the configuration for logging a type of permissions.


### PR DESCRIPTION
The correct "root" scope for entities created in `model.rs` is
`crate::model::`, we were using only `crate::`.