### PR TITLE
impl(generator): MOAR service config information

### DIFF
--- a/generator/cmd/openapi/main.go
+++ b/generator/cmd/openapi/main.go
@@ -24,23 +24,33 @@ import (
 	"github.com/googleapis/google-cloud-rust/generator/internal/genclient/translator/openapi"
 )
 
+var (
+	language      = flag.String("language", "", "the generated language")
+	output        = flag.String("out", "output", "the path to the output directory")
+	templateDir   = flag.String("template-dir", "templates/", "the path to the template directory")
+	serviceConfig = flag.String("service-config", "testdata/google/cloud/secretmanager/v1/secretmanager_v1.yaml", "path to service config")
+	inputPath     = flag.String("input-path", "", "the path to a file with an OpenAPI v3 JSON object")
+)
+
 func main() {
-	inputPath := flag.String("input-path", "", "the path to a file with an OpenAPI v3 JSON object")
-	outDir := flag.String("out-dir", "", "the path to the output directory")
-	language := flag.String("language", "", "the generated language")
-	templateDir := flag.String("template-dir", "templates/", "the path to the template directory")
 	flag.Parse()
 
 	if *inputPath == "" {
 		log.Fatalf("must provide input-path")
 	}
-	if err := run(*inputPath, *language, *outDir, *templateDir); err != nil {
+	opts := &openapi.Options{
+		Language:      *language,
+		OutDir:        *output,
+		TemplateDir:   *templateDir,
+		ServiceConfig: *serviceConfig,
+	}
+	if err := run(*inputPath, opts); err != nil {
 		log.Fatal(err)
 	}
 	slog.Info("Generation Completed Successfully")
 }
 
-func run(inputPath, language, outDir, templateDir string) error {
+func run(inputPath string, opts *openapi.Options) error {
 	var (
 		contents []byte
 		err      error
@@ -49,15 +59,11 @@ func run(inputPath, language, outDir, templateDir string) error {
 	if err != nil {
 		return err
 	}
-	return generateFrom(contents, language, outDir, templateDir)
+	return generateFrom(contents, opts)
 }
 
-func generateFrom(contents []byte, language, outDir, templateDir string) error {
-	req, err := openapi.Translate(contents, &openapi.Options{
-		Language:    language,
-		OutDir:      outDir,
-		TemplateDir: templateDir,
-	})
+func generateFrom(contents []byte, options *openapi.Options) error {
+	req, err := openapi.Translate(contents, options)
 	if err != nil {
 		return err
 	}

--- a/generator/cmd/openapi/main_test.go
+++ b/generator/cmd/openapi/main_test.go
@@ -18,6 +18,8 @@ import (
 	"flag"
 	"os"
 	"testing"
+
+	"github.com/googleapis/google-cloud-rust/generator/internal/genclient/translator/openapi"
 )
 
 func TestMain(m *testing.M) {
@@ -27,12 +29,15 @@ func TestMain(m *testing.M) {
 
 func TestRun_Rust(t *testing.T) {
 	const (
-		inputPath   = "../../testdata/openapi/secretmanager_openapi_v1.json"
-		language    = "rust"
-		outDir      = "../../testdata/rust/openapi/golden"
-		templateDir = "../../templates"
+		inputPath = "../../testdata/openapi/secretmanager_openapi_v1.json"
 	)
-	if err := run(inputPath, language, outDir, templateDir); err != nil {
+	options := &openapi.Options{
+		Language:      "rust",
+		OutDir:        "../../testdata/rust/openapi/golden",
+		TemplateDir:   "../../templates",
+		ServiceConfig: "../../testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml",
+	}
+	if err := run(inputPath, options); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/generator/internal/genclient/model.go
+++ b/generator/internal/genclient/model.go
@@ -50,8 +50,12 @@ const (
 
 // API represents and API surface.
 type API struct {
-	// Name of the API.
+	// Name of the API (e.g. secretmanager).
 	Name string
+	// The API Title (e.g. "Secret Manager API" or "Cloud Spanner API").
+	Title string
+	// The API Description
+	Description string
 	// Services are a collection of services that make up the API.
 	Services []*Service
 	// Messages are a collection of messages used to process request and

--- a/generator/internal/genclient/templatedata.go
+++ b/generator/internal/genclient/templatedata.go
@@ -39,6 +39,17 @@ type templateData struct {
 	c LanguageCodec
 }
 
+func (t *templateData) Name() string {
+	return t.s.Name
+}
+
+func (t *templateData) Title() string {
+	return t.s.Title
+}
+func (t *templateData) Description() string {
+	return t.s.Description
+}
+
 func (t *templateData) Services() []*service {
 	return mapSlice(t.s.Services, func(s *Service) *service {
 		return &service{

--- a/generator/internal/genclient/translator/openapi/openapi_test.go
+++ b/generator/internal/genclient/translator/openapi/openapi_test.go
@@ -56,7 +56,7 @@ func TestAllOf(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	api, err := makeAPI(model)
+	api, err := makeAPI(nil, model)
 	if err != nil {
 		t.Fatalf("Error in makeAPI() %q", err)
 	}
@@ -119,7 +119,7 @@ func TestBasicTypes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	api, err := makeAPI(model)
+	api, err := makeAPI(nil, model)
 	if err != nil {
 		t.Fatalf("Error in makeAPI() %q", err)
 	}
@@ -178,7 +178,7 @@ func TestArrayTypes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	api, err := makeAPI(model)
+	api, err := makeAPI(nil, model)
 	if err != nil {
 		t.Fatalf("Error in makeAPI() %q", err)
 	}
@@ -234,7 +234,7 @@ func TestSimpleObject(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	api, err := makeAPI(model)
+	api, err := makeAPI(nil, model)
 	if err != nil {
 		t.Fatalf("Error in makeAPI() %q", err)
 	}
@@ -279,7 +279,7 @@ func TestAny(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	api, err := makeAPI(model)
+	api, err := makeAPI(nil, model)
 	if err != nil {
 		t.Errorf("Error in makeAPI() %q", err)
 	}
@@ -312,7 +312,7 @@ func TestMapString(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	api, err := makeAPI(model)
+	api, err := makeAPI(nil, model)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -346,7 +346,7 @@ func TestMapInteger(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	api, err := makeAPI(model)
+	api, err := makeAPI(nil, model)
 	if err != nil {
 		t.Errorf("Error in makeAPI() %q", err)
 	}
@@ -368,7 +368,7 @@ func TestMakeAPI(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	api, err := makeAPI(model)
+	api, err := makeAPI(nil, model)
 	if err != nil {
 		t.Fatalf("Error in makeAPI() %q", err)
 	}

--- a/generator/internal/genclient/translator/protobuf/protobuf.go
+++ b/generator/internal/genclient/translator/protobuf/protobuf.go
@@ -59,27 +59,27 @@ func Translate(req *pluginpb.CodeGeneratorRequest, opts *Options) (*genclient.Ge
 	if err != nil {
 		return nil, err
 	}
-	var name string
-	if opts.ServiceConfig != nil {
-		name = opts.ServiceConfig.Name
-	}
 	return &genclient.GenerateRequest{
-		API:         makeAPI(name, req),
+		API:         makeAPI(opts.ServiceConfig, req),
 		Codec:       codec,
 		OutDir:      opts.OutDir,
 		TemplateDir: opts.TemplateDir,
 	}, nil
 }
 
-func makeAPI(apiName string, req *pluginpb.CodeGeneratorRequest) *genclient.API {
+func makeAPI(serviceConfig *serviceconfig.Service, req *pluginpb.CodeGeneratorRequest) *genclient.API {
 	state := &genclient.APIState{
 		ServiceByID: make(map[string]*genclient.Service),
 		MessageByID: make(map[string]*genclient.Message),
 		EnumByID:    make(map[string]*genclient.Enum),
 	}
 	api := &genclient.API{
-		Name:  apiName,
 		State: state,
+	}
+	if serviceConfig != nil {
+		api.Name = strings.TrimSuffix(serviceConfig.Name, ".googleapis.com")
+		api.Title = serviceConfig.Title
+		api.Description = serviceConfig.Documentation.Summary
 	}
 
 	files := req.GetSourceFileDescriptors()

--- a/generator/internal/genclient/translator/protobuf/protobuf_test.go
+++ b/generator/internal/genclient/translator/protobuf/protobuf_test.go
@@ -24,18 +24,36 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/googleapis/google-cloud-rust/generator/internal/genclient"
+	"google.golang.org/genproto/googleapis/api/serviceconfig"
 	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/pluginpb"
 )
 
-const testAPIName = "testAPI"
+func TestInfo(t *testing.T) {
+	var serviceConfig = &serviceconfig.Service{
+		Name:  "secretmanager.googleapis.com",
+		Title: "Secret Manager API",
+		Documentation: &serviceconfig.Documentation{
+			Summary:  "Stores sensitive data such as API keys, passwords, and certificates.\nProvides convenience while improving security.",
+			Overview: "Secret Manager Overview",
+		},
+	}
+
+	api := makeAPI(serviceConfig, newCodeGeneratorRequest(t, "scalar.proto"))
+	if api.Name != "secretmanager" {
+		t.Errorf("want = %q; got = %q", "secretmanager", api.Name)
+	}
+	if api.Title != serviceConfig.Title {
+		t.Errorf("want = %q; got = %q", serviceConfig.Title, api.Name)
+	}
+	if diff := cmp.Diff(api.Description, serviceConfig.Documentation.Summary); len(diff) > 0 {
+		t.Errorf("description mismatch (-want, +got):\n%s", diff)
+	}
+}
 
 func TestScalar(t *testing.T) {
-	api := makeAPI(testAPIName, newCodeGeneratorRequest(t, "scalar.proto"))
-	if api.Name != testAPIName {
-		t.Errorf("want = %q; got = %q", testAPIName, api.Name)
-	}
+	api := makeAPI(nil, newCodeGeneratorRequest(t, "scalar.proto"))
 
 	message, ok := api.State.MessageByID[".test.Fake"]
 	if !ok {
@@ -155,7 +173,7 @@ func TestScalar(t *testing.T) {
 }
 
 func TestScalarArray(t *testing.T) {
-	api := makeAPI(testAPIName, newCodeGeneratorRequest(t, "scalar_array.proto"))
+	api := makeAPI(nil, newCodeGeneratorRequest(t, "scalar_array.proto"))
 
 	message, ok := api.State.MessageByID[".test.Fake"]
 	if !ok {
@@ -202,7 +220,7 @@ func TestScalarArray(t *testing.T) {
 }
 
 func TestScalarOptional(t *testing.T) {
-	api := makeAPI(testAPIName, newCodeGeneratorRequest(t, "scalar_optional.proto"))
+	api := makeAPI(nil, newCodeGeneratorRequest(t, "scalar_optional.proto"))
 
 	message, ok := api.State.MessageByID[".test.Fake"]
 	if !ok {
@@ -249,7 +267,7 @@ func TestScalarOptional(t *testing.T) {
 }
 
 func TestComments(t *testing.T) {
-	api := makeAPI(testAPIName, newCodeGeneratorRequest(t, "comments.proto"))
+	api := makeAPI(nil, newCodeGeneratorRequest(t, "comments.proto"))
 
 	message, ok := api.State.MessageByID[".test.Request"]
 	if !ok {
@@ -311,7 +329,7 @@ func TestComments(t *testing.T) {
 }
 
 func TestOneOfs(t *testing.T) {
-	api := makeAPI(testAPIName, newCodeGeneratorRequest(t, "oneofs.proto"))
+	api := makeAPI(nil, newCodeGeneratorRequest(t, "oneofs.proto"))
 	message, ok := api.State.MessageByID[".test.Fake"]
 	if !ok {
 		t.Fatalf("Cannot find message %s in API State", ".test.Request")
@@ -381,7 +399,7 @@ func TestOneOfs(t *testing.T) {
 }
 
 func TestObjectFields(t *testing.T) {
-	api := makeAPI(testAPIName, newCodeGeneratorRequest(t, "object_fields.proto"))
+	api := makeAPI(nil, newCodeGeneratorRequest(t, "object_fields.proto"))
 
 	message, ok := api.State.MessageByID[".test.Fake"]
 	if !ok {
@@ -414,7 +432,7 @@ func TestObjectFields(t *testing.T) {
 }
 
 func TestMapFields(t *testing.T) {
-	api := makeAPI(testAPIName, newCodeGeneratorRequest(t, "map_fields.proto"))
+	api := makeAPI(nil, newCodeGeneratorRequest(t, "map_fields.proto"))
 
 	message, ok := api.State.MessageByID[".test.Fake"]
 	if !ok {

--- a/generator/templates/rust/README.md.mustache
+++ b/generator/templates/rust/README.md.mustache
@@ -13,5 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-# Placeholder - the name of the API goes here - Rust Client Library
+# {{Title}} - Rust Client Library
 
+{{Description}}

--- a/generator/testdata/rust/gclient/golden/README.md
+++ b/generator/testdata/rust/gclient/golden/README.md
@@ -1,2 +1,3 @@
-# Placeholder - the name of the API goes here - Rust Client Library
+#  - Rust Client Library
+
 

--- a/generator/testdata/rust/openapi/golden/README.md
+++ b/generator/testdata/rust/openapi/golden/README.md
@@ -1,2 +1,4 @@
-# Placeholder - the name of the API goes here - Rust Client Library
+# Secret Manager API - Rust Client Library
 
+Stores sensitive data such as API keys, passwords, and certificates.
+Provides convenience while improving security.


### PR DESCRIPTION
With this PR the OpenAPI variant also reads the service config file. We also
capture more information from the service config file: the API title and
summary are useful to generate acceptable README files.