### PR TITLE
test(generator): compile Rust golden files

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -33,7 +33,9 @@ jobs:
         run: cargo version
       - name: Display rustc version
         run: rustc --version
-      - run: cargo test
+        # TODO(#92) - disable the doc tests because the generated code contains non-rusty blockquotes
+      - run: cargo test --lib --bins --tests
+      - run: cargo test --package types --package google-cloud-auth --package check-copyright
   lint:
     runs-on: ubuntu-24.04
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,9 +367,9 @@ dependencies = [
  "backoff",
  "base64 0.13.1",
  "chrono",
- "http",
- "reqwest",
- "rustls",
+ "http 0.2.12",
+ "reqwest 0.11.27",
+ "rustls 0.20.9",
  "rustls-pemfile 0.2.1",
  "serde",
  "serde_json",
@@ -382,7 +388,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap 2.6.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap 2.6.0",
  "slab",
  "tokio",
@@ -426,13 +451,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -458,9 +517,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -473,16 +532,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.5.0",
+ "hyper-util",
+ "rustls 0.23.16",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.31",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.5.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.5.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -776,6 +907,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
+name = "placeholder"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "reqwest 0.12.9",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "time",
+ "types",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,11 +1031,11 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-tls",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.31",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -904,8 +1048,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
- "system-configuration",
+ "sync_wrapper 0.1.2",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -914,6 +1058,49 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.0",
+ "hyper-rustls",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 2.2.0",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "system-configuration 0.6.1",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-registry",
 ]
 
 [[package]]
@@ -978,6 +1165,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,6 +1193,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -1024,6 +1250,19 @@ checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring 0.17.8",
  "untrusted 0.9.0",
+]
+
+[[package]]
+name = "secretmanager"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "reqwest 0.12.9",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "time",
+ "types",
 ]
 
 [[package]]
@@ -1182,6 +1421,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,6 +1444,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,7 +1460,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -1214,6 +1479,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1367,6 +1642,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.16",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -1610,6 +1896,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,3 +2103,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,10 @@
 [workspace]
 resolver = "2"
 
-members = ["auth", "tools/check-copyright", "types"]
+members = [
+  "auth",
+  "tools/check-copyright",
+  "types",
+  "generator/testdata/rust/openapi/golden",
+  "generator/testdata/rust/gclient/golden",
+]

--- a/generator/cmd/protoc-gen-gclient/main_test.go
+++ b/generator/cmd/protoc-gen-gclient/main_test.go
@@ -15,8 +15,10 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"os"
+	"os/exec"
 	"testing"
 )
 
@@ -33,5 +35,13 @@ func TestRun_Rust(t *testing.T) {
 	)
 	if err := run(os.Stdin, os.Stdout, inputPath, outDir, templateDir); err != nil {
 		t.Fatal(err)
+	}
+
+	cmd := exec.Command("cargo", "fmt", "--manifest-path", outDir+"/Cargo.toml")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		if ee := (*exec.ExitError)(nil); errors.As(err, &ee) && len(ee.Stderr) > 0 {
+			t.Fatalf("%v: %v\n%s", cmd, err, ee.Stderr)
+		}
+		t.Fatalf("%v: %v\n%s", cmd, err, output)
 	}
 }

--- a/generator/templates/rust/Cargo.toml.mustache
+++ b/generator/templates/rust/Cargo.toml.mustache
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 }}
 [package]
-name = "placeholder"
+{{! TODO(#93) - we should be able to override this name for local development }}
+name = "{{Name}}{{^Name}}placeholder{{/Name}}"
 version = "0.1.0"
 edition = "2021"
 
@@ -25,3 +26,5 @@ serde_json = "1.0.132"
 time = { version = "0.3.36", features = ["formatting", "parsing"] }
 reqwest = { version = "0.12.9", features = ["json"] }
 bytes = { version = "1.8.0", features = ["serde"] }
+{{! TODO(#93) - this path should be configurable for local development }}
+gax_placeholder = { path = "../../../../../types", package="types" }

--- a/generator/templates/rust/src/lib.rs.mustache
+++ b/generator/templates/rust/src/lib.rs.mustache
@@ -13,6 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
+{{! TODO(#120) - re-enable dead_code warnings once OpenAPI generates some functions }}
+#![allow(dead_code)]
+
 use std::sync::Arc;
 
 pub mod model;

--- a/generator/testdata/rust/gclient/golden/Cargo.toml
+++ b/generator/testdata/rust/gclient/golden/Cargo.toml
@@ -10,3 +10,4 @@ serde_json = "1.0.132"
 time = { version = "0.3.36", features = ["formatting", "parsing"] }
 reqwest = { version = "0.12.9", features = ["json"] }
 bytes = { version = "1.8.0", features = ["serde"] }
+gax_placeholder = { path = "../../../../../types", package="types" }

--- a/generator/testdata/rust/gclient/golden/src/lib.rs
+++ b/generator/testdata/rust/gclient/golden/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::sync::Arc;
 
 pub mod model;
@@ -54,44 +56,49 @@ pub struct SecretManagerService {
 }
 
 impl SecretManagerService {
-
     /// Creates a new [Secret][google.cloud.secretmanager.v1.Secret] containing no
     /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
-    pub async fn create_secret(&self, req: model::CreateSecretRequest) -> Result<model::Secret, Box<dyn std::error::Error>> {
+    pub async fn create_secret(
+        &self,
+        req: model::CreateSecretRequest,
+    ) -> Result<model::Secret, Box<dyn std::error::Error>> {
         let client = self.client.inner.clone();
-        let res = client.http_client
-            .post(format!(
-               "{}/v1/{}/secrets",
-               self.base_path,
-               req.parent,
-            ))
+        let res = client
+            .http_client
+            .post(format!("{}/v1/{}/secrets", self.base_path, req.parent,))
             .query(&[("alt", "json")])
             .query(&[("secretId", req.secret_id.as_str())])
             .bearer_auth(&client.token)
             .json(&req.secret)
-            .send().await?;
+            .send()
+            .await?;
         if !res.status().is_success() {
-            return Err("sorry the api you are looking for is not available, please try again".into());
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
         }
         let response = res.json::<model::Secret>().await?;
         Ok(response)
     }
 
     /// Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].
-    pub async fn get_secret(&self, req: model::GetSecretRequest) -> Result<model::Secret, Box<dyn std::error::Error>> {
+    pub async fn get_secret(
+        &self,
+        req: model::GetSecretRequest,
+    ) -> Result<model::Secret, Box<dyn std::error::Error>> {
         let client = self.client.inner.clone();
-        let res = client.http_client
-            .get(format!(
-               "{}/v1/{}",
-               self.base_path,
-               req.name,
-            ))
+        let res = client
+            .http_client
+            .get(format!("{}/v1/{}", self.base_path, req.name,))
             .query(&[("alt", "json")])
             .query(&[("name", req.name.as_str())])
             .bearer_auth(&client.token)
-            .send().await?;
+            .send()
+            .await?;
         if !res.status().is_success() {
-            return Err("sorry the api you are looking for is not available, please try again".into());
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
         }
         let response = res.json::<model::Secret>().await?;
         Ok(response)

--- a/generator/testdata/rust/gclient/golden/src/model.rs
+++ b/generator/testdata/rust/gclient/golden/src/model.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code)]
 
-
 /// A [Secret][google.cloud.secretmanager.v1.Secret] is a logical secret whose
 /// value and versions can be accessed.
 ///
@@ -11,7 +10,6 @@
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Secret {
-
     /// Output only. The resource name of the
     /// [Secret][google.cloud.secretmanager.v1.Secret] in the format
     /// `projects/*/secrets/*`.
@@ -38,7 +36,7 @@ pub struct Secret {
     /// regular expression: `[\p{Ll}\p{Lo}\p{N}_-]{0,63}`
     ///
     /// No more than 64 labels can be assigned to a given resource.
-    pub labels: std::collections::HashMap<String,String>,
+    pub labels: std::collections::HashMap<String, String>,
 
     /// Optional. A list of up to 10 Pub/Sub topics to which messages are published
     /// when control plane operations are called on the secret or its versions.
@@ -64,7 +62,7 @@ pub struct Secret {
     /// Version-Alias pairs will be viewable via GetSecret and modifiable via
     /// UpdateSecret. Access by alias is only be supported on
     /// GetSecretVersion and AccessSecretVersion.
-    pub version_aliases: std::collections::HashMap<String,i64>,
+    pub version_aliases: std::collections::HashMap<String, i64>,
 
     /// Optional. Custom metadata about the secret.
     ///
@@ -78,7 +76,7 @@ pub struct Secret {
     /// alphanumerics in between these symbols.
     ///
     /// The total size of annotation keys and values must be less than 16KiB.
-    pub annotations: std::collections::HashMap<String,String>,
+    pub annotations: std::collections::HashMap<String, String>,
 
     /// Optional. Secret Version TTL after destruction request
     ///
@@ -146,7 +144,6 @@ pub mod secret {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct SecretVersion {
-
     /// Output only. The resource name of the
     /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format
     /// `projects/*/secrets/*/versions/*`.
@@ -240,7 +237,6 @@ pub mod secret_version {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Replication {
-
     /// The replication policy for this secret.
     pub replication: Option<crate::model::replication::Replication>,
 }
@@ -255,7 +251,6 @@ pub mod replication {
     #[serde(rename_all = "camelCase")]
     #[non_exhaustive]
     pub struct Automatic {
-
         /// Optional. The customer-managed encryption configuration of the
         /// [Secret][google.cloud.secretmanager.v1.Secret]. If no configuration is
         /// provided, Google-managed default encryption is used.
@@ -275,7 +270,6 @@ pub mod replication {
     #[serde(rename_all = "camelCase")]
     #[non_exhaustive]
     pub struct UserManaged {
-
         /// Required. The list of Replicas for this
         /// [Secret][google.cloud.secretmanager.v1.Secret].
         ///
@@ -292,7 +286,6 @@ pub mod replication {
         #[serde(rename_all = "camelCase")]
         #[non_exhaustive]
         pub struct Replica {
-
             /// The canonical IDs of the location to replicate data.
             /// For example: `"us-east1"`.
             pub location: String,
@@ -330,7 +323,6 @@ pub mod replication {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct CustomerManagedEncryption {
-
     /// Required. The resource name of the Cloud KMS CryptoKey used to encrypt
     /// secret payloads.
     ///
@@ -353,7 +345,6 @@ pub struct CustomerManagedEncryption {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ReplicationStatus {
-
     /// The replication status of the
     /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
     pub replication_status: Option<crate::model::replication_status::ReplicationStatus>,
@@ -372,7 +363,6 @@ pub mod replication_status {
     #[serde(rename_all = "camelCase")]
     #[non_exhaustive]
     pub struct AutomaticStatus {
-
         /// Output only. The customer-managed encryption status of the
         /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. Only
         /// populated if customer-managed encryption is used.
@@ -389,7 +379,6 @@ pub mod replication_status {
     #[serde(rename_all = "camelCase")]
     #[non_exhaustive]
     pub struct UserManagedStatus {
-
         /// Output only. The list of replica statuses for the
         /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
         pub replicas: Vec<crate::model::replication_status::user_managed_status::ReplicaStatus>,
@@ -404,7 +393,6 @@ pub mod replication_status {
         #[serde(rename_all = "camelCase")]
         #[non_exhaustive]
         pub struct ReplicaStatus {
-
             /// Output only. The canonical ID of the replica location.
             /// For example: `"us-east1"`.
             pub location: String,
@@ -446,7 +434,6 @@ pub mod replication_status {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct CustomerManagedEncryptionStatus {
-
     /// Required. The resource name of the Cloud KMS CryptoKeyVersion used to
     /// encrypt the secret payload, in the following format:
     /// `projects/*/locations/*/keyRings/*/cryptoKeys/*/versions/*`.
@@ -459,7 +446,6 @@ pub struct CustomerManagedEncryptionStatus {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Topic {
-
     /// Required. The resource name of the Pub/Sub topic that will be published to,
     /// in the following format: `projects/*/topics/*`. For publication to succeed,
     /// the Secret Manager service agent must have the `pubsub.topic.publish`
@@ -477,7 +463,6 @@ pub struct Topic {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Rotation {
-
     /// Optional. Timestamp in UTC at which the
     /// [Secret][google.cloud.secretmanager.v1.Secret] is scheduled to rotate.
     /// Cannot be set to less than 300s (5 min) in the future and at most
@@ -510,7 +495,6 @@ pub struct Rotation {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct SecretPayload {
-
     /// The secret data. Must be no larger than 64KiB.
     pub data: bytes::Bytes,
 
@@ -539,7 +523,6 @@ pub struct SecretPayload {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct CreateSecretRequest {
-
     /// Required. The resource name of the project to associate with the
     /// [Secret][google.cloud.secretmanager.v1.Secret], in the format `projects/*`
     /// or `projects/*/locations/*`.
@@ -563,7 +546,6 @@ pub struct CreateSecretRequest {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct GetSecretRequest {
-
     /// Required. The resource name of the
     /// [Secret][google.cloud.secretmanager.v1.Secret], in the format
     /// `projects/*/secrets/*` or `projects/*/locations/*/secrets/*`.

--- a/generator/testdata/rust/openapi/golden/Cargo.toml
+++ b/generator/testdata/rust/openapi/golden/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "placeholder"
+name = "secretmanager"
 version = "0.1.0"
 edition = "2021"
 
@@ -10,3 +10,4 @@ serde_json = "1.0.132"
 time = { version = "0.3.36", features = ["formatting", "parsing"] }
 reqwest = { version = "0.12.9", features = ["json"] }
 bytes = { version = "1.8.0", features = ["serde"] }
+gax_placeholder = { path = "../../../../../types", package="types" }

--- a/generator/testdata/rust/openapi/golden/src/lib.rs
+++ b/generator/testdata/rust/openapi/golden/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::sync::Arc;
 
 pub mod model;
@@ -25,4 +27,3 @@ impl Client {
         }
     }
 }
-

--- a/generator/testdata/rust/openapi/golden/src/model.rs
+++ b/generator/testdata/rust/openapi/golden/src/model.rs
@@ -1,12 +1,10 @@
 #![allow(dead_code)]
 
-
 /// The response message for Locations.ListLocations.
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ListLocationsResponse {
-
     /// A list of locations that matches the specified filter in the request.
     pub locations: Vec<crate::model::Location>,
 
@@ -19,7 +17,6 @@ pub struct ListLocationsResponse {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Location {
-
     /// Resource name for the location, which may vary between implementations.
     /// For example: `"projects/example-project/locations/us-east1"`
     pub name: Option<String>,
@@ -34,7 +31,7 @@ pub struct Location {
     /// Cross-service attributes for the location. For example
     ///
     ///     {"cloud.googleapis.com/region": "us-east1"}
-    pub labels: std::collections::HashMap<String,String>,
+    pub labels: std::collections::HashMap<String, String>,
 
     /// Service-specific metadata. For example the available capacity at the given
     /// location.
@@ -46,7 +43,6 @@ pub struct Location {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ListSecretsResponse {
-
     /// The list of Secrets sorted in reverse by create_time (newest
     /// first).
     pub secrets: Vec<crate::model::Secret>,
@@ -69,7 +65,6 @@ pub struct ListSecretsResponse {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Secret {
-
     /// Output only. The resource name of the Secret in the format `projects/_*_/secrets/*`.
     pub name: Option<String>,
 
@@ -92,7 +87,7 @@ pub struct Secret {
     /// regular expression: `[\p{Ll}\p{Lo}\p{N}_-]{0,63}`
     ///
     /// No more than 64 labels can be assigned to a given resource.
-    pub labels: std::collections::HashMap<String,String>,
+    pub labels: std::collections::HashMap<String, String>,
 
     /// Optional. A list of up to 10 Pub/Sub topics to which messages are published when
     /// control plane operations are called on the secret or its versions.
@@ -123,7 +118,7 @@ pub struct Secret {
     /// Version-Alias pairs will be viewable via GetSecret and modifiable via
     /// UpdateSecret. Access by alias is only be supported on
     /// GetSecretVersion and AccessSecretVersion.
-    pub version_aliases: std::collections::HashMap<String,i64>,
+    pub version_aliases: std::collections::HashMap<String, i64>,
 
     /// Optional. Custom metadata about the secret.
     ///
@@ -137,7 +132,7 @@ pub struct Secret {
     /// alphanumerics in between these symbols.
     ///
     /// The total size of annotation keys and values must be less than 16KiB.
-    pub annotations: std::collections::HashMap<String,String>,
+    pub annotations: std::collections::HashMap<String, String>,
 
     /// Optional. Secret Version TTL after destruction request
     ///
@@ -161,7 +156,6 @@ pub struct Secret {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Replication {
-
     /// The Secret will automatically be replicated without any restrictions.
     pub automatic: Option<crate::model::Automatic>,
 
@@ -175,7 +169,6 @@ pub struct Replication {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Automatic {
-
     /// Optional. The customer-managed encryption configuration of the Secret. If no
     /// configuration is provided, Google-managed default encryption is used.
     ///
@@ -191,7 +184,6 @@ pub struct Automatic {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct CustomerManagedEncryption {
-
     /// Required. The resource name of the Cloud KMS CryptoKey used to encrypt secret
     /// payloads.
     ///
@@ -212,7 +204,6 @@ pub struct CustomerManagedEncryption {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct UserManaged {
-
     /// Required. The list of Replicas for this Secret.
     ///
     /// Cannot be empty.
@@ -224,7 +215,6 @@ pub struct UserManaged {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Replica {
-
     /// The canonical IDs of the location to replicate data.
     /// For example: `"us-east1"`.
     pub location: Option<String>,
@@ -245,7 +235,6 @@ pub struct Replica {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Topic {
-
     /// Required. The resource name of the Pub/Sub topic that will be published to, in the
     /// following format: `projects/_*_/topics/*`. For publication to succeed, the
     /// Secret Manager service agent must have the `pubsub.topic.publish`
@@ -261,7 +250,6 @@ pub struct Topic {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Rotation {
-
     /// Optional. Timestamp in UTC at which the Secret is scheduled to rotate. Cannot be
     /// set to less than 300s (5 min) in the future and at most 3153600000s (100
     /// years).
@@ -283,7 +271,6 @@ pub struct Rotation {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct AddSecretVersionRequest {
-
     /// Required. The secret payload of the SecretVersion.
     pub payload: Option<crate::model::SecretPayload>,
 }
@@ -294,7 +281,6 @@ pub struct AddSecretVersionRequest {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct SecretPayload {
-
     /// The secret data. Must be no larger than 64KiB.
     pub data: Option<bytes::Bytes>,
 
@@ -316,7 +302,6 @@ pub struct SecretPayload {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct SecretVersion {
-
     /// Output only. The resource name of the SecretVersion in the
     /// format `projects/_*_/secrets/_*_/versions/*`.
     ///
@@ -364,7 +349,6 @@ pub struct SecretVersion {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ReplicationStatus {
-
     /// Describes the replication status of a SecretVersion with
     /// automatic replication.
     ///
@@ -388,7 +372,6 @@ pub struct ReplicationStatus {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct AutomaticStatus {
-
     /// Output only. The customer-managed encryption status of the SecretVersion. Only
     /// populated if customer-managed encryption is used.
     pub customer_managed_encryption: Option<crate::model::CustomerManagedEncryptionStatus>,
@@ -399,7 +382,6 @@ pub struct AutomaticStatus {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct CustomerManagedEncryptionStatus {
-
     /// Required. The resource name of the Cloud KMS CryptoKeyVersion used to encrypt the
     /// secret payload, in the following format:
     /// `projects/_*_/locations/_*_/keyRings/_*_/cryptoKeys/_*_/versions/*`.
@@ -415,7 +397,6 @@ pub struct CustomerManagedEncryptionStatus {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct UserManagedStatus {
-
     /// Output only. The list of replica statuses for the SecretVersion.
     pub replicas: Vec<crate::model::ReplicaStatus>,
 }
@@ -425,7 +406,6 @@ pub struct UserManagedStatus {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ReplicaStatus {
-
     /// Output only. The canonical ID of the replica location.
     /// For example: `"us-east1"`.
     pub location: Option<String>,
@@ -445,15 +425,13 @@ pub struct ReplicaStatus {
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-pub struct Empty {
-}
+pub struct Empty {}
 
 /// Response message for SecretManagerService.ListSecretVersions.
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ListSecretVersionsResponse {
-
     /// The list of SecretVersions sorted in reverse by
     /// create_time (newest first).
     pub versions: Vec<crate::model::SecretVersion>,
@@ -472,7 +450,6 @@ pub struct ListSecretVersionsResponse {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct AccessSecretVersionResponse {
-
     /// The resource name of the SecretVersion in the format
     /// `projects/_*_/secrets/_*_/versions/*` or
     /// `projects/_*_/locations/_*_/secrets/_*_/versions/*`.
@@ -487,7 +464,6 @@ pub struct AccessSecretVersionResponse {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct DisableSecretVersionRequest {
-
     /// Optional. Etag of the SecretVersion. The request succeeds if it matches
     /// the etag of the currently stored secret version object. If the etag is
     /// omitted, the request succeeds.
@@ -499,7 +475,6 @@ pub struct DisableSecretVersionRequest {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct EnableSecretVersionRequest {
-
     /// Optional. Etag of the SecretVersion. The request succeeds if it matches
     /// the etag of the currently stored secret version object. If the etag is
     /// omitted, the request succeeds.
@@ -511,7 +486,6 @@ pub struct EnableSecretVersionRequest {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct DestroySecretVersionRequest {
-
     /// Optional. Etag of the SecretVersion. The request succeeds if it matches
     /// the etag of the currently stored secret version object. If the etag is
     /// omitted, the request succeeds.
@@ -523,7 +497,6 @@ pub struct DestroySecretVersionRequest {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct SetIamPolicyRequest {
-
     /// REQUIRED: The complete policy to be applied to the `resource`. The size of
     /// the policy is limited to a few 10s of KB. An empty policy is a
     /// valid policy but certain Google Cloud services (such as Projects)
@@ -613,7 +586,6 @@ pub struct SetIamPolicyRequest {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Policy {
-
     /// Specifies the format of the policy.
     ///
     /// Valid values are `0`, `1`, and `3`. Requests that specify an invalid value
@@ -675,7 +647,6 @@ pub struct Policy {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Binding {
-
     /// Role that is assigned to the list of `members`, or principals.
     /// For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
     ///
@@ -819,7 +790,6 @@ pub struct Binding {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Expr {
-
     /// Textual representation of an expression in Common Expression Language
     /// syntax.
     pub expression: Option<String>,
@@ -893,7 +863,6 @@ pub struct Expr {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct AuditConfig {
-
     /// Specifies a service that will be enabled for audit logging.
     /// For example, `storage.googleapis.com`, `cloudsql.googleapis.com`.
     /// `allServices` is a special value that covers all services.
@@ -926,7 +895,6 @@ pub struct AuditConfig {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct AuditLogConfig {
-
     /// The log type that this config enables.
     pub log_type: Option<String>,
 
@@ -941,7 +909,6 @@ pub struct AuditLogConfig {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct TestIamPermissionsRequest {
-
     /// The set of permissions to check for the `resource`. Permissions with
     /// wildcards (such as `*` or `storage.*`) are not allowed. For more
     /// information see
@@ -954,7 +921,6 @@ pub struct TestIamPermissionsRequest {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct TestIamPermissionsResponse {
-
     /// A subset of `TestPermissionsRequest.permissions` that the caller is
     /// allowed.
     pub permissions: Vec<String>,


### PR DESCRIPTION
Hardcode a few things to get the code compiling.

I want to add these files to the Rust CI builds, and that includes enforcing
any formatting for them. I could have fixed the generator to correct some of
the formatting problems, but the last few nits would have complicated the
templates too much.

Whenever the generator gets moved to its own repository: we should remove this
step. That will complicate the tooling for generator developers.

I left a number of TODO entries (pointing to bugs).  I think the changes in the CI scripts are necessary if we want to compile the golden files, but they may also be a reason to **not** merge this PR. I thought the discussion would be easier with a visible PR.
