### PR TITLE
test(generator): use `protoc` to parse test files

### DIFF
--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -27,7 +27,9 @@ jobs:
         working-directory: generator
     steps:
       - uses: actions/checkout@v4
-      - run: apt-get update && apt-get install -y protobuf-compiler
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -31,8 +31,9 @@ jobs:
           set -e
           curl -fSSL -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protoc-28.3-linux-x86_64.zip
           cd /usr/local
-          unzip -x /tmp/protoc.zip
+          sudo unzip -x /tmp/protoc.zip
           protoc --version
+          protoc --help
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -27,7 +27,8 @@ jobs:
         working-directory: generator
     steps:
       - uses: actions/checkout@v4
-      - run: |
+      - name: Install protoc
+        run: |
           set -e
           curl -fSSL -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protoc-28.3-linux-x86_64.zip
           cd /usr/local

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           set -e
-          curl -fSSL -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v29.0-rc2/protoc-29.0-rc-2-linux-x86_64.zip
+          curl -fSSL -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protoc-28.3-linux-x86_64.zip
           cd /usr/local
           unzip -x /tmp/protoc.zip
           protoc --version

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -34,7 +34,6 @@ jobs:
           cd /usr/local
           sudo unzip -x /tmp/protoc.zip
           protoc --version
-          protoc --help
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -27,6 +27,7 @@ jobs:
         working-directory: generator
     steps:
       - uses: actions/checkout@v4
+      - run: apt-get update && apt-get install -y protobuf-compiler
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -27,9 +27,7 @@ jobs:
         working-directory: generator
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+      - run: apt update && apt install -y protobuf-compiler
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -27,7 +27,12 @@ jobs:
         working-directory: generator
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt update && sudo apt install -y protobuf-compiler
+      - run: |
+          set -e
+          curl -fSSL -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v29.0-rc2/protoc-29.0-rc-2-linux-x86_64.zip
+          cd /usr/local
+          unzip -x /tmp/protoc.zip
+          protoc --version
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -27,7 +27,7 @@ jobs:
         working-directory: generator
     steps:
       - uses: actions/checkout@v4
-      - run: apt update && apt install -y protobuf-compiler
+      - run: sudo apt update && sudo apt install -y protobuf-compiler
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v5
         with:
@@ -46,7 +46,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Fix Proto files Formatting
         run: |
-          apt update && apt install -y clang-format
           git ls-files -z -- '*.proto' ':!:**/testdata/googleapis/**' | \
             xargs -0 -r -P "$(nproc)" -n 50 clang-format
       - name: Detect Changes

--- a/generator/README.md
+++ b/generator/README.md
@@ -27,3 +27,27 @@ or to playback an old input without the need for `protoc`:
 ```bash
 go run github.com/googleapis/google-cloud-rust/generator/cmd/protoc-gen-gclient -input-path=cmd/protoc-gen-gclient/testdata/rust/rust.bin
 ```
+
+## Installing `protoc`: the Protobuf Compiler
+
+The unit tests use `protoc` to parse text `.proto` files. You will need this
+installed in your `$PATH` to run the tests.
+
+You can find numerous guides on how to install the Protobuf Compiler. Here
+we suggest two approaches:
+
+- Follow the instructions in the [gRPC Tutorial].
+
+- The Protobuf team ships easy to install binaries with each release. In the
+  [latest Protobuf release][protobuf-latest] you can find a `.zip` file for
+  your platform. Download and extract such that the `bin/` subdirectory is in
+  your path.  For example:
+
+  ```shell
+  curl -fSSL -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protoc-28.3-linux-x86_64.zip
+  cd /usr/local
+  sudo unzip -x /tmp/protoc.zip
+  ```
+
+[grpc tutorial]: https://grpc.io/docs/protoc-installation/
+[protobuf-latest]: https://github.com/protocolbuffers/protobuf/releases/latest

--- a/generator/go.mod
+++ b/generator/go.mod
@@ -3,7 +3,6 @@ module github.com/googleapis/google-cloud-rust/generator
 go 1.23.2
 
 require (
-	github.com/bufbuild/protocompile v0.14.1
 	github.com/cbroglie/mustache v1.4.0
 	github.com/google/go-cmp v0.6.0
 	github.com/iancoleman/strcase v0.3.0
@@ -20,5 +19,4 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/vmware-labs/yaml-jsonpath v0.3.2 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.9-0.20240815153524-6ea36470d1bd // indirect
-	golang.org/x/sync v0.8.0 // indirect
 )

--- a/generator/go.sum
+++ b/generator/go.sum
@@ -1,7 +1,5 @@
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
-github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
-github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cbroglie/mustache v1.4.0 h1:Azg0dVhxTml5me+7PsZ7WPrQq1Gkf3WApcHMjMprYoU=
@@ -94,8 +92,6 @@ golang.org/x/net v0.28.0/go.mod h1:yqtgsTWOOnlGLG9GFRrK3++bGOUEkNBoHZc8MEDWPNg=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
-golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/generator/internal/genclient/translator/protobuf/protobuf_test.go
+++ b/generator/internal/genclient/translator/protobuf/protobuf_test.go
@@ -15,17 +15,16 @@
 package protobuf
 
 import (
-	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
-	"github.com/bufbuild/protocompile"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/googleapis/google-cloud-rust/generator/internal/genclient"
 	"google.golang.org/genproto/googleapis/api/serviceconfig"
-	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/pluginpb"
 )
@@ -485,32 +484,46 @@ func TestMapFields(t *testing.T) {
 
 func newCodeGeneratorRequest(t *testing.T, filename string) *pluginpb.CodeGeneratorRequest {
 	t.Helper()
-	contents, err := os.ReadFile(filepath.Join("testdata", filename))
+	tempFile, err := os.CreateTemp("", "protoc-out-")
 	if err != nil {
 		t.Fatal(err)
 	}
-	accessor := protocompile.SourceAccessorFromMap(map[string]string{
-		filename: string(contents),
-	})
-	compiler := protocompile.Compiler{
-		Resolver:       &protocompile.SourceResolver{Accessor: accessor},
-		MaxParallelism: 1,
-		SourceInfoMode: protocompile.SourceInfoStandard,
-	}
-	files, err := compiler.Compile(context.Background(), filename)
+	defer os.Remove(tempFile.Name())
+
+	cmd := exec.Command("protoc",
+		"--proto_path", "testdata",
+		"--proto_path", "../../../../testdata/googleapis",
+		"--include_imports",
+		"--include_source_info",
+		"--retain_options",
+		"--descriptor_set_out", tempFile.Name(),
+		filepath.Join("testdata", filename))
+	err = cmd.Run()
 	if err != nil {
-		t.Fatalf("error compiling proto %q", err)
+		t.Fatal(err)
 	}
-	if len(files) != 1 {
-		t.Errorf("Expected exactly one output descriptor, got=%d", len(files))
+
+	contents, err := os.ReadFile(tempFile.Name())
+	if err != nil {
+		t.Fatal(err)
 	}
-	descriptor := protodesc.ToFileDescriptorProto(files[0])
-	return &pluginpb.CodeGeneratorRequest{
+	descriptors := &descriptorpb.FileDescriptorSet{}
+	if err := proto.Unmarshal(contents, descriptors); err != nil {
+		t.Fatal(err)
+	}
+	var target *descriptorpb.FileDescriptorProto
+	for _, pb := range descriptors.File {
+		if *pb.Name == filename {
+			target = pb
+		}
+	}
+	request := &pluginpb.CodeGeneratorRequest{
 		FileToGenerate:        []string{filename},
-		ProtoFile:             []*descriptorpb.FileDescriptorProto{descriptor},
-		SourceFileDescriptors: []*descriptorpb.FileDescriptorProto{descriptor},
+		ProtoFile:             []*descriptorpb.FileDescriptorProto{target},
+		SourceFileDescriptors: descriptors.File,
 		CompilerVersion:       newCompilerVersion(),
 	}
+	return request
 }
 
 func checkMessage(t *testing.T, got genclient.Message, want genclient.Message) {

--- a/generator/internal/genclient/translator/protobuf/protobuf_test.go
+++ b/generator/internal/genclient/translator/protobuf/protobuf_test.go
@@ -503,7 +503,7 @@ func newCodeGeneratorRequest(t *testing.T, filename string) *pluginpb.CodeGenera
 	cmd.Stderr = &stderr
 	err = cmd.Run()
 	if err != nil {
-		t.Errorf("protoc error: %s", stderr.String())
+		t.Logf("protoc error: %s", stderr.String())
 		t.Fatal(err)
 	}
 

--- a/generator/internal/genclient/translator/protobuf/protobuf_test.go
+++ b/generator/internal/genclient/translator/protobuf/protobuf_test.go
@@ -15,6 +15,7 @@
 package protobuf
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -490,6 +491,7 @@ func newCodeGeneratorRequest(t *testing.T, filename string) *pluginpb.CodeGenera
 	}
 	defer os.Remove(tempFile.Name())
 
+	var stderr bytes.Buffer
 	cmd := exec.Command("protoc",
 		"--proto_path", "testdata",
 		"--proto_path", "../../../../testdata/googleapis",
@@ -498,8 +500,10 @@ func newCodeGeneratorRequest(t *testing.T, filename string) *pluginpb.CodeGenera
 		"--retain_options",
 		"--descriptor_set_out", tempFile.Name(),
 		filepath.Join("testdata", filename))
+	cmd.Stderr = &stderr
 	err = cmd.Run()
 	if err != nil {
+		t.Errorf("protoc error: %s", stderr.String())
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
I could not get `bufbuild/protocompile` to handle all the complex options we
use in our service proto files. Since we use files to keep the test input, we
can just call `protoc` to parse the file.

Motivated by #120: I will need to do some refactoring in protobuf.go, and I would prefer having some unit tests before doing that.

