### PR TITLE
test(generator/protobuf): add unit test for services

### DIFF
--- a/generator/internal/genclient/translator/protobuf/protobuf_test.go
+++ b/generator/internal/genclient/translator/protobuf/protobuf_test.go
@@ -483,6 +483,42 @@ func TestMapFields(t *testing.T) {
 	})
 }
 
+func TestService(t *testing.T) {
+	api := makeAPI(nil, newCodeGeneratorRequest(t, "test_service.proto"))
+
+	service, ok := api.State.ServiceByID[".test.TestService"]
+	if !ok {
+		t.Fatalf("Cannot find service %s in API State", ".test.TestService")
+	}
+	checkService(t, *service, genclient.Service{
+		Name:          "TestService",
+		ID:            ".test.TestService",
+		Documentation: "A service to unit test the protobuf translator.",
+		DefaultHost:   "test.googleapis.com",
+		Methods: []*genclient.Method{
+			{
+				Name:          "GetFoo",
+				Documentation: "Gets a Foo resource.",
+				InputTypeID:   ".test.GetFooRequest",
+				OutputTypeID:  ".test.Foo",
+				HTTPInfo: &genclient.HTTPInfo{
+					Method:  "GET",
+					RawPath: "/v1/{name=projects/*/foos/*}"},
+			},
+			{
+				Name:          "CreateFoo",
+				Documentation: "Creates a new Foo resource.",
+				InputTypeID:   ".test.CreateFooRequest",
+				OutputTypeID:  ".test.Foo",
+				HTTPInfo: &genclient.HTTPInfo{
+					Method:  "POST",
+					RawPath: "/v1/{parent=projects/*}/foos",
+					Body:    "foo"},
+			},
+		},
+	})
+}
+
 func newCodeGeneratorRequest(t *testing.T, filename string) *pluginpb.CodeGeneratorRequest {
 	t.Helper()
 	tempFile, err := os.CreateTemp("", "protoc-out-")

--- a/generator/internal/genclient/translator/protobuf/testdata/test_service.proto
+++ b/generator/internal/genclient/translator/protobuf/testdata/test_service.proto
@@ -1,0 +1,86 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package test;
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+
+// A service to unit test the protobuf translator.
+service TestService {
+  option (google.api.default_host) = "test.googleapis.com";
+  option (google.api.oauth_scopes) =
+      "https://www.googleapis.com/auth/cloud-platform";
+
+  // Gets a Foo resource.
+  rpc GetFoo(GetFooRequest) returns (Foo) {
+    option (google.api.http) = {
+      get: "/v1/{name=projects/*/foos/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Creates a new Foo resource.
+  rpc CreateFoo(CreateFooRequest) returns (Foo) {
+    option (google.api.http) = {
+      post: "/v1/{parent=projects/*}/foos"
+      body: "foo"
+    };
+    option (google.api.method_signature) = "parent,foo_id,foo";
+  }
+}
+
+// The resource message.
+message Foo {
+  option (google.api.resource) = {
+    type: "test.googleapis.com/Foo"
+    pattern: "projects/{project}/foos/{foo}"
+  };
+
+  // Output only. The resource name of the resource, in the format
+  // `projects/{project}/foos/{foo}`.
+  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The contents.
+  string content = 2;
+}
+
+// The request message for `GetFoo`.
+message GetFooRequest {
+  // Required. The resource name in `projects/{project}/foos/{foo}` format.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = { type: "test.googleapis.com/Foo" }
+  ];
+}
+
+message CreateFooRequest {
+  // Required. The resource name of the project, in the format
+  // `projects/{project}`.
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "cloudresourcemanager.googleapis.com/Project"
+    }
+  ];
+
+  // Required. This must be unique within the project.
+  string foo_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. A [Foo][test.Foo] with initial field values.
+  Foo foo = 3 [(google.api.field_behavior) = REQUIRED];
+}


### PR DESCRIPTION
This is a step towards refactoring the protobuf translator. It simply adds a
new unit tests for a small (test-only) service.

Motivated by #120 