### PR TITLE
impl(generator/protobuf): new representation for HTTP RPCs

### DIFF
--- a/generator/internal/genclient/translator/protobuf/annotations.go
+++ b/generator/internal/genclient/translator/protobuf/annotations.go
@@ -15,11 +15,14 @@
 package protobuf
 
 import (
+	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/googleapis/google-cloud-rust/generator/internal/genclient"
 	"google.golang.org/genproto/googleapis/api/annotations"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
 )
 
 func parseHTTPInfo(m proto.Message) *genclient.HTTPInfo {
@@ -59,6 +62,95 @@ func parseHTTPInfo(m proto.Message) *genclient.HTTPInfo {
 		info.Body = httpRule.GetBody()
 	}
 	return info
+}
+
+func parsePathInfo(m *descriptorpb.MethodDescriptorProto, state *genclient.APIState) (*genclient.PathInfo, error) {
+	eHTTP := proto.GetExtension(m.GetOptions(), annotations.E_Http)
+	httpRule := eHTTP.(*annotations.HttpRule)
+	var verb string
+	var rawPath string
+	switch httpRule.GetPattern().(type) {
+	case *annotations.HttpRule_Get:
+		verb = "GET"
+		rawPath = httpRule.GetGet()
+	case *annotations.HttpRule_Post:
+		verb = "POST"
+		rawPath = httpRule.GetPost()
+	case *annotations.HttpRule_Put:
+		verb = "PUT"
+		rawPath = httpRule.GetPut()
+	case *annotations.HttpRule_Delete:
+		verb = "DELETE"
+		rawPath = httpRule.GetDelete()
+	case *annotations.HttpRule_Patch:
+		verb = "PATCH"
+		rawPath = httpRule.GetPatch()
+	default:
+		return nil, fmt.Errorf("unsupported http method: %q", httpRule.GetPattern())
+	}
+	pathTemplate := parseRawPath(rawPath)
+	queryParameters, err := queryParameters(m, pathTemplate, httpRule.GetBody(), state)
+	if err != nil {
+		return nil, err
+	}
+
+	return &genclient.PathInfo{
+		Verb:            verb,
+		PathTemplate:    pathTemplate,
+		QueryParameters: queryParameters,
+		BodyFieldPath:   httpRule.GetBody(),
+	}, nil
+}
+
+func queryParameters(m *descriptorpb.MethodDescriptorProto, pathTemplate []genclient.PathSegment, body string, state *genclient.APIState) (map[string]bool, error) {
+	msg, ok := state.MessageByID[m.GetInputType()]
+	if !ok {
+		return nil, fmt.Errorf("unable to lookup type %s", m.GetInputType())
+	}
+	params := map[string]bool{}
+	// Start with all the fields marked as query parameters.
+	for _, field := range msg.Fields {
+		params[field.Name] = true
+	}
+	for _, s := range pathTemplate {
+		if s.FieldPath != nil {
+			delete(params, *s.FieldPath)
+		}
+	}
+	if body != "" && body != "*" {
+		delete(params, body)
+	}
+	return params, nil
+}
+
+func parseRawPath(rawPath string) []genclient.PathSegment {
+	// TODO(#121) - use a proper parser for the template syntax
+	template := genclient.HTTPPathVarRegex.ReplaceAllStringFunc(rawPath, func(s string) string {
+		members := strings.Split(s, "=")
+		if len(members) == 1 {
+			return members[0]
+		}
+		return members[0] + "}"
+	})
+	segments := []genclient.PathSegment{}
+	for idx, component := range strings.Split(template, ":") {
+		if idx != 0 {
+			segments = append(segments, genclient.PathSegment{Verb: &component})
+			continue
+		}
+		for _, element := range strings.Split(component, "/") {
+			if element == "" {
+				continue
+			}
+			if strings.HasPrefix(element, "{") && strings.HasSuffix(element, "}") {
+				element = element[1 : len(element)-1]
+				segments = append(segments, genclient.PathSegment{FieldPath: &element})
+				continue
+			}
+			segments = append(segments, genclient.PathSegment{Literal: &element})
+		}
+	}
+	return segments
 }
 
 func parseDefaultHost(m proto.Message) string {

--- a/generator/internal/genclient/translator/protobuf/protobuf.go
+++ b/generator/internal/genclient/translator/protobuf/protobuf.go
@@ -103,8 +103,14 @@ func makeAPI(serviceConfig *serviceconfig.Service, req *pluginpb.CodeGeneratorRe
 			}
 			state.ServiceByID[service.ID] = service
 			for _, m := range s.Method {
+				pathInfo, err := parsePathInfo(m, state)
+				if err != nil {
+					slog.Error("unsupported http method", "method", m)
+					continue
+				}
 				method := &genclient.Method{
 					HTTPInfo:     parseHTTPInfo(m.GetOptions()),
+					PathInfo:     pathInfo,
 					Name:         m.GetName(),
 					InputTypeID:  m.GetInputType(),
 					OutputTypeID: m.GetOutputType(),

--- a/generator/internal/genclient/translator/protobuf/protobuf_test.go
+++ b/generator/internal/genclient/translator/protobuf/protobuf_test.go
@@ -317,12 +317,27 @@ func TestComments(t *testing.T) {
 		Name:          "Service",
 		ID:            ".test.Service",
 		Documentation: "A service.\n\nWith a longer service description.",
+		DefaultHost:   "test.googleapis.com",
 		Methods: []*genclient.Method{
 			{
 				Name:          "Create",
 				Documentation: "Some RPC.\n\nIt does not do much.",
 				InputTypeID:   ".test.Request",
 				OutputTypeID:  ".test.Response",
+				HTTPInfo: &genclient.HTTPInfo{
+					Method:  "POST",
+					RawPath: "/v1/{parent=projects/*}/foos", Body: "*",
+				},
+				PathInfo: &genclient.PathInfo{
+					Verb: "POST",
+					PathTemplate: []genclient.PathSegment{
+						genclient.NewLiteralPathSegment("v1"),
+						genclient.NewFieldPathPathSegment("parent"),
+						genclient.NewLiteralPathSegment("foos"),
+					},
+					QueryParameters: map[string]bool{},
+					BodyFieldPath:   "*",
+				},
 			},
 		},
 	})
@@ -504,6 +519,15 @@ func TestService(t *testing.T) {
 				HTTPInfo: &genclient.HTTPInfo{
 					Method:  "GET",
 					RawPath: "/v1/{name=projects/*/foos/*}"},
+				PathInfo: &genclient.PathInfo{
+					Verb: "GET",
+					PathTemplate: []genclient.PathSegment{
+						genclient.NewLiteralPathSegment("v1"),
+						genclient.NewFieldPathPathSegment("name"),
+					},
+					QueryParameters: map[string]bool{},
+					BodyFieldPath:   "",
+				},
 			},
 			{
 				Name:          "CreateFoo",
@@ -514,6 +538,16 @@ func TestService(t *testing.T) {
 					Method:  "POST",
 					RawPath: "/v1/{parent=projects/*}/foos",
 					Body:    "foo"},
+				PathInfo: &genclient.PathInfo{
+					Verb: "POST",
+					PathTemplate: []genclient.PathSegment{
+						genclient.NewLiteralPathSegment("v1"),
+						genclient.NewFieldPathPathSegment("parent"),
+						genclient.NewLiteralPathSegment("foos"),
+					},
+					QueryParameters: map[string]bool{"foo_id": true},
+					BodyFieldPath:   "foo",
+				},
 			},
 		},
 	})

--- a/generator/internal/genclient/translator/protobuf/testdata/comments.proto
+++ b/generator/internal/genclient/translator/protobuf/testdata/comments.proto
@@ -15,6 +15,11 @@
 syntax = "proto3";
 package test;
 
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+
 // A test message.
 //
 // With even more of a description.
@@ -54,8 +59,17 @@ message Response {
 //
 // With a longer service description.
 service Service {
+  option (google.api.default_host) = "test.googleapis.com";
+  option (google.api.oauth_scopes) =
+      "https://www.googleapis.com/auth/cloud-platform";
+
   // Some RPC.
   //
   // It does not do much.
-  rpc Create(Request) returns (Response);
+  rpc Create(Request) returns (Response) {
+    option (google.api.http) = {
+      post: "/v1/{parent=projects/*}/foos"
+      body: "*"
+    };
+  }
 }


### PR DESCRIPTION
This introduces an (at the moment) alternative representation for HTTP RPCs. I
cannot produce the previous representation from the OpenAPI specification, and
it seems overly difficult to use. In a pending PR I will change the Codecs to
use `PathInfo` and then remove `genclient.HTTPInfo`.

Motivated by #120
