### PR TITLE
cleanup: simplify some tests

### DIFF
--- a/types/src/any.rs
+++ b/types/src/any.rs
@@ -169,6 +169,7 @@ mod test {
     use super::*;
     use crate::duration::*;
     use serde_json::json;
+    type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
     #[serde_with::skip_serializing_none]
     #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -178,8 +179,6 @@ mod test {
         pub parent: String,
         pub id: String,
     }
-
-    type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
     #[test]
     fn serialize_duration() -> Result {

--- a/types/src/duration.rs
+++ b/types/src/duration.rs
@@ -242,7 +242,8 @@ mod test {
     fn serialize(seconds: i64, nanos: i32, want: &str) -> Result {
         let got = serde_json::to_value(Duration { seconds, nanos })?
             .as_str()
-            .map(str::to_string).ok_or("cannot convert value to string")?;
+            .map(str::to_string)
+            .ok_or("cannot convert value to string")?;
         assert_eq!(want, got);
         Ok(())
     }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -24,7 +24,7 @@ pub use crate::timestamp::*;
 #[cfg(test)]
 mod test {
     use serde_json::json;
-    use std::error::Error;
+    type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
     #[serde_with::serde_as]
     #[serde_with::skip_serializing_none]
@@ -37,7 +37,7 @@ mod test {
     }
 
     #[test]
-    fn test_serialize_large_i64() -> Result<(), Box<dyn Error>> {
+    fn test_serialize_large_i64() -> Result {
         // 1 << 60 is too large to be represented as a JSON number, those are
         // always IEEE 754 double precision floating point numbers, which only
         // has about 52 bits of mantissa.
@@ -53,7 +53,7 @@ mod test {
     }
 
     #[test]
-    fn test_deserialize_large_i64() -> Result<(), Box<dyn Error>> {
+    fn test_deserialize_large_i64() -> Result {
         // 1 << 60 is too large to be represented as a JSON number, those are
         // always IEEE 754 double precision floating point numbers, which only
         // has about 52 bits of mantissa.
@@ -77,7 +77,7 @@ mod test {
     }
 
     #[test]
-    fn test_serialize_bytes() -> Result<(), Box<dyn Error>> {
+    fn test_serialize_bytes() -> Result {
         // 1 << 60 is too large to be represented as a JSON number, those are
         // always IEEE 754 double precision floating point numbers, which only
         // has about 52 bits of mantissa.
@@ -94,7 +94,7 @@ mod test {
     }
 
     #[test]
-    fn test_deserialize_bytes() -> Result<(), Box<dyn Error>> {
+    fn test_deserialize_bytes() -> Result {
         // 1 << 60 is too large to be represented as a JSON number, those are
         // always IEEE 754 double precision floating point numbers, which only
         // has about 52 bits of mantissa.


### PR DESCRIPTION
Or at least make them more uniform:

- Prefer `?` over `.unwrap()` to short-circuit on failures.
- Prefer `test_case` over for loops for several similar tests.