### PR TITLE
impl(types): `.google.protobuf.Empty` is a well-known-type

### DIFF
--- a/types/src/empty.rs
+++ b/types/src/empty.rs
@@ -1,0 +1,48 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A generic empty message that you can re-use to avoid defining duplicated
+/// empty messages in your APIs. A typical example is to use it as the request
+/// or the response type of an API method. For instance:
+///
+/// ```norust
+/// service Foo {
+///   rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+/// }
+/// ```
+///
+#[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Empty {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+    #[test]
+    fn serialize() -> Result {
+        let empty = Empty::default();
+        let got = serde_json::to_value(empty)?;
+        assert_eq!(json!({}), got);
+        Ok(())
+    }
+
+    #[test]
+    fn deserialize() -> Result {
+        let got = serde_json::from_value(json!({}))?;
+        assert_eq!(Empty::default(), got);
+        Ok(())
+    }
+}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -16,6 +16,8 @@ mod any;
 pub use crate::any::*;
 mod duration;
 pub use crate::duration::*;
+mod empty;
+pub use crate::empty::*;
 mod field_mask;
 pub use crate::field_mask::*;
 mod timestamp;

--- a/types/tests/empty.rs
+++ b/types/tests/empty.rs
@@ -1,0 +1,21 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use types::Empty;
+
+#[test]
+fn access() {
+    let e = Empty{};
+    assert_eq!(Empty::default(), e);
+}


### PR DESCRIPTION
Part of the work for #77
