### PR TITLE
impl(generator): use `PathInfo` to generate methods

### DIFF
--- a/generator/internal/genclient/genclient.go
+++ b/generator/internal/genclient/genclient.go
@@ -65,11 +65,11 @@ type LanguageCodec interface {
 	// HTTPPathFmt returns a format string used for adding path arguments to a
 	// URL. The replacements should align in both order and value from what is
 	// returned from HTTPPathArgs.
-	HTTPPathFmt(m *HTTPInfo, state *APIState) string
+	HTTPPathFmt(m *PathInfo, state *APIState) string
 	// HTTPPathArgs returns a string representation of the path arguments. This
 	// should be used in conjunction with HTTPPathFmt. An example return value
 	// might be `, req.PathParam()`
-	HTTPPathArgs(h *HTTPInfo, state *APIState) []string
+	HTTPPathArgs(h *PathInfo, state *APIState) []string
 	// QueryParams returns key-value pairs of name to accessor for query params.
 	// An example return value might be
 	// `&Pair{Key: "secretId", Value: "req.SecretId()"}`

--- a/generator/internal/genclient/model.go
+++ b/generator/internal/genclient/model.go
@@ -106,59 +106,11 @@ type Method struct {
 	InputTypeID string
 	// OutputType is the output of the Method
 	OutputTypeID string
-	// HTTPInfo information about the method
-	HTTPInfo *HTTPInfo
 	// PathInfo information about the HTTP request
 	PathInfo *PathInfo
 }
 
-// NotQueryParams returns a set of items that are not query params, notably the
-// body and path params.
-func (m *Method) NotQueryParams() map[string]bool {
-	body := m.HTTPInfo.Body
-	if m.HTTPInfo.Body == "" || m.HTTPInfo.Body == "*" {
-		return nil
-	}
-	notQuery := map[string]bool{
-		body: true,
-	}
-	for _, arg := range m.HTTPInfo.PathArgs() {
-		notQuery[arg] = true
-	}
-	return notQuery
-}
-
-// HTTPInfo information about the method.
-type HTTPInfo struct {
-	// HTTP method.
-	//
-	// This is one of:
-	// - GET
-	// - POST
-	// - PUT
-	// - DELETE
-	// - PATCH
-	Method string
-	// RawPath is the path fragment of a URL.
-	//
-	// This is a string that may contain positional arguments. For example:
-	// `/v1/{name=projects/*/secrets/*}`
-	//
-	// The positional arguments may be extracted using the HTTPPathVarRegex.
-	RawPath string
-	// Body is the name of the field that should be used as the body of the
-	// request.
-	//
-	// This is a string that may be "*" which indicates that the entire request
-	// should be used as the body.
-	//
-	// If this is empty then the body is not used.
-	Body string
-}
-
-// Normalized request path information. I (coryan@) think we can normalize
-// both OpenAPI `PathItem` elements and Protobuf HTTPInfo annotations into this
-// structure.
+// Normalized request path information.
 type PathInfo struct {
 	// HTTP Verb.
 	//
@@ -221,16 +173,6 @@ func NewFieldPathPathSegment(s string) PathSegment {
 
 func NewVerbPathSegment(s string) PathSegment {
 	return PathSegment{Verb: &s}
-}
-
-// PathArgs returns the names of the positional arguments in the order they
-// can be found in the RawPath.
-func (h *HTTPInfo) PathArgs() []string {
-	var args []string
-	for _, match := range HTTPPathVarRegex.FindAllStringSubmatch(h.RawPath, -1) {
-		args = append(args, match[1])
-	}
-	return args
 }
 
 // Message defines a message used in request/response handling.

--- a/generator/internal/genclient/templatedata.go
+++ b/generator/internal/genclient/templatedata.go
@@ -149,19 +149,19 @@ func (m *method) OutputTypeName() string {
 }
 
 func (m *method) HTTPMethod() string {
-	return m.s.HTTPInfo.Method
+	return m.s.PathInfo.Verb
 }
 
 func (m *method) HTTPMethodToLower() string {
-	return strings.ToLower(m.s.HTTPInfo.Method)
+	return strings.ToLower(m.s.PathInfo.Verb)
 }
 
 func (m *method) HTTPPathFmt() string {
-	return m.c.HTTPPathFmt(m.s.HTTPInfo, m.state)
+	return m.c.HTTPPathFmt(m.s.PathInfo, m.state)
 }
 
 func (m *method) HTTPPathArgs() []string {
-	return m.c.HTTPPathArgs(m.s.HTTPInfo, m.state)
+	return m.c.HTTPPathArgs(m.s.PathInfo, m.state)
 }
 
 func (m *method) QueryParams() []*Pair {
@@ -169,7 +169,7 @@ func (m *method) QueryParams() []*Pair {
 }
 
 func (m *method) HasBody() bool {
-	return m.s.HTTPInfo.Body != ""
+	return m.s.PathInfo.BodyFieldPath != ""
 }
 
 func (m *method) BodyAccessor() string {

--- a/generator/internal/genclient/translator/protobuf/annotations.go
+++ b/generator/internal/genclient/translator/protobuf/annotations.go
@@ -25,45 +25,6 @@ import (
 	"google.golang.org/protobuf/types/descriptorpb"
 )
 
-func parseHTTPInfo(m proto.Message) *genclient.HTTPInfo {
-	eHTTP := proto.GetExtension(m, annotations.E_Http)
-	httpRule := eHTTP.(*annotations.HttpRule)
-	var info *genclient.HTTPInfo
-	switch httpRule.GetPattern().(type) {
-	case *annotations.HttpRule_Get:
-		info = &genclient.HTTPInfo{
-			Method:  "GET",
-			RawPath: httpRule.GetGet(),
-		}
-	case *annotations.HttpRule_Post:
-		info = &genclient.HTTPInfo{
-			Method:  "POST",
-			RawPath: httpRule.GetPost(),
-		}
-	case *annotations.HttpRule_Put:
-		info = &genclient.HTTPInfo{
-			Method:  "PUT",
-			RawPath: httpRule.GetPut(),
-		}
-	case *annotations.HttpRule_Delete:
-		info = &genclient.HTTPInfo{
-			Method:  "DELETE",
-			RawPath: httpRule.GetDelete(),
-		}
-	case *annotations.HttpRule_Patch:
-		info = &genclient.HTTPInfo{
-			Method:  "PATCH",
-			RawPath: httpRule.GetPatch(),
-		}
-	default:
-		slog.Warn("unsupported http method", "method", httpRule.GetPattern())
-	}
-	if info != nil {
-		info.Body = httpRule.GetBody()
-	}
-	return info
-}
-
 func parsePathInfo(m *descriptorpb.MethodDescriptorProto, state *genclient.APIState) (*genclient.PathInfo, error) {
 	eHTTP := proto.GetExtension(m.GetOptions(), annotations.E_Http)
 	httpRule := eHTTP.(*annotations.HttpRule)

--- a/generator/internal/genclient/translator/protobuf/protobuf.go
+++ b/generator/internal/genclient/translator/protobuf/protobuf.go
@@ -109,7 +109,6 @@ func makeAPI(serviceConfig *serviceconfig.Service, req *pluginpb.CodeGeneratorRe
 					continue
 				}
 				method := &genclient.Method{
-					HTTPInfo:     parseHTTPInfo(m.GetOptions()),
 					PathInfo:     pathInfo,
 					Name:         m.GetName(),
 					InputTypeID:  m.GetInputType(),

--- a/generator/internal/genclient/translator/protobuf/protobuf_test.go
+++ b/generator/internal/genclient/translator/protobuf/protobuf_test.go
@@ -324,10 +324,6 @@ func TestComments(t *testing.T) {
 				Documentation: "Some RPC.\n\nIt does not do much.",
 				InputTypeID:   ".test.Request",
 				OutputTypeID:  ".test.Response",
-				HTTPInfo: &genclient.HTTPInfo{
-					Method:  "POST",
-					RawPath: "/v1/{parent=projects/*}/foos", Body: "*",
-				},
 				PathInfo: &genclient.PathInfo{
 					Verb: "POST",
 					PathTemplate: []genclient.PathSegment{
@@ -516,9 +512,6 @@ func TestService(t *testing.T) {
 				Documentation: "Gets a Foo resource.",
 				InputTypeID:   ".test.GetFooRequest",
 				OutputTypeID:  ".test.Foo",
-				HTTPInfo: &genclient.HTTPInfo{
-					Method:  "GET",
-					RawPath: "/v1/{name=projects/*/foos/*}"},
 				PathInfo: &genclient.PathInfo{
 					Verb: "GET",
 					PathTemplate: []genclient.PathSegment{
@@ -534,10 +527,6 @@ func TestService(t *testing.T) {
 				Documentation: "Creates a new Foo resource.",
 				InputTypeID:   ".test.CreateFooRequest",
 				OutputTypeID:  ".test.Foo",
-				HTTPInfo: &genclient.HTTPInfo{
-					Method:  "POST",
-					RawPath: "/v1/{parent=projects/*}/foos",
-					Body:    "foo"},
 				PathInfo: &genclient.PathInfo{
 					Verb: "POST",
 					PathTemplate: []genclient.PathSegment{

--- a/generator/testdata/rust/gclient/golden/src/lib.rs
+++ b/generator/testdata/rust/gclient/golden/src/lib.rs
@@ -91,7 +91,6 @@ impl SecretManagerService {
             .http_client
             .get(format!("{}/v1/{}", self.base_path, req.name,))
             .query(&[("alt", "json")])
-            .query(&[("name", req.name.as_str())])
             .bearer_auth(&client.token)
             .send()
             .await?;


### PR DESCRIPTION
The `PathInfo` field is representation of the HTTP parameters that works for
both OpenAPI and Protobuf. This PR changes the codec to use `PathInfo` and
removes `HTTPInfo` and its support code.

Incidentally, this fixes a bug in the Protobuf parsing, where some parameters
were treated as both path parameters and query parameters.

Motivated by #120
