### PR TITLE
fix: make types usable outside the crate

### DIFF
--- a/types/src/duration.rs
+++ b/types/src/duration.rs
@@ -52,6 +52,20 @@ pub struct Duration {
     pub nanos: i32,
 }
 
+impl Duration {
+    /// Set the `seconds` field.
+    pub fn set_seconds(mut self, v: i64) -> Self {
+        self.seconds = v;
+        self
+    }
+
+    /// Set the `nanos` field.
+    pub fn set_nanos(mut self, v: i32) -> Self {
+        self.nanos = v;
+        self
+    }
+}
+
 const NS: i32 = 1_000_000_000;
 
 impl Duration {
@@ -263,57 +277,6 @@ mod test {
                 "mismatched value for input={input}"
             );
         }
-        Ok(())
-    }
-
-    #[serde_with::skip_serializing_none]
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-    #[serde(rename_all = "camelCase")]
-    #[non_exhaustive]
-    pub struct Helper {
-        pub time_to_live: Option<Duration>,
-    }
-
-    #[test]
-    fn serialize_in_struct() -> Result {
-        let input = Helper {
-            ..Default::default()
-        };
-        let json = serde_json::to_value(input)?;
-        assert_eq!(json, json!({}));
-
-        let input = Helper {
-            time_to_live: Some(Duration {
-                seconds: 12,
-                nanos: 345678900,
-            }),
-            ..Default::default()
-        };
-
-        let json = serde_json::to_value(input)?;
-        assert_eq!(json, json!({ "timeToLive": "12.345678900s" }));
-        Ok(())
-    }
-
-    #[test]
-    fn deserialize_in_struct() -> Result {
-        let input = json!({});
-        let want = Helper {
-            ..Default::default()
-        };
-        let got = serde_json::from_value::<Helper>(input)?;
-        assert_eq!(want, got);
-
-        let input = json!({ "timeToLive": "12.345678900s" });
-        let want = Helper {
-            time_to_live: Some(Duration {
-                seconds: 12,
-                nanos: 345678900,
-            }),
-            ..Default::default()
-        };
-        let got = serde_json::from_value::<Helper>(input)?;
-        assert_eq!(want, got);
         Ok(())
     }
 }

--- a/types/src/field_mask.rs
+++ b/types/src/field_mask.rs
@@ -242,7 +242,15 @@
 pub struct FieldMask {
     /// The set of field mask paths.
     #[serde(deserialize_with = "crate::field_mask::deserialize_paths")]
-    paths: Vec<String>,
+    pub paths: Vec<String>,
+}
+
+impl FieldMask {
+    /// Set the paths.
+    pub fn set_paths(mut self, paths: Vec<String>) -> Self {
+        self.paths = paths;
+        self
+    }
 }
 
 /// Implement [`serde`](::serde) serialization for [FieldMask]
@@ -313,61 +321,6 @@ mod test {
         let value = json!({ "paths": paths });
         let got = serde_json::from_value::<FieldMask>(value)?;
         assert_eq!(got.paths.clone().sort(), want.clone().sort());
-        Ok(())
-    }
-
-    #[serde_with::skip_serializing_none]
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-    #[serde(rename_all = "camelCase")]
-    #[non_exhaustive]
-    pub struct Helper {
-        pub mask: Option<FieldMask>,
-    }
-
-    #[test]
-    fn serialize_in_struct() -> Result {
-        let input = Helper {
-            ..Default::default()
-        };
-        let json = serde_json::to_value(input)?;
-        assert_eq!(json, json!({}));
-
-        let input = Helper {
-            mask: Some(FieldMask {
-                paths: vec!["f1", "f2", "f3"]
-                    .into_iter()
-                    .map(str::to_string)
-                    .collect(),
-            }),
-            ..Default::default()
-        };
-
-        let json = serde_json::to_value(input)?;
-        assert_eq!(json, json!({ "mask": {"paths": "f1,f2,f3"} }));
-        Ok(())
-    }
-
-    #[test]
-    fn deserialize_in_struct() -> Result {
-        let input = json!({});
-        let want = Helper {
-            ..Default::default()
-        };
-        let got = serde_json::from_value::<Helper>(input)?;
-        assert_eq!(want, got);
-
-        let input = json!({ "mask": {"paths": "field1,field2,field3" }});
-        let want = Helper {
-            mask: Some(FieldMask {
-                paths: vec!["field1", "field2", "field3"]
-                    .into_iter()
-                    .map(str::to_string)
-                    .collect(),
-            }),
-            ..Default::default()
-        };
-        let got = serde_json::from_value::<Helper>(input)?;
-        assert_eq!(want, got);
         Ok(())
     }
 }

--- a/types/src/timestamp.rs
+++ b/types/src/timestamp.rs
@@ -58,6 +58,20 @@ pub struct Timestamp {
     pub nanos: i32,
 }
 
+impl Timestamp {
+    /// Set the `seconds` field.
+    pub fn set_seconds(mut self, v: i64) -> Self {
+        self.seconds = v;
+        self
+    }
+
+    /// Set the `nanos` field.
+    pub fn set_nanos(mut self, v: i32) -> Self {
+        self.nanos = v;
+        self
+    }
+}
+
 use time::format_description::well_known::Rfc3339;
 const NS: i128 = 1_000_000_000;
 
@@ -145,57 +159,6 @@ mod test {
             roundtrip,
             "mismatched value for input={input}"
         );
-        Ok(())
-    }
-
-    #[serde_with::skip_serializing_none]
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-    #[serde(rename_all = "camelCase")]
-    #[non_exhaustive]
-    pub struct Helper {
-        pub create_time: Option<Timestamp>,
-    }
-
-    #[test]
-    fn serialize_in_struct() -> Result {
-        let input = Helper {
-            ..Default::default()
-        };
-        let json = serde_json::to_value(input)?;
-        assert_eq!(json, json!({}));
-
-        let input = Helper {
-            create_time: Some(Timestamp {
-                seconds: 12,
-                nanos: 345678000,
-            }),
-            ..Default::default()
-        };
-
-        let json = serde_json::to_value(input)?;
-        assert_eq!(json, json!({ "createTime": "1970-01-01T00:00:12.345678Z" }));
-        Ok(())
-    }
-
-    #[test]
-    fn deserialize_in_struct() -> Result {
-        let input = json!({});
-        let want = Helper {
-            ..Default::default()
-        };
-        let got = serde_json::from_value::<Helper>(input)?;
-        assert_eq!(want, got);
-
-        let input = json!({ "createTime": "1970-01-01T00:00:12.345678Z" });
-        let want = Helper {
-            create_time: Some(Timestamp {
-                seconds: 12,
-                nanos: 345678000,
-            }),
-            ..Default::default()
-        };
-        let got = serde_json::from_value::<Helper>(input)?;
-        assert_eq!(want, got);
         Ok(())
     }
 }

--- a/types/tests/any.rs
+++ b/types/tests/any.rs
@@ -1,0 +1,51 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use types::Any;
+use types::Duration;
+
+type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TestOnly {
+    pub parent: String,
+    pub filter: Option<String>,
+}
+
+#[test]
+fn roundtrip_generic() -> Result {
+    let input = TestOnly {
+        parent: "parent".to_string(),
+        ..Default::default()
+    };
+    let any = Any::from(&input)?;
+    let json = serde_json::to_value(any)?;
+    let any = serde_json::from_value::<Any>(json)?;
+    let output = any.try_into_message::<TestOnly>()?;
+    assert_eq!(input, output);
+    Ok(())
+}
+
+#[test]
+fn roundtrip_duration() -> Result {
+    let input = Duration::new(12, 3456);
+    let any = Any::from(&input)?;
+    let json = serde_json::to_value(any)?;
+    let any = serde_json::from_value::<Any>(json)?;
+    let output = any.try_into_message::<Duration>()?;
+    assert_eq!(input, output);
+    Ok(())
+}

--- a/types/tests/duration.rs
+++ b/types/tests/duration.rs
@@ -1,0 +1,68 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde_json::json;
+use types::Duration;
+type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Helper {
+    pub time_to_live: Option<Duration>,
+}
+
+#[test]
+fn access() {
+    let d = Duration::default();
+    assert_eq!(d.nanos, 0);
+    assert_eq!(d.seconds, 0);
+}
+
+#[test]
+fn serialize_in_struct() -> Result {
+    let input = Helper {
+        ..Default::default()
+    };
+    let json = serde_json::to_value(input)?;
+    assert_eq!(json, json!({}));
+
+    let input = Helper {
+        time_to_live: Some(Duration::new(12, 345678900)),
+        ..Default::default()
+    };
+
+    let json = serde_json::to_value(input)?;
+    assert_eq!(json, json!({ "timeToLive": "12.345678900s" }));
+    Ok(())
+}
+
+#[test]
+fn deserialize_in_struct() -> Result {
+    let input = json!({});
+    let want = Helper {
+        ..Default::default()
+    };
+    let got = serde_json::from_value::<Helper>(input)?;
+    assert_eq!(want, got);
+
+    let input = json!({ "timeToLive": "12.345678900s" });
+    let want = Helper {
+        time_to_live: Some(Duration::new(12, 345678900)),
+        ..Default::default()
+    };
+    let got = serde_json::from_value::<Helper>(input)?;
+    assert_eq!(want, got);
+    Ok(())
+}

--- a/types/tests/field_mask.rs
+++ b/types/tests/field_mask.rs
@@ -1,0 +1,71 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde_json::json;
+use types::FieldMask;
+type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct Helper {
+    pub mask: Option<FieldMask>,
+}
+
+#[test]
+fn access() {
+    let fm = FieldMask::default();
+    assert_eq!(fm.paths, Vec::<String>::new());
+}
+
+#[test]
+fn serialize_in_struct() -> Result {
+    let input = Helper {
+        ..Default::default()
+    };
+    let json = serde_json::to_value(input)?;
+    assert_eq!(json, json!({}));
+
+    let input = Helper {
+        mask: Some(FieldMask::default().set_paths(["f1", "f2", "f3"].map(str::to_string).to_vec())),
+        ..Default::default()
+    };
+
+    let json = serde_json::to_value(input)?;
+    assert_eq!(json, json!({ "mask": {"paths": "f1,f2,f3"} }));
+    Ok(())
+}
+
+#[test]
+fn deserialize_in_struct() -> Result {
+    let input = json!({});
+    let want = Helper {
+        ..Default::default()
+    };
+    let got = serde_json::from_value::<Helper>(input)?;
+    assert_eq!(want, got);
+
+    let input = json!({ "mask": {"paths": "field1,field2,field3" }});
+    let want = Helper {
+        mask: Some(
+            FieldMask::default()
+                .set_paths(["field1", "field2", "field3"].map(str::to_string).to_vec()),
+        ),
+        ..Default::default()
+    };
+    let got = serde_json::from_value::<Helper>(input)?;
+    assert_eq!(want, got);
+    Ok(())
+}

--- a/types/tests/timestamp.rs
+++ b/types/tests/timestamp.rs
@@ -1,0 +1,71 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde_json::json;
+use types::Timestamp;
+type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Helper {
+    pub create_time: Option<Timestamp>,
+}
+
+#[test]
+fn access() {
+    let ts = Timestamp::default();
+    assert_eq!(ts.nanos, 0);
+    assert_eq!(ts.seconds, 0);
+}
+
+#[test]
+fn serialize_in_struct() -> Result {
+    let input = Helper {
+        ..Default::default()
+    };
+    let json = serde_json::to_value(input)?;
+    assert_eq!(json, json!({}));
+
+    let input = Helper {
+        create_time: Some(Timestamp::default().set_seconds(12).set_nanos(345_678_900)),
+        ..Default::default()
+    };
+
+    let json = serde_json::to_value(input)?;
+    assert_eq!(
+        json,
+        json!({ "createTime": "1970-01-01T00:00:12.3456789Z" })
+    );
+    Ok(())
+}
+
+#[test]
+fn deserialize_in_struct() -> Result {
+    let input = json!({});
+    let want = Helper {
+        ..Default::default()
+    };
+    let got = serde_json::from_value::<Helper>(input)?;
+    assert_eq!(want, got);
+
+    let input = json!({ "createTime": "1970-01-01T00:00:12.3456789Z" });
+    let want = Helper {
+        create_time: Some(Timestamp::default().set_seconds(12).set_nanos(345678900)),
+        ..Default::default()
+    };
+    let got = serde_json::from_value::<Helper>(input)?;
+    assert_eq!(want, got);
+    Ok(())
+}


### PR DESCRIPTION
`FieldMask` had private fields when they should have been public. We were
missing setters for a number of fields.

I refactored some of the tests to be integration tests, so we can verify the
intended usage outside the crate.

Motivated by #132 and #129