### PR TITLE
impl: helpers for query parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gax"
+version = "0.1.0"
+dependencies = [
+ "reqwest 0.12.9",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "types",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ members = [
   "tools/check-copyright",
   "types",
   "generator/testdata/rust/openapi/golden",
-  "generator/testdata/rust/gclient/golden",
+  "generator/testdata/rust/gclient/golden", "gax",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
   "auth",
   "tools/check-copyright",
   "types",
+  "gax",
   "generator/testdata/rust/openapi/golden",
-  "generator/testdata/rust/gclient/golden", "gax",
+  "generator/testdata/rust/gclient/golden",
 ]

--- a/gax/Cargo.toml
+++ b/gax/Cargo.toml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [package]
 name = "gax"
 version = "0.1.0"

--- a/gax/Cargo.toml
+++ b/gax/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "gax"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde_json = "1.0.132"
+types = { version = "0.1.0", path = "../types" }
+
+[dev-dependencies]
+reqwest = "0.12.9"
+serde = { version = "1.0.214", features = ["serde_derive"] }
+serde_with = "3.11.0"

--- a/gax/src/lib.rs
+++ b/gax/src/lib.rs
@@ -1,0 +1,31 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Defines traits and helpers to serialize query parameters.
+///
+/// Query parameters in the Google APIs can be types other than strings and
+/// integers. We need a helper to efficiently serialize parameters of different
+/// types. We also want the generator to be relatively simple.
+///
+/// The Rust SDK generator produces query parameters as optional fields in the
+/// request object. The generator code can be simplified if all the query
+/// parameters can be treated uniformly, without any conditionally generated
+/// code to handle different types.
+///
+/// This module defines some traits and helpers to simplify the code generator.
+///
+/// The types are not intended for application developers to use. They are
+/// public because we will generate many crates (roughly one per service), and
+/// most of these crates will use these helpers.
+pub mod query_parameter;

--- a/gax/src/query_parameter.rs
+++ b/gax/src/query_parameter.rs
@@ -1,0 +1,162 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub type Error = serde_json::Error;
+type Result = serde_json::Result<String>;
+
+pub fn format<T>(
+    name: &'static str,
+    parameter: &T,
+) -> serde_json::Result<Option<(&'static str, String)>>
+where
+    T: QueryParameter,
+{
+    QueryParameter::format(parameter.into())
+        .map(|result| result.map(|s| (name, s)))
+        .transpose()
+}
+
+pub trait QueryParameter {
+    fn format(&self) -> Option<Result>;
+}
+
+impl<T: QueryParameter> QueryParameter for Option<T> {
+    fn format(&self) -> Option<Result> {
+        self.as_ref().map(|v| QueryParameter::format(v)).flatten()
+    }
+}
+
+impl<T: RequiredQueryParameter> QueryParameter for T {
+    fn format(&self) -> Option<Result> {
+        Some(RequiredQueryParameter::format(self))
+    }
+}
+
+/// Format query parameters as strings.
+trait RequiredQueryParameter {
+    fn format(&self) -> Result;
+}
+
+impl RequiredQueryParameter for String {
+    fn format(&self) -> Result {
+        Ok(self.clone())
+    }
+}
+
+impl RequiredQueryParameter for i32 {
+    fn format(&self) -> Result {
+        Ok(format!("{self}"))
+    }
+}
+
+impl RequiredQueryParameter for u32 {
+    fn format(&self) -> Result {
+        Ok(format!("{self}"))
+    }
+}
+
+impl RequiredQueryParameter for i64 {
+    fn format(&self) -> Result {
+        Ok(format!("{self}"))
+    }
+}
+
+impl RequiredQueryParameter for u64 {
+    fn format(&self) -> Result {
+        Ok(format!("{self}"))
+    }
+}
+
+impl RequiredQueryParameter for f32 {
+    fn format(&self) -> Result {
+        Ok(format!("{self}"))
+    }
+}
+
+impl RequiredQueryParameter for f64 {
+    fn format(&self) -> Result {
+        Ok(format!("{self}"))
+    }
+}
+
+impl RequiredQueryParameter for types::Duration {
+    fn format(&self) -> Result {
+        Ok(serde_json::to_value(self)?.as_str().unwrap().to_string())
+    }
+}
+
+impl RequiredQueryParameter for types::FieldMask {
+    fn format(&self) -> Result {
+        Ok(self.paths.join(","))
+    }
+}
+
+impl RequiredQueryParameter for types::Timestamp {
+    fn format(&self) -> Result {
+        Ok(serde_json::to_value(self)?.as_str().unwrap().to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+    #[test]
+    fn none() -> Result {
+        assert_eq!(None, QueryParameter::format(&None::<i32>).transpose()?);
+        assert_eq!(None, QueryParameter::format(&None::<i64>).transpose()?);
+        assert_eq!(None, QueryParameter::format(&None::<u32>).transpose()?);
+        assert_eq!(None, QueryParameter::format(&None::<u64>).transpose()?);
+        assert_eq!(None, QueryParameter::format(&None::<f32>).transpose()?);
+        assert_eq!(None, QueryParameter::format(&None::<f64>).transpose()?);
+        Ok(())
+    }
+
+    #[test]
+    fn with_value() -> Result {
+        let want = Some("42".to_string());
+        assert_eq!(want, QueryParameter::format(&Some(42 as i32)).transpose()?);
+        assert_eq!(want, QueryParameter::format(&Some(42 as i64)).transpose()?);
+        assert_eq!(want, QueryParameter::format(&Some(42 as u32)).transpose()?);
+        assert_eq!(want, QueryParameter::format(&Some(42 as u64)).transpose()?);
+        assert_eq!(want, QueryParameter::format(&Some(42 as f32)).transpose()?);
+        assert_eq!(want, QueryParameter::format(&Some(42 as f64)).transpose()?);
+        Ok(())
+    }
+
+    #[test]
+    fn duration() -> Result {
+        let d = types::Duration::new(12, 345_678_900);
+        let f = QueryParameter::format(&d).transpose()?;
+        assert_eq!(Some("12.345678900s".to_string()), f);
+        Ok(())
+    }
+
+    #[test]
+    fn field_mask() -> Result {
+        let fm = types::FieldMask::default().set_paths(["a", "b"].map(str::to_string).to_vec());
+        let f = QueryParameter::format(&fm).transpose()?;
+        assert_eq!(Some("a,b".to_string()), f);
+        Ok(())
+    }
+
+    #[test]
+    fn timestamp() -> Result {
+        let ts = types::Timestamp::default();
+        let f = QueryParameter::format(&ts).transpose()?;
+        assert_eq!(Some("1970-01-01T00:00:00Z".to_string()), f);
+        Ok(())
+    }
+}

--- a/gax/src/query_parameter.rs
+++ b/gax/src/query_parameter.rs
@@ -22,7 +22,7 @@ pub fn format<T>(
 where
     T: QueryParameter,
 {
-    QueryParameter::format(parameter.into())
+    QueryParameter::format(parameter)
         .map(|result| result.map(|s| (name, s)))
         .transpose()
 }
@@ -33,7 +33,7 @@ pub trait QueryParameter {
 
 impl<T: QueryParameter> QueryParameter for Option<T> {
     fn format(&self) -> Option<Result> {
-        self.as_ref().map(|v| QueryParameter::format(v)).flatten()
+        self.as_ref().and_then(|v| QueryParameter::format(v))
     }
 }
 
@@ -127,12 +127,12 @@ mod tests {
     #[test]
     fn with_value() -> Result {
         let want = Some("42".to_string());
-        assert_eq!(want, QueryParameter::format(&Some(42 as i32)).transpose()?);
-        assert_eq!(want, QueryParameter::format(&Some(42 as i64)).transpose()?);
-        assert_eq!(want, QueryParameter::format(&Some(42 as u32)).transpose()?);
-        assert_eq!(want, QueryParameter::format(&Some(42 as u64)).transpose()?);
-        assert_eq!(want, QueryParameter::format(&Some(42 as f32)).transpose()?);
-        assert_eq!(want, QueryParameter::format(&Some(42 as f64)).transpose()?);
+        assert_eq!(want, QueryParameter::format(&Some(42_i32)).transpose()?);
+        assert_eq!(want, QueryParameter::format(&Some(42_i64)).transpose()?);
+        assert_eq!(want, QueryParameter::format(&Some(42_u32)).transpose()?);
+        assert_eq!(want, QueryParameter::format(&Some(42_u64)).transpose()?);
+        assert_eq!(want, QueryParameter::format(&Some(42_f32)).transpose()?);
+        assert_eq!(want, QueryParameter::format(&Some(42_f64)).transpose()?);
         Ok(())
     }
 

--- a/gax/tests/query_parameters.rs
+++ b/gax/tests/query_parameters.rs
@@ -34,12 +34,10 @@ pub struct FakeRequest {
 #[test]
 fn make_reqwest_no_query() -> Result {
     let client = reqwest::Client::builder().build()?;
-    let empty : [Option<(&str, String)>;0] = [];
-    let builder = client.get("https://test.googleapis.com/v1/unused").query(
-        &empty.into_iter()
-            .flatten()
-            .collect::<Vec<(&str, String)>>(),
-    );
+    let empty: [Option<(&str, String)>; 0] = [];
+    let builder = client
+        .get("https://test.googleapis.com/v1/unused")
+        .query(&empty.into_iter().flatten().collect::<Vec<(&str, String)>>());
 
     let r = builder.build()?;
     assert_eq!(None, r.url().query());

--- a/gax/tests/query_parameters.rs
+++ b/gax/tests/query_parameters.rs
@@ -1,0 +1,183 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+// We use this to simulate a request and how it is used in
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FakeRequest {
+    // Typically the struct would have a
+    pub parent: String,
+    // Most query parameter fields are optional.
+    pub count: Option<i32>,
+    pub filter_expression: Option<String>,
+    pub get_mask: Option<types::FieldMask>,
+    pub ttl: Option<types::Duration>,
+    pub expiration: Option<types::Timestamp>,
+    // Some query parameter fields are required.
+    pub required: String,
+}
+
+#[test]
+fn make_reqwest_no_query() -> Result {
+    let client = reqwest::Client::builder().build()?;
+    let builder = client.get("https://test.googleapis.com/v1/unused").query(
+        &[].into_iter()
+            .filter_map(|p| p)
+            .map(|u| u)
+            .collect::<Vec<(&str, String)>>(),
+    );
+
+    let r = builder.build()?;
+    assert_eq!(None, r.url().query());
+
+    Ok(())
+}
+
+#[test]
+fn basic_query() -> Result {
+    // Create a basic request.
+    let request = FakeRequest {
+        parent: "projects/test-only-invalid".into(),
+        filter_expression: Some("only-the-good-stuff".into()),
+        ..Default::default()
+    };
+    let client = reqwest::Client::builder().build()?;
+    let builder = client.get("https://test.googleapis.com/v1/unused").query(
+        &[
+            gax::query_parameter::format("count", &request.count)?,
+            gax::query_parameter::format("filterExpression", &request.filter_expression)?,
+            gax::query_parameter::format("getMask", &request.get_mask)?,
+            gax::query_parameter::format("ttl", &request.ttl)?,
+            gax::query_parameter::format("expiration", &request.expiration)?,
+            gax::query_parameter::format("required", &request.required)?,
+        ]
+        .into_iter()
+        .filter_map(|p| p)
+        .map(|u| u)
+        .collect::<Vec<(&str, String)>>(),
+    );
+
+    let r = builder.build()?;
+    assert_eq!(
+        Some("filterExpression=only-the-good-stuff&required="),
+        r.url().query()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn with_fieldmask() -> Result {
+    // Create a basic request.
+    let request = FakeRequest {
+        parent: "projects/test-only-invalid".into(),
+        get_mask: Some(
+            types::FieldMask::default().set_paths(["f0", "f1"].map(str::to_string).to_vec()),
+        ),
+        ..Default::default()
+    };
+    let client = reqwest::Client::builder().build()?;
+    let builder = client.get("https://test.googleapis.com/v1/unused").query(
+        &[
+            gax::query_parameter::format("count", &request.count)?,
+            gax::query_parameter::format("filterExpression", &request.filter_expression)?,
+            gax::query_parameter::format("getMask", &request.get_mask)?,
+            gax::query_parameter::format("ttl", &request.ttl)?,
+            gax::query_parameter::format("expiration", &request.expiration)?,
+            gax::query_parameter::format("required", &request.required)?,
+        ]
+        .into_iter()
+        .filter_map(|p| p)
+        .map(|u| u)
+        .collect::<Vec<(&str, String)>>(),
+    );
+
+    let r = builder.build()?;
+    // %2C is the URL-safe encoding for comma (`,`)
+    assert_eq!(Some("getMask=f0%2Cf1&required="), r.url().query());
+
+    Ok(())
+}
+
+#[test]
+fn with_duration() -> Result {
+    // Create a basic request.
+    let request = FakeRequest {
+        parent: "projects/test-only-invalid".into(),
+        ttl: Some(types::Duration::new(12, 345_678_900)),
+        ..Default::default()
+    };
+    let client = reqwest::Client::builder().build()?;
+    let builder = client.get("https://test.googleapis.com/v1/unused").query(
+        &[
+            gax::query_parameter::format("count", &request.count)?,
+            gax::query_parameter::format("filterExpression", &request.filter_expression)?,
+            gax::query_parameter::format("getMask", &request.get_mask)?,
+            gax::query_parameter::format("ttl", &request.ttl)?,
+            gax::query_parameter::format("expiration", &request.expiration)?,
+            gax::query_parameter::format("required", &request.required)?,
+        ]
+        .into_iter()
+        .filter_map(|p| p)
+        .map(|u| u)
+        .collect::<Vec<(&str, String)>>(),
+    );
+
+    let r = builder.build()?;
+    // %2C is the URL-safe encoding for comma (`,`)
+    assert_eq!(Some("ttl=12.345678900s&required="), r.url().query());
+
+    Ok(())
+}
+
+#[test]
+fn with_timestamp() -> Result {
+    // Create a basic request.
+    let request = FakeRequest {
+        parent: "projects/test-only-invalid".into(),
+        expiration: Some(
+            types::Timestamp::default()
+                .set_seconds(12)
+                .set_nanos(345_678_900),
+        ),
+        ..Default::default()
+    };
+    let client = reqwest::Client::builder().build()?;
+    let builder = client.get("https://test.googleapis.com/v1/unused").query(
+        &[
+            gax::query_parameter::format("count", &request.count)?,
+            gax::query_parameter::format("filterExpression", &request.filter_expression)?,
+            gax::query_parameter::format("getMask", &request.get_mask)?,
+            gax::query_parameter::format("ttl", &request.ttl)?,
+            gax::query_parameter::format("expiration", &request.expiration)?,
+            gax::query_parameter::format("required", &request.required)?,
+        ]
+        .into_iter()
+        .filter_map(|p| p)
+        .map(|u| u)
+        .collect::<Vec<(&str, String)>>(),
+    );
+
+    let r = builder.build()?;
+    // %3A is the URL-safe encoding for colon (`:`)
+    assert_eq!(
+        Some("expiration=1970-01-01T00%3A00%3A12.3456789Z&required="),
+        r.url().query()
+    );
+
+    Ok(())
+}

--- a/gax/tests/query_parameters.rs
+++ b/gax/tests/query_parameters.rs
@@ -34,10 +34,10 @@ pub struct FakeRequest {
 #[test]
 fn make_reqwest_no_query() -> Result {
     let client = reqwest::Client::builder().build()?;
+    let empty : [Option<(&str, String)>;0] = [];
     let builder = client.get("https://test.googleapis.com/v1/unused").query(
-        &[].into_iter()
-            .filter_map(|p| p)
-            .map(|u| u)
+        &empty.into_iter()
+            .flatten()
             .collect::<Vec<(&str, String)>>(),
     );
 
@@ -66,8 +66,7 @@ fn basic_query() -> Result {
             gax::query_parameter::format("required", &request.required)?,
         ]
         .into_iter()
-        .filter_map(|p| p)
-        .map(|u| u)
+        .flatten()
         .collect::<Vec<(&str, String)>>(),
     );
 
@@ -101,8 +100,7 @@ fn with_fieldmask() -> Result {
             gax::query_parameter::format("required", &request.required)?,
         ]
         .into_iter()
-        .filter_map(|p| p)
-        .map(|u| u)
+        .flatten()
         .collect::<Vec<(&str, String)>>(),
     );
 
@@ -132,8 +130,7 @@ fn with_duration() -> Result {
             gax::query_parameter::format("required", &request.required)?,
         ]
         .into_iter()
-        .filter_map(|p| p)
-        .map(|u| u)
+        .flatten()
         .collect::<Vec<(&str, String)>>(),
     );
 
@@ -167,8 +164,7 @@ fn with_timestamp() -> Result {
             gax::query_parameter::format("required", &request.required)?,
         ]
         .into_iter()
-        .filter_map(|p| p)
-        .map(|u| u)
+        .flatten()
         .collect::<Vec<(&str, String)>>(),
     );
 


### PR DESCRIPTION
I want to keep the generated code for query parameters relatively simple, and
at the same time I want to support optional query parameters, required query
parameters, query parameters of different types, including some well-known
types.

This introduces a new crate[^1] which initially just has a helper function to
convert all the expected types to strings. The integration tests show how this
helper would be used in generated code.

[^1]: curiously named `gax` for no reason I can think of

Part of the work for #128 and #129