### PR TITLE
impl(generator/rust): use query parameter helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,6 +922,7 @@ name = "placeholder"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "gax",
  "reqwest 0.12.9",
  "serde",
  "serde_json",
@@ -1268,6 +1269,7 @@ name = "secretmanager"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "gax",
  "reqwest 0.12.9",
  "serde",
  "serde_json",

--- a/generator/internal/genclient/language/internal/rust/rust.go
+++ b/generator/internal/genclient/language/internal/rust/rust.go
@@ -255,7 +255,7 @@ func (c *Codec) QueryParams(m *genclient.Method, state *genclient.APIState) []*g
 		}
 		queryParams = append(queryParams, &genclient.Pair{
 			Key:   field.JSONName,
-			Value: "req." + c.ToSnake(field.Name) + ".as_str()"})
+			Value: c.ToSnake(field.Name)})
 	}
 	return queryParams
 }

--- a/generator/templates/rust/Cargo.toml.mustache
+++ b/generator/templates/rust/Cargo.toml.mustache
@@ -28,3 +28,4 @@ reqwest = { version = "0.12.9", features = ["json"] }
 bytes = { version = "1.8.0", features = ["serde"] }
 {{! TODO(#93) - this path should be configurable for local development }}
 gax_placeholder = { path = "../../../../../types", package="types" }
+gax = { path = "../../../../../gax", package="gax" }

--- a/generator/templates/rust/src/lib.rs.mustache
+++ b/generator/templates/rust/src/lib.rs.mustache
@@ -73,6 +73,14 @@ impl {{NameToPascal}} {
     {{{.}}}
     {{/DocLines}}
     pub async fn {{NameToSnake}}(&self, req: model::{{InputTypeName}}) -> Result<model::{{OutputTypeName}}, Box<dyn std::error::Error>> {
+        let query_parameters = [
+                    {{^QueryParams}}
+                    None::<(&str, String)>; 0
+                    {{/QueryParams}}
+                    {{#QueryParams}}
+                    gax::query_parameter::format("{{Key}}", &req.{{Value}})?,
+                    {{/QueryParams}}
+        ];
         let client = self.client.inner.clone();
         let res = client.http_client
             .{{HTTPMethodToLower}}(format!(
@@ -83,9 +91,12 @@ impl {{NameToPascal}} {
                {{/HTTPPathArgs}}
             ))
             .query(&[("alt", "json")])
-            {{#QueryParams}}
-            .query(&[("{{Key}}", {{Value}})])
-            {{/QueryParams}}
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>()
+            )
             .bearer_auth(&client.token)
             {{#HasBody}}
             .json(&req{{BodyAccessor}})

--- a/generator/testdata/rust/gclient/golden/Cargo.toml
+++ b/generator/testdata/rust/gclient/golden/Cargo.toml
@@ -11,3 +11,4 @@ time = { version = "0.3.36", features = ["formatting", "parsing"] }
 reqwest = { version = "0.12.9", features = ["json"] }
 bytes = { version = "1.8.0", features = ["serde"] }
 gax_placeholder = { path = "../../../../../types", package="types" }
+gax = { path = "../../../../../gax", package="gax" }

--- a/generator/testdata/rust/gclient/golden/src/lib.rs
+++ b/generator/testdata/rust/gclient/golden/src/lib.rs
@@ -62,12 +62,18 @@ impl SecretManagerService {
         &self,
         req: model::CreateSecretRequest,
     ) -> Result<model::Secret, Box<dyn std::error::Error>> {
+        let query_parameters = [gax::query_parameter::format("secretId", &req.secret_id)?];
         let client = self.client.inner.clone();
         let res = client
             .http_client
             .post(format!("{}/v1/{}/secrets", self.base_path, req.parent,))
             .query(&[("alt", "json")])
-            .query(&[("secretId", req.secret_id.as_str())])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
             .bearer_auth(&client.token)
             .json(&req.secret)
             .send()
@@ -86,11 +92,18 @@ impl SecretManagerService {
         &self,
         req: model::GetSecretRequest,
     ) -> Result<model::Secret, Box<dyn std::error::Error>> {
+        let query_parameters = [None::<(&str, String)>; 0];
         let client = self.client.inner.clone();
         let res = client
             .http_client
             .get(format!("{}/v1/{}", self.base_path, req.name,))
             .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
             .bearer_auth(&client.token)
             .send()
             .await?;

--- a/generator/testdata/rust/openapi/golden/Cargo.toml
+++ b/generator/testdata/rust/openapi/golden/Cargo.toml
@@ -11,3 +11,4 @@ time = { version = "0.3.36", features = ["formatting", "parsing"] }
 reqwest = { version = "0.12.9", features = ["json"] }
 bytes = { version = "1.8.0", features = ["serde"] }
 gax_placeholder = { path = "../../../../../types", package="types" }
+gax = { path = "../../../../../gax", package="gax" }


### PR DESCRIPTION
Using these helpers we can handle more query parameter types, including the
well-known-types that may appear as such.

Part of the work for #128 and #129