### PR TITLE
impl(generator/openapi): generate service and RPCs

### DIFF
--- a/generator/internal/genclient/translator/openapi/openapi.go
+++ b/generator/internal/genclient/translator/openapi/openapi.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pb33f/libopenapi"
 	base "github.com/pb33f/libopenapi/datamodel/high/base"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+	"github.com/pb33f/libopenapi/orderedmap"
 	"google.golang.org/genproto/googleapis/api/serviceconfig"
 )
 
@@ -122,7 +123,263 @@ func makeAPI(serviceConfig *serviceconfig.Service, model *libopenapi.DocumentMod
 		api.Messages = append(api.Messages, message)
 		api.State.MessageByID[id] = message
 	}
+
+	err := makeServices(api, serviceConfig, model)
+	if err != nil {
+		return nil, err
+	}
 	return api, nil
+}
+
+func makeServices(api *genclient.API, serviceConfig *serviceconfig.Service, model *libopenapi.DocumentModel[v3.Document]) error {
+	// It is hard to imagine an OpenAPI specification without at least some
+	// RPCs, but we can simplify the tests if we support specifications without
+	// paths or without any useful methods in the paths.
+	if model.Model.Paths == nil {
+		return nil
+	}
+	methods, err := makeMethods(api, model)
+	if err != nil {
+		return err
+	}
+	if len(methods) == 0 {
+		return nil
+	}
+	// OpenAPI does not define a service name. The service config may provide
+	// one. In tests, the service config is typically `nil`.
+	serviceName := "Service"
+	if serviceConfig != nil {
+		for _, api := range serviceConfig.Apis {
+			serviceName = api.Name
+			break
+		}
+	}
+	service := &genclient.Service{
+		Name:          serviceName,
+		ID:            ".." + serviceName,
+		Documentation: api.Description,
+		DefaultHost:   defaultHost(model),
+		Methods:       methods,
+	}
+	api.Services = append(api.Services, service)
+	api.State.ServiceByID[service.ID] = service
+	return nil
+}
+
+func defaultHost(model *libopenapi.DocumentModel[v3.Document]) string {
+	defaultHost := ""
+	for _, server := range model.Model.Servers {
+		if defaultHost == "" {
+			defaultHost = server.URL
+		} else if len(defaultHost) > len(server.URL) {
+			defaultHost = server.URL
+		}
+	}
+	return defaultHost
+}
+
+func makeMethods(api *genclient.API, model *libopenapi.DocumentModel[v3.Document]) ([]*genclient.Method, error) {
+	methods := []*genclient.Method{}
+	if model.Model.Paths == nil {
+		return methods, nil
+	}
+	for pattern, item := range model.Model.Paths.PathItems.FromOldest() {
+		pathTemplate := makePathTemplate(pattern)
+
+		type NamedOperation struct {
+			Verb      string
+			Operation *v3.Operation
+		}
+		operations := []NamedOperation{
+			{Verb: "GET", Operation: item.Get},
+			{Verb: "PUT", Operation: item.Put},
+			{Verb: "POST", Operation: item.Post},
+			{Verb: "DELETE", Operation: item.Delete},
+			{Verb: "OPTIONS", Operation: item.Options},
+			{Verb: "HEAD", Operation: item.Head},
+			{Verb: "PATCH", Operation: item.Patch},
+			{Verb: "TRACE", Operation: item.Trace},
+		}
+		for _, op := range operations {
+			if op.Operation == nil {
+				continue
+			}
+			requestMessage, err := makeRequestMessage(api, op.Operation)
+			if err != nil {
+				return nil, err
+			}
+			responseMessage, err := makeResponseMessage(api, op.Operation)
+			if err != nil {
+				return nil, err
+			}
+			bodyFieldPath := ""
+			if op.Operation.RequestBody != nil {
+				bodyFieldPath = "*"
+			}
+			pathInfo := &genclient.PathInfo{
+				Verb:            op.Verb,
+				PathTemplate:    pathTemplate,
+				QueryParameters: makeQueryParameters(op.Operation),
+				BodyFieldPath:   bodyFieldPath,
+			}
+			m := &genclient.Method{
+				Name:          op.Operation.OperationId,
+				ID:            op.Operation.OperationId,
+				Documentation: op.Operation.Description,
+				InputTypeID:   requestMessage.ID,
+				OutputTypeID:  responseMessage.ID,
+				PathInfo:      pathInfo,
+			}
+			methods = append(methods, m)
+		}
+	}
+	return methods, nil
+}
+
+func makePathTemplate(template string) []genclient.PathSegment {
+	segments := []genclient.PathSegment{}
+	for idx, component := range strings.Split(template, ":") {
+		if idx != 0 {
+			segments = append(segments, genclient.PathSegment{Verb: &component})
+			continue
+		}
+		for _, element := range strings.Split(component, "/") {
+			if element == "" {
+				continue
+			}
+			if strings.HasPrefix(element, "{") && strings.HasSuffix(element, "}") {
+				element = element[1 : len(element)-1]
+				segments = append(segments, genclient.PathSegment{FieldPath: &element})
+				continue
+			}
+			segments = append(segments, genclient.PathSegment{Literal: &element})
+		}
+	}
+	return segments
+}
+
+func makeRequestMessage(api *genclient.API, operation *v3.Operation) (*genclient.Message, error) {
+	messageName := fmt.Sprintf("%sRequest", operation.OperationId)
+	id := fmt.Sprintf("..%s", messageName)
+	message := &genclient.Message{
+		Name:          messageName,
+		ID:            id,
+		Documentation: fmt.Sprintf("The request message for %s.", operation.OperationId),
+	}
+
+	if operation.RequestBody != nil {
+		reference, err := findReferenceInContentMap(operation.RequestBody.Content)
+		if err != nil {
+			return nil, err
+		}
+		bid := fmt.Sprintf("..%s", strings.TrimPrefix(reference, "#/components/schemas/"))
+		msg, ok := api.State.MessageByID[bid]
+		if !ok {
+			return nil, fmt.Errorf("cannot find referenced type (%s) in API messages", reference)
+		}
+		if strings.HasSuffix(reference, "Request") {
+			// Our OpenAPI specs do this weird thing: sometimes the `*Request`
+			// message appears in the list of known messages. But sometimes only
+			// the payload appears. I have not found any attribute to tell appart
+			// between the two. Only the name suffix.
+			message = msg
+		} else {
+			inserted := false
+			for _, name := range []string{"requestBody", "openapiRequestBody"} {
+				field := &genclient.Field{
+					Name:          name,
+					Documentation: "The request body.",
+					Typez:         genclient.MESSAGE_TYPE,
+					TypezID:       bid,
+					Optional:      true,
+				}
+				inserted = addFieldIfNew(message, field)
+				if inserted {
+					break
+				}
+			}
+			if !inserted {
+				return nil, fmt.Errorf("cannot insert the request body to message %s", message.Name)
+			}
+		}
+		message = msg
+	} else {
+		// The message is new
+		api.Messages = append(api.Messages, message)
+		api.State.MessageByID[message.ID] = message
+	}
+
+	for _, p := range operation.Parameters {
+		schema, err := p.Schema.BuildSchema()
+		if err != nil {
+			return nil, fmt.Errorf("error building schema for parameter %s: %w", p.Name, err)
+		}
+		typez, typezID, err := scalarType(messageName, p.Name, schema)
+		if err != nil {
+			return nil, err
+		}
+		field := &genclient.Field{
+			Name:          p.Name,
+			JSONName:      p.Name, // OpenAPI fields are already camelCase
+			Documentation: p.Description,
+			Optional:      p.Required == nil || !*p.Required,
+			Typez:         typez,
+			TypezID:       typezID,
+		}
+		addFieldIfNew(message, field)
+	}
+	return message, nil
+}
+
+func addFieldIfNew(message *genclient.Message, field *genclient.Field) bool {
+	for _, f := range message.Fields {
+		if f.Name == field.Name {
+			// If the exact same field exists, treat that as a success.
+			return *f == *field
+		}
+	}
+	message.Fields = append(message.Fields, field)
+	return true
+}
+
+func makeResponseMessage(api *genclient.API, operation *v3.Operation) (*genclient.Message, error) {
+	if operation.Responses == nil {
+		return nil, fmt.Errorf("missing Responses in specification for operation %s", operation.OperationId)
+	}
+	if operation.Responses.Default == nil {
+		// Google's OpenAPI v3 specifications only include the "default" response. In the future we may want to support
+		return nil, fmt.Errorf("expected Default response for operation %s", operation.OperationId)
+	}
+	reference, err := findReferenceInContentMap(operation.Responses.Default.Content)
+	if err != nil {
+		return nil, err
+	}
+	id := ".." + strings.TrimPrefix(reference, "#/components/schemas/")
+	if message, ok := api.State.MessageByID[id]; ok {
+		return message, nil
+	}
+	return nil, fmt.Errorf("cannot find response message ref=%s", reference)
+}
+
+func findReferenceInContentMap(content *orderedmap.Map[string, *v3.MediaType]) (string, error) {
+	for pair := content.Oldest(); pair != nil; pair = pair.Next() {
+		if pair.Key != "application/json" {
+			continue
+		}
+		return pair.Value.Schema.GetReference(), nil
+	}
+	return "", fmt.Errorf("cannot find an application/json content type")
+}
+
+func makeQueryParameters(operation *v3.Operation) map[string]bool {
+	queryParameters := map[string]bool{}
+	for _, p := range operation.Parameters {
+		if p.In != "query" {
+			continue
+		}
+		queryParameters[p.Name] = true
+	}
+	return queryParameters
 }
 
 func makeMessageFields(state *genclient.APIState, messageName string, message *base.Schema) ([]*genclient.Field, error) {
@@ -175,6 +432,7 @@ func makeScalarField(messageName, name string, schema *base.Schema, optional boo
 	}
 	return &genclient.Field{
 		Name:          name,
+		JSONName:      name, // OpenAPI field names are always camelCase
 		Documentation: field.Description,
 		Typez:         typez,
 		TypezID:       typezID,
@@ -198,6 +456,7 @@ func makeObjectField(state *genclient.APIState, messageName, name string, field 
 			// Untyped message fields are .google.protobuf.Any
 			return &genclient.Field{
 				Name:          name,
+				JSONName:      name, // OpenAPI field names are always camelCase
 				Documentation: field.Description,
 				Typez:         genclient.MESSAGE_TYPE,
 				TypezID:       ".google.protobuf.Any",
@@ -210,6 +469,7 @@ func makeObjectField(state *genclient.APIState, messageName, name string, field 
 		}
 		return &genclient.Field{
 			Name:          name,
+			JSONName:      name, // OpenAPI field names are always camelCase
 			Documentation: field.Description,
 			Typez:         genclient.MESSAGE_TYPE,
 			TypezID:       message.ID,
@@ -221,6 +481,7 @@ func makeObjectField(state *genclient.APIState, messageName, name string, field 
 		typezID := ".." + strings.TrimPrefix(proxy.GetReference(), "#/components/schemas/")
 		return &genclient.Field{
 			Name:          name,
+			JSONName:      name, // OpenAPI field names are always camelCase
 			Documentation: field.Description,
 			Typez:         genclient.MESSAGE_TYPE,
 			TypezID:       typezID,
@@ -251,6 +512,7 @@ func makeArrayField(state *genclient.APIState, messageName, name string, field *
 		if len(typezID) > 0 {
 			new := &genclient.Field{
 				Name:          name,
+				JSONName:      name, // OpenAPI field names are always camelCase
 				Documentation: field.Description,
 				Typez:         genclient.MESSAGE_TYPE,
 				TypezID:       typezID,
@@ -275,6 +537,7 @@ func makeObjectFieldAllOf(messageName, name string, field *base.Schema) (*gencli
 		typezID := strings.TrimPrefix(proxy.GetReference(), "#/components/schemas/")
 		return &genclient.Field{
 			Name:          name,
+			JSONName:      name, // OpenAPI field names are always camelCase
 			Documentation: field.Description,
 			Typez:         genclient.MESSAGE_TYPE,
 			TypezID:       ".." + typezID,

--- a/generator/internal/genclient/translator/openapi/openapi.go
+++ b/generator/internal/genclient/translator/openapi/openapi.go
@@ -280,7 +280,7 @@ func makeRequestMessage(api *genclient.API, operation *v3.Operation) (*genclient
 		if strings.HasSuffix(reference, "Request") {
 			// Our OpenAPI specs do this weird thing: sometimes the `*Request`
 			// message appears in the list of known messages. But sometimes only
-			// the payload appears. I have not found any attribute to tell appart
+			// the payload appears. I have not found any attribute to tell apart
 			// between the two. Only the name suffix.
 			message = msg
 		} else {

--- a/generator/internal/genclient/translator/openapi/openapi_test.go
+++ b/generator/internal/genclient/translator/openapi/openapi_test.go
@@ -73,6 +73,7 @@ func TestAllOf(t *testing.T) {
 		Fields: []*genclient.Field{
 			{
 				Name:          "customerManagedEncryption",
+				JSONName:      "customerManagedEncryption",
 				Documentation: "Optional. The customer-managed encryption configuration of the Secret.",
 				Typez:         genclient.MESSAGE_TYPE,
 				TypezID:       "..CustomerManagedEncryption",
@@ -134,20 +135,93 @@ func TestBasicTypes(t *testing.T) {
 		ID:            "..Fake",
 		Documentation: "A test message.",
 		Fields: []*genclient.Field{
-			{Name: "fBool", Typez: genclient.BOOL_TYPE, TypezID: "bool"},
-			{Name: "fInt64", Typez: genclient.INT64_TYPE, TypezID: "int64"},
-			{Name: "fInt32", Typez: genclient.INT32_TYPE, TypezID: "int32"},
-			{Name: "fUInt32", Typez: genclient.UINT32_TYPE, TypezID: "uint32"},
-			{Name: "fFloat", Typez: genclient.FLOAT_TYPE, TypezID: "float"},
-			{Name: "fDouble", Typez: genclient.DOUBLE_TYPE, TypezID: "double"},
-			{Name: "fString", Typez: genclient.STRING_TYPE, TypezID: "string"},
-			{Name: "fOptional", Typez: genclient.STRING_TYPE, TypezID: "string", Optional: true},
-			{Name: "fSInt64", Typez: genclient.INT64_TYPE, TypezID: "int64"},
-			{Name: "fSUInt64", Typez: genclient.UINT64_TYPE, TypezID: "uint64"},
-			{Name: "fDuration", Typez: genclient.MESSAGE_TYPE, TypezID: ".google.protobuf.Duration", Optional: true},
-			{Name: "fTimestamp", Typez: genclient.MESSAGE_TYPE, TypezID: ".google.protobuf.Timestamp", Optional: true},
-			{Name: "fFieldMask", Typez: genclient.MESSAGE_TYPE, TypezID: ".google.protobuf.FieldMask", Optional: true},
-			{Name: "fBytes", Typez: genclient.BYTES_TYPE, TypezID: "bytes"},
+			{
+				Name:     "fBool",
+				JSONName: "fBool",
+				Typez:    genclient.BOOL_TYPE,
+				TypezID:  "bool",
+			},
+			{
+				Name:     "fInt64",
+				JSONName: "fInt64",
+				Typez:    genclient.INT64_TYPE,
+				TypezID:  "int64",
+			},
+			{
+				Name:     "fInt32",
+				JSONName: "fInt32",
+				Typez:    genclient.INT32_TYPE,
+				TypezID:  "int32",
+			},
+			{
+				Name:     "fUInt32",
+				JSONName: "fUInt32",
+				Typez:    genclient.UINT32_TYPE,
+				TypezID:  "uint32",
+			},
+			{
+				Name:     "fFloat",
+				JSONName: "fFloat",
+				Typez:    genclient.FLOAT_TYPE,
+				TypezID:  "float",
+			},
+			{
+				Name:     "fDouble",
+				JSONName: "fDouble",
+				Typez:    genclient.DOUBLE_TYPE,
+				TypezID:  "double",
+			},
+			{
+				Name:     "fString",
+				JSONName: "fString",
+				Typez:    genclient.STRING_TYPE,
+				TypezID:  "string",
+			},
+			{
+				Name:     "fOptional",
+				JSONName: "fOptional",
+				Typez:    genclient.STRING_TYPE,
+				TypezID:  "string",
+				Optional: true},
+			{
+				Name:     "fSInt64",
+				JSONName: "fSInt64",
+				Typez:    genclient.INT64_TYPE,
+				TypezID:  "int64",
+			},
+			{
+				Name:     "fSUInt64",
+				JSONName: "fSUInt64",
+				Typez:    genclient.UINT64_TYPE,
+				TypezID:  "uint64",
+			},
+			{
+				Name:     "fDuration",
+				JSONName: "fDuration",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  ".google.protobuf.Duration",
+				Optional: true,
+			},
+			{
+				Name:     "fTimestamp",
+				JSONName: "fTimestamp",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  ".google.protobuf.Timestamp",
+				Optional: true,
+			},
+			{
+				Name:     "fFieldMask",
+				JSONName: "fFieldMask",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  ".google.protobuf.FieldMask",
+				Optional: true,
+			},
+			{
+				Name:     "fBytes",
+				JSONName: "fBytes",
+				Typez:    genclient.BYTES_TYPE,
+				TypezID:  "bytes",
+			},
 		},
 	})
 }
@@ -193,17 +267,76 @@ func TestArrayTypes(t *testing.T) {
 		ID:            "..Fake",
 		Documentation: "A test message.",
 		Fields: []*genclient.Field{
-			{Repeated: true, Name: "fBool", Typez: genclient.BOOL_TYPE, TypezID: "bool"},
-			{Repeated: true, Name: "fInt64", Typez: genclient.INT64_TYPE, TypezID: "int64"},
-			{Repeated: true, Name: "fInt32", Typez: genclient.INT32_TYPE, TypezID: "int32"},
-			{Repeated: true, Name: "fUInt32", Typez: genclient.UINT32_TYPE, TypezID: "uint32"},
-			{Repeated: true, Name: "fString", Typez: genclient.STRING_TYPE, TypezID: "string"},
-			{Repeated: true, Name: "fSInt64", Typez: genclient.INT64_TYPE, TypezID: "int64"},
-			{Repeated: true, Name: "fSUInt64", Typez: genclient.UINT64_TYPE, TypezID: "uint64"},
-			{Repeated: true, Name: "fDuration", Typez: genclient.MESSAGE_TYPE, TypezID: ".google.protobuf.Duration"},
-			{Repeated: true, Name: "fTimestamp", Typez: genclient.MESSAGE_TYPE, TypezID: ".google.protobuf.Timestamp"},
-			{Repeated: true, Name: "fFieldMask", Typez: genclient.MESSAGE_TYPE, TypezID: ".google.protobuf.FieldMask"},
-			{Repeated: true, Name: "fBytes", Typez: genclient.BYTES_TYPE, TypezID: "bytes"},
+			{
+				Repeated: true,
+				Name:     "fBool",
+				JSONName: "fBool",
+				Typez:    genclient.BOOL_TYPE,
+				TypezID:  "bool"},
+			{
+				Repeated: true,
+				Name:     "fInt64",
+				JSONName: "fInt64",
+				Typez:    genclient.INT64_TYPE,
+				TypezID:  "int64"},
+			{
+				Repeated: true,
+				Name:     "fInt32",
+				JSONName: "fInt32",
+				Typez:    genclient.INT32_TYPE,
+				TypezID:  "int32"},
+			{
+				Repeated: true,
+				Name:     "fUInt32",
+				JSONName: "fUInt32",
+				Typez:    genclient.UINT32_TYPE,
+				TypezID:  "uint32"},
+			{
+				Repeated: true,
+				Name:     "fString",
+				JSONName: "fString",
+				Typez:    genclient.STRING_TYPE,
+				TypezID:  "string"},
+			{
+				Repeated: true,
+				Name:     "fSInt64",
+				JSONName: "fSInt64",
+				Typez:    genclient.INT64_TYPE,
+				TypezID:  "int64"},
+			{
+				Repeated: true,
+				Name:     "fSUInt64",
+				JSONName: "fSUInt64",
+				Typez:    genclient.UINT64_TYPE,
+				TypezID:  "uint64"},
+			{
+				Repeated: true,
+				Name:     "fDuration",
+				JSONName: "fDuration",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  ".google.protobuf.Duration",
+			},
+			{
+				Repeated: true,
+				Name:     "fTimestamp",
+				JSONName: "fTimestamp",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  ".google.protobuf.Timestamp",
+			},
+			{
+				Repeated: true,
+				Name:     "fFieldMask",
+				JSONName: "fFieldMask",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  ".google.protobuf.FieldMask",
+			},
+			{
+				Repeated: true,
+				Name:     "fBytes",
+				JSONName: "fBytes",
+				Typez:    genclient.BYTES_TYPE,
+				TypezID:  "bytes",
+			},
 		},
 	})
 }
@@ -246,6 +379,7 @@ func TestSimpleObject(t *testing.T) {
 		Fields: []*genclient.Field{
 			{
 				Name:          "fObject",
+				JSONName:      "fObject",
 				Typez:         genclient.MESSAGE_TYPE,
 				TypezID:       "..Foo",
 				Documentation: "An object field.",
@@ -253,6 +387,7 @@ func TestSimpleObject(t *testing.T) {
 			},
 			{
 				Name:          "fObjectArray",
+				JSONName:      "fObjectArray",
 				Typez:         genclient.MESSAGE_TYPE,
 				TypezID:       "..Bar",
 				Documentation: "An object array field.",
@@ -289,7 +424,7 @@ func TestAny(t *testing.T) {
 		ID:            "..Fake",
 		Documentation: "A test message.",
 		Fields: []*genclient.Field{
-			{Name: "fMap", Typez: genclient.MESSAGE_TYPE, TypezID: ".google.protobuf.Any", Optional: true},
+			{Name: "fMap", JSONName: "fMap", Typez: genclient.MESSAGE_TYPE, TypezID: ".google.protobuf.Any", Optional: true},
 		},
 	})
 }
@@ -322,9 +457,24 @@ func TestMapString(t *testing.T) {
 		ID:            "..Fake",
 		Documentation: "A test message.",
 		Fields: []*genclient.Field{
-			{Name: "fMap", Typez: genclient.MESSAGE_TYPE, TypezID: "$map<string, string>"},
-			{Name: "fMapS32", Typez: genclient.MESSAGE_TYPE, TypezID: "$map<string, int32>"},
-			{Name: "fMapS64", Typez: genclient.MESSAGE_TYPE, TypezID: "$map<string, int64>"},
+			{
+				Name:     "fMap",
+				JSONName: "fMap",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  "$map<string, string>",
+			},
+			{
+				Name:     "fMapS32",
+				JSONName: "fMapS32",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  "$map<string, int32>",
+			},
+			{
+				Name:     "fMapS64",
+				JSONName: "fMapS64",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  "$map<string, int64>",
+			},
 		},
 	})
 }
@@ -356,8 +506,18 @@ func TestMapInteger(t *testing.T) {
 		ID:            "..Fake",
 		Documentation: "A test message.",
 		Fields: []*genclient.Field{
-			{Name: "fMapI32", Typez: genclient.MESSAGE_TYPE, TypezID: "$map<string, int32>", Optional: false},
-			{Name: "fMapI64", Typez: genclient.MESSAGE_TYPE, TypezID: "$map<string, int64>", Optional: false},
+			{
+				Name:     "fMapI32",
+				JSONName: "fMapI32",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  "$map<string, int32>",
+				Optional: false},
+			{
+				Name:     "fMapI64",
+				JSONName: "fMapI64",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  "$map<string, int64>",
+				Optional: false},
 		},
 	})
 }
@@ -385,6 +545,7 @@ func TestMakeAPI(t *testing.T) {
 		Fields: []*genclient.Field{
 			{
 				Name:          "name",
+				JSONName:      "name",
 				Documentation: "Resource name for the location, which may vary between implementations.",
 				Typez:         genclient.STRING_TYPE,
 				TypezID:       "string",
@@ -392,6 +553,7 @@ func TestMakeAPI(t *testing.T) {
 			},
 			{
 				Name:          "locationId",
+				JSONName:      "locationId",
 				Documentation: `The canonical id for this location.`,
 				Typez:         genclient.STRING_TYPE,
 				TypezID:       "string",
@@ -399,6 +561,7 @@ func TestMakeAPI(t *testing.T) {
 			},
 			{
 				Name:          "displayName",
+				JSONName:      "displayName",
 				Documentation: `The friendly name for this location, typically a nearby city name.`,
 				Typez:         genclient.STRING_TYPE,
 				TypezID:       "string",
@@ -406,6 +569,7 @@ func TestMakeAPI(t *testing.T) {
 			},
 			{
 				Name:          "labels",
+				JSONName:      "labels",
 				Documentation: "Cross-service attributes for the location.",
 				Typez:         genclient.MESSAGE_TYPE,
 				TypezID:       "$map<string, string>",
@@ -413,6 +577,7 @@ func TestMakeAPI(t *testing.T) {
 			},
 			{
 				Name:          "metadata",
+				JSONName:      "metadata",
 				Documentation: `Service-specific metadata. For example the available capacity at the given location.`,
 				Typez:         genclient.MESSAGE_TYPE,
 				TypezID:       ".google.protobuf.Any",
@@ -433,6 +598,7 @@ func TestMakeAPI(t *testing.T) {
 		Fields: []*genclient.Field{
 			{
 				Name:          "locations",
+				JSONName:      "locations",
 				Documentation: "A list of locations that matches the specified filter in the request.",
 				Typez:         genclient.MESSAGE_TYPE,
 				TypezID:       "..Location",
@@ -440,6 +606,7 @@ func TestMakeAPI(t *testing.T) {
 			},
 			{
 				Name:          "nextPageToken",
+				JSONName:      "nextPageToken",
 				Documentation: "The standard List next-page token.",
 				Typez:         genclient.STRING_TYPE,
 				TypezID:       "string",
@@ -447,6 +614,118 @@ func TestMakeAPI(t *testing.T) {
 			},
 		},
 	})
+
+	// This is a synthetic message, the OpenAPI spec does not contain requests
+	// messages for messages without a body.
+	listLocationsRequest, ok := api.State.MessageByID["..ListLocationsRequest"]
+	if !ok {
+		t.Errorf("missing message (ListLocationsRequest) in MessageByID index")
+		return
+	}
+	checkMessage(t, *listLocationsRequest, genclient.Message{
+		Name:          "ListLocationsRequest",
+		ID:            "..ListLocationsRequest",
+		Documentation: "The request message for ListLocations.",
+		Fields: []*genclient.Field{
+			{
+				Name:          "project",
+				JSONName:      "project",
+				Documentation: "",
+				Typez:         genclient.STRING_TYPE,
+				TypezID:       "string",
+			},
+			{
+				Name:          "filter",
+				JSONName:      "filter",
+				Documentation: "A filter to narrow down results to a preferred subset.",
+				Typez:         genclient.STRING_TYPE,
+				TypezID:       "string",
+				Optional:      true,
+			},
+			{
+				Name:          "pageSize",
+				JSONName:      "pageSize",
+				Documentation: "The maximum number of results to return.",
+				Typez:         genclient.INT32_TYPE,
+				TypezID:       "int32",
+				Optional:      true,
+			},
+			{
+				Name:          "pageToken",
+				JSONName:      "pageToken",
+				Documentation: "A page token received from the `next_page_token` field in the response.\nSend that page token to receive the subsequent page.",
+				Typez:         genclient.STRING_TYPE,
+				TypezID:       "string",
+				Optional:      true,
+			},
+		},
+	})
+
+	service, ok := api.State.ServiceByID["..Service"]
+	if !ok {
+		t.Errorf("missing service (Service) in ServiceByID index")
+		return
+	}
+	checkService(t, *service, genclient.Service{
+		Name:          "Service",
+		ID:            "..Service",
+		Documentation: "Stores sensitive data such as API keys, passwords, and certificates. Provides convenience while improving security.",
+		DefaultHost:   "https://secretmanager.googleapis.com",
+		Methods: []*genclient.Method{
+			{
+				Name:          "ListLocations",
+				ID:            "ListLocations",
+				Documentation: "Lists information about the supported locations for this service.",
+				InputTypeID:   "..ListLocationsRequest",
+				OutputTypeID:  "..ListLocationsResponse",
+				PathInfo: &genclient.PathInfo{
+					Verb: "GET",
+					PathTemplate: []genclient.PathSegment{
+						genclient.NewLiteralPathSegment("v1"),
+						genclient.NewLiteralPathSegment("projects"),
+						genclient.NewFieldPathPathSegment("project"),
+						genclient.NewLiteralPathSegment("locations"),
+					},
+					QueryParameters: map[string]bool{
+						"filter":    true,
+						"pageSize":  true,
+						"pageToken": true,
+					},
+				},
+			},
+			{
+				Name:          "CreateSecret",
+				ID:            "CreateSecret",
+				Documentation: "Creates a new Secret containing no SecretVersions.",
+				InputTypeID:   "..Secret",
+				OutputTypeID:  "..Secret",
+				PathInfo: &genclient.PathInfo{
+					Verb:          "POST",
+					BodyFieldPath: "*",
+					PathTemplate: []genclient.PathSegment{
+						genclient.NewLiteralPathSegment("v1"),
+						genclient.NewLiteralPathSegment("projects"),
+						genclient.NewFieldPathPathSegment("project"),
+						genclient.NewLiteralPathSegment("secrets"),
+					},
+					QueryParameters: map[string]bool{
+						"secretId": true,
+					},
+				},
+			},
+		},
+	})
+}
+
+func checkService(t *testing.T, got genclient.Service, want genclient.Service) {
+	t.Helper()
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(genclient.Service{}, "Methods")); len(diff) > 0 {
+		t.Errorf("Mismatched attributes (-want, +got):\n%s", diff)
+	}
+	less := func(a, b *genclient.Method) bool { return a.Name < b.Name }
+	if diff := cmp.Diff(want.Methods, got.Methods, cmpopts.SortSlices(less)); len(diff) > 0 {
+		t.Errorf("field mismatch (-want, +got):\n%s", diff)
+	}
 }
 
 func checkMessage(t *testing.T, got genclient.Message, want genclient.Message) {
@@ -542,7 +821,7 @@ const testDocument = `
           },
           {
             "name": "filter",
-            "description": "A filter to narrow down results to a preferred subset.\nThe filtering language accepts strings like \"displayName=tokyo\", and\nis documented in more detail in [AIP-160](https://google.aip.dev/160).",
+            "description": "A filter to narrow down results to a preferred subset.",
             "in": "query",
             "schema": {
               "type": "string"
@@ -550,7 +829,7 @@ const testDocument = `
           },
           {
             "name": "pageSize",
-            "description": "The maximum number of results to return.\nIf not set, the service selects a default.",
+            "description": "The maximum number of results to return.",
             "in": "query",
             "schema": {
               "type": "integer",
@@ -573,6 +852,75 @@ const testDocument = `
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ListLocationsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{project}/secrets": {
+      "parameters": [
+        { "$ref": "#/components/parameters/alt"},
+        { "$ref": "#/components/parameters/callback"},
+        { "$ref": "#/components/parameters/prettyPrint"},
+        { "$ref": "#/components/parameters/_.xgafv"}
+      ],
+      "post": {
+        "tags": ["secretmanager"],
+        "operationId": "CreateSecret",
+        "description": "Creates a new Secret containing no SecretVersions.",
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secretId",
+            "description": "Required. This must be unique within the project.",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required. A Secret with initial field values.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Secret"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Secret"
                 }
               }
             }
@@ -716,6 +1064,65 @@ const testDocument = `
           "nextPageToken": {
             "description": "The standard List next-page token.",
             "type": "string"
+          }
+        }
+      },
+      "Secret": {
+        "description": "A Secret is a logical secret whose value and versions can\nbe accessed.\n\nA Secret is made up of zero or more SecretVersions that\nrepresent the secret data.",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Output only. The resource name of the Secret in the format` + " `projects/_*_/secrets/*` " + `.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "createTime": {
+            "description": "Output only. The time at which the Secret was created.",
+            "readOnly": true,
+            "type": "string",
+            "format": "date-time"
+          },
+          "labels": {
+            "description": "The labels assigned to this Secret.\n\nLabel keys must be between 1 and 63 characters long",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "expireTime": {
+            "description": "Optional. Timestamp in UTC when the Secret is scheduled to expire. This is\nalways provided on output, regardless of what was sent on input.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "ttl": {
+            "description": "Input only. The TTL for the Secret.",
+            "writeOnly": true,
+            "type": "string",
+            "format": "google-duration"
+          },
+          "etag": {
+            "description": "Optional. Etag of the currently stored Secret.",
+            "type": "string"
+          },
+          "versionAliases": {
+            "description": "Optional. Mapping from version alias to version name.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "format": "int64"
+            }
+          },
+          "annotations": {
+            "description": "Optional. Custom metadata about the secret.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "versionDestroyTtl": {
+            "description": "Optional. Secret Version TTL after destruction request\n\nThis is a part of the Delayed secret version destroy feature.\nFor secret with TTL>0, version destruction doesn't happen immediately\non calling destroy instead the version goes to a disabled state and\ndestruction happens after the TTL expires.",
+            "type": "string",
+            "format": "google-duration"
           }
         }
       }

--- a/generator/testdata/rust/openapi/golden/src/lib.rs
+++ b/generator/testdata/rust/openapi/golden/src/lib.rs
@@ -26,4 +26,1155 @@ impl Client {
             inner: Arc::new(inner),
         }
     }
+
+    /// Stores sensitive data such as API keys, passwords, and certificates.
+    /// Provides convenience while improving security.
+    pub fn google_cloud_secretmanager_v_1_secret_manager_service(
+        &self,
+    ) -> GoogleCloudSecretmanagerV1SecretManagerService {
+        GoogleCloudSecretmanagerV1SecretManagerService {
+            client: self.clone(),
+            base_path: "https://https://secretmanager.googleapis.com/".to_string(),
+        }
+    }
+}
+
+/// Stores sensitive data such as API keys, passwords, and certificates.
+/// Provides convenience while improving security.
+#[derive(Debug)]
+pub struct GoogleCloudSecretmanagerV1SecretManagerService {
+    client: Client,
+    base_path: String,
+}
+
+impl GoogleCloudSecretmanagerV1SecretManagerService {
+    /// Lists information about the supported locations for this service.
+    pub async fn list_locations(
+        &self,
+        req: model::ListLocationsRequest,
+    ) -> Result<model::ListLocationsResponse, Box<dyn std::error::Error>> {
+        let query_parameters = [
+            gax::query_parameter::format("filter", &req.filter)?,
+            gax::query_parameter::format("pageSize", &req.page_size)?,
+            gax::query_parameter::format("pageToken", &req.page_token)?,
+        ];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .get(format!(
+                "{}/v1/projects/{}/locations",
+                self.base_path, req.project,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::ListLocationsResponse>().await?;
+        Ok(response)
+    }
+
+    /// Gets information about a location.
+    pub async fn get_location(
+        &self,
+        req: model::GetLocationRequest,
+    ) -> Result<model::Location, Box<dyn std::error::Error>> {
+        let query_parameters = [None::<(&str, String)>; 0];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .get(format!(
+                "{}/v1/projects/{}/locations/{}",
+                self.base_path, req.project, req.location,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::Location>().await?;
+        Ok(response)
+    }
+
+    /// Lists Secrets.
+    pub async fn list_secrets(
+        &self,
+        req: model::ListSecretsRequest,
+    ) -> Result<model::ListSecretsResponse, Box<dyn std::error::Error>> {
+        let query_parameters = [
+            gax::query_parameter::format("pageSize", &req.page_size)?,
+            gax::query_parameter::format("pageToken", &req.page_token)?,
+            gax::query_parameter::format("filter", &req.filter)?,
+        ];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .get(format!(
+                "{}/v1/projects/{}/secrets",
+                self.base_path, req.project,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::ListSecretsResponse>().await?;
+        Ok(response)
+    }
+
+    /// Creates a new Secret containing no SecretVersions.
+    pub async fn create_secret(
+        &self,
+        req: model::Secret,
+    ) -> Result<model::Secret, Box<dyn std::error::Error>> {
+        let query_parameters = [gax::query_parameter::format("secretId", &req.secret_id)?];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .post(format!(
+                "{}/v1/projects/{}/secrets",
+                self.base_path, req.project,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .json(&req)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::Secret>().await?;
+        Ok(response)
+    }
+
+    /// Lists Secrets.
+    pub async fn list_secrets_by_project_and_location(
+        &self,
+        req: model::ListSecretsByProjectAndLocationRequest,
+    ) -> Result<model::ListSecretsResponse, Box<dyn std::error::Error>> {
+        let query_parameters = [
+            gax::query_parameter::format("pageSize", &req.page_size)?,
+            gax::query_parameter::format("pageToken", &req.page_token)?,
+            gax::query_parameter::format("filter", &req.filter)?,
+        ];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .get(format!(
+                "{}/v1/projects/{}/locations/{}/secrets",
+                self.base_path, req.project, req.location,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::ListSecretsResponse>().await?;
+        Ok(response)
+    }
+
+    /// Creates a new Secret containing no SecretVersions.
+    pub async fn create_secret_by_project_and_location(
+        &self,
+        req: model::Secret,
+    ) -> Result<model::Secret, Box<dyn std::error::Error>> {
+        let query_parameters = [gax::query_parameter::format("secretId", &req.secret_id)?];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .post(format!(
+                "{}/v1/projects/{}/locations/{}/secrets",
+                self.base_path, req.project, req.location,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .json(&req)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::Secret>().await?;
+        Ok(response)
+    }
+
+    /// Creates a new SecretVersion containing secret data and attaches
+    /// it to an existing Secret.
+    pub async fn add_secret_version(
+        &self,
+        req: model::AddSecretVersionRequest,
+    ) -> Result<model::SecretVersion, Box<dyn std::error::Error>> {
+        let query_parameters = [None::<(&str, String)>; 0];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .post(format!(
+                "{}/v1/projects/{}/secrets/{}:addVersion",
+                self.base_path, req.project, req.secret,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .json(&req)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::SecretVersion>().await?;
+        Ok(response)
+    }
+
+    /// Creates a new SecretVersion containing secret data and attaches
+    /// it to an existing Secret.
+    pub async fn add_secret_version_by_project_and_location_and_secret(
+        &self,
+        req: model::AddSecretVersionRequest,
+    ) -> Result<model::SecretVersion, Box<dyn std::error::Error>> {
+        let query_parameters = [None::<(&str, String)>; 0];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .post(format!(
+                "{}/v1/projects/{}/locations/{}/secrets/{}:addVersion",
+                self.base_path, req.project, req.location, req.secret,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .json(&req)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::SecretVersion>().await?;
+        Ok(response)
+    }
+
+    /// Gets metadata for a given Secret.
+    pub async fn get_secret(
+        &self,
+        req: model::GetSecretRequest,
+    ) -> Result<model::Secret, Box<dyn std::error::Error>> {
+        let query_parameters = [None::<(&str, String)>; 0];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .get(format!(
+                "{}/v1/projects/{}/secrets/{}",
+                self.base_path, req.project, req.secret,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::Secret>().await?;
+        Ok(response)
+    }
+
+    /// Deletes a Secret.
+    pub async fn delete_secret(
+        &self,
+        req: model::DeleteSecretRequest,
+    ) -> Result<model::Empty, Box<dyn std::error::Error>> {
+        let query_parameters = [gax::query_parameter::format("etag", &req.etag)?];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .delete(format!(
+                "{}/v1/projects/{}/secrets/{}",
+                self.base_path, req.project, req.secret,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::Empty>().await?;
+        Ok(response)
+    }
+
+    /// Updates metadata of an existing Secret.
+    pub async fn update_secret(
+        &self,
+        req: model::Secret,
+    ) -> Result<model::Secret, Box<dyn std::error::Error>> {
+        let query_parameters = [gax::query_parameter::format(
+            "updateMask",
+            &req.update_mask,
+        )?];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .patch(format!(
+                "{}/v1/projects/{}/secrets/{}",
+                self.base_path, req.project, req.secret,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .json(&req)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::Secret>().await?;
+        Ok(response)
+    }
+
+    /// Gets metadata for a given Secret.
+    pub async fn get_secret_by_project_and_location_and_secret(
+        &self,
+        req: model::GetSecretByProjectAndLocationAndSecretRequest,
+    ) -> Result<model::Secret, Box<dyn std::error::Error>> {
+        let query_parameters = [None::<(&str, String)>; 0];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .get(format!(
+                "{}/v1/projects/{}/locations/{}/secrets/{}",
+                self.base_path, req.project, req.location, req.secret,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::Secret>().await?;
+        Ok(response)
+    }
+
+    /// Deletes a Secret.
+    pub async fn delete_secret_by_project_and_location_and_secret(
+        &self,
+        req: model::DeleteSecretByProjectAndLocationAndSecretRequest,
+    ) -> Result<model::Empty, Box<dyn std::error::Error>> {
+        let query_parameters = [gax::query_parameter::format("etag", &req.etag)?];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .delete(format!(
+                "{}/v1/projects/{}/locations/{}/secrets/{}",
+                self.base_path, req.project, req.location, req.secret,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::Empty>().await?;
+        Ok(response)
+    }
+
+    /// Updates metadata of an existing Secret.
+    pub async fn update_secret_by_project_and_location_and_secret(
+        &self,
+        req: model::Secret,
+    ) -> Result<model::Secret, Box<dyn std::error::Error>> {
+        let query_parameters = [gax::query_parameter::format(
+            "updateMask",
+            &req.update_mask,
+        )?];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .patch(format!(
+                "{}/v1/projects/{}/locations/{}/secrets/{}",
+                self.base_path, req.project, req.location, req.secret,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .json(&req)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::Secret>().await?;
+        Ok(response)
+    }
+
+    /// Lists SecretVersions. This call does not return secret
+    /// data.
+    pub async fn list_secret_versions(
+        &self,
+        req: model::ListSecretVersionsRequest,
+    ) -> Result<model::ListSecretVersionsResponse, Box<dyn std::error::Error>> {
+        let query_parameters = [
+            gax::query_parameter::format("pageSize", &req.page_size)?,
+            gax::query_parameter::format("pageToken", &req.page_token)?,
+            gax::query_parameter::format("filter", &req.filter)?,
+        ];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .get(format!(
+                "{}/v1/projects/{}/secrets/{}/versions",
+                self.base_path, req.project, req.secret,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::ListSecretVersionsResponse>().await?;
+        Ok(response)
+    }
+
+    /// Lists SecretVersions. This call does not return secret
+    /// data.
+    pub async fn list_secret_versions_by_project_and_location_and_secret(
+        &self,
+        req: model::ListSecretVersionsByProjectAndLocationAndSecretRequest,
+    ) -> Result<model::ListSecretVersionsResponse, Box<dyn std::error::Error>> {
+        let query_parameters = [
+            gax::query_parameter::format("pageSize", &req.page_size)?,
+            gax::query_parameter::format("pageToken", &req.page_token)?,
+            gax::query_parameter::format("filter", &req.filter)?,
+        ];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .get(format!(
+                "{}/v1/projects/{}/locations/{}/secrets/{}/versions",
+                self.base_path, req.project, req.location, req.secret,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::ListSecretVersionsResponse>().await?;
+        Ok(response)
+    }
+
+    /// Gets metadata for a SecretVersion.
+    ///
+    /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
+    /// created SecretVersion.
+    pub async fn get_secret_version(
+        &self,
+        req: model::GetSecretVersionRequest,
+    ) -> Result<model::SecretVersion, Box<dyn std::error::Error>> {
+        let query_parameters = [None::<(&str, String)>; 0];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .get(format!(
+                "{}/v1/projects/{}/secrets/{}/versions/{}",
+                self.base_path, req.project, req.secret, req.version,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::SecretVersion>().await?;
+        Ok(response)
+    }
+
+    /// Gets metadata for a SecretVersion.
+    ///
+    /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
+    /// created SecretVersion.
+    pub async fn get_secret_version_by_project_and_location_and_secret_and_version(
+        &self,
+        req: model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest,
+    ) -> Result<model::SecretVersion, Box<dyn std::error::Error>> {
+        let query_parameters = [None::<(&str, String)>; 0];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .get(format!(
+                "{}/v1/projects/{}/locations/{}/secrets/{}/versions/{}",
+                self.base_path, req.project, req.location, req.secret, req.version,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::SecretVersion>().await?;
+        Ok(response)
+    }
+
+    /// Accesses a SecretVersion. This call returns the secret data.
+    ///
+    /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
+    /// created SecretVersion.
+    pub async fn access_secret_version(
+        &self,
+        req: model::AccessSecretVersionRequest,
+    ) -> Result<model::AccessSecretVersionResponse, Box<dyn std::error::Error>> {
+        let query_parameters = [None::<(&str, String)>; 0];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .get(format!(
+                "{}/v1/projects/{}/secrets/{}/versions/{}:access",
+                self.base_path, req.project, req.secret, req.version,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::AccessSecretVersionResponse>().await?;
+        Ok(response)
+    }
+
+    /// Accesses a SecretVersion. This call returns the secret data.
+    ///
+    /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
+    /// created SecretVersion.
+    pub async fn access_secret_version_by_project_and_location_and_secret_and_version(
+        &self,
+        req: model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest,
+    ) -> Result<model::AccessSecretVersionResponse, Box<dyn std::error::Error>> {
+        let query_parameters = [None::<(&str, String)>; 0];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .get(format!(
+                "{}/v1/projects/{}/locations/{}/secrets/{}/versions/{}:access",
+                self.base_path, req.project, req.location, req.secret, req.version,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::AccessSecretVersionResponse>().await?;
+        Ok(response)
+    }
+
+    /// Disables a SecretVersion.
+    ///
+    /// Sets the state of the SecretVersion to
+    /// DISABLED.
+    pub async fn disable_secret_version(
+        &self,
+        req: model::DisableSecretVersionRequest,
+    ) -> Result<model::SecretVersion, Box<dyn std::error::Error>> {
+        let query_parameters = [None::<(&str, String)>; 0];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .post(format!(
+                "{}/v1/projects/{}/secrets/{}/versions/{}:disable",
+                self.base_path, req.project, req.secret, req.version,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .json(&req)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::SecretVersion>().await?;
+        Ok(response)
+    }
+
+    /// Disables a SecretVersion.
+    ///
+    /// Sets the state of the SecretVersion to
+    /// DISABLED.
+    pub async fn disable_secret_version_by_project_and_location_and_secret_and_version(
+        &self,
+        req: model::DisableSecretVersionRequest,
+    ) -> Result<model::SecretVersion, Box<dyn std::error::Error>> {
+        let query_parameters = [None::<(&str, String)>; 0];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .post(format!(
+                "{}/v1/projects/{}/locations/{}/secrets/{}/versions/{}:disable",
+                self.base_path, req.project, req.location, req.secret, req.version,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .json(&req)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::SecretVersion>().await?;
+        Ok(response)
+    }
+
+    /// Enables a SecretVersion.
+    ///
+    /// Sets the state of the SecretVersion to
+    /// ENABLED.
+    pub async fn enable_secret_version(
+        &self,
+        req: model::EnableSecretVersionRequest,
+    ) -> Result<model::SecretVersion, Box<dyn std::error::Error>> {
+        let query_parameters = [None::<(&str, String)>; 0];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .post(format!(
+                "{}/v1/projects/{}/secrets/{}/versions/{}:enable",
+                self.base_path, req.project, req.secret, req.version,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .json(&req)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::SecretVersion>().await?;
+        Ok(response)
+    }
+
+    /// Enables a SecretVersion.
+    ///
+    /// Sets the state of the SecretVersion to
+    /// ENABLED.
+    pub async fn enable_secret_version_by_project_and_location_and_secret_and_version(
+        &self,
+        req: model::EnableSecretVersionRequest,
+    ) -> Result<model::SecretVersion, Box<dyn std::error::Error>> {
+        let query_parameters = [None::<(&str, String)>; 0];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .post(format!(
+                "{}/v1/projects/{}/locations/{}/secrets/{}/versions/{}:enable",
+                self.base_path, req.project, req.location, req.secret, req.version,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .json(&req)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::SecretVersion>().await?;
+        Ok(response)
+    }
+
+    /// Destroys a SecretVersion.
+    ///
+    /// Sets the state of the SecretVersion to
+    /// DESTROYED and irrevocably destroys the
+    /// secret data.
+    pub async fn destroy_secret_version(
+        &self,
+        req: model::DestroySecretVersionRequest,
+    ) -> Result<model::SecretVersion, Box<dyn std::error::Error>> {
+        let query_parameters = [None::<(&str, String)>; 0];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .post(format!(
+                "{}/v1/projects/{}/secrets/{}/versions/{}:destroy",
+                self.base_path, req.project, req.secret, req.version,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .json(&req)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::SecretVersion>().await?;
+        Ok(response)
+    }
+
+    /// Destroys a SecretVersion.
+    ///
+    /// Sets the state of the SecretVersion to
+    /// DESTROYED and irrevocably destroys the
+    /// secret data.
+    pub async fn destroy_secret_version_by_project_and_location_and_secret_and_version(
+        &self,
+        req: model::DestroySecretVersionRequest,
+    ) -> Result<model::SecretVersion, Box<dyn std::error::Error>> {
+        let query_parameters = [None::<(&str, String)>; 0];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .post(format!(
+                "{}/v1/projects/{}/locations/{}/secrets/{}/versions/{}:destroy",
+                self.base_path, req.project, req.location, req.secret, req.version,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .json(&req)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::SecretVersion>().await?;
+        Ok(response)
+    }
+
+    /// Sets the access control policy on the specified secret. Replaces any
+    /// existing policy.
+    ///
+    /// Permissions on SecretVersions are enforced according
+    /// to the policy set on the associated Secret.
+    pub async fn set_iam_policy(
+        &self,
+        req: model::SetIamPolicyRequest,
+    ) -> Result<model::Policy, Box<dyn std::error::Error>> {
+        let query_parameters = [None::<(&str, String)>; 0];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .post(format!(
+                "{}/v1/projects/{}/secrets/{}:setIamPolicy",
+                self.base_path, req.project, req.secret,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .json(&req)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::Policy>().await?;
+        Ok(response)
+    }
+
+    /// Sets the access control policy on the specified secret. Replaces any
+    /// existing policy.
+    ///
+    /// Permissions on SecretVersions are enforced according
+    /// to the policy set on the associated Secret.
+    pub async fn set_iam_policy_by_project_and_location_and_secret(
+        &self,
+        req: model::SetIamPolicyRequest,
+    ) -> Result<model::Policy, Box<dyn std::error::Error>> {
+        let query_parameters = [None::<(&str, String)>; 0];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .post(format!(
+                "{}/v1/projects/{}/locations/{}/secrets/{}:setIamPolicy",
+                self.base_path, req.project, req.location, req.secret,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .json(&req)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::Policy>().await?;
+        Ok(response)
+    }
+
+    /// Gets the access control policy for a secret.
+    /// Returns empty policy if the secret exists and does not have a policy set.
+    pub async fn get_iam_policy(
+        &self,
+        req: model::GetIamPolicyRequest,
+    ) -> Result<model::Policy, Box<dyn std::error::Error>> {
+        let query_parameters = [gax::query_parameter::format(
+            "options.requestedPolicyVersion",
+            &req.options_requested_policy_version,
+        )?];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .get(format!(
+                "{}/v1/projects/{}/secrets/{}:getIamPolicy",
+                self.base_path, req.project, req.secret,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::Policy>().await?;
+        Ok(response)
+    }
+
+    /// Gets the access control policy for a secret.
+    /// Returns empty policy if the secret exists and does not have a policy set.
+    pub async fn get_iam_policy_by_project_and_location_and_secret(
+        &self,
+        req: model::GetIamPolicyByProjectAndLocationAndSecretRequest,
+    ) -> Result<model::Policy, Box<dyn std::error::Error>> {
+        let query_parameters = [gax::query_parameter::format(
+            "options.requestedPolicyVersion",
+            &req.options_requested_policy_version,
+        )?];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .get(format!(
+                "{}/v1/projects/{}/locations/{}/secrets/{}:getIamPolicy",
+                self.base_path, req.project, req.location, req.secret,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::Policy>().await?;
+        Ok(response)
+    }
+
+    /// Returns permissions that a caller has for the specified secret.
+    /// If the secret does not exist, this call returns an empty set of
+    /// permissions, not a NOT_FOUND error.
+    ///
+    /// Note: This operation is designed to be used for building permission-aware
+    /// UIs and command-line tools, not for authorization checking. This operation
+    /// may "fail open" without warning.
+    pub async fn test_iam_permissions(
+        &self,
+        req: model::TestIamPermissionsRequest,
+    ) -> Result<model::TestIamPermissionsResponse, Box<dyn std::error::Error>> {
+        let query_parameters = [None::<(&str, String)>; 0];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .post(format!(
+                "{}/v1/projects/{}/secrets/{}:testIamPermissions",
+                self.base_path, req.project, req.secret,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .json(&req)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::TestIamPermissionsResponse>().await?;
+        Ok(response)
+    }
+
+    /// Returns permissions that a caller has for the specified secret.
+    /// If the secret does not exist, this call returns an empty set of
+    /// permissions, not a NOT_FOUND error.
+    ///
+    /// Note: This operation is designed to be used for building permission-aware
+    /// UIs and command-line tools, not for authorization checking. This operation
+    /// may "fail open" without warning.
+    pub async fn test_iam_permissions_by_project_and_location_and_secret(
+        &self,
+        req: model::TestIamPermissionsRequest,
+    ) -> Result<model::TestIamPermissionsResponse, Box<dyn std::error::Error>> {
+        let query_parameters = [None::<(&str, String)>; 0];
+        let client = self.client.inner.clone();
+        let res = client
+            .http_client
+            .post(format!(
+                "{}/v1/projects/{}/locations/{}/secrets/{}:testIamPermissions",
+                self.base_path, req.project, req.location, req.secret,
+            ))
+            .query(&[("alt", "json")])
+            .query(
+                &query_parameters
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<(&str, String)>>(),
+            )
+            .bearer_auth(&client.token)
+            .json(&req)
+            .send()
+            .await?;
+        if !res.status().is_success() {
+            return Err(
+                "sorry the api you are looking for is not available, please try again".into(),
+            );
+        }
+        let response = res.json::<model::TestIamPermissionsResponse>().await?;
+        Ok(response)
+    }
 }

--- a/generator/testdata/rust/openapi/golden/src/model.rs
+++ b/generator/testdata/rust/openapi/golden/src/model.rs
@@ -149,6 +149,25 @@ pub struct Secret {
     /// SecretVersions added afterwards. They do not apply
     /// retroactively to existing SecretVersions.
     pub customer_managed_encryption: Option<crate::model::CustomerManagedEncryption>,
+
+    ///
+    pub project: String,
+
+    /// Required. This must be unique within the project.
+    ///
+    /// A secret ID is a string with a maximum length of 255 characters and can
+    /// contain uppercase and lowercase letters, numerals, and the hyphen (`-`) and
+    /// underscore (`_`) characters.
+    pub secret_id: String,
+
+    ///
+    pub location: String,
+
+    ///
+    pub secret: String,
+
+    /// Required. Specifies the fields to be updated.
+    pub update_mask: gax_placeholder::FieldMask,
 }
 
 /// A policy that defines the replication and encryption configuration of data.
@@ -273,6 +292,15 @@ pub struct Rotation {
 pub struct AddSecretVersionRequest {
     /// Required. The secret payload of the SecretVersion.
     pub payload: Option<crate::model::SecretPayload>,
+
+    ///
+    pub project: String,
+
+    ///
+    pub secret: String,
+
+    ///
+    pub location: String,
 }
 
 /// A secret payload resource in the Secret Manager API. This contains the
@@ -468,6 +496,18 @@ pub struct DisableSecretVersionRequest {
     /// the etag of the currently stored secret version object. If the etag is
     /// omitted, the request succeeds.
     pub etag: Option<String>,
+
+    ///
+    pub project: String,
+
+    ///
+    pub secret: String,
+
+    ///
+    pub version: String,
+
+    ///
+    pub location: String,
 }
 
 /// Request message for SecretManagerService.EnableSecretVersion.
@@ -479,6 +519,18 @@ pub struct EnableSecretVersionRequest {
     /// the etag of the currently stored secret version object. If the etag is
     /// omitted, the request succeeds.
     pub etag: Option<String>,
+
+    ///
+    pub project: String,
+
+    ///
+    pub secret: String,
+
+    ///
+    pub version: String,
+
+    ///
+    pub location: String,
 }
 
 /// Request message for SecretManagerService.DestroySecretVersion.
@@ -490,6 +542,18 @@ pub struct DestroySecretVersionRequest {
     /// the etag of the currently stored secret version object. If the etag is
     /// omitted, the request succeeds.
     pub etag: Option<String>,
+
+    ///
+    pub project: String,
+
+    ///
+    pub secret: String,
+
+    ///
+    pub version: String,
+
+    ///
+    pub location: String,
 }
 
 /// Request message for `SetIamPolicy` method.
@@ -509,6 +573,15 @@ pub struct SetIamPolicyRequest {
     ///
     /// `paths: "bindings, etag"`
     pub update_mask: Option<gax_placeholder::FieldMask>,
+
+    ///
+    pub project: String,
+
+    ///
+    pub secret: String,
+
+    ///
+    pub location: String,
 }
 
 /// An Identity and Access Management (IAM) policy, which specifies access
@@ -914,6 +987,15 @@ pub struct TestIamPermissionsRequest {
     /// information see
     /// [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
     pub permissions: Vec<String>,
+
+    ///
+    pub project: String,
+
+    ///
+    pub secret: String,
+
+    ///
+    pub location: String,
 }
 
 /// Response message for `TestIamPermissions` method.
@@ -924,4 +1006,347 @@ pub struct TestIamPermissionsResponse {
     /// A subset of `TestPermissionsRequest.permissions` that the caller is
     /// allowed.
     pub permissions: Vec<String>,
+}
+
+/// The request message for ListLocations.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct ListLocationsRequest {
+    ///
+    pub project: String,
+
+    /// A filter to narrow down results to a preferred subset.
+    /// The filtering language accepts strings like `"displayName=tokyo"`, and
+    /// is documented in more detail in [AIP-160](https://google.aip.dev/160).
+    pub filter: Option<String>,
+
+    /// The maximum number of results to return.
+    /// If not set, the service selects a default.
+    pub page_size: Option<i32>,
+
+    /// A page token received from the `next_page_token` field in the response.
+    /// Send that page token to receive the subsequent page.
+    pub page_token: Option<String>,
+}
+
+/// The request message for GetLocation.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct GetLocationRequest {
+    ///
+    pub project: String,
+
+    ///
+    pub location: String,
+}
+
+/// The request message for ListSecrets.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct ListSecretsRequest {
+    ///
+    pub project: String,
+
+    /// Optional. The maximum number of results to be returned in a single page. If
+    /// set to 0, the server decides the number of results to return. If the
+    /// number is greater than 25000, it is capped at 25000.
+    pub page_size: Option<i32>,
+
+    /// Optional. Pagination token, returned earlier via
+    /// ListSecretsResponse.next_page_token.
+    pub page_token: Option<String>,
+
+    /// Optional. Filter string, adhering to the rules in
+    /// [List-operation
+    /// filtering](https://cloud.google.com/secret-manager/docs/filtering). List
+    /// only secrets matching the filter. If filter is empty, all secrets are
+    /// listed.
+    pub filter: Option<String>,
+}
+
+/// The request message for ListSecretsByProjectAndLocation.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct ListSecretsByProjectAndLocationRequest {
+    ///
+    pub project: String,
+
+    ///
+    pub location: String,
+
+    /// Optional. The maximum number of results to be returned in a single page. If
+    /// set to 0, the server decides the number of results to return. If the
+    /// number is greater than 25000, it is capped at 25000.
+    pub page_size: Option<i32>,
+
+    /// Optional. Pagination token, returned earlier via
+    /// ListSecretsResponse.next_page_token.
+    pub page_token: Option<String>,
+
+    /// Optional. Filter string, adhering to the rules in
+    /// [List-operation
+    /// filtering](https://cloud.google.com/secret-manager/docs/filtering). List
+    /// only secrets matching the filter. If filter is empty, all secrets are
+    /// listed.
+    pub filter: Option<String>,
+}
+
+/// The request message for GetSecret.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct GetSecretRequest {
+    ///
+    pub project: String,
+
+    ///
+    pub secret: String,
+}
+
+/// The request message for DeleteSecret.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct DeleteSecretRequest {
+    ///
+    pub project: String,
+
+    ///
+    pub secret: String,
+
+    /// Optional. Etag of the Secret. The request succeeds if it matches
+    /// the etag of the currently stored secret object. If the etag is omitted,
+    /// the request succeeds.
+    pub etag: Option<String>,
+}
+
+/// The request message for GetSecretByProjectAndLocationAndSecret.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct GetSecretByProjectAndLocationAndSecretRequest {
+    ///
+    pub project: String,
+
+    ///
+    pub location: String,
+
+    ///
+    pub secret: String,
+}
+
+/// The request message for DeleteSecretByProjectAndLocationAndSecret.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct DeleteSecretByProjectAndLocationAndSecretRequest {
+    ///
+    pub project: String,
+
+    ///
+    pub location: String,
+
+    ///
+    pub secret: String,
+
+    /// Optional. Etag of the Secret. The request succeeds if it matches
+    /// the etag of the currently stored secret object. If the etag is omitted,
+    /// the request succeeds.
+    pub etag: Option<String>,
+}
+
+/// The request message for ListSecretVersions.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct ListSecretVersionsRequest {
+    ///
+    pub project: String,
+
+    ///
+    pub secret: String,
+
+    /// Optional. The maximum number of results to be returned in a single page. If
+    /// set to 0, the server decides the number of results to return. If the
+    /// number is greater than 25000, it is capped at 25000.
+    pub page_size: Option<i32>,
+
+    /// Optional. Pagination token, returned earlier via
+    /// ListSecretVersionsResponse.next_page_token][].
+    pub page_token: Option<String>,
+
+    /// Optional. Filter string, adhering to the rules in
+    /// [List-operation
+    /// filtering](https://cloud.google.com/secret-manager/docs/filtering). List
+    /// only secret versions matching the filter. If filter is empty, all secret
+    /// versions are listed.
+    pub filter: Option<String>,
+}
+
+/// The request message for ListSecretVersionsByProjectAndLocationAndSecret.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct ListSecretVersionsByProjectAndLocationAndSecretRequest {
+    ///
+    pub project: String,
+
+    ///
+    pub location: String,
+
+    ///
+    pub secret: String,
+
+    /// Optional. The maximum number of results to be returned in a single page. If
+    /// set to 0, the server decides the number of results to return. If the
+    /// number is greater than 25000, it is capped at 25000.
+    pub page_size: Option<i32>,
+
+    /// Optional. Pagination token, returned earlier via
+    /// ListSecretVersionsResponse.next_page_token][].
+    pub page_token: Option<String>,
+
+    /// Optional. Filter string, adhering to the rules in
+    /// [List-operation
+    /// filtering](https://cloud.google.com/secret-manager/docs/filtering). List
+    /// only secret versions matching the filter. If filter is empty, all secret
+    /// versions are listed.
+    pub filter: Option<String>,
+}
+
+/// The request message for GetSecretVersion.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct GetSecretVersionRequest {
+    ///
+    pub project: String,
+
+    ///
+    pub secret: String,
+
+    ///
+    pub version: String,
+}
+
+/// The request message for GetSecretVersionByProjectAndLocationAndSecretAndVersion.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest {
+    ///
+    pub project: String,
+
+    ///
+    pub location: String,
+
+    ///
+    pub secret: String,
+
+    ///
+    pub version: String,
+}
+
+/// The request message for AccessSecretVersion.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct AccessSecretVersionRequest {
+    ///
+    pub project: String,
+
+    ///
+    pub secret: String,
+
+    ///
+    pub version: String,
+}
+
+/// The request message for AccessSecretVersionByProjectAndLocationAndSecretAndVersion.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest {
+    ///
+    pub project: String,
+
+    ///
+    pub location: String,
+
+    ///
+    pub secret: String,
+
+    ///
+    pub version: String,
+}
+
+/// The request message for GetIamPolicy.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct GetIamPolicyRequest {
+    ///
+    pub project: String,
+
+    ///
+    pub secret: String,
+
+    /// Optional. The maximum policy version that will be used to format the
+    /// policy.
+    ///
+    /// Valid values are 0, 1, and 3. Requests specifying an invalid value will be
+    /// rejected.
+    ///
+    /// Requests for policies with any conditional role bindings must specify
+    /// version 3. Policies with no conditional role bindings may specify any valid
+    /// value or leave the field unset.
+    ///
+    /// The policy in the response might use the policy version that you specified,
+    /// or it might use a lower policy version. For example, if you specify version
+    /// 3, but the policy has no conditional role bindings, the response uses
+    /// version 1.
+    ///
+    /// To learn which resources support conditions in their IAM policies, see the
+    /// [IAM
+    /// documentation](https://cloud.google.com/iam/help/conditions/resource-policies).
+    pub options_requested_policy_version: Option<i32>,
+}
+
+/// The request message for GetIamPolicyByProjectAndLocationAndSecret.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct GetIamPolicyByProjectAndLocationAndSecretRequest {
+    ///
+    pub project: String,
+
+    ///
+    pub location: String,
+
+    ///
+    pub secret: String,
+
+    /// Optional. The maximum policy version that will be used to format the
+    /// policy.
+    ///
+    /// Valid values are 0, 1, and 3. Requests specifying an invalid value will be
+    /// rejected.
+    ///
+    /// Requests for policies with any conditional role bindings must specify
+    /// version 3. Policies with no conditional role bindings may specify any valid
+    /// value or leave the field unset.
+    ///
+    /// The policy in the response might use the policy version that you specified,
+    /// or it might use a lower policy version. For example, if you specify version
+    /// 3, but the policy has no conditional role bindings, the response uses
+    /// version 1.
+    ///
+    /// To learn which resources support conditions in their IAM policies, see the
+    /// [IAM
+    /// documentation](https://cloud.google.com/iam/help/conditions/resource-policies).
+    pub options_requested_policy_version: Option<i32>,
 }


### PR DESCRIPTION
Use the information from the `paths` section to find out what RPCs are
available. They all go into the same service, because there is nothing obvious
to use.

We create synthetic request objects because the OpenAPI spec does not seem to
have them for all RPCs. We inject the require path and query parameters into
the request object, whether that is synthetic or included by the specification.

Fixes #120 and fixes #128 and fixes #129
