### PR TITLE
refactor(gax): extract request parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,6 +350,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "thiserror 2.0.1",
  "types",
 ]
 
@@ -384,7 +385,7 @@ dependencies = [
  "rustls-pemfile 0.2.1",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.65",
  "tokio",
 ]
 
@@ -1441,9 +1442,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.85"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1559,7 +1560,16 @@ version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.65",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c1e40dd48a282ae8edc36c732cbc219144b87fb6a4c7316d611c6b1f06ec0c"
+dependencies = [
+ "thiserror-impl 2.0.1",
 ]
 
 [[package]]
@@ -1567,6 +1577,17 @@ name = "thiserror-impl"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874aa7e446f1da8d9c3a5c95b1c5eb41d800045252121dc7f8e0ba370cee55f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/gax/Cargo.toml
+++ b/gax/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2021"
 
 [dependencies]
 serde_json = "1.0.132"
+thiserror = "2.0.1"
 types = { version = "0.1.0", path = "../types" }
 
 [dev-dependencies]

--- a/gax/src/lib.rs
+++ b/gax/src/lib.rs
@@ -12,6 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Google APIs helpers.
+//! 
+//! This crate contains a number of types and functions used in the
+//! implementation of the Google Cloud SDK for Rust. Unless otherwise noted,
+//! these are **not** intended for general use. This crate will remain unstable
+//! for the foreseeable future, even if used in stable SDKs. We (the Google
+//! Cloud SDK for Rust team) control both and will change both if needed.
+
 /// Defines traits and helpers to serialize query parameters.
 ///
 /// Query parameters in the Google APIs can be types other than strings and
@@ -29,3 +37,6 @@
 /// public because we will generate many crates (roughly one per service), and
 /// most of these crates will use these helpers.
 pub mod query_parameter;
+
+/// Implementation details for [query_parameter](::crate::query_parameter).
+mod request_parameter;

--- a/gax/src/query_parameter.rs
+++ b/gax/src/query_parameter.rs
@@ -12,13 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub type Error = serde_json::Error;
-type Result = serde_json::Result<String>;
+type Result<T> = std::result::Result<T, crate::request_parameter::Error>;
 
+/// Formats a query parameter.
+/// 
+/// Google APIs use [gRPC Transcoding](https://google.aip.dev/127). Some request
+/// fields are sent as query parameters and may need special formatting:
+/// - [Option] fields that do not contain a value are not included in the HTTP
+///   query.
+/// - Fields of well-known types are formatted as strings. These include
+///   [Duration](types::Duration), [FieldMask](types::FieldMask), and
+///   [Timestamp](types::Timestamp).
+/// - Simple scalars are formatted as usual.
+/// 
+/// This function is called from the generated code. It is not intended for
+/// general use. The goal  
 pub fn format<T>(
     name: &'static str,
     parameter: &T,
-) -> serde_json::Result<Option<(&'static str, String)>>
+) -> Result<Option<(&'static str, String)>>
 where
     T: QueryParameter,
 {
@@ -27,84 +39,22 @@ where
         .transpose()
 }
 
+/// [QueryParameter] is a trait representing types that can be used as a query
+/// parameter.
+/// 
 pub trait QueryParameter {
-    fn format(&self) -> Option<Result>;
+    fn format(&self) -> Option<Result<String>>;
 }
 
 impl<T: QueryParameter> QueryParameter for Option<T> {
-    fn format(&self) -> Option<Result> {
+    fn format(&self) -> Option<Result<String>> {
         self.as_ref().and_then(|v| QueryParameter::format(v))
     }
 }
 
-impl<T: RequiredQueryParameter> QueryParameter for T {
-    fn format(&self) -> Option<Result> {
-        Some(RequiredQueryParameter::format(self))
-    }
-}
-
-/// Format query parameters as strings.
-trait RequiredQueryParameter {
-    fn format(&self) -> Result;
-}
-
-impl RequiredQueryParameter for String {
-    fn format(&self) -> Result {
-        Ok(self.clone())
-    }
-}
-
-impl RequiredQueryParameter for i32 {
-    fn format(&self) -> Result {
-        Ok(format!("{self}"))
-    }
-}
-
-impl RequiredQueryParameter for u32 {
-    fn format(&self) -> Result {
-        Ok(format!("{self}"))
-    }
-}
-
-impl RequiredQueryParameter for i64 {
-    fn format(&self) -> Result {
-        Ok(format!("{self}"))
-    }
-}
-
-impl RequiredQueryParameter for u64 {
-    fn format(&self) -> Result {
-        Ok(format!("{self}"))
-    }
-}
-
-impl RequiredQueryParameter for f32 {
-    fn format(&self) -> Result {
-        Ok(format!("{self}"))
-    }
-}
-
-impl RequiredQueryParameter for f64 {
-    fn format(&self) -> Result {
-        Ok(format!("{self}"))
-    }
-}
-
-impl RequiredQueryParameter for types::Duration {
-    fn format(&self) -> Result {
-        Ok(serde_json::to_value(self)?.as_str().unwrap().to_string())
-    }
-}
-
-impl RequiredQueryParameter for types::FieldMask {
-    fn format(&self) -> Result {
-        Ok(self.paths.join(","))
-    }
-}
-
-impl RequiredQueryParameter for types::Timestamp {
-    fn format(&self) -> Result {
-        Ok(serde_json::to_value(self)?.as_str().unwrap().to_string())
+impl<T: crate::request_parameter::RequestParameter> QueryParameter for T {
+    fn format(&self) -> Option<Result<String>> {
+        Some(self.format())
     }
 }
 

--- a/gax/src/request_parameter.rs
+++ b/gax/src/request_parameter.rs
@@ -1,0 +1,99 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+type Result = std::result::Result<String, Error>;
+
+pub(crate) trait RequestParameter {
+    fn format(&self) -> Result;
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("cannot format as request parameter {0:?}")]
+    Format(Box<dyn std::error::Error>),
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(e: serde_json::Error) -> Self {
+        Self::Format(e.into())
+    }
+}
+
+impl RequestParameter for i32 { fn format(&self) -> Result { Ok(format!("{self}")) } }
+impl RequestParameter for i64 { fn format(&self) -> Result { Ok(format!("{self}")) } }
+impl RequestParameter for u32 { fn format(&self) -> Result { Ok(format!("{self}")) } }
+impl RequestParameter for u64 { fn format(&self) -> Result { Ok(format!("{self}")) } }
+impl RequestParameter for f32 { fn format(&self) -> Result { Ok(format!("{self}")) } }
+impl RequestParameter for f64 { fn format(&self) -> Result { Ok(format!("{self}")) } }
+impl RequestParameter for String { fn format(&self) -> Result { Ok(self.clone()) } }
+
+impl RequestParameter for types::Duration {  
+    fn format(&self) -> Result {
+        Ok(serde_json::to_value(self)?.as_str().unwrap().to_string())
+    }
+}
+
+impl RequestParameter for types::FieldMask {  
+    fn format(&self) -> Result {
+        Ok(self.paths.join(","))
+    }
+}
+
+impl RequestParameter for types::Timestamp {  
+    fn format(&self) -> Result {
+        Ok(serde_json::to_value(self)?.as_str().unwrap().to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+    #[test]
+    fn with_value() -> Result {
+        let want = "42".to_string();
+        assert_eq!(want, RequestParameter::format(&42_i32)?);
+        assert_eq!(want, RequestParameter::format(&42_i64)?);
+        assert_eq!(want, RequestParameter::format(&42_u32)?);
+        assert_eq!(want, RequestParameter::format(&42_u64)?);
+        assert_eq!(want, RequestParameter::format(&42_f32)?);
+        assert_eq!(want, RequestParameter::format(&42_f64)?);
+        Ok(())
+    }
+
+    #[test]
+    fn duration() -> Result {
+        let d = types::Duration::new(12, 345_678_900);
+        let f = RequestParameter::format(&d)?;
+        assert_eq!("12.345678900s", f);
+        Ok(())
+    }
+
+    #[test]
+    fn field_mask() -> Result {
+        let fm = types::FieldMask::default().set_paths(["a", "b"].map(str::to_string).to_vec());
+        let f = RequestParameter::format(&fm)?;
+        assert_eq!("a,b", f);
+        Ok(())
+    }
+
+    #[test]
+    fn timestamp() -> Result {
+        let ts = types::Timestamp::default();
+        let f = RequestParameter::format(&ts)?;
+        assert_eq!("1970-01-01T00:00:00Z", f);
+        Ok(())
+    }
+}


### PR DESCRIPTION
Refactor a trait to represent "a request parameter". Both "query parameters"
(represented by `query_parameter::QueryParameter`) and the upcoming "path
parameters" will use this trait.

Fixes #140
