### PR TITLE
fix(generator/protobuf): handle body in query parameters

### DIFF
--- a/generator/internal/genclient/translator/protobuf/annotations.go
+++ b/generator/internal/genclient/translator/protobuf/annotations.go
@@ -69,6 +69,10 @@ func queryParameters(m *descriptorpb.MethodDescriptorProto, pathTemplate []gencl
 		return nil, fmt.Errorf("unable to lookup type %s", m.GetInputType())
 	}
 	params := map[string]bool{}
+	if body == "*" {
+		// All parameters are body parameters.
+		return params, nil
+	}
 	// Start with all the fields marked as query parameters.
 	for _, field := range msg.Fields {
 		params[field.Name] = true
@@ -78,7 +82,7 @@ func queryParameters(m *descriptorpb.MethodDescriptorProto, pathTemplate []gencl
 			delete(params, *s.FieldPath)
 		}
 	}
-	if body != "" && body != "*" {
+	if body != "" {
 		delete(params, body)
 	}
 	return params, nil

--- a/generator/internal/genclient/translator/protobuf/protobuf_test.go
+++ b/generator/internal/genclient/translator/protobuf/protobuf_test.go
@@ -542,6 +542,55 @@ func TestService(t *testing.T) {
 	})
 }
 
+func TestQueryParameters(t *testing.T) {
+	api := makeAPI(nil, newCodeGeneratorRequest(t, "query_parameters.proto"))
+
+	service, ok := api.State.ServiceByID[".test.TestService"]
+	if !ok {
+		t.Fatalf("Cannot find service %s in API State", ".test.TestService")
+	}
+	checkService(t, *service, genclient.Service{
+		Name:          "TestService",
+		ID:            ".test.TestService",
+		Documentation: "A service to unit test the protobuf translator.",
+		DefaultHost:   "test.googleapis.com",
+		Methods: []*genclient.Method{
+			{
+				Name:          "CreateFoo",
+				Documentation: "Creates a new `Foo` resource. `Foo`s are containers for `Bar`s.\n\nShows how a `body: \"${field}\"` option works.",
+				InputTypeID:   ".test.CreateFooRequest",
+				OutputTypeID:  ".test.Foo",
+				PathInfo: &genclient.PathInfo{
+					Verb: "POST",
+					PathTemplate: []genclient.PathSegment{
+						genclient.NewLiteralPathSegment("v1"),
+						genclient.NewFieldPathPathSegment("parent"),
+						genclient.NewLiteralPathSegment("foos"),
+					},
+					QueryParameters: map[string]bool{"foo_id": true},
+					BodyFieldPath:   "bar",
+				},
+			},
+			{
+				Name:          "AddBar",
+				Documentation: "Add a Bar resource.\n\nShows how a `body: \"*\"` option works.",
+				InputTypeID:   ".test.AddBarRequest",
+				OutputTypeID:  ".test.Bar",
+				PathInfo: &genclient.PathInfo{
+					Verb: "POST",
+					PathTemplate: []genclient.PathSegment{
+						genclient.NewLiteralPathSegment("v1"),
+						genclient.NewFieldPathPathSegment("parent"),
+						genclient.NewVerbPathSegment("addFoo"),
+					},
+					QueryParameters: map[string]bool{},
+					BodyFieldPath:   "*",
+				},
+			},
+		},
+	})
+}
+
 func newCodeGeneratorRequest(t *testing.T, filename string) *pluginpb.CodeGeneratorRequest {
 	t.Helper()
 	tempFile, err := os.CreateTemp("", "protoc-out-")

--- a/generator/internal/genclient/translator/protobuf/testdata/query_parameters.proto
+++ b/generator/internal/genclient/translator/protobuf/testdata/query_parameters.proto
@@ -1,0 +1,112 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package test;
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "google/protobuf/timestamp.proto";
+
+// A service to unit test the protobuf translator.
+service TestService {
+  option (google.api.default_host) = "test.googleapis.com";
+  option (google.api.oauth_scopes) =
+      "https://www.googleapis.com/auth/cloud-platform";
+
+  // Creates a new `Foo` resource. `Foo`s are containers for `Bar`s.
+  //
+  // Shows how a `body: "${field}"` option works.
+  rpc CreateFoo(CreateFooRequest) returns (Foo) {
+    option (google.api.http) = {
+      post: "/v1/{parent=projects/*}/foos"
+      body: "bar"
+    };
+    option (google.api.method_signature) = "parent,foo_id,bar";
+  }
+
+  // Add a Bar resource.
+  //
+  // Shows how a `body: "*"` option works.
+  rpc AddBar(AddBarRequest) returns (Bar) {
+    option (google.api.http) = {
+      post: "/v1/{parent=projects/*/foos/*}:addFoo"
+      body: "*"
+    };
+    option (google.api.method_signature) = "parent,payload";
+  }
+}
+
+// Request message for `CreateFoo`.
+message CreateFooRequest {
+  // Required. The resource name of the project to associate with the
+  // [Secret][google.cloud.secretmanager.v1.Secret], in the format `projects/*`.
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "cloudresourcemanager.googleapis.com/Project"
+    }
+  ];
+
+  // Required. This must be unique within the project.
+  string foo_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. A `Bar` with initial values.
+  Bar bar = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// The `Foo` resource.
+message Foo {
+  option (google.api.resource) = {
+    type: "test.googleapis.com/Foo"
+    pattern: "projects/{project}/foos/{foo}"
+  };
+
+  // Output only. The resource name of `Foo`, in the format
+  // `projects/{project}/foos/{foo}`.
+  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Output only. The contained `Bar`s.
+  repeated Bar bar = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// Request message for `AddBar`.
+message AddBarRequest {
+  // Required. The resource name of the `Foo` that will contain the `Bar`.
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = { type: "test.googleapis.com/Foo" }
+  ];
+
+  // Required. Some extra stuff to make the test less trivial.
+  string payload = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// The `Bar` resource.
+message Bar {
+  option (google.api.resource) = {
+    type: "test.googleapis.com/Bar"
+    pattern: "projects/{project}/foos/{foo}/bars/{bar}"
+  };
+
+  // Output only. The resource name of `Bar`, in the format
+  // `projects/{project}/foos/{foo}/bars/{bar}`.
+  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Output only. The time at which the `Bar`.
+  google.protobuf.Timestamp create_time = 2
+      [(google.api.field_behavior) = OUTPUT_ONLY];
+}


### PR DESCRIPTION
When the RPC has a `body: "*"` annotation then none of the request fields are
query parameters.

Fixes #142
