### PR TITLE
fix(generator/protobuf): not all object fields are repeated

### DIFF
--- a/generator/internal/genclient/translator/protobuf/protobuf.go
+++ b/generator/internal/genclient/translator/protobuf/protobuf.go
@@ -193,7 +193,9 @@ func normalizeTypes(state *genclient.APIState, in *descriptorpb.FieldDescriptorP
 			// as they typically are represented by a single `map<k, v>`-like
 			// datatype. Protobuf leaks the wire-representation of maps, i.e.,
 			// repeated pairs.
-			field.Repeated = !message.IsMap
+			if message.IsMap {
+				field.Repeated = false
+			}
 		}
 	case descriptorpb.FieldDescriptorProto_TYPE_ENUM:
 		field.TypezID = in.GetTypeName()

--- a/generator/internal/genclient/translator/protobuf/protobuf_test.go
+++ b/generator/internal/genclient/translator/protobuf/protobuf_test.go
@@ -442,6 +442,69 @@ func TestObjectFields(t *testing.T) {
 	})
 }
 
+func TestWellKnownTypeFields(t *testing.T) {
+	api := makeAPI(nil, newCodeGeneratorRequest(t, "wkt_fields.proto"))
+
+	message, ok := api.State.MessageByID[".test.Fake"]
+	if !ok {
+		t.Fatalf("Cannot find message %s in API State", ".test.Fake")
+	}
+	checkMessage(t, *message, genclient.Message{
+		Name: "Fake",
+		ID:   ".test.Fake",
+		Fields: []*genclient.Field{
+			{
+				Name:     "field_mask",
+				JSONName: "fieldMask",
+				ID:       ".test.Fake.field_mask",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  ".google.protobuf.FieldMask",
+				Optional: true,
+			},
+			{
+				Name:     "timestamp",
+				JSONName: "timestamp",
+				ID:       ".test.Fake.timestamp",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  ".google.protobuf.Timestamp",
+				Optional: true,
+			},
+			{
+				Name:     "any",
+				JSONName: "any",
+				ID:       ".test.Fake.any",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  ".google.protobuf.Any",
+				Optional: true,
+			},
+			{
+				Name:     "repeated_field_mask",
+				JSONName: "repeatedFieldMask",
+				ID:       ".test.Fake.repeated_field_mask",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  ".google.protobuf.FieldMask",
+				Repeated: true,
+			},
+			{
+				Name:     "repeated_timestamp",
+				JSONName: "repeatedTimestamp",
+				ID:       ".test.Fake.repeated_timestamp",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  ".google.protobuf.Timestamp",
+				Repeated: true,
+			},
+			{
+				Name:     "repeated_any",
+				JSONName: "repeatedAny",
+				ID:       ".test.Fake.repeated_any",
+				Typez:    genclient.MESSAGE_TYPE,
+				TypezID:  ".google.protobuf.Any",
+				Repeated: true,
+			},
+		},
+	})
+}
+
 func TestMapFields(t *testing.T) {
 	api := makeAPI(nil, newCodeGeneratorRequest(t, "map_fields.proto"))
 

--- a/generator/internal/genclient/translator/protobuf/testdata/wkt_fields.proto
+++ b/generator/internal/genclient/translator/protobuf/testdata/wkt_fields.proto
@@ -1,0 +1,29 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package test;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/field_mask.proto";
+import "google/protobuf/timestamp.proto";
+
+message Fake {
+  google.protobuf.Any any = 1;
+  google.protobuf.FieldMask field_mask = 2;
+  google.protobuf.Timestamp timestamp = 3;
+  repeated google.protobuf.Any repeated_any = 4;
+  repeated google.protobuf.FieldMask repeated_field_mask = 5;
+  repeated google.protobuf.Timestamp repeated_timestamp = 6;
+}

--- a/generator/testdata/rust/gclient/golden/src/model.rs
+++ b/generator/testdata/rust/gclient/golden/src/model.rs
@@ -537,7 +537,7 @@ pub struct CreateSecretRequest {
 
     /// Required. A [Secret][google.cloud.secretmanager.v1.Secret] with initial
     /// field values.
-    pub secret: Vec<crate::model::Secret>,
+    pub secret: Option<crate::model::Secret>,
 }
 
 /// Request message for


### PR DESCRIPTION
When I "fixed" the code to handle maps as non-repeated fields, I accidentally
made all object fields repeated.

Fixes #144
