### PR TITLE
feat(gax): support optional path parameters

### DIFF
--- a/gax/src/lib.rs
+++ b/gax/src/lib.rs
@@ -38,5 +38,21 @@
 /// most of these crates will use these helpers.
 pub mod query_parameter;
 
+/// Defines traits and helpers to serialize path parameters.
+///
+/// Path parameters in the Google APIs are always required, but they may need
+/// to be source from fields that are inside a message field, which are always
+/// `Option<T>`.
+///
+/// This module defines some traits and helpers to simplify the code generator.
+/// They automatically convert `Option<T>` to `Result<T, Error>`, so the
+/// generator always writes:
+///
+/// gax::path_parameter::required(req.field)?.sub
+///
+/// If accessing deeply nested fields that can results in multiple calls to
+/// `required`.
+pub mod path_parameter;
+
 /// Implementation details for [query_parameter](::crate::query_parameter).
 mod request_parameter;

--- a/gax/src/path_parameter.rs
+++ b/gax/src/path_parameter.rs
@@ -1,0 +1,72 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub trait PathParameter {
+    type P: Sized;
+    fn required<'a>(&'a self, name: &str) -> std::result::Result<&'a Self::P, Error>;
+}
+
+impl<T> PathParameter for Option<T> {
+    type P = T;
+    fn required<'a>(&'a self, name: &str) -> std::result::Result<&'a Self::P, Error> {
+        self.as_ref()
+            .ok_or_else(|| Error::MissingRequiredParameter(name.into()))
+    }
+}
+
+impl<T> PathParameter for T
+where
+    T: crate::request_parameter::RequestParameter,
+{
+    type P = T;
+    fn required<'a>(&'a self, _: &str) -> std::result::Result<&'a Self::P, Error> {
+        Ok(self)
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("missing required parameter {0}")]
+    MissingRequiredParameter(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    type Result = std::result::Result<(), Error>;
+
+    #[test]
+    fn optional_with_value() -> Result {
+        let v = Some("abc".to_string());
+        let got = PathParameter::required(&v, "name")?;
+        assert_eq!("abc", got);
+        Ok(())
+    }
+
+    #[test]
+    fn optional_without_value() -> Result {
+        let v = None::<String>;
+        let got = PathParameter::required(&v, "name");
+        assert!(got.is_err(), "expected error {:?}", got);
+        Ok(())
+    }
+
+    #[test]
+    fn required() -> Result {
+        let v = "value".to_string();
+        let got = PathParameter::required(&v, "name")?;
+        assert_eq!("value", got);
+        Ok(())
+    }
+}

--- a/gax/tests/path_parameters.rs
+++ b/gax/tests/path_parameters.rs
@@ -20,6 +20,7 @@ type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 #[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct FakeRequest {
     // Typically the struct would have a required path parameter.
     pub parent: String,
@@ -42,6 +43,7 @@ impl FakeRequest {
 #[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct FakePayload {
     // This may be one of the fields used in the request.
     pub id: String,

--- a/gax/tests/path_parameters.rs
+++ b/gax/tests/path_parameters.rs
@@ -1,0 +1,99 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use gax::path_parameter::PathParameter;
+
+type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+// We use this to simulate a request and how it is used in the client.
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FakeRequest {
+    // Typically the struct would have a required path parameter.
+    pub parent: String,
+    // Sometimes there is a required parameter inside another struct.
+    pub payload: Option<FakePayload>,
+}
+
+impl FakeRequest {
+    pub fn set_parent(mut self, v: impl Into<String>) -> Self {
+        self.parent = v.into();
+        self
+    }
+    pub fn set_payload(mut self, v: impl Into<Option<FakePayload>>) -> Self {
+        self.payload = v.into();
+        self
+    }
+}
+
+// We use this to simulate a request and how it is used in the client.
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FakePayload {
+    // This may be one of the fields used in the request.
+    pub id: String,
+}
+
+impl FakePayload {
+    pub fn set_id(mut self, v: impl Into<String>) -> Self {
+        self.id = v.into();
+        self
+    }
+}
+
+#[test]
+fn make_reqwest_with_optional_path_parameter() -> Result {
+    let client = reqwest::Client::builder().build()?;
+    let request = FakeRequest::default()
+        .set_parent("projects/test-only")
+        .set_payload(FakePayload::default().set_id("abc"));
+    let builder = client.get(format!(
+        "https://test.googleapis.com/v1/{}/foos/{}",
+        &request.parent,
+        PathParameter::required(&request.payload, "payload")?.id
+    ));
+
+    let r = builder.build()?;
+    assert_eq!("test.googleapis.com", r.url().authority());
+    assert_eq!("/v1/projects/test-only/foos/abc", r.url().path());
+
+    Ok(())
+}
+
+#[test]
+fn make_reqwest_with_missing_optional_path() -> Result {
+    let client = reqwest::Client::builder().build()?;
+    let request = FakeRequest::default().set_parent("projects/test-only");
+    let result = || -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let _builder = client.get(format!(
+            "https://test.googleapis.com/v1/{}/foos/{}",
+            &request.parent,
+            PathParameter::required(&request.payload, "payload")?.id
+        ));
+        Ok(())
+    }();
+
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert!(
+            format!("{e:?}").contains("payload"),
+            "expected the field name (payload) in the error message {:?}",
+            e
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Sometimes path parameters appear inside optional fields.  Consider:

https://github.com/googleapis/google-cloud-rust/blob/c9f74adf12932f910aa69c167a9ca5ec0fe258fd/generator/testdata/googleapis/google/cloud/secretmanager/v1/service.proto#L88

That requests the `.name` field from the `.secret` field in the request.  But
`.secret` is mapped to `Option<Secret>` because it is a message. We need to say
something like `.secret.ok_or_else(...)?.name`. This PR introduces some helpers
to simplify the generator. The generator always calls the
`PathParameter::required()` function. The function expands to either `self` or
`self.ok_or_else()` depending on whether the parameter is an `Option<_>` or not.

A future PR will take advantage of these helpers in the generated code.

Part of the work for #140
