### PR TITLE
impl(generator/protobuf): skip imported messages

### DIFF
--- a/generator/internal/genclient/translator/protobuf/protobuf_test.go
+++ b/generator/internal/genclient/translator/protobuf/protobuf_test.go
@@ -272,7 +272,7 @@ func TestSkipExternalMessages(t *testing.T) {
 	// Both `ImportedMessage` and `LocalMessage` should be in the index:
 	_, ok := api.State.MessageByID[".away.ImportedMessage"]
 	if !ok {
-		t.Fatalf("Cannot find message %s in API State", ".away.ImportedMesage")
+		t.Fatalf("Cannot find message %s in API State", ".away.ImportedMessage")
 	}
 	message, ok := api.State.MessageByID[".test.LocalMessage"]
 	if !ok {

--- a/generator/internal/genclient/translator/protobuf/protobuf_test.go
+++ b/generator/internal/genclient/translator/protobuf/protobuf_test.go
@@ -266,6 +266,89 @@ func TestScalarOptional(t *testing.T) {
 	})
 }
 
+func TestSkipExternalMessages(t *testing.T) {
+	api := makeAPI(nil, newCodeGeneratorRequest(t, "with_import.proto"))
+
+	// Both `ImportedMessage` and `LocalMessage` should be in the index:
+	_, ok := api.State.MessageByID[".away.ImportedMessage"]
+	if !ok {
+		t.Fatalf("Cannot find message %s in API State", ".away.ImportedMesage")
+	}
+	message, ok := api.State.MessageByID[".test.LocalMessage"]
+	if !ok {
+		t.Fatalf("Cannot find message %s in API State", ".test.LocalMessage")
+	}
+	checkMessage(t, *message, genclient.Message{
+		Name:          "LocalMessage",
+		ID:            ".test.LocalMessage",
+		Documentation: "This is a local message, it should be generated.",
+		Fields: []*genclient.Field{
+			{
+				Name:          "payload",
+				JSONName:      "payload",
+				ID:            ".test.LocalMessage.payload",
+				Documentation: "This field uses an imported message.",
+				Typez:         genclient.MESSAGE_TYPE,
+				TypezID:       ".away.ImportedMessage",
+				Optional:      true,
+			},
+			{
+				Name:          "value",
+				JSONName:      "value",
+				ID:            ".test.LocalMessage.value",
+				Documentation: "This field uses an imported enum.",
+				Typez:         genclient.ENUM_TYPE,
+				TypezID:       ".away.ImportedEnum",
+				Optional:      false,
+			},
+		},
+	})
+	// Only `LocalMessage` should be found in the messages list:
+	for _, msg := range api.Messages {
+		if msg.ID == ".test.ImportedMessage" {
+			t.Errorf("imported messages should not be in message list %v", msg)
+		}
+	}
+}
+
+func TestSkipExternaEnums(t *testing.T) {
+	api := makeAPI(nil, newCodeGeneratorRequest(t, "with_import.proto"))
+
+	// Both `ImportedEnum` and `LocalEnum` should be in the index:
+	_, ok := api.State.EnumByID[".away.ImportedEnum"]
+	if !ok {
+		t.Fatalf("Cannot find enum %s in API State", ".away.ImportedEnum")
+	}
+	enum, ok := api.State.EnumByID[".test.LocalEnum"]
+	if !ok {
+		t.Fatalf("Cannot find enum %s in API State", ".test.LocalEnum")
+	}
+	checkEnum(t, *enum, genclient.Enum{
+		Name:          "LocalEnum",
+		Documentation: "This is a local enum, it should be generated.",
+		Values: []*genclient.EnumValue{
+			{
+				Name:   "RED",
+				Number: 0,
+			},
+			{
+				Name:   "WHITE",
+				Number: 1,
+			},
+			{
+				Name:   "BLUE",
+				Number: 2,
+			},
+		},
+	})
+	// Only `LocalMessage` should be found in the messages list:
+	for _, msg := range api.Messages {
+		if msg.ID == ".test.ImportedMessage" {
+			t.Errorf("imported messages should not be in message list %v", msg)
+		}
+	}
+}
+
 func TestComments(t *testing.T) {
 	api := makeAPI(nil, newCodeGeneratorRequest(t, "comments.proto"))
 
@@ -718,8 +801,8 @@ func newCodeGeneratorRequest(t *testing.T, filename string) *pluginpb.CodeGenera
 	}
 	request := &pluginpb.CodeGeneratorRequest{
 		FileToGenerate:        []string{filename},
-		ProtoFile:             []*descriptorpb.FileDescriptorProto{target},
-		SourceFileDescriptors: descriptors.File,
+		SourceFileDescriptors: []*descriptorpb.FileDescriptorProto{target},
+		ProtoFile:             descriptors.File,
 		CompilerVersion:       newCompilerVersion(),
 	}
 	return request

--- a/generator/internal/genclient/translator/protobuf/testdata/imported.proto
+++ b/generator/internal/genclient/translator/protobuf/testdata/imported.proto
@@ -1,0 +1,27 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package away;
+
+// This is an imported message, it should not be generated.
+message ImportedMessage {
+    // A field to make the message non-empty.
+    string parent = 1;
+}
+
+// This is an imported enum, it should not be generated.
+enum ImportedEnum {
+    ONE = 0;
+}

--- a/generator/internal/genclient/translator/protobuf/testdata/with_import.proto
+++ b/generator/internal/genclient/translator/protobuf/testdata/with_import.proto
@@ -1,0 +1,33 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package test;
+
+import "imported.proto";
+
+// This is a local message, it should be generated.
+message LocalMessage {
+    // This field uses an imported message.
+    away.ImportedMessage payload = 1;
+    // This field uses an imported enum.
+    away.ImportedEnum value = 2;
+}
+
+// This is a local enum, it should be generated.
+enum LocalEnum {
+    RED = 0;
+    WHITE = 1;
+    BLUE = 2;
+}


### PR DESCRIPTION
Imported messages should not be generated, so we exclude them from the
`api.Messages` list. They do need to be in the `api.State.MessageByID` index,
as these messages may be referenced by other messages or services.

Part of the work for #150
