### PR TITLE
cleanup(generator): simplify codec initialization

### DIFF
--- a/generator/cmd/main.go
+++ b/generator/cmd/main.go
@@ -96,7 +96,7 @@ func Generate(specFormat string, popts *genclient.ParserOptions, copts *genclien
 		return err
 	}
 
-	codec, err := language.NewCodec(copts.Language)
+	codec, err := language.NewCodec(copts)
 	if err != nil {
 		return err
 	}

--- a/generator/internal/genclient/language/language_test.go
+++ b/generator/internal/genclient/language/language_test.go
@@ -1,0 +1,35 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package language
+
+import (
+	"testing"
+
+	"github.com/googleapis/google-cloud-rust/generator/internal/genclient"
+)
+
+func TestCreateRustSuccess(t *testing.T) {
+	copts := &genclient.CodecOptions{
+		Language: "rust",
+	}
+	codec, err := NewCodec(copts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := codec.TemplateDir()
+	if got != "rust" {
+		t.Errorf("mismatched template dir, want=%s, got=%s", "rust", got)
+	}
+}


### PR DESCRIPTION
Part of the work #158 

The idea is to receive per-codec configuration in an incoming PR.
