### PR TITLE
feat(generator/rust): configurable package names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,20 +919,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
-name = "placeholder"
-version = "0.1.0"
-dependencies = [
- "bytes",
- "gax",
- "reqwest 0.12.9",
- "serde",
- "serde_json",
- "serde_with",
- "time",
- "types",
-]
-
-[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,7 +1252,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "secretmanager"
+name = "secretmanager-golden-gclient"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "gax",
+ "reqwest 0.12.9",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "time",
+ "types",
+]
+
+[[package]]
+name = "secretmanager-golden-openapi"
 version = "0.1.0"
 dependencies = [
  "bytes",

--- a/generator/cmd/main_test.go
+++ b/generator/cmd/main_test.go
@@ -48,6 +48,7 @@ func TestRustFromOpenAPI(t *testing.T) {
 		OutDir:      "testdata/rust/openapi/golden",
 		TemplateDir: "../templates",
 		Options: map[string]string{
+			"package-name-override":   "secretmanager-golden-openapi",
 			"package:gax_placeholder": "package=types,path=../../../../../types,source=google.protobuf",
 			"package:gax":             "package=gax,path=../../../../../gax",
 		},
@@ -86,6 +87,7 @@ func TestRustFromProtobuf(t *testing.T) {
 		OutDir:      "testdata/rust/gclient/golden",
 		TemplateDir: "../templates",
 		Options: map[string]string{
+			"package-name-override":   "secretmanager-golden-gclient",
 			"package:gax_placeholder": "package=types,path=../../../../../types,source=google.protobuf",
 			"package:gax":             "package=gax,path=../../../../../gax",
 		},

--- a/generator/internal/genclient/genclient.go
+++ b/generator/internal/genclient/genclient.go
@@ -98,6 +98,8 @@ type LanguageCodec interface {
 	// Returns a extra set of lines to insert in the module file.
 	// The format of these lines is specific to each language.
 	RequiredPackages() []string
+	// The package name. Empty for languags without a package manager.
+	PackageName(api *API) string
 }
 
 // Parser converts an textual specification to a `genclient.API` object.

--- a/generator/internal/genclient/language/internal/golang/golang.go
+++ b/generator/internal/genclient/language/internal/golang/golang.go
@@ -220,6 +220,10 @@ func (*Codec) RequiredPackages() []string {
 	return []string{}
 }
 
+func (*Codec) PackageName(api *genclient.API) string {
+	return api.Name
+}
+
 // The list of Golang keywords and reserved words can be found at:
 //
 // https://go.dev/ref/spec#Keywords

--- a/generator/internal/genclient/language/internal/rust/rust_test.go
+++ b/generator/internal/genclient/language/internal/rust/rust_test.go
@@ -31,8 +31,8 @@ func testCodec() *Codec {
 	}
 
 	return &Codec{
-		extraPackages: []*RustPackage{wkt},
-		packageMapping: map[string]*RustPackage{
+		ExtraPackages: []*RustPackage{wkt},
+		PackageMapping: map[string]*RustPackage{
 			"google.protobuf": wkt,
 		},
 	}
@@ -42,6 +42,7 @@ func TestParseOptions(t *testing.T) {
 	copts := &genclient.CodecOptions{
 		Language: "rust",
 		Options: map[string]string{
+			"package-name-override":   "test-only",
 			"package:gax_placeholder": "package=types,path=../../types,source=google.protobuf,source=test-only",
 			"package:gax":             "package=gax,path=../../gax",
 		},
@@ -50,30 +51,33 @@ func TestParseOptions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	gp := &RustPackage{
+		Name:    "gax_placeholder",
+		Package: "types",
+		Path:    "../../types",
+	}
 	want := &Codec{
-		extraPackages: []*RustPackage{
-			{
-				Name:    "gax_placeholder",
-				Package: "types",
-				Path:    "../../types",
-			},
+		PackageNameOverride: "test-only",
+		ExtraPackages: []*RustPackage{
+			gp,
 			{
 				Name:    "gax",
 				Package: "gax",
 				Path:    "../../gax",
 			},
 		},
+		PackageMapping: map[string]*RustPackage{
+			"google.protobuf": gp,
+			"test-only":       gp,
+		},
+	}
+	if diff := cmp.Diff(want, codec, cmpopts.IgnoreFields(Codec{}, "ExtraPackages", "PackageMapping")); len(diff) > 0 {
+		t.Errorf("codec mismatch (-want, +got):\n%s", diff)
+	}
+	if want.PackageNameOverride != codec.PackageNameOverride {
+		t.Errorf("mismatched in packageNameOverride, want=%s, got=%s", want.PackageNameOverride, codec.PackageNameOverride)
 	}
 	checkPackages(t, codec, want)
-	for _, source := range []string{"google.protobuf", "test-only"} {
-		pkg, ok := codec.packageMapping[source]
-		if !ok {
-			t.Errorf("missing package mapping for source=%s", source)
-		}
-		if pkg.Name != "gax_placeholder" {
-			t.Errorf("mismatched package for %s, want=%s, got=%s", source, "gax_placeholder", pkg.Name)
-		}
-	}
 }
 
 func TestRequiredPackages(t *testing.T) {
@@ -99,10 +103,39 @@ func TestRequiredPackages(t *testing.T) {
 	}
 }
 
+func TestPackageName(t *testing.T) {
+	packageNameImpl(t, "test-only-overriden", &genclient.CodecOptions{
+		Language: "rust",
+		Options: map[string]string{
+			"package-name-override": "test-only-overriden",
+		},
+	})
+	packageNameImpl(t, "test-only-default", &genclient.CodecOptions{
+		Language: "rust",
+	})
+
+}
+
+func packageNameImpl(t *testing.T, want string, copts *genclient.CodecOptions) {
+	t.Helper()
+	api := &genclient.API{
+		Name: "test-only-default",
+	}
+	codec, err := NewCodec(copts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := codec.PackageName(api)
+	if want != got {
+		t.Errorf("mismatch in package name, want=%s, got=%s", want, got)
+	}
+
+}
+
 func checkPackages(t *testing.T, got *Codec, want *Codec) {
 	t.Helper()
 	less := func(a, b *RustPackage) bool { return a.Name < b.Name }
-	if diff := cmp.Diff(want.extraPackages, got.extraPackages, cmpopts.SortSlices(less)); len(diff) > 0 {
+	if diff := cmp.Diff(want.ExtraPackages, got.ExtraPackages, cmpopts.SortSlices(less)); len(diff) > 0 {
 		t.Errorf("package mismatch (-want, +got):\n%s", diff)
 	}
 }

--- a/generator/internal/genclient/language/internal/rust/rust_test.go
+++ b/generator/internal/genclient/language/internal/rust/rust_test.go
@@ -104,10 +104,10 @@ func TestRequiredPackages(t *testing.T) {
 }
 
 func TestPackageName(t *testing.T) {
-	packageNameImpl(t, "test-only-overriden", &genclient.CodecOptions{
+	packageNameImpl(t, "test-only-overridden", &genclient.CodecOptions{
 		Language: "rust",
 		Options: map[string]string{
-			"package-name-override": "test-only-overriden",
+			"package-name-override": "test-only-overridden",
 		},
 	})
 	packageNameImpl(t, "test-only-default", &genclient.CodecOptions{

--- a/generator/internal/genclient/templatedata.go
+++ b/generator/internal/genclient/templatedata.go
@@ -51,6 +51,10 @@ func (t *templateData) Description() string {
 	return t.s.Description
 }
 
+func (t *templateData) PackageName() string {
+	return t.c.PackageName(t.s)
+}
+
 func (t *templateData) RequiredPackages() []string {
 	return t.c.RequiredPackages()
 }

--- a/generator/templates/rust/Cargo.toml.mustache
+++ b/generator/templates/rust/Cargo.toml.mustache
@@ -14,8 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 }}
 [package]
-{{! TODO(#93) - we should be able to override this name for local development }}
-name = "{{Name}}{{^Name}}placeholder{{/Name}}"
+name = "{{PackageName}}"
 version = "0.1.0"
 edition = "2021"
 

--- a/generator/testdata/rust/gclient/golden/Cargo.toml
+++ b/generator/testdata/rust/gclient/golden/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "placeholder"
+name = "secretmanager-golden-gclient"
 version = "0.1.0"
 edition = "2021"
 

--- a/generator/testdata/rust/openapi/golden/Cargo.toml
+++ b/generator/testdata/rust/openapi/golden/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "secretmanager"
+name = "secretmanager-golden-openapi"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
Make it possible to override the package name via
the command-line. Use this to generate unique
names for the golden files.

Part of the work for #162