### PR TITLE
impl(generator/rust): support external packages

### DIFF
--- a/generator/cmd/main.go
+++ b/generator/cmd/main.go
@@ -100,6 +100,9 @@ func Generate(specFormat string, popts *genclient.ParserOptions, copts *genclien
 	if err != nil {
 		return err
 	}
+	if err = codec.Validate(api); err != nil {
+		return err
+	}
 	request := &genclient.GenerateRequest{
 		API:         api,
 		Codec:       codec,

--- a/generator/internal/genclient/genclient.go
+++ b/generator/internal/genclient/genclient.go
@@ -98,8 +98,11 @@ type LanguageCodec interface {
 	// Returns a extra set of lines to insert in the module file.
 	// The format of these lines is specific to each language.
 	RequiredPackages() []string
-	// The package name. Empty for languags without a package manager.
+	// The package name in the destination language. May be empty, some
+	// languages do not have a package manager.
 	PackageName(api *API) string
+	// Validate an API, some codecs impose restrictions on the input API.
+	Validate(api *API) error
 }
 
 // Parser converts an textual specification to a `genclient.API` object.

--- a/generator/internal/genclient/language/internal/golang/golang_test.go
+++ b/generator/internal/genclient/language/internal/golang/golang_test.go
@@ -168,3 +168,46 @@ Maybe they wanted to show some JSON:
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
 }
+
+func TestValidate(t *testing.T) {
+	api := genclient.NewTestAPI(
+		[]*genclient.Message{{Name: "m1", Package: "p1"}},
+		[]*genclient.Enum{{Name: "e1", Package: "p1"}},
+		[]*genclient.Service{{Name: "s1", Package: "p1"}})
+	c := &Codec{}
+	if err := c.Validate(api); err != nil {
+		t.Errorf("unexpected error in API validation %q", err)
+	}
+	if c.SourceSpecificationPackageName != "p1" {
+		t.Errorf("mismatched source package name, want=p1, got=%s", c.SourceSpecificationPackageName)
+	}
+}
+
+func TestValidateMessageMismatch(t *testing.T) {
+	api := genclient.NewTestAPI(
+		[]*genclient.Message{{Name: "m1", Package: "p1"}, {Name: "m2", Package: "p2"}},
+		[]*genclient.Enum{{Name: "e1", Package: "p1"}},
+		[]*genclient.Service{{Name: "s1", Package: "p1"}})
+	c := &Codec{}
+	if err := c.Validate(api); err == nil {
+		t.Errorf("expected an error in API validation got=%s", c.SourceSpecificationPackageName)
+	}
+
+	api = genclient.NewTestAPI(
+		[]*genclient.Message{{Name: "m1", Package: "p1"}},
+		[]*genclient.Enum{{Name: "e1", Package: "p1"}, {Name: "e2", Package: "p2"}},
+		[]*genclient.Service{{Name: "s1", Package: "p1"}})
+	c = &Codec{}
+	if err := c.Validate(api); err == nil {
+		t.Errorf("expected an error in API validation got=%s", c.SourceSpecificationPackageName)
+	}
+
+	api = genclient.NewTestAPI(
+		[]*genclient.Message{{Name: "m1", Package: "p1"}},
+		[]*genclient.Enum{{Name: "e1", Package: "p1"}},
+		[]*genclient.Service{{Name: "s1", Package: "p1"}, {Name: "s2", Package: "p2"}})
+	c = &Codec{}
+	if err := c.Validate(api); err == nil {
+		t.Errorf("expected an error in API validation got=%s", c.SourceSpecificationPackageName)
+	}
+}

--- a/generator/internal/genclient/language/internal/rust/rust_test.go
+++ b/generator/internal/genclient/language/internal/rust/rust_test.go
@@ -140,6 +140,49 @@ func checkPackages(t *testing.T, got *Codec, want *Codec) {
 	}
 }
 
+func TestValidate(t *testing.T) {
+	api := genclient.NewTestAPI(
+		[]*genclient.Message{{Name: "m1", Package: "p1"}},
+		[]*genclient.Enum{{Name: "e1", Package: "p1"}},
+		[]*genclient.Service{{Name: "s1", Package: "p1"}})
+	c := &Codec{}
+	if err := c.Validate(api); err != nil {
+		t.Errorf("unexpected error in API validation %q", err)
+	}
+	if c.SourceSpecificationPackageName != "p1" {
+		t.Errorf("mismatched source package name, want=p1, got=%s", c.SourceSpecificationPackageName)
+	}
+}
+
+func TestValidateMessageMismatch(t *testing.T) {
+	api := genclient.NewTestAPI(
+		[]*genclient.Message{{Name: "m1", Package: "p1"}, {Name: "m2", Package: "p2"}},
+		[]*genclient.Enum{{Name: "e1", Package: "p1"}},
+		[]*genclient.Service{{Name: "s1", Package: "p1"}})
+	c := &Codec{}
+	if err := c.Validate(api); err == nil {
+		t.Errorf("expected an error in API validation got=%s", c.SourceSpecificationPackageName)
+	}
+
+	api = genclient.NewTestAPI(
+		[]*genclient.Message{{Name: "m1", Package: "p1"}},
+		[]*genclient.Enum{{Name: "e1", Package: "p1"}, {Name: "e2", Package: "p2"}},
+		[]*genclient.Service{{Name: "s1", Package: "p1"}})
+	c = &Codec{}
+	if err := c.Validate(api); err == nil {
+		t.Errorf("expected an error in API validation got=%s", c.SourceSpecificationPackageName)
+	}
+
+	api = genclient.NewTestAPI(
+		[]*genclient.Message{{Name: "m1", Package: "p1"}},
+		[]*genclient.Enum{{Name: "e1", Package: "p1"}},
+		[]*genclient.Service{{Name: "s1", Package: "p1"}, {Name: "s2", Package: "p2"}})
+	c = &Codec{}
+	if err := c.Validate(api); err == nil {
+		t.Errorf("expected an error in API validation got=%s", c.SourceSpecificationPackageName)
+	}
+}
+
 func TestWellKnownTypesExist(t *testing.T) {
 	api := genclient.NewTestAPI([]*genclient.Message{}, []*genclient.Enum{}, []*genclient.Service{})
 	c := &Codec{}

--- a/generator/internal/genclient/model.go
+++ b/generator/internal/genclient/model.go
@@ -92,6 +92,8 @@ type Service struct {
 	Methods []*Method
 	// DefaultHost fragment of a URL.
 	DefaultHost string
+	// The Protobuf package this service belongs to.
+	Package string
 }
 
 // Method defines a RPC belonging to a Service.
@@ -196,7 +198,8 @@ type Message struct {
 	// OneOfs associated with the Message.
 	OneOfs []*OneOf
 	// Parent returns the ancestor of this message, if any.
-	Parent  *Message
+	Parent *Message
+	// The Protobuf package this message belongs to.
 	Package string
 	IsMap   bool
 }
@@ -213,6 +216,8 @@ type Enum struct {
 	Values []*EnumValue
 	// Parent returns the ancestor of this node, if any.
 	Parent *Message
+	// The Protobuf package this enum belongs to.
+	Package string
 }
 
 // EnumValue defines a value in an Enum.

--- a/generator/internal/genclient/parser/protobuf/protobuf_test.go
+++ b/generator/internal/genclient/parser/protobuf/protobuf_test.go
@@ -55,6 +55,8 @@ func TestScalar(t *testing.T) {
 	}
 	checkMessage(t, *message, genclient.Message{
 		Name:          "Fake",
+		Package:       "test",
+		ID:            ".test.Fake",
 		Documentation: "A test message.",
 		Fields: []*genclient.Field{
 			{
@@ -175,6 +177,8 @@ func TestScalarArray(t *testing.T) {
 	}
 	checkMessage(t, *message, genclient.Message{
 		Name:          "Fake",
+		Package:       "test",
+		ID:            ".test.Fake",
 		Documentation: "A test message.",
 		Fields: []*genclient.Field{
 			{
@@ -222,6 +226,8 @@ func TestScalarOptional(t *testing.T) {
 	}
 	checkMessage(t, *message, genclient.Message{
 		Name:          "Fake",
+		Package:       "test",
+		ID:            ".test.Fake",
 		Documentation: "A test message.",
 		Fields: []*genclient.Field{
 			{
@@ -274,6 +280,7 @@ func TestSkipExternalMessages(t *testing.T) {
 	}
 	checkMessage(t, *message, genclient.Message{
 		Name:          "LocalMessage",
+		Package:       "test",
 		ID:            ".test.LocalMessage",
 		Documentation: "This is a local message, it should be generated.",
 		Fields: []*genclient.Field{
@@ -319,6 +326,7 @@ func TestSkipExternaEnums(t *testing.T) {
 	}
 	checkEnum(t, *enum, genclient.Enum{
 		Name:          "LocalEnum",
+		Package:       "test",
 		Documentation: "This is a local enum, it should be generated.",
 		Values: []*genclient.EnumValue{
 			{
@@ -352,6 +360,7 @@ func TestComments(t *testing.T) {
 	}
 	checkMessage(t, *message, genclient.Message{
 		Name:          "Request",
+		Package:       "test",
 		ID:            ".test.Request",
 		Documentation: "A test message.\n\nWith even more of a description.\nMaybe in more than one line.\nAnd some markdown:\n- An item\n  - A nested item\n- Another item",
 		Fields: []*genclient.Field{
@@ -371,6 +380,7 @@ func TestComments(t *testing.T) {
 	}
 	checkEnum(t, *e, genclient.Enum{
 		Name:          "Status",
+		Package:       "test",
 		Documentation: "Some enum.\n\nLine 1.\nLine 2.",
 		Values: []*genclient.EnumValue{
 			{
@@ -393,6 +403,7 @@ func TestComments(t *testing.T) {
 	checkService(t, *service, genclient.Service{
 		Name:          "Service",
 		ID:            ".test.Service",
+		Package:       "test",
 		Documentation: "A service.\n\nWith a longer service description.",
 		DefaultHost:   "test.googleapis.com",
 		Methods: []*genclient.Method{
@@ -424,6 +435,7 @@ func TestOneOfs(t *testing.T) {
 	}
 	checkMessage(t, *message, genclient.Message{
 		Name:          "Fake",
+		Package:       "test",
 		ID:            ".test.Fake",
 		Documentation: "A test message.",
 		Fields: []*genclient.Field{
@@ -494,8 +506,9 @@ func TestObjectFields(t *testing.T) {
 		t.Fatalf("Cannot find message %s in API State", ".test.Fake")
 	}
 	checkMessage(t, *message, genclient.Message{
-		Name: "Fake",
-		ID:   ".test.Fake",
+		Name:    "Fake",
+		Package: "test",
+		ID:      ".test.Fake",
 		Fields: []*genclient.Field{
 			{
 				Repeated: false,
@@ -527,8 +540,9 @@ func TestWellKnownTypeFields(t *testing.T) {
 		t.Fatalf("Cannot find message %s in API State", ".test.Fake")
 	}
 	checkMessage(t, *message, genclient.Message{
-		Name: "Fake",
-		ID:   ".test.Fake",
+		Name:    "Fake",
+		Package: "test",
+		ID:      ".test.Fake",
 		Fields: []*genclient.Field{
 			{
 				Name:     "field_mask",
@@ -590,8 +604,9 @@ func TestMapFields(t *testing.T) {
 		t.Fatalf("Cannot find message %s in API State", ".test.Fake")
 	}
 	checkMessage(t, *message, genclient.Message{
-		Name: "Fake",
-		ID:   ".test.Fake",
+		Name:    "Fake",
+		Package: "test",
+		ID:      ".test.Fake",
 		Fields: []*genclient.Field{
 			{
 				Repeated: false,
@@ -610,9 +625,10 @@ func TestMapFields(t *testing.T) {
 		t.Fatalf("Cannot find message %s in API State", ".test.Fake")
 	}
 	checkMessage(t, *message, genclient.Message{
-		Name:  "SingularMapEntry",
-		ID:    ".test.Fake.SingularMapEntry",
-		IsMap: true,
+		Name:    "SingularMapEntry",
+		Package: "test",
+		ID:      ".test.Fake.SingularMapEntry",
+		IsMap:   true,
 		Fields: []*genclient.Field{
 			{
 				Repeated: false,
@@ -643,6 +659,7 @@ func TestService(t *testing.T) {
 	}
 	checkService(t, *service, genclient.Service{
 		Name:          "TestService",
+		Package:       "test",
 		ID:            ".test.TestService",
 		Documentation: "A service to unit test the protobuf translator.",
 		DefaultHost:   "test.googleapis.com",
@@ -691,6 +708,7 @@ func TestQueryParameters(t *testing.T) {
 	}
 	checkService(t, *service, genclient.Service{
 		Name:          "TestService",
+		Package:       "test",
 		ID:            ".test.TestService",
 		Documentation: "A service to unit test the protobuf translator.",
 		DefaultHost:   "test.googleapis.com",
@@ -739,6 +757,7 @@ func TestEnum(t *testing.T) {
 	}
 	checkEnum(t, *e, genclient.Enum{
 		Name:          "Code",
+		Package:       "test",
 		Documentation: "An enum.",
 		Values: []*genclient.EnumValue{
 			{
@@ -773,11 +792,9 @@ func newTestCodeGeneratorRequest(t *testing.T, filename string) *pluginpb.CodeGe
 
 func checkMessage(t *testing.T, got genclient.Message, want genclient.Message) {
 	t.Helper()
-	if want.Name != got.Name {
-		t.Errorf("Mismatched message name, got=%q, want=%q", got.Name, want.Name)
-	}
-	if diff := cmp.Diff(want.Documentation, got.Documentation); len(diff) > 0 {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
+	// Checking Parent, Messages, Fields, and OneOfs requires special handling.
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(genclient.Message{}, "Fields", "OneOfs", "Parent", "Messages")); len(diff) > 0 {
+		t.Errorf("message attributes mismatch (-want +got):\n%s", diff)
 	}
 	less := func(a, b *genclient.Field) bool { return a.Name < b.Name }
 	if diff := cmp.Diff(want.Fields, got.Fields, cmpopts.SortSlices(less)); len(diff) > 0 {


### PR DESCRIPTION
First, capture the package name (in the source specification lingo) of each
service, message, and top-level enum. We will need those to reference the
symbol by their fully qualified name.

Second, capture the *single* top-level package name for the symbols the Codec
needs to generate. With the current design / structure the Codecs cannot handle
more than one top-level package name, so return an error in that case.

Then we can change the rust codec to generate the correctly mapped package name.

Part of the work for #158