### PR TITLE
impl(generator): full service config parser

### DIFF
--- a/generator/go.mod
+++ b/generator/go.mod
@@ -4,12 +4,12 @@ go 1.23.2
 
 require (
 	github.com/cbroglie/mustache v1.4.0
+	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.6.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/pb33f/libopenapi v0.18.6
-	google.golang.org/genproto/googleapis/api v0.0.0-20241021214115-324edc3d5d38
+	google.golang.org/genproto/googleapis/api v0.0.0-20241113202542-65e8d215514f
 	google.golang.org/protobuf v1.35.1
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -19,4 +19,6 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/vmware-labs/yaml-jsonpath v0.3.2 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.9-0.20240815153524-6ea36470d1bd // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/generator/go.sum
+++ b/generator/go.sum
@@ -16,6 +16,8 @@ github.com/dprotaso/go-yit v0.0.0-20240618133044-5a0af90af097/go.mod h1:FTAVyH6t
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
@@ -123,8 +125,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/genproto/googleapis/api v0.0.0-20241021214115-324edc3d5d38 h1:2oV8dfuIkM1Ti7DwXc0BJfnwr9csz4TDXI9EmiI+Rbw=
-google.golang.org/genproto/googleapis/api v0.0.0-20241021214115-324edc3d5d38/go.mod h1:vuAjtvlwkDKF6L1GQ0SokiRLCGFfeBUXWr/aFFkHACc=
+google.golang.org/genproto/googleapis/api v0.0.0-20241113202542-65e8d215514f h1:M65LEviCfuZTfrfzwwEoxVtgvfkFkBUbFnRbxCXuXhU=
+google.golang.org/genproto/googleapis/api v0.0.0-20241113202542-65e8d215514f/go.mod h1:Yo94eF2nj7igQt+TiJ49KxjIH8ndLYPZMIRSiRcEbg0=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/generator/internal/genclient/parser/openapi/openapi.go
+++ b/generator/internal/genclient/parser/openapi/openapi.go
@@ -151,7 +151,10 @@ func makeServices(api *genclient.API, serviceConfig *serviceconfig.Service, mode
 	if serviceConfig != nil {
 		for _, api := range serviceConfig.Apis {
 			serviceName = api.Name
-			break
+			// Keep searching after well-known mixin services.
+			if !strings.HasPrefix(api.Name, "google.cloud.location.Location") && !strings.HasPrefix(api.Name, "google.iam.v1.IAMPolicy") {
+				break
+			}
 		}
 	}
 	service := &genclient.Service{

--- a/generator/internal/genclient/parser/openapi/openapi.go
+++ b/generator/internal/genclient/parser/openapi/openapi.go
@@ -131,6 +131,12 @@ func makeAPI(serviceConfig *serviceconfig.Service, model *libopenapi.DocumentMod
 	return api, nil
 }
 
+func wellKnownMixin(apiName string) bool {
+	return strings.HasPrefix(apiName, "google.cloud.location.Location") ||
+		strings.HasPrefix(apiName, "google.longrunning.Operations") ||
+		strings.HasPrefix(apiName, "google.iam.v1.IAMPolicy")
+}
+
 func makeServices(api *genclient.API, serviceConfig *serviceconfig.Service, model *libopenapi.DocumentModel[v3.Document]) error {
 	// It is hard to imagine an OpenAPI specification without at least some
 	// RPCs, but we can simplify the tests if we support specifications without
@@ -152,7 +158,7 @@ func makeServices(api *genclient.API, serviceConfig *serviceconfig.Service, mode
 		for _, api := range serviceConfig.Apis {
 			serviceName = api.Name
 			// Keep searching after well-known mixin services.
-			if !strings.HasPrefix(api.Name, "google.cloud.location.Location") && !strings.HasPrefix(api.Name, "google.iam.v1.IAMPolicy") {
+			if !wellKnownMixin(api.Name) {
 				break
 			}
 		}

--- a/generator/internal/genclient/service_config.go
+++ b/generator/internal/genclient/service_config.go
@@ -18,8 +18,10 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/ghodss/yaml"
 	"google.golang.org/genproto/googleapis/api/serviceconfig"
-	"gopkg.in/yaml.v3"
+	"google.golang.org/protobuf/encoding/protojson"
+	_ "google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func ReadServiceConfig(serviceConfigPath string) (*serviceconfig.Service, error) {
@@ -28,9 +30,14 @@ func ReadServiceConfig(serviceConfigPath string) (*serviceconfig.Service, error)
 		return nil, fmt.Errorf("error reading service config: %v", err)
 	}
 
-	var cfg serviceconfig.Service
-	if err := yaml.Unmarshal(y, &cfg); err != nil {
-		return nil, fmt.Errorf("error unmarshalling service config: %v", err)
+	j, err := yaml.YAMLToJSON(y)
+	if err != nil {
+		return nil, fmt.Errorf("error converting YAML to JSON: %v", err)
+	}
+
+	cfg := &serviceconfig.Service{}
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(j, cfg); err != nil {
+		return nil, fmt.Errorf("error unmarshaling service config: %v", err)
 	}
 
 	// An API Service Config will always have a `name` so if it is not populated,
@@ -38,5 +45,5 @@ func ReadServiceConfig(serviceConfigPath string) (*serviceconfig.Service, error)
 	if cfg.GetName() == "" {
 		return nil, fmt.Errorf("invalid API service config file %q", serviceConfigPath)
 	}
-	return &cfg, nil
+	return cfg, nil
 }

--- a/generator/internal/genclient/service_config.go
+++ b/generator/internal/genclient/service_config.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ghodss/yaml"
 	"google.golang.org/genproto/googleapis/api/serviceconfig"
 	"google.golang.org/protobuf/encoding/protojson"
-	_ "google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func ReadServiceConfig(serviceConfigPath string) (*serviceconfig.Service, error) {

--- a/generator/internal/genclient/service_config.go
+++ b/generator/internal/genclient/service_config.go
@@ -37,7 +37,7 @@ func ReadServiceConfig(serviceConfigPath string) (*serviceconfig.Service, error)
 
 	cfg := &serviceconfig.Service{}
 	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(j, cfg); err != nil {
-		return nil, fmt.Errorf("error unmarshaling service config: %v", err)
+		return nil, fmt.Errorf("error unmarshalling service config: %v", err)
 	}
 
 	// An API Service Config will always have a `name` so if it is not populated,

--- a/generator/internal/genclient/service_config_test.go
+++ b/generator/internal/genclient/service_config_test.go
@@ -32,6 +32,7 @@ func TestReadServiceConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	if diff := cmp.Diff(sample.ServiceConfig, got,
+		cmpopts.IgnoreFields(serviceconfig.Service{}, "ConfigVersion", "Publishing", "Authentication"),
 		cmpopts.IgnoreUnexported(annotations.HttpRule{}),
 		cmpopts.IgnoreUnexported(annotations.Http{}),
 		cmpopts.IgnoreUnexported(apipb.Api{}),

--- a/generator/internal/sample/sample.go
+++ b/generator/internal/sample/sample.go
@@ -26,6 +26,9 @@ var ServiceConfig = &serviceconfig.Service{
 	Title: "Secret Manager API",
 	Apis: []*apipb.Api{
 		{
+			Name: "google.cloud.location.Locations",
+		},
+		{
 			Name: "google.cloud.secretmanager.v1.SecretManagerService",
 		},
 	},
@@ -43,29 +46,19 @@ var ServiceConfig = &serviceconfig.Service{
 		},
 		Overview: "Secret Manager Overview",
 	},
-	Backend: &serviceconfig.Backend{
-		Rules: []*serviceconfig.BackendRule{
-			{
-				Selector: "google.cloud.location.Locations.GetLocation",
-				Deadline: 60,
-			},
-			{
-				Selector: "google.cloud.location.Locations.ListLocations",
-				Deadline: 60,
-			},
-			{
-				Selector: "google.cloud.secretmanager.v1.SecretManagerService.*",
-				Deadline: 60,
-			},
-		},
-	},
 	Http: &annotations.Http{
 		Rules: []*annotations.HttpRule{
 			{
 				Selector: "google.cloud.location.Locations.GetLocation",
+				Pattern: &annotations.HttpRule_Get{
+					Get: "/v1/{name=projects/*/locations/*}",
+				},
 			},
 			{
 				Selector: "google.cloud.location.Locations.ListLocations",
+				Pattern: &annotations.HttpRule_Get{
+					Get: "/v1/{name=projects/*}/locations",
+				},
 			},
 		},
 	},

--- a/generator/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml
+++ b/generator/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml
@@ -18,6 +18,7 @@ name: secretmanager.googleapis.com
 title: Secret Manager API
 
 apis:
+- name: google.cloud.location.Locations
 - name: google.cloud.secretmanager.v1.SecretManagerService
 
 documentation:
@@ -31,15 +32,6 @@ documentation:
 
   - selector: google.cloud.location.Locations.ListLocations
     description: Lists information about the supported locations for this service.
-
-backend:
-  rules:
-  - selector: google.cloud.location.Locations.GetLocation
-    deadline: 60.0
-  - selector: google.cloud.location.Locations.ListLocations
-    deadline: 60.0
-  - selector: 'google.cloud.secretmanager.v1.SecretManagerService.*'
-    deadline: 60.0
 
 http:
   rules:
@@ -62,3 +54,47 @@ authentication:
     oauth:
       canonical_scopes: |-
         https://www.googleapis.com/auth/cloud-platform
+
+publishing:
+  new_issue_uri: https://issuetracker.google.com/issues/new?component=784854&template=1380926
+  documentation_uri: https://cloud.google.com/secret-manager/docs/overview
+  api_short_name: secretmanager
+  github_label: 'api: secretmanager'
+  doc_tag_prefix: secretmanager
+  organization: CLOUD
+  library_settings:
+  - version: google.cloud.secretmanager.v1
+    launch_stage: GA
+    java_settings:
+      common:
+        destinations:
+        - PACKAGE_MANAGER
+    cpp_settings:
+      common:
+        destinations:
+        - PACKAGE_MANAGER
+    php_settings:
+      common:
+        destinations:
+        - PACKAGE_MANAGER
+    python_settings:
+      common:
+        destinations:
+        - PACKAGE_MANAGER
+    node_settings:
+      common:
+        destinations:
+        - PACKAGE_MANAGER
+    dotnet_settings:
+      common:
+        destinations:
+        - PACKAGE_MANAGER
+    ruby_settings:
+      common:
+        destinations:
+        - PACKAGE_MANAGER
+    go_settings:
+      common:
+        destinations:
+        - PACKAGE_MANAGER
+  proto_reference_documentation_uri: https://cloud.google.com/secret-manager/docs/reference/rpc


### PR DESCRIPTION
Parsing via yaml -> jsonproto -> proto works for enums as strings, and
for well-know protos and for a number of other corner cases.

Part of the work for #158
