### PR TITLE
refactor: move internal helpers to a rust feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,7 @@ dependencies = [
 name = "gax"
 version = "0.1.0"
 dependencies = [
+ "gax",
  "reqwest 0.12.9",
  "serde",
  "serde_json",

--- a/gax/Cargo.toml
+++ b/gax/Cargo.toml
@@ -27,3 +27,9 @@ types = { version = "0.1.0", path = "../types" }
 reqwest = "0.12.9"
 serde = { version = "1.0.214", features = ["serde_derive"] }
 serde_with = "3.11.0"
+# This is a workaround to integration test features of this crate. Open issue
+# https://github.com/rust-lang/cargo/issues/2911.
+gax = { path = ".", features = [ "sdk_client" ] }
+
+[features]
+sdk_client = []

--- a/gax/Cargo.toml
+++ b/gax/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1.0.214", features = ["serde_derive"] }
 serde_with = "3.11.0"
 # This is a workaround to integration test features of this crate. Open issue
 # https://github.com/rust-lang/cargo/issues/2911.
-gax = { path = ".", features = [ "sdk_client" ] }
+gax = { path = ".", features = ["sdk_client"] }
 
 [features]
 sdk_client = []

--- a/gax/src/lib.rs
+++ b/gax/src/lib.rs
@@ -36,6 +36,7 @@
 /// The types are not intended for application developers to use. They are
 /// public because we will generate many crates (roughly one per service), and
 /// most of these crates will use these helpers.
+#[cfg(feature = "sdk_client")]
 pub mod query_parameter;
 
 /// Defines traits and helpers to serialize path parameters.
@@ -52,6 +53,7 @@ pub mod query_parameter;
 ///
 /// If accessing deeply nested fields that can results in multiple calls to
 /// `required`.
+#[cfg(feature = "sdk_client")]
 pub mod path_parameter;
 
 /// Implementation details for [query_parameter](::crate::query_parameter).

--- a/generator/cmd/main_test.go
+++ b/generator/cmd/main_test.go
@@ -52,7 +52,7 @@ func TestRustFromOpenAPI(t *testing.T) {
 		Options: map[string]string{
 			"package-name-override":   "secretmanager-golden-openapi",
 			"package:gax_placeholder": "package=types,path=../../../../../types,source=google.protobuf",
-			"package:gax":             "package=gax,path=../../../../../gax",
+			"package:gax":             "package=gax,path=../../../../../gax,feature=sdk_client",
 		},
 	}
 	err := Generate("openapi", popts, copts)
@@ -118,7 +118,7 @@ func TestRustFromProtobuf(t *testing.T) {
 		options := map[string]string{
 			"package-name-override":   strings.Replace(config.Name, "/", "-", -1) + "-golden-gclient",
 			"package:gax_placeholder": fmt.Sprintf("package=types,path=%s/types,source=google.protobuf", toProjectRoot),
-			"package:gax":             fmt.Sprintf("package=gax,path=%s/gax", toProjectRoot),
+			"package:gax":             fmt.Sprintf("package=gax,path=%s/gax,feature=sdk_client", toProjectRoot),
 		}
 		for k, v := range config.ExtraOptions {
 			options[k] = v

--- a/generator/internal/genclient/language/internal/rust/rust_test.go
+++ b/generator/internal/genclient/language/internal/rust/rust_test.go
@@ -44,7 +44,7 @@ func TestParseOptions(t *testing.T) {
 		Options: map[string]string{
 			"package-name-override":   "test-only",
 			"package:gax_placeholder": "package=types,path=../../types,source=google.protobuf,source=test-only",
-			"package:gax":             "package=gax,path=../../gax",
+			"package:gax":             "package=gax,path=../../gax,feature=sdk_client",
 		},
 	}
 	codec, err := NewCodec(copts)
@@ -64,6 +64,9 @@ func TestParseOptions(t *testing.T) {
 				Name:    "gax",
 				Package: "gax",
 				Path:    "../../gax",
+				Features: []string{
+					"sdk_client",
+				},
 			},
 		},
 		PackageMapping: map[string]*RustPackage{

--- a/generator/testdata/rust/gclient/golden/iam/v1/Cargo.toml
+++ b/generator/testdata/rust/gclient/golden/iam/v1/Cargo.toml
@@ -10,6 +10,6 @@ serde_json = "1.0.132"
 time = { version = "0.3.36", features = ["formatting", "parsing"] }
 reqwest = { version = "0.12.9", features = ["json"] }
 bytes = { version = "1.8.0", features = ["serde"] }
-gax = { path = "../../../../../../../gax", package = "gax" }
+gax = { path = "../../../../../../../gax", package = "gax", features = ["sdk_client"] }
 gax_placeholder = { path = "../../../../../../../types", package = "types" }
 gtype = { path = "../../type", package = "type-golden-gclient" }

--- a/generator/testdata/rust/gclient/golden/secretmanager/Cargo.toml
+++ b/generator/testdata/rust/gclient/golden/secretmanager/Cargo.toml
@@ -10,6 +10,6 @@ serde_json = "1.0.132"
 time = { version = "0.3.36", features = ["formatting", "parsing"] }
 reqwest = { version = "0.12.9", features = ["json"] }
 bytes = { version = "1.8.0", features = ["serde"] }
-gax = { path = "../../../../../../gax", package = "gax" }
+gax = { path = "../../../../../../gax", package = "gax", features = ["sdk_client"] }
 gax_placeholder = { path = "../../../../../../types", package = "types" }
 iam = { path = "../iam/v1", package = "iam-v1-golden-gclient" }

--- a/generator/testdata/rust/gclient/golden/type/Cargo.toml
+++ b/generator/testdata/rust/gclient/golden/type/Cargo.toml
@@ -10,5 +10,5 @@ serde_json = "1.0.132"
 time = { version = "0.3.36", features = ["formatting", "parsing"] }
 reqwest = { version = "0.12.9", features = ["json"] }
 bytes = { version = "1.8.0", features = ["serde"] }
-gax = { path = "../../../../../../gax", package = "gax" }
+gax = { path = "../../../../../../gax", package = "gax", features = ["sdk_client"] }
 gax_placeholder = { path = "../../../../../../types", package = "types" }

--- a/generator/testdata/rust/openapi/golden/Cargo.toml
+++ b/generator/testdata/rust/openapi/golden/Cargo.toml
@@ -10,5 +10,5 @@ serde_json = "1.0.132"
 time = { version = "0.3.36", features = ["formatting", "parsing"] }
 reqwest = { version = "0.12.9", features = ["json"] }
 bytes = { version = "1.8.0", features = ["serde"] }
-gax = { path = "../../../../../gax", package = "gax" }
+gax = { path = "../../../../../gax", package = "gax", features = ["sdk_client"] }
 gax_placeholder = { path = "../../../../../types", package = "types" }


### PR DESCRIPTION
Created a feature called sdk_client which we can use from our clients but that customers should not have to depend on. This makes it more clear which APIs are meant for internal consumption vs public.