### PR TITLE
refactor(generator): test using command-line args

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -48,8 +48,6 @@ go run ./cmd -project-root=.. generate \
   -codec-option package:gax=package=gax,path=gax,feature=sdk_client
 ```
 
-[Secret Manager]: https://cloud.google.com/secret-manager/
-
 ## Installing `protoc`: the Protobuf Compiler
 
 The unit tests use `protoc` to parse text `.proto` files. You will need this
@@ -73,3 +71,4 @@ we suggest two approaches:
 
 [grpc tutorial]: https://grpc.io/docs/protoc-installation/
 [protobuf-latest]: https://github.com/protocolbuffers/protobuf/releases/latest
+[secret manager]: https://cloud.google.com/secret-manager/

--- a/generator/README.md
+++ b/generator/README.md
@@ -1,32 +1,54 @@
-# generator
+# sidekick: a tool to generate and maintain Google Cloud SDKs
 
-A tool for generating client libraries.
+`sidekick` automates (or will soon automate) most activities around generating
+and maintaining SDKs for Google Cloud.
 
-## Example Run
+## Example Run with Protobuf
 
-Run the following command from the generator directory:
+You wneed to have `protoc` installed in your path. You can find useful links
+below.
 
-```bash
-go run ./devtools/cmd/generate -language=rust
-```
-
-Alternatively, you can run the protoc command directly:
-
-```bash
-go install ./cmd/protoc-gen-gclient
-
-protoc -I testdata/googleapis \
-    --gclient_out=. \
-    --gclient_opt=capture-input=true,language=rust \
-    testdata/googleapis/google/cloud/secretmanager/v1/resources.proto \
-    testdata/googleapis/google/cloud/secretmanager/v1/service.proto
-```
-
-or to playback an old input without the need for `protoc`:
+This will generate the client library for [Secret Manager] in the
+`generator/testdata/rust/openapi/golden` directory. In future releases most
+options should be already configured in a `.sidekick.toml` file.
 
 ```bash
-go run github.com/googleapis/google-cloud-rust/generator/cmd/protoc-gen-gclient -input-path=cmd/protoc-gen-gclient/testdata/rust/rust.bin
+cd generator
+go run ./cmd -project-root=.. generate \
+  -specification-format protobuf \
+  -specification-source generator/testdata/googleapis/google/cloud/secretmanager/v1 \
+  -service-config generator/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml \
+  -parser-option googleapis-root=generator/testdata/googleapis \
+  -language rust \
+  -output generator/testdata/rust/gclient/golden/secretmanager \
+  -template-dir generator/templates \
+  -codec-option package-name-override=secretmanager-golden-gclient \
+  -codec-option package:gax_placeholder=package=types,path=types,source=google.protobuf \
+  -codec-option package:gax=package=gax,path=gax,feature=sdk_client \
+  -codec-option package:iam=package=iam-v1-golden-gclient,path=generator/testdata/rust/gclient/golden/iam/v1,source=google.iam.v1
 ```
+
+## Example Run with OpenAPI
+
+This will generate the client library for [Secret Manager] in the
+`generator/testdata/rust/openapi/golden` directory. In future releases most
+options should be already configured in a `.sidekick.toml` file.
+
+```bash
+cd generator
+go run ./cmd -project-root=.. generate \
+  -specification-format openapi \
+  -specification-source generator/testdata/openapi/secretmanager_openapi_v1.json \
+  -service-config generator/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml \
+  -language rust \
+  -output generator/testdata/rust/openapi/golden \
+  -template-dir generator/templates \
+  -codec-option package-name-override=secretmanager-golden-openapi \
+  -codec-option package:gax_placeholder=package=types,path=types,source=google.protobuf \
+  -codec-option package:gax=package=gax,path=gax,feature=sdk_client
+```
+
+[Secret Manager]: https://cloud.google.com/secret-manager/
 
 ## Installing `protoc`: the Protobuf Compiler
 

--- a/generator/README.md
+++ b/generator/README.md
@@ -14,7 +14,7 @@ options should be already configured in a `.sidekick.toml` file.
 
 ```bash
 cd generator
-go run ./cmd -project-root=.. generate \
+go run github.com/googleapis/google-cloud-rust/generator/cmd@latest -project-root=.. generate \
   -specification-format protobuf \
   -specification-source generator/testdata/googleapis/google/cloud/secretmanager/v1 \
   -service-config generator/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml \
@@ -36,7 +36,7 @@ options should be already configured in a `.sidekick.toml` file.
 
 ```bash
 cd generator
-go run ./cmd -project-root=.. generate \
+go run github.com/googleapis/google-cloud-rust/generator/cmd@latest -project-root=.. generate \
   -specification-format openapi \
   -specification-source generator/testdata/openapi/secretmanager_openapi_v1.json \
   -service-config generator/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml \

--- a/generator/cmd/generate.go
+++ b/generator/cmd/generate.go
@@ -30,7 +30,6 @@ func Generate(args []string) error {
 		serviceConfig = fs.String("service-config", "", "path to service config")
 		parserOpts    = map[string]string{}
 		language      = fs.String("language", "", "the generated language")
-		projectRoot   = fs.String("project-root", "", "the root of the output project")
 		output        = fs.String("output", "generated", "the path within project-root to put generated files")
 		templateDir   = fs.String("template-dir", "templates/", "the path to the template directory")
 		codecOpts     = map[string]string{}
@@ -69,7 +68,6 @@ func Generate(args []string) error {
 
 	copts := genclient.CodecOptions{
 		Language:    *language,
-		ProjectRoot: *projectRoot,
 		OutDir:      *output,
 		TemplateDir: *templateDir,
 		Options:     codecOpts,

--- a/generator/cmd/refresh.go
+++ b/generator/cmd/refresh.go
@@ -15,8 +15,6 @@
 package main
 
 import (
-	"path"
-
 	"github.com/googleapis/google-cloud-rust/generator/internal/genclient"
 	"github.com/googleapis/google-cloud-rust/generator/internal/genclient/language"
 	"github.com/googleapis/google-cloud-rust/generator/internal/genclient/parser"
@@ -43,7 +41,7 @@ func Refresh(specFormat string, popts *genclient.ParserOptions, copts *genclient
 	request := &genclient.GenerateRequest{
 		API:         api,
 		Codec:       codec,
-		OutDir:      path.Join(copts.ProjectRoot, copts.OutDir),
+		OutDir:      copts.OutDir,
 		TemplateDir: copts.TemplateDir,
 	}
 	return genclient.Generate(request)

--- a/generator/cmd/sidekick.go
+++ b/generator/cmd/sidekick.go
@@ -28,6 +28,14 @@ func main() {
 }
 
 func root() error {
+	var projectRoot = flag.String("project-root", "", "the root of the output project")
+	flag.Parse()
+
+	if *projectRoot != "" {
+		if err := os.Chdir(*projectRoot); err != nil {
+			return err
+		}
+	}
 	args := flag.Args()
 	if len(args) < 2 {
 		return fmt.Errorf("you must pass a subcommand")

--- a/generator/internal/genclient/genclient.go
+++ b/generator/internal/genclient/genclient.go
@@ -132,8 +132,6 @@ type ParserOptions struct {
 type CodecOptions struct {
 	// The location where the specification can be found.
 	Language string
-	// The output location.
-	ProjectRoot string
 	// The output location within ProjectRoot.
 	OutDir string
 	// The directory containing all mustache templates.

--- a/generator/testdata/rust/gclient/golden/iam/v1/Cargo.toml
+++ b/generator/testdata/rust/gclient/golden/iam/v1/Cargo.toml
@@ -12,4 +12,4 @@ reqwest = { version = "0.12.9", features = ["json"] }
 bytes = { version = "1.8.0", features = ["serde"] }
 gax = { path = "../../../../../../../gax", package = "gax", features = ["sdk_client"] }
 gax_placeholder = { path = "../../../../../../../types", package = "types" }
-gtype = { path = "../../type", package = "type-golden-gclient" }
+gtype = { path = "../../../../../../../generator/testdata/rust/gclient/golden/type", package = "type-golden-gclient" }

--- a/generator/testdata/rust/gclient/golden/secretmanager/Cargo.toml
+++ b/generator/testdata/rust/gclient/golden/secretmanager/Cargo.toml
@@ -12,4 +12,4 @@ reqwest = { version = "0.12.9", features = ["json"] }
 bytes = { version = "1.8.0", features = ["serde"] }
 gax = { path = "../../../../../../gax", package = "gax", features = ["sdk_client"] }
 gax_placeholder = { path = "../../../../../../types", package = "types" }
-iam = { path = "../iam/v1", package = "iam-v1-golden-gclient" }
+iam = { path = "../../../../../../generator/testdata/rust/gclient/golden/iam/v1", package = "iam-v1-golden-gclient" }

--- a/generator/testdata/rust/gclient/golden/secretmanager/README.md
+++ b/generator/testdata/rust/gclient/golden/secretmanager/README.md
@@ -1,3 +1,4 @@
-#  - Rust Client Library
+# Secret Manager API - Rust Client Library
 
-
+Stores sensitive data such as API keys, passwords, and certificates.
+Provides convenience while improving security.


### PR DESCRIPTION
Change the main program test to use command-line arguments. That makes
the test more comprehensive, and it helps me document the commands in
the README file.

Part of the work for #188
