### PR TITLE
feat(generated): include copyright boilerplate

### DIFF
--- a/generator/cmd/sidekick_test.go
+++ b/generator/cmd/sidekick_test.go
@@ -50,6 +50,7 @@ func TestRustFromOpenAPI(t *testing.T) {
 		"-language", "rust",
 		"-output", outDir,
 		"-template-dir", "generator/templates",
+		"-codec-option", "copyright-year=2024",
 		"-codec-option", "package-name-override=secretmanager-golden-openapi",
 		"-codec-option", "package:gax_placeholder=package=types,path=types,source=google.protobuf",
 		"-codec-option", "package:gax=package=gax,path=gax,feature=sdk_client",
@@ -117,6 +118,7 @@ func TestRustFromProtobuf(t *testing.T) {
 			"-language", "rust",
 			"-output", path.Join(outDir, config.Name),
 			"-template-dir", "generator/templates",
+			"-codec-option", "copyright-year=2024",
 			"-codec-option", "package-name-override=" + strings.Replace(config.Name, "/", "-", -1) + "-golden-gclient",
 			"-codec-option", "package:gax_placeholder=package=types,path=types,source=google.protobuf",
 			"-codec-option", "package:gax=package=gax,path=gax,feature=sdk_client",
@@ -160,6 +162,7 @@ func TestRustModuleFromProtobuf(t *testing.T) {
 		"-language", "rust",
 		"-output", "generator/testdata/rust/gclient/golden/module",
 		"-template-dir", "generator/templates",
+		"-codec-option", "copyright-year=2024",
 		"-codec-option", "generate-module=true",
 	}
 

--- a/generator/internal/genclient/genclient.go
+++ b/generator/internal/genclient/genclient.go
@@ -103,6 +103,8 @@ type LanguageCodec interface {
 	PackageName(api *API) string
 	// Validate an API, some codecs impose restrictions on the input API.
 	Validate(api *API) error
+	// The year when this package was first generated.
+	CopyrightYear() string
 }
 
 // Parser converts an textual specification to a `genclient.API` object.

--- a/generator/internal/genclient/language/internal/golang/golang.go
+++ b/generator/internal/genclient/language/internal/golang/golang.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/googleapis/google-cloud-rust/generator/internal/genclient"
@@ -25,13 +26,18 @@ import (
 )
 
 func NewCodec() *Codec {
-	return &Codec{}
+	year, _, _ := time.Now().Date()
+	return &Codec{
+		GenerationYear: fmt.Sprintf("%04d", year),
+	}
 }
 
 type Codec struct {
 	// The source package name (e.g. google.iam.v1 in Protobuf). The codec can
 	// generate code for one source package at a time.
 	SourceSpecificationPackageName string
+	// The year when the files were first generated.
+	GenerationYear string
 }
 
 func (c *Codec) LoadWellKnownTypes(s *genclient.APIState) {
@@ -222,6 +228,10 @@ func (*Codec) FormatDocComments(documentation string) []string {
 
 func (*Codec) RequiredPackages() []string {
 	return []string{}
+}
+
+func (c *Codec) CopyrightYear() string {
+	return c.GenerationYear
 }
 
 func (*Codec) PackageName(api *genclient.API) string {

--- a/generator/internal/genclient/language/internal/rust/rust.go
+++ b/generator/internal/genclient/language/internal/rust/rust.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/googleapis/google-cloud-rust/generator/internal/genclient"
@@ -28,7 +29,9 @@ import (
 )
 
 func NewCodec(copts *genclient.CodecOptions) (*Codec, error) {
+	year, _, _ := time.Now().Date()
 	codec := &Codec{
+		GenerationYear:  fmt.Sprintf("%04d", year),
 		OutputDirectory: copts.OutDir,
 		ExtraPackages:   []*RustPackage{},
 		PackageMapping:  map[string]*RustPackage{},
@@ -44,6 +47,9 @@ func NewCodec(copts *genclient.CodecOptions) (*Codec, error) {
 				return nil, err
 			}
 			codec.GenerateModule = value
+			continue
+		case "copyright-year":
+			codec.GenerationYear = definition
 			continue
 		}
 		if !strings.HasPrefix(key, "package:") {
@@ -89,6 +95,8 @@ type Codec struct {
 	OutputDirectory string
 	// Package name override. If not empty, overrides the default package name.
 	PackageNameOverride string
+	// The year when the files were first generated.
+	GenerationYear string
 	// Generate a module of a larger crate, as opposed to a full crate.
 	GenerateModule bool
 	// Additional Rust packages imported by this module. The Mustache template
@@ -495,6 +503,10 @@ func (c *Codec) RequiredPackages() []string {
 	}
 	sort.Strings(lines)
 	return lines
+}
+
+func (c *Codec) CopyrightYear() string {
+	return c.GenerationYear
 }
 
 func (c *Codec) PackageName(api *genclient.API) string {

--- a/generator/internal/genclient/language/internal/rust/rust_test.go
+++ b/generator/internal/genclient/language/internal/rust/rust_test.go
@@ -43,6 +43,7 @@ func TestParseOptions(t *testing.T) {
 		Language: "rust",
 		Options: map[string]string{
 			"package-name-override":   "test-only",
+			"copyright-year":          "2035",
 			"package:gax_placeholder": "package=types,path=../../types,source=google.protobuf,source=test-only",
 			"package:gax":             "package=gax,path=../../gax,feature=sdk_client",
 		},
@@ -58,6 +59,7 @@ func TestParseOptions(t *testing.T) {
 	}
 	want := &Codec{
 		PackageNameOverride: "test-only",
+		GenerationYear:      "2035",
 		ExtraPackages: []*RustPackage{
 			gp,
 			{

--- a/generator/internal/genclient/templatedata.go
+++ b/generator/internal/genclient/templatedata.go
@@ -63,6 +63,27 @@ func (t *templateData) HasServices() bool {
 	return len(t.s.Services) > 0
 }
 
+func (t *templateData) CopyrightYear() string {
+	return t.c.CopyrightYear()
+}
+
+func (t *templateData) BoilerPlate() []string {
+	return []string{
+		"",
+		" Licensed under the Apache License, Version 2.0 (the \"License\");",
+		" you may not use this file except in compliance with the License.",
+		" You may obtain a copy of the License at",
+		"",
+		"     https://www.apache.org/licenses/LICENSE-2.0",
+		"",
+		" Unless required by applicable law or agreed to in writing, software",
+		" distributed under the License is distributed on an \"AS IS\" BASIS,",
+		" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+		" See the License for the specific language governing permissions and",
+		" limitations under the License.",
+	}
+}
+
 func (t *templateData) Services() []*service {
 	return mapSlice(t.s.Services, func(s *Service) *service {
 		return &service{

--- a/generator/templates/go/client.go.mustache
+++ b/generator/templates/go/client.go.mustache
@@ -1,3 +1,23 @@
+{{!
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+// Copyright {{CopyrightYear}} Google LLC
+{{#BoilerPlate}}
+//{{{.}}}
+{{/BoilerPlate}}
+
 package {{NameToLower}}
 
 import (

--- a/generator/templates/go/enum.mustache
+++ b/generator/templates/go/enum.mustache
@@ -1,3 +1,18 @@
+{{!
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
 
 type {{Name}} int32
 

--- a/generator/templates/go/message.mustache
+++ b/generator/templates/go/message.mustache
@@ -1,3 +1,18 @@
+{{!
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
 {{^IsMap}}
 
 {{#DocLines}}

--- a/generator/templates/rust/crate/Cargo.toml.mustache
+++ b/generator/templates/rust/crate/Cargo.toml.mustache
@@ -13,6 +13,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
+# Copyright {{CopyrightYear}} Google LLC
+{{#BoilerPlate}}
+#{{{.}}}
+{{/BoilerPlate}}
+
 [package]
 name = "{{PackageName}}"
 version = "0.1.0"

--- a/generator/templates/rust/crate/src/lib.rs.mustache
+++ b/generator/templates/rust/crate/src/lib.rs.mustache
@@ -13,6 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
+// Copyright {{CopyrightYear}} Google LLC
+{{#BoilerPlate}}
+//{{{.}}}
+{{/BoilerPlate}}
+
+/// The messages and enums that are part of this client library.
 pub mod model;
 
 {{#HasServices}}

--- a/generator/templates/rust/crate/src/model.rs.mustache
+++ b/generator/templates/rust/crate/src/model.rs.mustache
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
+// Copyright {{CopyrightYear}} Google LLC
+{{#BoilerPlate}}
+//{{{.}}}
+{{/BoilerPlate}}
 {{#Messages}}
 {{> message}}
 {{/Messages}}

--- a/generator/templates/rust/mod/mod.rs.mustache
+++ b/generator/templates/rust/mod/mod.rs.mustache
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
+// Copyright {{CopyrightYear}} Google LLC
+{{#BoilerPlate}}
+//{{{.}}}
+{{/BoilerPlate}}
 {{#Messages}}
 {{> message}}
 {{/Messages}}

--- a/generator/testdata/rust/gclient/golden/iam/v1/Cargo.toml
+++ b/generator/testdata/rust/gclient/golden/iam/v1/Cargo.toml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [package]
 name = "iam-v1-golden-gclient"
 version = "0.1.0"

--- a/generator/testdata/rust/gclient/golden/iam/v1/src/lib.rs
+++ b/generator/testdata/rust/gclient/golden/iam/v1/src/lib.rs
@@ -1,3 +1,18 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// The messages and enums that are part of this client library.
 pub mod model;
 
 use std::sync::Arc;

--- a/generator/testdata/rust/gclient/golden/iam/v1/src/model.rs
+++ b/generator/testdata/rust/gclient/golden/iam/v1/src/model.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /// Request message for `SetIamPolicy` method.
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/generator/testdata/rust/gclient/golden/module/mod.rs
+++ b/generator/testdata/rust/gclient/golden/module/mod.rs
@@ -1,3 +1,16 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 /// Represents a textual expression in the Common Expression Language (CEL)
 /// syntax. CEL is a C-like expression language. The syntax and semantics of CEL

--- a/generator/testdata/rust/gclient/golden/secretmanager/Cargo.toml
+++ b/generator/testdata/rust/gclient/golden/secretmanager/Cargo.toml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [package]
 name = "secretmanager-golden-gclient"
 version = "0.1.0"

--- a/generator/testdata/rust/gclient/golden/secretmanager/src/lib.rs
+++ b/generator/testdata/rust/gclient/golden/secretmanager/src/lib.rs
@@ -1,3 +1,18 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// The messages and enums that are part of this client library.
 pub mod model;
 
 use std::sync::Arc;

--- a/generator/testdata/rust/gclient/golden/secretmanager/src/model.rs
+++ b/generator/testdata/rust/gclient/golden/secretmanager/src/model.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /// A [Secret][google.cloud.secretmanager.v1.Secret] is a logical secret whose
 /// value and versions can be accessed.
 ///

--- a/generator/testdata/rust/gclient/golden/type/Cargo.toml
+++ b/generator/testdata/rust/gclient/golden/type/Cargo.toml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [package]
 name = "type-golden-gclient"
 version = "0.1.0"

--- a/generator/testdata/rust/gclient/golden/type/src/lib.rs
+++ b/generator/testdata/rust/gclient/golden/type/src/lib.rs
@@ -1,1 +1,16 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// The messages and enums that are part of this client library.
 pub mod model;

--- a/generator/testdata/rust/gclient/golden/type/src/model.rs
+++ b/generator/testdata/rust/gclient/golden/type/src/model.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /// Represents a textual expression in the Common Expression Language (CEL)
 /// syntax. CEL is a C-like expression language. The syntax and semantics of CEL
 /// are documented at https://github.com/google/cel-spec.

--- a/generator/testdata/rust/openapi/golden/Cargo.toml
+++ b/generator/testdata/rust/openapi/golden/Cargo.toml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [package]
 name = "secretmanager-golden-openapi"
 version = "0.1.0"

--- a/generator/testdata/rust/openapi/golden/src/lib.rs
+++ b/generator/testdata/rust/openapi/golden/src/lib.rs
@@ -1,3 +1,18 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// The messages and enums that are part of this client library.
 pub mod model;
 
 use std::sync::Arc;

--- a/generator/testdata/rust/openapi/golden/src/model.rs
+++ b/generator/testdata/rust/openapi/golden/src/model.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /// The response message for Locations.ListLocations.
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
Wherever is possible we are supposed to include the copyright boilerplace, even
in generated code. We will capture the generation year when the library is
first created. That prevents noisy changes when regenerating in a different
year. From time to time we will create new files, we can bump the year across
all files (this is allowed for generated code), when that happens.

