### PR TITLE
cleanup: configure `.toml` formatting

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -12,10 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[package]
-name    = "check-copyright"
-version = "0.1.0"
-edition = "2021"
+[formatting]
+align_entries = true
+column_width  = 120
 
-[dependencies]
-regex = "1.11.1"
+# The CI builds exclude these explicitly. Having them here makes it easier to
+# format everything we care about. 
+#
+# ```
+# taplot format .
+# ```
+#
+exclude = ['generator/testdata/**']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,10 +40,10 @@ members = [
 ]
 
 [workspace.package]
-edition = "2021"
-authors = ["Google LLC"]
+edition     = "2021"
+authors     = ["Google LLC"]
 description = "Google Cloud SDK for Rust"
-license = "Apache-2.0"
-repository = "https://github.com/googleapis/google-cloud-rust/tree/main"
-keywords = ["google-cloud", "google-cloud-rust", "gcp", "sdk"]
-categories = ["network-programming"]
+license     = "Apache-2.0"
+repository  = "https://github.com/googleapis/google-cloud-rust/tree/main"
+keywords    = ["google-cloud", "google-cloud-rust", "gcp", "sdk"]
+categories  = ["network-programming"]

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -13,26 +13,26 @@
 # limitations under the License.
 
 [package]
-name = "google-cloud-auth"
-version = "0.1.0"
-authors = ["Google LLC"]
+name        = "google-cloud-auth"
+version     = "0.1.0"
+authors     = ["Google LLC"]
 description = "An auth library for Cloud Google APIs."
-license = "Apache-2.0"
-repository = "https://github.com/googleapis/google-cloud-rust/tree/main/auth"
-keywords = ["auth", "google", "google-cloud"]
-categories = ["authentication", "web-programming"]
-edition = "2021"
+license     = "Apache-2.0"
+repository  = "https://github.com/googleapis/google-cloud-rust/tree/main/auth"
+keywords    = ["auth", "google", "google-cloud"]
+categories  = ["authentication", "web-programming"]
+edition     = "2021"
 
 [dependencies]
-base64 = "0.13"
-chrono = { version = "0.4", features = ["serde"] }
-reqwest = { version = "0.11", features = ["json"] }
-rustls = "0.20"
+base64         = "0.13"
+chrono         = { version = "0.4", features = ["serde"] }
+reqwest        = { version = "0.11", features = ["json"] }
+rustls         = "0.20"
 rustls-pemfile = "0.2"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-thiserror = "1"
-tokio = { version = "1.12", features = ["full", "macros"] }
-async-trait = "0.1"
-http = "0.2"
-backoff = { version = "0.4", features = ["tokio"] }
+serde          = { version = "1", features = ["derive"] }
+serde_json     = "1"
+thiserror      = "1"
+tokio          = { version = "1.12", features = ["full", "macros"] }
+async-trait    = "0.1"
+http           = "0.2"
+backoff        = { version = "0.4", features = ["tokio"] }

--- a/gax/Cargo.toml
+++ b/gax/Cargo.toml
@@ -18,18 +18,18 @@ name    = "gax"
 version = "0.1.0"
 
 [dependencies]
-bytes = "1.8.0"
-http = "1.1.0"
-reqwest = { version = "0.12.9", optional = true }
-serde = "1.0.214"
+bytes      = "1.8.0"
+http       = "1.1.0"
+reqwest    = { version = "0.12.9", optional = true }
+serde      = "1.0.214"
 serde_json = "1.0.132"
 thiserror  = "2.0.1"
 types      = { version = "0.1.0", path = "../types" }
 
 [dev-dependencies]
-serde = { version = "1.0.214", features = ["serde_derive"] }
+serde      = { version = "1.0.214", features = ["serde_derive"] }
 serde_with = "3.11.0"
-tokio = { version = "1.41.1", features = ["macros"] }
+tokio      = { version = "1.41.1", features = ["macros"] }
 # This is a workaround to integration test features of this crate. Open issue
 # https://github.com/rust-lang/cargo/issues/2911.
 gax = { path = ".", features = ["sdk_client"] }

--- a/gax/Cargo.toml
+++ b/gax/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 edition = "2021"
-name = "gax"
+name    = "gax"
 version = "0.1.0"
 
 [dependencies]
@@ -23,8 +23,8 @@ http = "1.1.0"
 reqwest = { version = "0.12.9", optional = true }
 serde = "1.0.214"
 serde_json = "1.0.132"
-thiserror = "2.0.1"
-types = { version = "0.1.0", path = "../types" }
+thiserror  = "2.0.1"
+types      = { version = "0.1.0", path = "../types" }
 
 [dev-dependencies]
 serde = { version = "1.0.214", features = ["serde_derive"] }

--- a/generator/internal/genclient/language/internal/rust/rust.go
+++ b/generator/internal/genclient/language/internal/rust/rust.go
@@ -586,7 +586,7 @@ func (c *Codec) RequiredPackages() []string {
 			feats := strings.Join(mapSlice(pkg.Features, func(s string) string { return fmt.Sprintf("%q", s) }), ", ")
 			components = append(components, fmt.Sprintf("features = [%s]", feats))
 		}
-		lines = append(lines, fmt.Sprintf("%s = { %s }", pkg.Name, strings.Join(components, ", ")))
+		lines = append(lines, fmt.Sprintf("%-10s = { %s }", pkg.Name, strings.Join(components, ", ")))
 	}
 	sort.Strings(lines)
 	return lines

--- a/generator/internal/genclient/language/internal/rust/rust_test.go
+++ b/generator/internal/genclient/language/internal/rust/rust_test.go
@@ -101,8 +101,8 @@ func TestRequiredPackages(t *testing.T) {
 	}
 	got := codec.RequiredPackages()
 	want := []string{
-		"gtype = { path = \"../../../src/generated/type\", package = \"types\" }",
-		"gax = { version = \"1.2.3\", path = \"../../../src/gax\", package = \"gax\" }",
+		"gtype      = { path = \"../../../src/generated/type\", package = \"types\" }",
+		"gax        = { version = \"1.2.3\", path = \"../../../src/gax\", package = \"gax\" }",
 	}
 	less := func(a, b string) bool { return a < b }
 	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); len(diff) > 0 {
@@ -126,7 +126,7 @@ func TestRequiredPackagesLocal(t *testing.T) {
 	}
 	got := codec.RequiredPackages()
 	want := []string{
-		"gtype = { path = \"src/generated/type\", package = \"types\" }",
+		"gtype      = { path = \"src/generated/type\", package = \"types\" }",
 	}
 	less := func(a, b string) bool { return a < b }
 	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); len(diff) > 0 {

--- a/generator/templates/rust/crate/Cargo.toml.mustache
+++ b/generator/templates/rust/crate/Cargo.toml.mustache
@@ -19,17 +19,22 @@ limitations under the License.
 {{/BoilerPlate}}
 
 [package]
-name = "{{PackageName}}"
-version = "0.1.0"
-edition = "2021"
+name                 = "{{PackageName}}"
+version              = "0.1.0"
+edition.workspace    = true
+authors.workspace    = true
+license.workspace    = true
+repository.workspace = true
+keywords.workspace   = true
+categories.workspace = true
 
 [dependencies]
-serde = { version = "1.0.214", features = ["serde_derive"] }
+serde      = { version = "1.0.214", features = ["serde_derive"] }
 serde_with = { version = "3.11.0", features = ["base64"] }
 serde_json = "1.0.132"
-time = { version = "0.3.36", features = ["formatting", "parsing"] }
-reqwest = { version = "0.12.9", features = ["json"] }
-bytes = { version = "1.8.0", features = ["serde"] }
+time       = { version = "0.3.36", features = ["formatting", "parsing"] }
+reqwest    = { version = "0.12.9", features = ["json"] }
+bytes      = { version = "1.8.0", features = ["serde"] }
 {{#RequiredPackages}}
 {{{.}}}
 {{/RequiredPackages}}

--- a/generator/testdata/rust/gclient/golden/iam/v1/Cargo.toml
+++ b/generator/testdata/rust/gclient/golden/iam/v1/Cargo.toml
@@ -13,17 +13,22 @@
 # limitations under the License.
 
 [package]
-name = "iam-v1-golden-gclient"
-version = "0.1.0"
-edition = "2021"
+name                 = "iam-v1-golden-gclient"
+version              = "0.1.0"
+edition.workspace    = true
+authors.workspace    = true
+license.workspace    = true
+repository.workspace = true
+keywords.workspace   = true
+categories.workspace = true
 
 [dependencies]
-serde = { version = "1.0.214", features = ["serde_derive"] }
+serde      = { version = "1.0.214", features = ["serde_derive"] }
 serde_with = { version = "3.11.0", features = ["base64"] }
 serde_json = "1.0.132"
-time = { version = "0.3.36", features = ["formatting", "parsing"] }
-reqwest = { version = "0.12.9", features = ["json"] }
-bytes = { version = "1.8.0", features = ["serde"] }
-gax = { path = "../../../../../../../gax", package = "gax", features = ["sdk_client"] }
-gtype = { path = "../../../../../../../generator/testdata/rust/gclient/golden/type", package = "type-golden-gclient" }
-wkt = { path = "../../../../../../../types", package = "types" }
+time       = { version = "0.3.36", features = ["formatting", "parsing"] }
+reqwest    = { version = "0.12.9", features = ["json"] }
+bytes      = { version = "1.8.0", features = ["serde"] }
+gax        = { path = "../../../../../../../gax", package = "gax", features = ["sdk_client"] }
+gtype      = { path = "../../../../../../../generator/testdata/rust/gclient/golden/type", package = "type-golden-gclient" }
+wkt        = { path = "../../../../../../../types", package = "types" }

--- a/generator/testdata/rust/gclient/golden/secretmanager/Cargo.toml
+++ b/generator/testdata/rust/gclient/golden/secretmanager/Cargo.toml
@@ -13,17 +13,22 @@
 # limitations under the License.
 
 [package]
-name = "secretmanager-golden-gclient"
-version = "0.1.0"
-edition = "2021"
+name                 = "secretmanager-golden-gclient"
+version              = "0.1.0"
+edition.workspace    = true
+authors.workspace    = true
+license.workspace    = true
+repository.workspace = true
+keywords.workspace   = true
+categories.workspace = true
 
 [dependencies]
-serde = { version = "1.0.214", features = ["serde_derive"] }
+serde      = { version = "1.0.214", features = ["serde_derive"] }
 serde_with = { version = "3.11.0", features = ["base64"] }
 serde_json = "1.0.132"
-time = { version = "0.3.36", features = ["formatting", "parsing"] }
-reqwest = { version = "0.12.9", features = ["json"] }
-bytes = { version = "1.8.0", features = ["serde"] }
-gax = { path = "../../../../../../gax", package = "gax", features = ["sdk_client"] }
-iam = { path = "../../../../../../generator/testdata/rust/gclient/golden/iam/v1", package = "iam-v1-golden-gclient" }
-wkt = { path = "../../../../../../types", package = "types" }
+time       = { version = "0.3.36", features = ["formatting", "parsing"] }
+reqwest    = { version = "0.12.9", features = ["json"] }
+bytes      = { version = "1.8.0", features = ["serde"] }
+gax        = { path = "../../../../../../gax", package = "gax", features = ["sdk_client"] }
+iam        = { path = "../../../../../../generator/testdata/rust/gclient/golden/iam/v1", package = "iam-v1-golden-gclient" }
+wkt        = { path = "../../../../../../types", package = "types" }

--- a/generator/testdata/rust/gclient/golden/type/Cargo.toml
+++ b/generator/testdata/rust/gclient/golden/type/Cargo.toml
@@ -13,16 +13,21 @@
 # limitations under the License.
 
 [package]
-name = "type-golden-gclient"
-version = "0.1.0"
-edition = "2021"
+name                 = "type-golden-gclient"
+version              = "0.1.0"
+edition.workspace    = true
+authors.workspace    = true
+license.workspace    = true
+repository.workspace = true
+keywords.workspace   = true
+categories.workspace = true
 
 [dependencies]
-serde = { version = "1.0.214", features = ["serde_derive"] }
+serde      = { version = "1.0.214", features = ["serde_derive"] }
 serde_with = { version = "3.11.0", features = ["base64"] }
 serde_json = "1.0.132"
-time = { version = "0.3.36", features = ["formatting", "parsing"] }
-reqwest = { version = "0.12.9", features = ["json"] }
-bytes = { version = "1.8.0", features = ["serde"] }
-gax = { path = "../../../../../../gax", package = "gax", features = ["sdk_client"] }
-wkt = { path = "../../../../../../types", package = "types" }
+time       = { version = "0.3.36", features = ["formatting", "parsing"] }
+reqwest    = { version = "0.12.9", features = ["json"] }
+bytes      = { version = "1.8.0", features = ["serde"] }
+gax        = { path = "../../../../../../gax", package = "gax", features = ["sdk_client"] }
+wkt        = { path = "../../../../../../types", package = "types" }

--- a/generator/testdata/rust/openapi/golden/Cargo.toml
+++ b/generator/testdata/rust/openapi/golden/Cargo.toml
@@ -13,16 +13,21 @@
 # limitations under the License.
 
 [package]
-name = "secretmanager-golden-openapi"
-version = "0.1.0"
-edition = "2021"
+name                 = "secretmanager-golden-openapi"
+version              = "0.1.0"
+edition.workspace    = true
+authors.workspace    = true
+license.workspace    = true
+repository.workspace = true
+keywords.workspace   = true
+categories.workspace = true
 
 [dependencies]
-serde = { version = "1.0.214", features = ["serde_derive"] }
+serde      = { version = "1.0.214", features = ["serde_derive"] }
 serde_with = { version = "3.11.0", features = ["base64"] }
 serde_json = "1.0.132"
-time = { version = "0.3.36", features = ["formatting", "parsing"] }
-reqwest = { version = "0.12.9", features = ["json"] }
-bytes = { version = "1.8.0", features = ["serde"] }
-gax = { path = "../../../../../gax", package = "gax", features = ["sdk_client"] }
-wkt = { path = "../../../../../types", package = "types" }
+time       = { version = "0.3.36", features = ["formatting", "parsing"] }
+reqwest    = { version = "0.12.9", features = ["json"] }
+bytes      = { version = "1.8.0", features = ["serde"] }
+gax        = { path = "../../../../../gax", package = "gax", features = ["sdk_client"] }
+wkt        = { path = "../../../../../types", package = "types" }

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 [package]
-name = "gcp-sdk-auth"
-version = "0.0.0"
-description = "Google Cloud SDK for Rust"
-edition.workspace = true
-authors.workspace = true
-license.workspace = true
+name                 = "gcp-sdk-auth"
+version              = "0.0.0"
+description          = "Google Cloud SDK for Rust"
+edition.workspace    = true
+authors.workspace    = true
+license.workspace    = true
 repository.workspace = true
-keywords.workspace = true
+keywords.workspace   = true
 categories.workspace = true

--- a/src/base/Cargo.toml
+++ b/src/base/Cargo.toml
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 [package]
-name = "gcp-sdk-base"
-version = "0.0.0"
-description = "Google Cloud SDK for Rust"
-edition.workspace = true
-authors.workspace = true
-license.workspace = true
+name                 = "gcp-sdk-base"
+version              = "0.0.0"
+description          = "Google Cloud SDK for Rust"
+edition.workspace    = true
+authors.workspace    = true
+license.workspace    = true
 repository.workspace = true
-keywords.workspace = true
+keywords.workspace   = true
 categories.workspace = true

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 [package]
-name = "gcp-sdk-gax"
-version = "0.0.0"
-description = "Google Cloud SDK for Rust"
-edition.workspace = true
-authors.workspace = true
-license.workspace = true
+name                 = "gcp-sdk-gax"
+version              = "0.0.0"
+description          = "Google Cloud SDK for Rust"
+edition.workspace    = true
+authors.workspace    = true
+license.workspace    = true
 repository.workspace = true
-keywords.workspace = true
+keywords.workspace   = true
 categories.workspace = true

--- a/src/generated/api/Cargo.toml
+++ b/src/generated/api/Cargo.toml
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 [package]
-name = "gcp-sdk-api"
-version = "0.0.0"
-description = "Google Cloud SDK for Rust"
-edition.workspace = true
-authors.workspace = true
-license.workspace = true
+name                 = "gcp-sdk-api"
+version              = "0.0.0"
+description          = "Google Cloud SDK for Rust"
+edition.workspace    = true
+authors.workspace    = true
+license.workspace    = true
 repository.workspace = true
-keywords.workspace = true
+keywords.workspace   = true
 categories.workspace = true

--- a/src/generated/cloud/common/Cargo.toml
+++ b/src/generated/cloud/common/Cargo.toml
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 [package]
-name = "gcp-sdk-common"
-version = "0.0.0"
-description = "Google Cloud SDK for Rust"
-edition.workspace = true
-authors.workspace = true
-license.workspace = true
+name                 = "gcp-sdk-common"
+version              = "0.0.0"
+description          = "Google Cloud SDK for Rust"
+edition.workspace    = true
+authors.workspace    = true
+license.workspace    = true
 repository.workspace = true
-keywords.workspace = true
+keywords.workspace   = true
 categories.workspace = true

--- a/src/generated/cloud/iam/v1/Cargo.toml
+++ b/src/generated/cloud/iam/v1/Cargo.toml
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 [package]
-name = "gcp-sdk-iam-v1"
-version = "0.0.0"
-description = "Google Cloud SDK for Rust"
-edition.workspace = true
-authors.workspace = true
-license.workspace = true
+name                 = "gcp-sdk-iam-v1"
+version              = "0.0.0"
+description          = "Google Cloud SDK for Rust"
+edition.workspace    = true
+authors.workspace    = true
+license.workspace    = true
 repository.workspace = true
-keywords.workspace = true
+keywords.workspace   = true
 categories.workspace = true

--- a/src/generated/cloud/location/Cargo.toml
+++ b/src/generated/cloud/location/Cargo.toml
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 [package]
-name = "gcp-sdk-location"
-version = "0.0.0"
-description = "Google Cloud SDK for Rust"
-edition.workspace = true
-authors.workspace = true
-license.workspace = true
+name                 = "gcp-sdk-location"
+version              = "0.0.0"
+description          = "Google Cloud SDK for Rust"
+edition.workspace    = true
+authors.workspace    = true
+license.workspace    = true
 repository.workspace = true
-keywords.workspace = true
+keywords.workspace   = true
 categories.workspace = true

--- a/src/generated/cloud/secretmanager/v1/Cargo.toml
+++ b/src/generated/cloud/secretmanager/v1/Cargo.toml
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 [package]
-name = "gcp-sdk-secretmanager-v1"
-version = "0.0.0"
-description = "Google Cloud SDK for Rust"
-edition.workspace = true
-authors.workspace = true
-license.workspace = true
+name                 = "gcp-sdk-secretmanager-v1"
+version              = "0.0.0"
+description          = "Google Cloud SDK for Rust"
+edition.workspace    = true
+authors.workspace    = true
+license.workspace    = true
 repository.workspace = true
-keywords.workspace = true
+keywords.workspace   = true
 categories.workspace = true

--- a/src/generated/longrunning/Cargo.toml
+++ b/src/generated/longrunning/Cargo.toml
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 [package]
-name = "gcp-sdk-longrunning"
-version = "0.0.0"
-description = "Google Cloud SDK for Rust"
-edition.workspace = true
-authors.workspace = true
-license.workspace = true
+name                 = "gcp-sdk-longrunning"
+version              = "0.0.0"
+description          = "Google Cloud SDK for Rust"
+edition.workspace    = true
+authors.workspace    = true
+license.workspace    = true
 repository.workspace = true
-keywords.workspace = true
+keywords.workspace   = true
 categories.workspace = true

--- a/src/generated/type/Cargo.toml
+++ b/src/generated/type/Cargo.toml
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 [package]
-name = "gcp-sdk-type"
-version = "0.0.0"
-description = "Google Cloud SDK for Rust"
-edition.workspace = true
-authors.workspace = true
-license.workspace = true
+name                 = "gcp-sdk-type"
+version              = "0.0.0"
+description          = "Google Cloud SDK for Rust"
+edition.workspace    = true
+authors.workspace    = true
+license.workspace    = true
 repository.workspace = true
-keywords.workspace = true
+keywords.workspace   = true
 categories.workspace = true

--- a/src/integration-tests/Cargo.toml
+++ b/src/integration-tests/Cargo.toml
@@ -13,20 +13,20 @@
 # limitations under the License.
 
 [package]
-name = "integration-tests"
-description = "Integration tests for google-cloud-rust."
-version = "0.0.0"
+name              = "integration-tests"
+description       = "Integration tests for google-cloud-rust."
+version           = "0.0.0"
 edition.workspace = true
-publish = ["prevent-accidental-publication"]
+publish           = ["prevent-accidental-publication"]
 
 [features]
 run-integration-tests = ["dep:tokio"]
 
 [dependencies]
-tokio = { version = "1.12", features = ["full", "macros"], optional = true }
-auth = { path = "../../auth", package = "google-cloud-auth" }
-gax = { path = "../../gax", package = "gax" }
-wkt = { path = "../../types", package = "types" }
-sm = { path = "../../generator/testdata/rust/gclient/golden/secretmanager", package = "secretmanager-golden-gclient" }
-rand = "0.8.5"
+tokio   = { version = "1.12", features = ["full", "macros"], optional = true }
+auth    = { path = "../../auth", package = "google-cloud-auth" }
+gax     = { path = "../../gax", package = "gax" }
+wkt     = { path = "../../types", package = "types" }
+sm      = { path = "../../generator/testdata/rust/gclient/golden/secretmanager", package = "secretmanager-golden-gclient" }
+rand    = "0.8.5"
 futures = "0.3.31"

--- a/src/root/Cargo.toml
+++ b/src/root/Cargo.toml
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 [package]
-name = "gcp-sdk"
-version = "0.0.0"
-description = "Google Cloud SDK for Rust"
-edition.workspace = true
-authors.workspace = true
-license.workspace = true
+name                 = "gcp-sdk"
+version              = "0.0.0"
+description          = "Google Cloud SDK for Rust"
+edition.workspace    = true
+authors.workspace    = true
+license.workspace    = true
 repository.workspace = true
-keywords.workspace = true
+keywords.workspace   = true
 categories.workspace = true

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 [package]
-name = "gcp-sdk-wkt"
-version = "0.0.0"
-description = "Google Cloud SDK for Rust"
-edition.workspace = true
-authors.workspace = true
-license.workspace = true
+name                 = "gcp-sdk-wkt"
+version              = "0.0.0"
+description          = "Google Cloud SDK for Rust"
+edition.workspace    = true
+authors.workspace    = true
+license.workspace    = true
 repository.workspace = true
-keywords.workspace = true
+keywords.workspace   = true
 categories.workspace = true

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -13,18 +13,18 @@
 # limitations under the License.
 
 [package]
-name = "types"
+name    = "types"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0.214", features = ["serde_derive"] }
+serde      = { version = "1.0.214", features = ["serde_derive"] }
 serde_with = { version = "3.11.0" }
 serde_json = "1.0.132"
-time = { version = "0.3.36", features = ["formatting", "parsing"] }
-bytes = { version = "1.8.0", features = ["serde"] }
+time       = { version = "0.3.36", features = ["formatting", "parsing"] }
+bytes      = { version = "1.8.0", features = ["serde"] }
 
 [dev-dependencies]
-test-case = "3.3.1"
-bytes = { version = "1.8.0", features = ["serde"] }
+test-case  = "3.3.1"
+bytes      = { version = "1.8.0", features = ["serde"] }
 serde_with = { version = "3.11.0", features = ["base64"] }


### PR DESCRIPTION
I think aligned entries within a table are more readable. Also fix the
generator to create `Cargo.toml` files that are very close to having
perfect formatting.