### PR TITLE
cleanup(generator): success runs are silent

### DIFF
--- a/generator/internal/genclient/genclient.go
+++ b/generator/internal/genclient/genclient.go
@@ -177,7 +177,6 @@ func (r *GenerateRequest) outDir() string {
 func Generate(req *GenerateRequest) error {
 	data := newTemplateData(req.API, req.Codec)
 	root := filepath.Join(req.TemplateDir, req.Codec.TemplateDir())
-	slog.Info(root)
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/generator/internal/genclient/parser/protobuf/protobuf.go
+++ b/generator/internal/genclient/parser/protobuf/protobuf.go
@@ -351,6 +351,26 @@ func normalizeTypes(state *genclient.APIState, in *descriptorpb.FieldDescriptorP
 		}
 	case descriptorpb.FieldDescriptorProto_TYPE_ENUM:
 		field.TypezID = in.GetTypeName()
+
+	case
+		descriptorpb.FieldDescriptorProto_TYPE_DOUBLE,
+		descriptorpb.FieldDescriptorProto_TYPE_FLOAT,
+		descriptorpb.FieldDescriptorProto_TYPE_INT64,
+		descriptorpb.FieldDescriptorProto_TYPE_UINT64,
+		descriptorpb.FieldDescriptorProto_TYPE_INT32,
+		descriptorpb.FieldDescriptorProto_TYPE_FIXED64,
+		descriptorpb.FieldDescriptorProto_TYPE_FIXED32,
+		descriptorpb.FieldDescriptorProto_TYPE_BOOL,
+		descriptorpb.FieldDescriptorProto_TYPE_STRING,
+		descriptorpb.FieldDescriptorProto_TYPE_BYTES,
+		descriptorpb.FieldDescriptorProto_TYPE_UINT32,
+		descriptorpb.FieldDescriptorProto_TYPE_SFIXED32,
+		descriptorpb.FieldDescriptorProto_TYPE_SFIXED64,
+		descriptorpb.FieldDescriptorProto_TYPE_SINT32,
+		descriptorpb.FieldDescriptorProto_TYPE_SINT64:
+		// These do not need normalization
+		return
+
 	default:
 		slog.Warn("found undefined field", "field", in.GetName())
 	}


### PR DESCRIPTION
Fix a bunch of warnings that really did not indicate a problem, and one
info message that we do not need on successful runs.