### PR TITLE
fix(generator/openapi): iterate on synthetic messages

### DIFF
--- a/generator/internal/genclient/parser/openapi/openapi.go
+++ b/generator/internal/genclient/parser/openapi/openapi.go
@@ -215,17 +215,13 @@ func makeMethods(api *genclient.API, model *libopenapi.DocumentModel[v3.Document
 			if op.Operation == nil {
 				continue
 			}
-			requestMessage, err := makeRequestMessage(api, op.Operation, pattern)
+			requestMessage, bodyFieldPath, err := makeRequestMessage(api, op.Operation, pattern)
 			if err != nil {
 				return nil, err
 			}
 			responseMessage, err := makeResponseMessage(api, op.Operation)
 			if err != nil {
 				return nil, err
-			}
-			bodyFieldPath := ""
-			if op.Operation.RequestBody != nil {
-				bodyFieldPath = "*"
 			}
 			pathInfo := &genclient.PathInfo{
 				Verb:            op.Verb,
@@ -269,7 +265,7 @@ func makePathTemplate(template string) []genclient.PathSegment {
 	return segments
 }
 
-func makeRequestMessage(api *genclient.API, operation *v3.Operation, template string) (*genclient.Message, error) {
+func makeRequestMessage(api *genclient.API, operation *v3.Operation, template string) (*genclient.Message, string, error) {
 	messageName := fmt.Sprintf("%sRequest", operation.OperationId)
 	id := fmt.Sprintf("..%s", messageName)
 	message := &genclient.Message{
@@ -278,25 +274,30 @@ func makeRequestMessage(api *genclient.API, operation *v3.Operation, template st
 		Documentation: fmt.Sprintf("The request message for %s.", operation.OperationId),
 	}
 
+	bodyFieldPath := ""
 	if operation.RequestBody != nil {
 		reference, err := findReferenceInContentMap(operation.RequestBody.Content)
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 		bid := fmt.Sprintf("..%s", strings.TrimPrefix(reference, "#/components/schemas/"))
 		msg, ok := api.State.MessageByID[bid]
 		if !ok {
-			return nil, fmt.Errorf("cannot find referenced type (%s) in API messages", reference)
+			return nil, "", fmt.Errorf("cannot find referenced type (%s) in API messages", reference)
 		}
+		// Our OpenAPI specs do this weird thing: sometimes the `*Request`
+		// message appears in the list of known messages. But sometimes only
+		// the payload appears. I have not found any attribute to tell apart
+		// between the two. Only the name suffix.
 		if strings.HasSuffix(reference, "Request") {
-			// Our OpenAPI specs do this weird thing: sometimes the `*Request`
-			// message appears in the list of known messages. But sometimes only
-			// the payload appears. I have not found any attribute to tell apart
-			// between the two. Only the name suffix.
+			// If the message ends in `Request` then we can assume it is fine
+			// adding more fields to it.
 			message = msg
 		} else {
+			// Let's try a couple of different names for the request body.
 			inserted := false
 			for _, name := range []string{"requestBody", "openapiRequestBody"} {
+				bodyFieldPath = name
 				field := &genclient.Field{
 					Name:          name,
 					Documentation: "The request body.",
@@ -310,10 +311,12 @@ func makeRequestMessage(api *genclient.API, operation *v3.Operation, template st
 				}
 			}
 			if !inserted {
-				return nil, fmt.Errorf("cannot insert the request body to message %s", message.Name)
+				return nil, "", fmt.Errorf("cannot insert the request body to message %s", message.Name)
 			}
+			// We need to create the message.
+			api.Messages = append(api.Messages, message)
+			api.State.MessageByID[message.ID] = message
 		}
-		message = msg
 	} else {
 		// The message is new
 		api.Messages = append(api.Messages, message)
@@ -323,11 +326,11 @@ func makeRequestMessage(api *genclient.API, operation *v3.Operation, template st
 	for _, p := range operation.Parameters {
 		schema, err := p.Schema.BuildSchema()
 		if err != nil {
-			return nil, fmt.Errorf("error building schema for parameter %s: %w", p.Name, err)
+			return nil, "", fmt.Errorf("error building schema for parameter %s: %w", p.Name, err)
 		}
 		typez, typezID, err := scalarType(messageName, p.Name, schema)
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 		documentation := p.Description
 		if len(documentation) == 0 {
@@ -348,7 +351,7 @@ func makeRequestMessage(api *genclient.API, operation *v3.Operation, template st
 		}
 		addFieldIfNew(message, field)
 	}
-	return message, nil
+	return message, bodyFieldPath, nil
 }
 
 func addFieldIfNew(message *genclient.Message, field *genclient.Field) bool {

--- a/generator/internal/genclient/parser/openapi/openapi_test.go
+++ b/generator/internal/genclient/parser/openapi/openapi_test.go
@@ -697,7 +697,7 @@ func TestMakeAPI(t *testing.T) {
 				Name:          "CreateSecret",
 				ID:            "CreateSecret",
 				Documentation: "Creates a new Secret containing no SecretVersions.",
-				InputTypeID:   "..Secret",
+				InputTypeID:   "..CreateSecretRequest",
 				OutputTypeID:  "..Secret",
 				PathInfo: &genclient.PathInfo{
 					Verb:          "POST",

--- a/generator/testdata/rust/openapi/golden/src/lib.rs
+++ b/generator/testdata/rust/openapi/golden/src/lib.rs
@@ -171,7 +171,10 @@ impl GoogleCloudSecretmanagerV1SecretManagerService {
     }
 
     /// Creates a new Secret containing no SecretVersions.
-    pub async fn create_secret(&self, req: crate::model::Secret) -> Result<crate::model::Secret> {
+    pub async fn create_secret(
+        &self,
+        req: crate::model::CreateSecretRequest,
+    ) -> Result<crate::model::Secret> {
         let client = self.client.inner.clone();
         let builder = client
             .http_client
@@ -184,7 +187,7 @@ impl GoogleCloudSecretmanagerV1SecretManagerService {
             gax::query_parameter::add(builder, "secretId", &req.secret_id).map_err(Error::other)?;
         let res = builder
             .bearer_auth(&client.token)
-            .json(&req)
+            .json(&req.request_body)
             .send()
             .await
             .map_err(Error::io)?;
@@ -241,7 +244,7 @@ impl GoogleCloudSecretmanagerV1SecretManagerService {
     /// Creates a new Secret containing no SecretVersions.
     pub async fn create_secret_by_project_and_location(
         &self,
-        req: crate::model::Secret,
+        req: crate::model::CreateSecretByProjectAndLocationRequest,
     ) -> Result<crate::model::Secret> {
         let client = self.client.inner.clone();
         let builder = client
@@ -255,7 +258,7 @@ impl GoogleCloudSecretmanagerV1SecretManagerService {
             gax::query_parameter::add(builder, "secretId", &req.secret_id).map_err(Error::other)?;
         let res = builder
             .bearer_auth(&client.token)
-            .json(&req)
+            .json(&req.request_body)
             .send()
             .await
             .map_err(Error::io)?;
@@ -288,7 +291,6 @@ impl GoogleCloudSecretmanagerV1SecretManagerService {
             .query(&[("alt", "json")]);
         let res = builder
             .bearer_auth(&client.token)
-            .json(&req)
             .send()
             .await
             .map_err(Error::io)?;
@@ -321,7 +323,6 @@ impl GoogleCloudSecretmanagerV1SecretManagerService {
             .query(&[("alt", "json")]);
         let res = builder
             .bearer_auth(&client.token)
-            .json(&req)
             .send()
             .await
             .map_err(Error::io)?;
@@ -403,7 +404,10 @@ impl GoogleCloudSecretmanagerV1SecretManagerService {
     }
 
     /// Updates metadata of an existing Secret.
-    pub async fn update_secret(&self, req: crate::model::Secret) -> Result<crate::model::Secret> {
+    pub async fn update_secret(
+        &self,
+        req: crate::model::UpdateSecretRequest,
+    ) -> Result<crate::model::Secret> {
         let client = self.client.inner.clone();
         let builder = client
             .http_client
@@ -420,7 +424,7 @@ impl GoogleCloudSecretmanagerV1SecretManagerService {
         .map_err(Error::other)?;
         let res = builder
             .bearer_auth(&client.token)
-            .json(&req)
+            .json(&req.request_body)
             .send()
             .await
             .map_err(Error::io)?;
@@ -504,7 +508,7 @@ impl GoogleCloudSecretmanagerV1SecretManagerService {
     /// Updates metadata of an existing Secret.
     pub async fn update_secret_by_project_and_location_and_secret(
         &self,
-        req: crate::model::Secret,
+        req: crate::model::UpdateSecretByProjectAndLocationAndSecretRequest,
     ) -> Result<crate::model::Secret> {
         let client = self.client.inner.clone();
         let builder = client
@@ -522,7 +526,7 @@ impl GoogleCloudSecretmanagerV1SecretManagerService {
         .map_err(Error::other)?;
         let res = builder
             .bearer_auth(&client.token)
-            .json(&req)
+            .json(&req.request_body)
             .send()
             .await
             .map_err(Error::io)?;
@@ -769,7 +773,6 @@ impl GoogleCloudSecretmanagerV1SecretManagerService {
             .query(&[("alt", "json")]);
         let res = builder
             .bearer_auth(&client.token)
-            .json(&req)
             .send()
             .await
             .map_err(Error::io)?;
@@ -804,7 +807,6 @@ impl GoogleCloudSecretmanagerV1SecretManagerService {
             .query(&[("alt", "json")]);
         let res = builder
             .bearer_auth(&client.token)
-            .json(&req)
             .send()
             .await
             .map_err(Error::io)?;
@@ -839,7 +841,6 @@ impl GoogleCloudSecretmanagerV1SecretManagerService {
             .query(&[("alt", "json")]);
         let res = builder
             .bearer_auth(&client.token)
-            .json(&req)
             .send()
             .await
             .map_err(Error::io)?;
@@ -874,7 +875,6 @@ impl GoogleCloudSecretmanagerV1SecretManagerService {
             .query(&[("alt", "json")]);
         let res = builder
             .bearer_auth(&client.token)
-            .json(&req)
             .send()
             .await
             .map_err(Error::io)?;
@@ -910,7 +910,6 @@ impl GoogleCloudSecretmanagerV1SecretManagerService {
             .query(&[("alt", "json")]);
         let res = builder
             .bearer_auth(&client.token)
-            .json(&req)
             .send()
             .await
             .map_err(Error::io)?;
@@ -946,7 +945,6 @@ impl GoogleCloudSecretmanagerV1SecretManagerService {
             .query(&[("alt", "json")]);
         let res = builder
             .bearer_auth(&client.token)
-            .json(&req)
             .send()
             .await
             .map_err(Error::io)?;
@@ -982,7 +980,6 @@ impl GoogleCloudSecretmanagerV1SecretManagerService {
             .query(&[("alt", "json")]);
         let res = builder
             .bearer_auth(&client.token)
-            .json(&req)
             .send()
             .await
             .map_err(Error::io)?;
@@ -1018,7 +1015,6 @@ impl GoogleCloudSecretmanagerV1SecretManagerService {
             .query(&[("alt", "json")]);
         let res = builder
             .bearer_auth(&client.token)
-            .json(&req)
             .send()
             .await
             .map_err(Error::io)?;
@@ -1132,7 +1128,6 @@ impl GoogleCloudSecretmanagerV1SecretManagerService {
             .query(&[("alt", "json")]);
         let res = builder
             .bearer_auth(&client.token)
-            .json(&req)
             .send()
             .await
             .map_err(Error::io)?;
@@ -1170,7 +1165,6 @@ impl GoogleCloudSecretmanagerV1SecretManagerService {
             .query(&[("alt", "json")]);
         let res = builder
             .bearer_auth(&client.token)
-            .json(&req)
             .send()
             .await
             .map_err(Error::io)?;

--- a/generator/testdata/rust/openapi/golden/src/model.rs
+++ b/generator/testdata/rust/openapi/golden/src/model.rs
@@ -236,31 +236,6 @@ pub struct Secret {
     /// SecretVersions added afterwards. They do not apply
     /// retroactively to existing SecretVersions.
     pub customer_managed_encryption: Option<crate::model::CustomerManagedEncryption>,
-
-    /// The `{project}` component of the target path.
-    ///
-    /// The full target path will be in the form `/v1/projects/{project}/secrets`.
-    pub project: String,
-
-    /// Required. This must be unique within the project.
-    ///
-    /// A secret ID is a string with a maximum length of 255 characters and can
-    /// contain uppercase and lowercase letters, numerals, and the hyphen (`-`) and
-    /// underscore (`_`) characters.
-    pub secret_id: String,
-
-    /// The `{location}` component of the target path.
-    ///
-    /// The full target path will be in the form `/v1/projects/{project}/locations/{location}/secrets`.
-    pub location: String,
-
-    /// The `{secret}` component of the target path.
-    ///
-    /// The full target path will be in the form `/v1/projects/{project}/secrets/{secret}`.
-    pub secret: String,
-
-    /// Required. Specifies the fields to be updated.
-    pub update_mask: wkt::FieldMask,
 }
 
 impl Secret {
@@ -350,36 +325,6 @@ impl Secret {
         v: T,
     ) -> Self {
         self.customer_managed_encryption = v.into();
-        self
-    }
-
-    /// Sets the value of `project`.
-    pub fn set_project<T: Into<String>>(mut self, v: T) -> Self {
-        self.project = v.into();
-        self
-    }
-
-    /// Sets the value of `secret_id`.
-    pub fn set_secret_id<T: Into<String>>(mut self, v: T) -> Self {
-        self.secret_id = v.into();
-        self
-    }
-
-    /// Sets the value of `location`.
-    pub fn set_location<T: Into<String>>(mut self, v: T) -> Self {
-        self.location = v.into();
-        self
-    }
-
-    /// Sets the value of `secret`.
-    pub fn set_secret<T: Into<String>>(mut self, v: T) -> Self {
-        self.secret = v.into();
-        self
-    }
-
-    /// Sets the value of `update_mask`.
-    pub fn set_update_mask<T: Into<wkt::FieldMask>>(mut self, v: T) -> Self {
-        self.update_mask = v.into();
         self
     }
 }
@@ -1986,6 +1931,48 @@ impl ListSecretsRequest {
     }
 }
 
+/// The request message for CreateSecret.
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(default, rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct CreateSecretRequest {
+    /// The request body.
+    pub request_body: Option<crate::model::Secret>,
+
+    /// The `{project}` component of the target path.
+    ///
+    /// The full target path will be in the form `/v1/projects/{project}/secrets`.
+    pub project: String,
+
+    /// Required. This must be unique within the project.
+    ///
+    /// A secret ID is a string with a maximum length of 255 characters and can
+    /// contain uppercase and lowercase letters, numerals, and the hyphen (`-`) and
+    /// underscore (`_`) characters.
+    pub secret_id: String,
+}
+
+impl CreateSecretRequest {
+    /// Sets the value of `request_body`.
+    pub fn set_request_body<T: Into<Option<crate::model::Secret>>>(mut self, v: T) -> Self {
+        self.request_body = v.into();
+        self
+    }
+
+    /// Sets the value of `project`.
+    pub fn set_project<T: Into<String>>(mut self, v: T) -> Self {
+        self.project = v.into();
+        self
+    }
+
+    /// Sets the value of `secret_id`.
+    pub fn set_secret_id<T: Into<String>>(mut self, v: T) -> Self {
+        self.secret_id = v.into();
+        self
+    }
+}
+
 /// The request message for ListSecretsByProjectAndLocation.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -2047,6 +2034,59 @@ impl ListSecretsByProjectAndLocationRequest {
     /// Sets the value of `filter`.
     pub fn set_filter<T: Into<Option<String>>>(mut self, v: T) -> Self {
         self.filter = v.into();
+        self
+    }
+}
+
+/// The request message for CreateSecretByProjectAndLocation.
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(default, rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct CreateSecretByProjectAndLocationRequest {
+    /// The request body.
+    pub request_body: Option<crate::model::Secret>,
+
+    /// The `{project}` component of the target path.
+    ///
+    /// The full target path will be in the form `/v1/projects/{project}/locations/{location}/secrets`.
+    pub project: String,
+
+    /// The `{location}` component of the target path.
+    ///
+    /// The full target path will be in the form `/v1/projects/{project}/locations/{location}/secrets`.
+    pub location: String,
+
+    /// Required. This must be unique within the project.
+    ///
+    /// A secret ID is a string with a maximum length of 255 characters and can
+    /// contain uppercase and lowercase letters, numerals, and the hyphen (`-`) and
+    /// underscore (`_`) characters.
+    pub secret_id: String,
+}
+
+impl CreateSecretByProjectAndLocationRequest {
+    /// Sets the value of `request_body`.
+    pub fn set_request_body<T: Into<Option<crate::model::Secret>>>(mut self, v: T) -> Self {
+        self.request_body = v.into();
+        self
+    }
+
+    /// Sets the value of `project`.
+    pub fn set_project<T: Into<String>>(mut self, v: T) -> Self {
+        self.project = v.into();
+        self
+    }
+
+    /// Sets the value of `location`.
+    pub fn set_location<T: Into<String>>(mut self, v: T) -> Self {
+        self.location = v.into();
+        self
+    }
+
+    /// Sets the value of `secret_id`.
+    pub fn set_secret_id<T: Into<String>>(mut self, v: T) -> Self {
+        self.secret_id = v.into();
         self
     }
 }
@@ -2120,6 +2160,55 @@ impl DeleteSecretRequest {
     /// Sets the value of `etag`.
     pub fn set_etag<T: Into<Option<String>>>(mut self, v: T) -> Self {
         self.etag = v.into();
+        self
+    }
+}
+
+/// The request message for UpdateSecret.
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(default, rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct UpdateSecretRequest {
+    /// The request body.
+    pub request_body: Option<crate::model::Secret>,
+
+    /// The `{project}` component of the target path.
+    ///
+    /// The full target path will be in the form `/v1/projects/{project}/secrets/{secret}`.
+    pub project: String,
+
+    /// The `{secret}` component of the target path.
+    ///
+    /// The full target path will be in the form `/v1/projects/{project}/secrets/{secret}`.
+    pub secret: String,
+
+    /// Required. Specifies the fields to be updated.
+    pub update_mask: wkt::FieldMask,
+}
+
+impl UpdateSecretRequest {
+    /// Sets the value of `request_body`.
+    pub fn set_request_body<T: Into<Option<crate::model::Secret>>>(mut self, v: T) -> Self {
+        self.request_body = v.into();
+        self
+    }
+
+    /// Sets the value of `project`.
+    pub fn set_project<T: Into<String>>(mut self, v: T) -> Self {
+        self.project = v.into();
+        self
+    }
+
+    /// Sets the value of `secret`.
+    pub fn set_secret<T: Into<String>>(mut self, v: T) -> Self {
+        self.secret = v.into();
+        self
+    }
+
+    /// Sets the value of `update_mask`.
+    pub fn set_update_mask<T: Into<wkt::FieldMask>>(mut self, v: T) -> Self {
+        self.update_mask = v.into();
         self
     }
 }
@@ -2215,6 +2304,66 @@ impl DeleteSecretByProjectAndLocationAndSecretRequest {
     /// Sets the value of `etag`.
     pub fn set_etag<T: Into<Option<String>>>(mut self, v: T) -> Self {
         self.etag = v.into();
+        self
+    }
+}
+
+/// The request message for UpdateSecretByProjectAndLocationAndSecret.
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(default, rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct UpdateSecretByProjectAndLocationAndSecretRequest {
+    /// The request body.
+    pub request_body: Option<crate::model::Secret>,
+
+    /// The `{project}` component of the target path.
+    ///
+    /// The full target path will be in the form `/v1/projects/{project}/locations/{location}/secrets/{secret}`.
+    pub project: String,
+
+    /// The `{location}` component of the target path.
+    ///
+    /// The full target path will be in the form `/v1/projects/{project}/locations/{location}/secrets/{secret}`.
+    pub location: String,
+
+    /// The `{secret}` component of the target path.
+    ///
+    /// The full target path will be in the form `/v1/projects/{project}/locations/{location}/secrets/{secret}`.
+    pub secret: String,
+
+    /// Required. Specifies the fields to be updated.
+    pub update_mask: wkt::FieldMask,
+}
+
+impl UpdateSecretByProjectAndLocationAndSecretRequest {
+    /// Sets the value of `request_body`.
+    pub fn set_request_body<T: Into<Option<crate::model::Secret>>>(mut self, v: T) -> Self {
+        self.request_body = v.into();
+        self
+    }
+
+    /// Sets the value of `project`.
+    pub fn set_project<T: Into<String>>(mut self, v: T) -> Self {
+        self.project = v.into();
+        self
+    }
+
+    /// Sets the value of `location`.
+    pub fn set_location<T: Into<String>>(mut self, v: T) -> Self {
+        self.location = v.into();
+        self
+    }
+
+    /// Sets the value of `secret`.
+    pub fn set_secret<T: Into<String>>(mut self, v: T) -> Self {
+        self.secret = v.into();
+        self
+    }
+
+    /// Sets the value of `update_mask`.
+    pub fn set_update_mask<T: Into<wkt::FieldMask>>(mut self, v: T) -> Self {
+        self.update_mask = v.into();
         self
     }
 }


### PR DESCRIPTION
We create synthetic request messages because OpenAPI does not always
include them. That would be fine, except that sometimes they do include
the `*Request` message and we need to modify it to add back the path
parameters and inject the body parameter.

I was (incorrectly) modifying the body parameter in some cases.

