### PR TITLE
test: all RPCs for secret manager + protobuf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,9 +819,11 @@ dependencies = [
 name = "integration-tests"
 version = "0.0.0"
 dependencies = [
+ "bytes",
  "futures",
  "gax",
  "google-cloud-auth",
+ "iam-v1-golden-gclient",
  "rand",
  "secretmanager-golden-gclient",
  "secretmanager-golden-openapi",

--- a/src/integration-tests/Cargo.toml
+++ b/src/integration-tests/Cargo.toml
@@ -27,7 +27,9 @@ tokio   = { version = "1.12", features = ["full", "macros"], optional = true }
 auth    = { path = "../../auth", package = "google-cloud-auth" }
 gax     = { path = "../../gax", package = "gax" }
 wkt     = { path = "../../types", package = "types" }
+iam_v1  = { path = "../../generator/testdata/rust/gclient/golden/iam/v1", package = "iam-v1-golden-gclient" }
 sm      = { path = "../../generator/testdata/rust/gclient/golden/secretmanager", package = "secretmanager-golden-gclient" }
 smo     = { path = "../../generator/testdata/rust/openapi/golden", package = "secretmanager-golden-openapi" }
 rand    = "0.8.5"
 futures = "0.3.31"
+bytes   = "1.8.0"

--- a/src/integration-tests/src/lib.rs
+++ b/src/integration-tests/src/lib.rs
@@ -21,6 +21,12 @@ pub fn project_id() -> Result<String> {
     Ok(project_id)
 }
 
+/// Returns an existing, but disabled service account to test IAM RPCs.
+pub fn service_account_for_iam_tests() -> Result<String> {
+    let value = std::env::var("GOOGLE_CLOUD_RUST_TEST_SERVICE_ACCOUNT")?;
+    Ok(value)
+}
+
 pub async fn test_token() -> Result<String> {
     let credentials = auth::Credential::find_default(
         auth::CredentialConfig::builder()


### PR DESCRIPTION
Test all the RPCs for Secret Manager over Protobuf. I do not believe we
should do this for each client, but at least one client should run the
full set.

We will also want at least one integration test for LROs. More
generally, one for AIP affecting the generator behavior.