### PR TITLE
fix(generator/rust): handle sneaky field names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,6 +829,7 @@ name = "integration-tests"
 version = "0.0.0"
 dependencies = [
  "bytes",
+ "crc32c",
  "futures",
  "gax",
  "google-cloud-auth",
@@ -1272,6 +1282,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,6 +1454,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"

--- a/generator/internal/genclient/parser/openapi/openapi.go
+++ b/generator/internal/genclient/parser/openapi/openapi.go
@@ -305,6 +305,7 @@ func makeRequestMessage(api *genclient.API, operation *v3.Operation, template st
 			for _, name := range []string{"requestBody", "openapiRequestBody"} {
 				field := &genclient.Field{
 					Name:          name,
+					JSONName:      name,
 					Documentation: "The request body.",
 					Typez:         genclient.MESSAGE_TYPE,
 					TypezID:       bid,

--- a/generator/internal/genclient/parser/openapi/openapi_test.go
+++ b/generator/internal/genclient/parser/openapi/openapi_test.go
@@ -668,6 +668,36 @@ func TestMakeAPI(t *testing.T) {
 		},
 	})
 
+	// This message has a weirdly named field that gets tricky to serialize.
+	secretPayload, ok := api.State.MessageByID["..SecretPayload"]
+	if !ok {
+		t.Errorf("missing message (SecretPayload) in MessageByID index")
+		return
+	}
+	checkMessage(t, *secretPayload, genclient.Message{
+		Name:          "SecretPayload",
+		ID:            "..SecretPayload",
+		Documentation: "A secret payload resource in the Secret Manager API. This contains the\nsensitive secret payload that is associated with a SecretVersion.",
+		Fields: []*genclient.Field{
+			{
+				Name:          "data",
+				JSONName:      "data",
+				Documentation: "The secret data. Must be no larger than 64KiB.",
+				Typez:         genclient.BYTES_TYPE,
+				TypezID:       "bytes",
+				Optional:      true,
+			},
+			{
+				Name:          "dataCrc32c",
+				JSONName:      "dataCrc32c",
+				Documentation: "Optional. If specified, SecretManagerService will verify the integrity of the\nreceived data on SecretManagerService.AddSecretVersion calls using\nthe crc32c checksum and store it to include in future\nSecretManagerService.AccessSecretVersion responses. If a checksum is\nnot provided in the SecretManagerService.AddSecretVersion request, the\nSecretManagerService will generate and store one for you.\n\nThe CRC32C value is encoded as a Int64 for compatibility, and can be\nsafely downconverted to uint32 in languages that support this type.\nhttps://cloud.google.com/apis/design/design_patterns#integer_types",
+				Typez:         genclient.INT64_TYPE,
+				TypezID:       "int64",
+				Optional:      true,
+			},
+		},
+	})
+
 	service, ok := api.State.ServiceByID["..Service"]
 	if !ok {
 		t.Errorf("missing service (Service) in ServiceByID index")

--- a/generator/testdata/rust/gclient/golden/secretmanager/src/model.rs
+++ b/generator/testdata/rust/gclient/golden/secretmanager/src/model.rs
@@ -866,6 +866,7 @@ pub struct SecretPayload {
     /// The CRC32C value is encoded as a Int64 for compatibility, and can be
     /// safely downconverted to uint32 in languages that support this type.
     /// https://cloud.google.com/apis/design/design_patterns#integer_types
+    #[serde(rename = "dataCrc32c")]
     #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
     pub data_crc32c: Option<i64>,
 }

--- a/generator/testdata/rust/openapi/golden/src/model.rs
+++ b/generator/testdata/rust/openapi/golden/src/model.rs
@@ -609,6 +609,7 @@ pub struct SecretPayload {
     /// The CRC32C value is encoded as a Int64 for compatibility, and can be
     /// safely downconverted to uint32 in languages that support this type.
     /// https://cloud.google.com/apis/design/design_patterns#integer_types
+    #[serde(rename = "dataCrc32c")]
     #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
     pub data_crc_32_c: Option<i64>,
 }
@@ -2735,6 +2736,7 @@ pub struct GetIamPolicyRequest {
     /// To learn which resources support conditions in their IAM policies, see the
     /// [IAM
     /// documentation](https://cloud.google.com/iam/help/conditions/resource-policies).
+    #[serde(rename = "options.requestedPolicyVersion")]
     pub options_requested_policy_version: Option<i32>,
 }
 
@@ -2797,6 +2799,7 @@ pub struct GetIamPolicyByProjectAndLocationAndSecretRequest {
     /// To learn which resources support conditions in their IAM policies, see the
     /// [IAM
     /// documentation](https://cloud.google.com/iam/help/conditions/resource-policies).
+    #[serde(rename = "options.requestedPolicyVersion")]
     pub options_requested_policy_version: Option<i32>,
 }
 

--- a/src/integration-tests/Cargo.toml
+++ b/src/integration-tests/Cargo.toml
@@ -33,3 +33,4 @@ smo     = { path = "../../generator/testdata/rust/openapi/golden", package = "se
 rand    = "0.8.5"
 futures = "0.3.31"
 bytes   = "1.8.0"
+crc32c  = "0.6.8"

--- a/src/integration-tests/tests/secret_manager_protobuf.rs
+++ b/src/integration-tests/tests/secret_manager_protobuf.rs
@@ -175,7 +175,8 @@ async fn secretmanager_protobuf_secret_versions(
                 .set_payload(
                     sm::model::SecretPayload::default()
                         .set_data(bytes::Bytes::from(data))
-                        .set_data_crc32c(checksum as i64)),
+                        .set_data_crc32c(checksum as i64),
+                ),
         )
         .await?;
     println!("CREATE_SECRET_VERSION = {create_secret_version:?}");

--- a/src/integration-tests/tests/secret_manager_protobuf.rs
+++ b/src/integration-tests/tests/secret_manager_protobuf.rs
@@ -167,7 +167,7 @@ async fn secretmanager_protobuf_secret_versions(
 ) -> Result<()> {
     println!("\nTesting create_secret_version()");
     let data = "The quick brown fox jumps over the lazy dog".as_bytes();
-    let checksum = crc32c::crc32c(&data);
+    let checksum = crc32c::crc32c(data);
     let create_secret_version = client
         .add_secret_version(
             sm::model::AddSecretVersionRequest::default()

--- a/src/integration-tests/tests/secret_manager_protobuf.rs
+++ b/src/integration-tests/tests/secret_manager_protobuf.rs
@@ -167,13 +167,15 @@ async fn secretmanager_protobuf_secret_versions(
 ) -> Result<()> {
     println!("\nTesting create_secret_version()");
     let data = "The quick brown fox jumps over the lazy dog".as_bytes();
+    let checksum = crc32c::crc32c(&data);
     let create_secret_version = client
         .add_secret_version(
             sm::model::AddSecretVersionRequest::default()
                 .set_parent(secret_name)
                 .set_payload(
-                    sm::model::SecretPayload::default().set_data(bytes::Bytes::from(data)),
-                ),
+                    sm::model::SecretPayload::default()
+                        .set_data(bytes::Bytes::from(data))
+                        .set_data_crc32c(checksum as i64)),
         )
         .await?;
     println!("CREATE_SECRET_VERSION = {create_secret_version:?}");

--- a/types/tests/field_name_override.rs
+++ b/types/tests/field_name_override.rs
@@ -1,0 +1,42 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(test)]
+mod test {
+    use serde_json::json;
+    type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+    #[serde_with::serde_as]
+    #[serde_with::skip_serializing_none]
+    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct FieldNameOverrides {
+        pub simple_snake: String,
+        #[serde(rename = "dataCrc32c")]
+        pub data_crc_32_c: String,
+    }
+
+    #[test]
+    fn test_serialize_names() -> Result {
+        let msg = FieldNameOverrides {
+            simple_snake: "123".to_string(),
+            data_crc_32_c: "abc".to_string(),
+        };
+        let got = serde_json::to_value(&msg)?;
+        let want = json!({"simpleSnake": "123", "dataCrc32c": "abc"});
+        assert_eq!(want, got);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Specially with OpenAPI specifications the field name may have gone
through a `snake_case` to `camelCase` translation. In Rust we want to
use `snake_case` for the fields, but that roundtrip is lossy.

I think the bad field name in Rust is undesirable, but it works. The bad
name is the serialized JSON does not work at all. This PR fixes that
problem.

Part of the work for #226 
