### PR TITLE
test: expand secret manager integration tests

### DIFF
--- a/src/integration-tests/tests/secret_manager_openapi.rs
+++ b/src/integration-tests/tests/secret_manager_openapi.rs
@@ -27,7 +27,8 @@ pub async fn run() -> Result<()> {
         .await?
         .google_cloud_secretmanager_v_1_secret_manager_service();
 
-    let create_response = client
+    println!("\nTesting create_secret()");
+    let create = client
         .create_secret(
             smo::model::CreateSecretRequest::default()
                 .set_project(&project_id)
@@ -45,24 +46,57 @@ pub async fn run() -> Result<()> {
                 ),
         )
         .await?;
-    println!("CREATE = {create_response:?}");
+    println!("CREATE = {create:?}");
 
-    let project_name = create_response
+    let project_name = create
         .name
         .as_ref()
         .and_then(|s| s.strip_suffix(format!("/secrets/{secret_id}").as_str()));
     assert!(project_name.is_some());
 
-    let get_response = client
+    println!("\nTesting get_secret()");
+    let get = client
         .get_secret(
             smo::model::GetSecretRequest::default()
                 .set_project(&project_id)
                 .set_secret(&secret_id),
         )
         .await?;
-    println!("GET = {get_response:?}");
-    assert_eq!(get_response, create_response);
+    println!("GET = {get:?}");
+    assert_eq!(get, create);
+    assert!(get.name.is_some());
 
+    let secret_name = get.name.as_ref().unwrap().clone();
+
+    println!("\nTesting update_secret()");
+    let mut new_labels = get.labels.clone();
+    new_labels.insert("updated".to_string(), "true".to_string());
+    let update = client
+        .update_secret(
+            smo::model::UpdateSecretRequest::default()
+                .set_project(&project_id)
+                .set_secret(&secret_id)
+                .set_update_mask(
+                    wkt::FieldMask::default().set_paths(["labels"].map(str::to_string).to_vec()),
+                )
+                .set_request_body(smo::model::Secret::default().set_labels(new_labels)),
+        )
+        .await?;
+    println!("UPDATE = {update:?}");
+
+    println!("\nTesting list_secrets()");
+    let list = get_all_secret_names(&client, &project_id).await?;
+    assert!(
+        list.iter().any(|name| name == &secret_name),
+        "missing secret {} in {list:?}",
+        &secret_name
+    );
+
+    run_secret_versions(&client, &project_id, &secret_id).await?;
+    run_iam(&client, &project_id, &secret_id).await?;
+    run_locations(&client, &project_id).await?;
+
+    println!("\nTesting delete_secret()");
     let response = client
         .delete_secret(
             smo::model::DeleteSecretRequest::default()
@@ -72,4 +106,273 @@ pub async fn run() -> Result<()> {
         .await?;
     println!("DELETE = {response:?}");
     Ok(())
+}
+
+async fn run_locations(
+    client: &smo::GoogleCloudSecretmanagerV1SecretManagerService,
+    project_id: &str,
+) -> Result<()> {
+    println!("\nTesting list_locations()");
+    let locations = client
+        .list_locations(smo::model::ListLocationsRequest::default().set_project(project_id))
+        .await?;
+    println!("LOCATIONS = {locations:?}");
+
+    assert!(
+        !locations.locations.is_empty(),
+        "got empty locations field for {locations:?}"
+    );
+    let first = locations.locations[0].clone();
+    assert!(
+        first.location_id.is_some(),
+        "expected some location field to be set in {first:?}"
+    );
+
+    println!("\nTesting get_location()");
+    let get = client
+        .get_location(
+            smo::model::GetLocationRequest::default()
+                .set_project(project_id)
+                .set_location(first.location_id.clone().unwrap()),
+        )
+        .await?;
+    println!("GET = {get:?}");
+
+    assert_eq!(get, first);
+
+    Ok(())
+}
+
+async fn run_iam(
+    client: &smo::GoogleCloudSecretmanagerV1SecretManagerService,
+    project_id: &str,
+    secret_id: &str,
+) -> Result<()> {
+    let service_account = integration_tests::service_account_for_iam_tests()?;
+
+    println!("\nTesting get_iam_policy()");
+    let policy = client
+        .get_iam_policy(
+            smo::model::GetIamPolicyRequest::default()
+                .set_project(project_id)
+                .set_secret(secret_id),
+        )
+        .await?;
+    println!("POLICY = {policy:?}");
+
+    println!("\nTesting test_iam_permissions()");
+    let response = client
+        .test_iam_permissions(
+            smo::model::TestIamPermissionsRequest::default()
+                .set_project(project_id)
+                .set_secret(secret_id)
+                .set_permissions(
+                    ["secretmanager.versions.access"]
+                        .map(str::to_string)
+                        .to_vec(),
+                ),
+        )
+        .await?;
+    println!("RESPONSE = {response:?}");
+
+    // This really could use an OCC loop.
+    println!("\nTesting set_iam_policy()");
+    let mut new_policy = policy.clone();
+    const ROLE: &str = "roles/secretmanager.secretVersionAdder";
+    let mut found = false;
+    for binding in &mut new_policy.bindings {
+        if let Some(ROLE) = binding.role.as_ref().map(String::as_str) {
+            continue;
+        }
+        found = true;
+        binding
+            .members
+            .push(format!("serviceAccount:{service_account}"));
+    }
+    if !found {
+        new_policy.bindings.push(
+            smo::model::Binding::default()
+                .set_role(ROLE.to_string())
+                .set_members([format!("serviceAccount:{service_account}")].to_vec()),
+        );
+    }
+    let response = client
+        .set_iam_policy(
+            smo::model::SetIamPolicyRequest::default()
+                .set_project(project_id)
+                .set_secret(secret_id)
+                .set_update_mask(
+                    wkt::FieldMask::default().set_paths(["bindings"].map(str::to_string).to_vec()),
+                )
+                .set_policy(new_policy),
+        )
+        .await?;
+    println!("RESPONSE = {response:?}");
+
+    Ok(())
+}
+
+async fn run_secret_versions(
+    client: &smo::GoogleCloudSecretmanagerV1SecretManagerService,
+    project_id: &str,
+    secret_id: &str,
+) -> Result<()> {
+    println!("\nTesting create_secret_version()");
+    let data = "The quick brown fox jumps over the lazy dog".as_bytes();
+    let checksum = crc32c::crc32c(data);
+    let create = client
+        .add_secret_version(
+            smo::model::AddSecretVersionRequest::default()
+                .set_project(project_id)
+                .set_secret(secret_id)
+                .set_payload(
+                    smo::model::SecretPayload::default()
+                        .set_data(bytes::Bytes::from(data))
+                        .set_data_crc_32_c(checksum as i64),
+                ),
+        )
+        .await?;
+    println!("CREATE_SECRET_VERSION = {create:?}");
+
+    assert!(
+        create.name.is_some(),
+        "missing name in create response {create:?}"
+    );
+    let name = create.name.clone().unwrap();
+    let pattern = format!("secrets/{secret_id}/versions/");
+    let version_id = name.find(pattern.as_str());
+    assert!(
+        version_id.is_some(),
+        "cannot field secret in secret version name={name}"
+    );
+    let version_id = &name[version_id.unwrap()..];
+    let version_id = &version_id[pattern.len()..];
+
+    println!("\nTesting get_secret_version()");
+    let get = client
+        .get_secret_version(
+            smo::model::GetSecretVersionRequest::default()
+                .set_project(project_id)
+                .set_secret(secret_id)
+                .set_version(version_id),
+        )
+        .await?;
+    println!("GET_SECRET_VERSION = {get:?}");
+    assert_eq!(get, create);
+
+    println!("\nTesting list_secret_versions()");
+    let secret_versions_list = get_all_secret_version_names(client, project_id, secret_id).await?;
+    assert!(
+        secret_versions_list
+            .iter()
+            .any(|name| Some(name) == get.name.as_ref()),
+        "missing secret version {:?} in {secret_versions_list:?}",
+        &get.name
+    );
+
+    println!("\nTesting access_secret_version()");
+    let access_secret_version = client
+        .access_secret_version(
+            smo::model::AccessSecretVersionRequest::default()
+                .set_project(project_id)
+                .set_secret(secret_id)
+                .set_version(version_id),
+        )
+        .await?;
+    println!("ACCESS_SECRET_VERSION = {access_secret_version:?}");
+    assert_eq!(
+        access_secret_version.payload.and_then(|p| p.data),
+        Some(bytes::Bytes::from(data))
+    );
+
+    println!("\nTesting disable_secret_version()");
+    let disable = client
+        .disable_secret_version(
+            smo::model::DisableSecretVersionRequest::default()
+                .set_project(project_id)
+                .set_secret(secret_id)
+                .set_version(version_id),
+        )
+        .await?;
+    println!("DISABLE_SECRET_VERSION = {disable:?}");
+
+    println!("\nTesting disable_secret_version()");
+    let enable = client
+        .enable_secret_version(
+            smo::model::EnableSecretVersionRequest::default()
+                .set_project(project_id)
+                .set_secret(secret_id)
+                .set_version(version_id),
+        )
+        .await?;
+    println!("ENABLE_SECRET_VERSION = {enable:?}");
+
+    println!("\nTesting destroy_secret_version()");
+    let delete = client
+        .destroy_secret_version(
+            smo::model::DestroySecretVersionRequest::default()
+                .set_project(project_id)
+                .set_secret(secret_id)
+                .set_version(version_id),
+        )
+        .await?;
+    println!("RESPONSE = {delete:?}");
+
+    Ok(())
+}
+
+async fn get_all_secret_version_names(
+    client: &smo::GoogleCloudSecretmanagerV1SecretManagerService,
+    project_id: &str,
+    secret_id: &str,
+) -> Result<Vec<String>> {
+    let mut names = Vec::new();
+    let mut page_token = None::<String>;
+    loop {
+        let response = client
+            .list_secret_versions(
+                smo::model::ListSecretVersionsRequest::default()
+                    .set_project(project_id)
+                    .set_secret(secret_id)
+                    .set_page_token(page_token),
+            )
+            .await?;
+        response
+            .versions
+            .into_iter()
+            .filter_map(|s| s.name)
+            .for_each(|name| names.push(name));
+        page_token = response.next_page_token;
+        if page_token.as_ref().map(String::is_empty).unwrap_or(true) {
+            break;
+        }
+    }
+    Ok(names)
+}
+
+async fn get_all_secret_names(
+    client: &smo::GoogleCloudSecretmanagerV1SecretManagerService,
+    project_id: &str,
+) -> Result<Vec<String>> {
+    let mut names = Vec::new();
+    let mut page_token = None::<String>;
+    loop {
+        let response = client
+            .list_secrets(
+                smo::model::ListSecretsRequest::default()
+                    .set_project(project_id)
+                    .set_page_token(page_token),
+            )
+            .await?;
+        response
+            .secrets
+            .into_iter()
+            .filter_map(|s| s.name)
+            .for_each(|name| names.push(name));
+        page_token = response.next_page_token;
+        if page_token.as_ref().map(String::is_empty).unwrap_or(true) {
+            break;
+        }
+    }
+    Ok(names)
 }

--- a/src/integration-tests/tests/secret_manager_openapi.rs
+++ b/src/integration-tests/tests/secret_manager_openapi.rs
@@ -181,7 +181,7 @@ async fn run_iam(
     const ROLE: &str = "roles/secretmanager.secretVersionAdder";
     let mut found = false;
     for binding in &mut new_policy.bindings {
-        if let Some(ROLE) = binding.role.as_ref().map(String::as_str) {
+        if let Some(ROLE) = binding.role.as_deref() {
             continue;
         }
         found = true;

--- a/src/integration-tests/tests/secret_manager_protobuf.rs
+++ b/src/integration-tests/tests/secret_manager_protobuf.rs
@@ -87,8 +87,8 @@ pub async fn run() -> Result<()> {
         &get.name
     );
 
-    secretmanager_protobuf_secret_versions(&client, &create.name).await?;
-    secretmanager_protobuf_iam(&client, &create.name).await?;
+    run_secret_versions(&client, &create.name).await?;
+    run_iam(&client, &create.name).await?;
 
     println!("\nTesting delete_secret()");
     let delete = client
@@ -99,10 +99,7 @@ pub async fn run() -> Result<()> {
     Ok(())
 }
 
-async fn secretmanager_protobuf_iam(
-    client: &sm::SecretManagerService,
-    secret_name: &str,
-) -> Result<()> {
+async fn run_iam(client: &sm::SecretManagerService, secret_name: &str) -> Result<()> {
     let service_account = integration_tests::service_account_for_iam_tests()?;
 
     println!("\nTesting get_iam_policy()");
@@ -161,10 +158,7 @@ async fn secretmanager_protobuf_iam(
     Ok(())
 }
 
-async fn secretmanager_protobuf_secret_versions(
-    client: &sm::SecretManagerService,
-    secret_name: &str,
-) -> Result<()> {
+async fn run_secret_versions(client: &sm::SecretManagerService, secret_name: &str) -> Result<()> {
     println!("\nTesting create_secret_version()");
     let data = "The quick brown fox jumps over the lazy dog".as_bytes();
     let checksum = crc32c::crc32c(data);


### PR DESCRIPTION
Expand the integration tests using the client generated from the OpenAPI
specification. With this PR we can verify we can create, update, list,
get, and delete secrets (without locations). We can also get their IAM
policies, change the IAM policy, and test the IAM permissions.

For secret versions, verify we can create, enable, disable, access,
list, and delete them.

Finally verify we can list and get details about locations.

Part of the work for #226
