### PR TITLE
cleanup: move integration test modules

### DIFF
--- a/src/integration-tests/src/secret_manager/mod.rs
+++ b/src/integration-tests/src/secret_manager/mod.rs
@@ -12,20 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use std::error::Error;
-pub type Result<T> = std::result::Result<T, Box<dyn Error>>;
-pub mod secret_manager;
-
-pub const SECRET_ID_LENGTH: usize = 64;
-
-/// Returns the project id used for the integration tests.
-pub fn project_id() -> Result<String> {
-    let project_id = std::env::var("GOOGLE_CLOUD_PROJECT")?;
-    Ok(project_id)
-}
-
-/// Returns an existing, but disabled service account to test IAM RPCs.
-pub fn service_account_for_iam_tests() -> Result<String> {
-    let value = std::env::var("GOOGLE_CLOUD_RUST_TEST_SERVICE_ACCOUNT")?;
-    Ok(value)
-}
+pub mod openapi;
+pub mod protobuf;

--- a/src/integration-tests/src/secret_manager/openapi.rs
+++ b/src/integration-tests/src/secret_manager/openapi.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use integration_tests::Result;
+use crate::Result;
 use rand::{distributions::Alphanumeric, Rng};
 
 pub async fn run() -> Result<()> {
-    let project_id = integration_tests::project_id()?;
+    let project_id = crate::project_id()?;
     let secret_id: String = rand::thread_rng()
         .sample_iter(&Alphanumeric)
-        .take(integration_tests::SECRET_ID_LENGTH)
+        .take(crate::SECRET_ID_LENGTH)
         .map(char::from)
         .collect();
 
@@ -148,7 +148,7 @@ async fn run_iam(
     project_id: &str,
     secret_id: &str,
 ) -> Result<()> {
-    let service_account = integration_tests::service_account_for_iam_tests()?;
+    let service_account = crate::service_account_for_iam_tests()?;
 
     println!("\nTesting get_iam_policy()");
     let policy = client

--- a/src/integration-tests/src/secret_manager/protobuf.rs
+++ b/src/integration-tests/src/secret_manager/protobuf.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use integration_tests::Result;
+use crate::Result;
 use rand::{distributions::Alphanumeric, Rng};
 
 pub async fn run() -> Result<()> {
-    let project_id = integration_tests::project_id()?;
+    let project_id = crate::project_id()?;
     let secret_id: String = rand::thread_rng()
         .sample_iter(&Alphanumeric)
-        .take(integration_tests::SECRET_ID_LENGTH)
+        .take(crate::SECRET_ID_LENGTH)
         .map(char::from)
         .collect();
 
@@ -100,7 +100,7 @@ pub async fn run() -> Result<()> {
 }
 
 async fn run_iam(client: &sm::SecretManagerService, secret_name: &str) -> Result<()> {
-    let service_account = integration_tests::service_account_for_iam_tests()?;
+    let service_account = crate::service_account_for_iam_tests()?;
 
     println!("\nTesting get_iam_policy()");
     let policy = client

--- a/src/integration-tests/tests/driver.rs
+++ b/src/integration-tests/tests/driver.rs
@@ -12,20 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Use separate modules to keep the file sizes under control and avoid name
-// clashes. We prefer to have a single driver program because cargo runs all
-// the tests within one program in parallel.
-pub mod secret_manager_openapi;
-pub mod secret_manager_protobuf;
-
 #[cfg(all(test, feature = "run-integration-tests"))]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn run_secretmanager_protobuf() -> integration_tests::Result<()> {
-    secret_manager_protobuf::run().await
+    integration_tests::secret_manager::protobuf::run().await
 }
 
 #[cfg(all(test, feature = "run-integration-tests"))]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn run_secretmanager_openapi() -> integration_tests::Result<()> {
-    secret_manager_openapi::run().await
+    integration_tests::secret_manager::openapi::run().await
 }


### PR DESCRIPTION
Easier to find things this way, and eventually it may be easier to share
code between tests too.