### PR TITLE
test: all OpenAPI + secret manager RPCs

### DIFF
--- a/src/integration-tests/src/secret_manager/mod.rs
+++ b/src/integration-tests/src/secret_manager/mod.rs
@@ -13,4 +13,5 @@
 // limitations under the License.
 
 pub mod openapi;
+pub mod openapi_locational;
 pub mod protobuf;

--- a/src/integration-tests/src/secret_manager/openapi_locational.rs
+++ b/src/integration-tests/src/secret_manager/openapi_locational.rs
@@ -242,11 +242,12 @@ async fn run_secret_versions(
     println!("\nTesting access_secret_version_by_project_and_location_and_secret_and_version()");
     let access_secret_version = client
         .access_secret_version_by_project_and_location_and_secret_and_version(
-            smo::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest::default()
-                .set_project(project_id)
-                .set_location(location_id)
-                .set_secret(secret_id)
-                .set_version(version_id),
+            smo::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest::default(
+            )
+            .set_project(project_id)
+            .set_location(location_id)
+            .set_secret(secret_id)
+            .set_version(version_id),
         )
         .await?;
     println!("ACCESS_SECRET_VERSION = {access_secret_version:?}");

--- a/src/integration-tests/tests/driver.rs
+++ b/src/integration-tests/tests/driver.rs
@@ -23,3 +23,9 @@ async fn run_secretmanager_protobuf() -> integration_tests::Result<()> {
 async fn run_secretmanager_openapi() -> integration_tests::Result<()> {
     integration_tests::secret_manager::openapi::run().await
 }
+
+#[cfg(all(test, feature = "run-integration-tests"))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn run_secretmanager_openapi_locational() -> integration_tests::Result<()> {
+    integration_tests::secret_manager::openapi_locational::run().await
+}


### PR DESCRIPTION
Complete the integration tests for secret manager and OpenAPI. Each RPC
has at least one test.

Fixes #226