### PR TITLE
ci: configure GCB to run integration tests

### DIFF
--- a/.gcb/README.md
+++ b/.gcb/README.md
@@ -1,0 +1,30 @@
+# Google Cloud Build support
+
+This directory contains configuration files and scripts to support GCB (Google
+Cloud Build) builds.
+
+We generally prefer GHA (GitHub Actions) for CI (Continuous Integration):
+building the code, running unit test, run any linters or formatters.
+
+We use GCB for integration tests against production.
+
+GCB can perform these operations with relatively simple management for
+authentication and authorization: the builds run using a service account
+specific to our project. We can grant this service account the necessary
+permissions to act on the test resources.
+
+In contrast, if we wanted to use GHA for the same role, we would need to either
+(1) download a service account key file and install it as a GHA secret, and
+manually rotate this secret, or (2) configure workload identify federation
+between GitHub and our project. Neither approach is very easy to reason about
+from a security perspective.
+
+## Managing Resources for Integration Test
+
+Integration tests need resources in production. We will need pre-existing
+databases, storage buckets, service accounts, and the configuration for the
+builds themselves.
+
+We have chosen Terraform to manage these resources. That makes it easy to audit
+them, recreate the resources when needed, and we can always change to a
+different IaaC platform if needed.

--- a/.gcb/bootstrap/.terraform.lock.hcl
+++ b/.gcb/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.44.2"
+  constraints = "~> 5.44.0"
+  hashes = [
+    "h1:gqtQa4oy2DGnwsGv2cYvvX0d4R6HYnMHEYMvTwYr8jI=",
+    "zh:2594d626d9148480688000b6c8e091d6bcc8f2a2dc28fe6e2ea27487f3c1726d",
+    "zh:2b0fafdb0ed7cbf4da5b4d7f3541ccd4402ee8cbdd66ebe26eaf9e904951da01",
+    "zh:310b1b0ac4f244a51abce22e41c7904e4bee50b5c1b66fd8646368f94ea6e563",
+    "zh:67c24e70b74e3d52f60e1b32d9c113f8d11e5db7265463e44a5b07474b79177c",
+    "zh:6d5069bf1e30570ef5189ad994a4b09c998b0f2630e169cc0b9cf68deafbb38d",
+    "zh:71bf6eb0d865082d736732cd48d9cb04a81500c55c48da91ac99816149cb3cb2",
+    "zh:970a29056d63a41bee915e634922cbb9caba7d34604f4884f001bfaf1e208b07",
+    "zh:a3b5ea6d67459a3237afcaaad4034998c8435b1d222f0c163d868a2863af5d24",
+    "zh:c049cb7edd8c797d7dd5b8f5a7a3a5b84cc08a1c60a50858fcdbec5d4db3f599",
+    "zh:c17c1133fce9ed5fea39da65f1c3024d5e04a5f0b94fd0d217c4988f6c1a3efd",
+    "zh:c657377f55a8a7abc16be34d26936d7879740d732136d40972013871c678db02",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/.gcb/bootstrap/README.md
+++ b/.gcb/bootstrap/README.md
@@ -1,0 +1,66 @@
+# Terraform configuration Bootstrap
+
+We use terraform (https://terraform.io) to create and update the state of our
+testing infrastructure. We describe the desired state of the infrastructure
+to terraform using `.tf` scripts. By default, Terraform stores [state][tf-state]
+locally, in a file called `terraform.tfstate`. This default configuration can
+make Terraform usage difficult for teams. If multiple team members run Terraform
+at the same time on different machine each state may have a different definition
+of the desired and current state.
+
+The recommended practice is to store terraform database in some remote storage,
+shared by the whole team. Google Cloud Storage is one of the available options,
+and one that works well for us.
+
+This directory creates the initial Cloud Storage bucket to store the terraform's
+for each sub-project. The scripts in this directory should be executed rarely,
+ideally only once.
+
+## Usage
+
+Change your working directory, for example:
+
+```shell
+cd $HOME/google-cloud-rust/.gcb/bootstrap
+```
+
+Initialize terraform:
+
+```shell
+terraform init
+```
+
+Restore the current state. This may result in no action if you happen to have
+an up-to-date state in your local files.
+
+
+```shell
+terraform plan -out /tmp/bootstrap.tplan
+```
+
+Execute the plan:
+
+```shell
+terraform apply /tmp/bootstrap.tplan
+```
+
+Make any changes to the configuration and commit them to git:
+
+```shell
+git commit -m"Cool changes" .
+```
+
+Prepare and execute a plan to update the bucket:
+
+```shell
+terraform plan -out /tmp/update.tplan
+terraform apply /tmp/update.tplan
+```
+
+## More Information
+
+This directory follows the [Store Terraform state in a Cloud Storage bucket]
+guide.
+
+[tf-state]: https://www.terraform.io/docs/state/
+[Store Terraform state in a Cloud Storage bucket]: https://cloud.google.com/docs/terraform/resource-management/store-state

--- a/.gcb/bootstrap/README.md
+++ b/.gcb/bootstrap/README.md
@@ -33,7 +33,6 @@ terraform init
 Restore the current state. This may result in no action if you happen to have
 an up-to-date state in your local files.
 
-
 ```shell
 terraform plan -out /tmp/bootstrap.tplan
 ```
@@ -62,5 +61,5 @@ terraform apply /tmp/update.tplan
 This directory follows the [Store Terraform state in a Cloud Storage bucket]
 guide.
 
+[store terraform state in a cloud storage bucket]: https://cloud.google.com/docs/terraform/resource-management/store-state
 [tf-state]: https://www.terraform.io/docs/state/
-[Store Terraform state in a Cloud Storage bucket]: https://cloud.google.com/docs/terraform/resource-management/store-state

--- a/.gcb/bootstrap/main.tf
+++ b/.gcb/bootstrap/main.tf
@@ -1,0 +1,70 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.44.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project
+  region  = var.region
+  zone    = var.zone
+}
+
+# Re-import the state of the bucket from GCP. Normally one would store
+# terraform's state in a global backend, such as Google Cloud Storage. But this
+# is the terraform configuration to bootstrap such a backend. While re-importing
+# the state of each resource would not scale as the number of resources grows,
+# re-importing a single bootstrap resource seems manageable.
+import {
+  to = google_storage_bucket.terraform
+  id = "${var.project}-terraform"
+}
+
+# Create a bucket to store the Terraform data.
+resource "google_storage_bucket" "terraform" {
+  name          = "${var.project}-terraform"
+  force_destroy = false
+  # This prevents Terraform from deleting the bucket. Any plan to do so is
+  # rejected. If we really need to delete the bucket we must take additional
+  # steps.
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  # The bucket configuration.
+  location                    = "US"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+  # Keep multiple versions of each object so we can recover if needed.
+  versioning {
+    enabled = true
+  }
+  # Tidy up archived objects after a year. They are small, so there is no need
+  # to rush.
+  lifecycle_rule {
+    condition {
+      days_since_noncurrent_time = 365
+      with_state                 = "ARCHIVED"
+    }
+    action {
+      type = "Delete"
+    }
+  }
+}

--- a/.gcb/bootstrap/terraform.tfstate
+++ b/.gcb/bootstrap/terraform.tfstate
@@ -1,0 +1,92 @@
+{
+  "version": 4,
+  "terraform_version": "1.9.3",
+  "serial": 1,
+  "lineage": "ec3950c0-6f44-4014-812e-c349a1521622",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "google_storage_bucket",
+      "name": "terraform",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 2,
+          "attributes": {
+            "autoclass": [],
+            "cors": [],
+            "custom_placement_config": [],
+            "default_event_based_hold": false,
+            "effective_labels": {},
+            "enable_object_retention": false,
+            "encryption": [],
+            "force_destroy": false,
+            "id": "rust-sdk-testing-terraform",
+            "labels": null,
+            "lifecycle_rule": [
+              {
+                "action": [
+                  {
+                    "storage_class": "",
+                    "type": "Delete"
+                  }
+                ],
+                "condition": [
+                  {
+                    "age": null,
+                    "created_before": "",
+                    "custom_time_before": "",
+                    "days_since_custom_time": null,
+                    "days_since_noncurrent_time": 365,
+                    "matches_prefix": [],
+                    "matches_storage_class": [],
+                    "matches_suffix": [],
+                    "no_age": null,
+                    "noncurrent_time_before": "",
+                    "num_newer_versions": null,
+                    "send_age_if_zero": true,
+                    "send_days_since_custom_time_if_zero": null,
+                    "send_days_since_noncurrent_time_if_zero": null,
+                    "send_num_newer_versions_if_zero": null,
+                    "with_state": "ARCHIVED"
+                  }
+                ]
+              }
+            ],
+            "location": "US",
+            "logging": [],
+            "name": "rust-sdk-testing-terraform",
+            "project": "rust-sdk-testing",
+            "project_number": 1044885715437,
+            "public_access_prevention": "inherited",
+            "requester_pays": false,
+            "retention_policy": [],
+            "rpo": "DEFAULT",
+            "self_link": "https://www.googleapis.com/storage/v1/b/rust-sdk-testing-terraform",
+            "soft_delete_policy": [
+              {
+                "effective_time": "2024-11-21T12:20:38.426Z",
+                "retention_duration_seconds": 604800
+              }
+            ],
+            "storage_class": "STANDARD",
+            "terraform_labels": {},
+            "timeouts": null,
+            "uniform_bucket_level_access": true,
+            "url": "gs://rust-sdk-testing-terraform",
+            "versioning": [
+              {
+                "enabled": true
+              }
+            ],
+            "website": []
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsInJlYWQiOjI0MDAwMDAwMDAwMCwidXBkYXRlIjoyNDAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjIifQ=="
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/.gcb/bootstrap/variables.tf
+++ b/.gcb/bootstrap/variables.tf
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Rust places its build artifacts in this directory
-/target/
+variable "project" {
+  default = "rust-sdk-testing"
+}
 
-# We use a few Python tools for development [^1]. Reserve `.env/` to install
-# these tools in a local Python virtual environment.
-/.venv/
+variable "region" {
+  default = "us-central1"
+}
 
-.vscode
-
-# Ignore terraform files.
-.terraform/
-terraform.tfstate
+variable "zone" {
+  default = "us-central1-f"
+}

--- a/.gcb/builds/.terraform.lock.hcl
+++ b/.gcb/builds/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.44.2"
+  constraints = "~> 5.44.0"
+  hashes = [
+    "h1:gqtQa4oy2DGnwsGv2cYvvX0d4R6HYnMHEYMvTwYr8jI=",
+    "zh:2594d626d9148480688000b6c8e091d6bcc8f2a2dc28fe6e2ea27487f3c1726d",
+    "zh:2b0fafdb0ed7cbf4da5b4d7f3541ccd4402ee8cbdd66ebe26eaf9e904951da01",
+    "zh:310b1b0ac4f244a51abce22e41c7904e4bee50b5c1b66fd8646368f94ea6e563",
+    "zh:67c24e70b74e3d52f60e1b32d9c113f8d11e5db7265463e44a5b07474b79177c",
+    "zh:6d5069bf1e30570ef5189ad994a4b09c998b0f2630e169cc0b9cf68deafbb38d",
+    "zh:71bf6eb0d865082d736732cd48d9cb04a81500c55c48da91ac99816149cb3cb2",
+    "zh:970a29056d63a41bee915e634922cbb9caba7d34604f4884f001bfaf1e208b07",
+    "zh:a3b5ea6d67459a3237afcaaad4034998c8435b1d222f0c163d868a2863af5d24",
+    "zh:c049cb7edd8c797d7dd5b8f5a7a3a5b84cc08a1c60a50858fcdbec5d4db3f599",
+    "zh:c17c1133fce9ed5fea39da65f1c3024d5e04a5f0b94fd0d217c4988f6c1a3efd",
+    "zh:c657377f55a8a7abc16be34d26936d7879740d732136d40972013871c678db02",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/.gcb/builds/backend.tf
+++ b/.gcb/builds/backend.tf
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,15 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Rust places its build artifacts in this directory
-/target/
-
-# We use a few Python tools for development [^1]. Reserve `.env/` to install
-# these tools in a local Python virtual environment.
-/.venv/
-
-.vscode
-
-# Ignore terraform files.
-.terraform/
-terraform.tfstate
+terraform {
+  backend "gcs" {
+    bucket = "rust-sdk-testing-terraform"
+    prefix = "gcb"
+  }
+}

--- a/.gcb/builds/grants/main.tf
+++ b/.gcb/builds/grants/main.tf
@@ -1,0 +1,56 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project" {
+  type = string
+}
+
+data "google_project" "project" {
+}
+
+locals {
+  gce_service_account = "${data.google_project.project.number}-compute@developer.gserviceaccount.com"
+  gcb_service_account = "${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+}
+
+# We need a service account to run the builds.
+# We use a dedicated account, as opposed to reusing the GCE or GCB account,
+# because we want full control over its permissions.
+resource "google_service_account" "integration-test-runner" {
+  account_id   = "integration-test-runner"
+  display_name = "Build and Run Integration Tests"
+}
+
+# The service account will need to write logs. That is needed so we can see the
+# build output.
+resource "google_project_iam_member" "sa-can-write-logs" {
+  project = var.project
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.integration-test-runner.email}"
+}
+
+# The service account will need to read tarballs uploaded by `gcloud submit`.
+resource "google_storage_bucket_iam_member" "sa-can-read-build-tarballs" {
+  bucket = "${var.project}_cloudbuild"
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.integration-test-runner.email}"
+}
+
+# We will run integration tests related to secret manager. These require full
+# control over the secrets.
+resource "google_project_iam_member" "run-secret-manager-integration-tests" {
+  project = var.project
+  role    = "roles/secretmanager.admin"
+  member  = "serviceAccount:${google_service_account.integration-test-runner.email}"
+}

--- a/.gcb/builds/main.tf
+++ b/.gcb/builds/main.tf
@@ -1,0 +1,56 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.44.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project
+  region  = var.region
+  zone    = var.zone
+}
+
+# Enable Cloud Build and create triggers.
+module "services" {
+  source  = "./services"
+  project = var.project
+}
+
+# Create the resources we will need to run integration tests on.
+module "resources" {
+  source  = "./resources"
+  project = var.project
+}
+
+# Create the service account needed for GCB and grant it the necessary
+# permissions.
+module "grants" {
+  source  = "./grants"
+  project = var.project
+}
+
+# Enable Cloud Build and create triggers.
+# module "triggers" {
+#   depends_on = [module.services, module.build]
+#   source     = "./triggers"
+#   project    = var.project
+#   region     = var.region
+#   repository = module.build.repository
+# }

--- a/.gcb/builds/resources/main.tf
+++ b/.gcb/builds/resources/main.tf
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Rust places its build artifacts in this directory
-/target/
+variable "project" {
+  type = string
+}
 
-# We use a few Python tools for development [^1]. Reserve `.env/` to install
-# these tools in a local Python virtual environment.
-/.venv/
-
-.vscode
-
-# Ignore terraform files.
-.terraform/
-terraform.tfstate
+# To test `SetIamPolicy()` calls we typically want to add bindings. We use this
+# account in such tests. The account is 
+# an existing account.
+resource "google_service_account" "set-iam-test-only" {
+  account_id   = "set-iam-test-only"
+  display_name = "Used in testing of set_iam_policy() and similar RPCs."
+  disabled     = true
+}

--- a/.gcb/builds/services/main.tf
+++ b/.gcb/builds/services/main.tf
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,15 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Rust places its build artifacts in this directory
-/target/
+variable "project" {}
 
-# We use a few Python tools for development [^1]. Reserve `.env/` to install
-# these tools in a local Python virtual environment.
-/.venv/
+resource "google_project_service" "cloudbuild" {
+  project = var.project
+  service = "cloudbuild.googleapis.com"
 
-.vscode
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
 
-# Ignore terraform files.
-.terraform/
-terraform.tfstate
+  disable_dependent_services = true
+}
+
+resource "google_project_service" "secretmanager" {
+  project = var.project
+  service = "secretmanager.googleapis.com"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+
+  disable_dependent_services = true
+}

--- a/.gcb/builds/triggers/main.tf
+++ b/.gcb/builds/triggers/main.tf
@@ -1,0 +1,58 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project" {}
+variable "region" {}
+variable "repository" {}
+
+locals {
+  builds = {
+    integration = {}
+  }
+}
+
+resource "google_cloudbuild_trigger" "pull-request" {
+  for_each = tomap(local.builds)
+  location = var.region
+  name     = "${each.key}-pr"
+  filename = ".gcb/${each.key}.yaml"
+  tags     = ["pull-request", "name:${each.key}"]
+
+  repository_event_config {
+    repository = var.repository
+    pull_request {
+      branch          = "^main$"
+      comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"
+    }
+  }
+
+  include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
+}
+
+resource "google_cloudbuild_trigger" "post-merge" {
+  for_each = tomap(local.builds)
+  location = var.region
+  name     = "${each.key}-pm"
+  filename = ".gcb/${each.key}.yaml"
+  tags     = ["post-merge", "push", "name:${each.key}"]
+
+  repository_event_config {
+    repository = var.repository
+    push {
+      branch = "^main$"
+    }
+  }
+
+  include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
+}

--- a/.gcb/builds/variables.tf
+++ b/.gcb/builds/variables.tf
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Rust places its build artifacts in this directory
-/target/
+variable "project" {
+  default = "rust-sdk-testing"
+}
 
-# We use a few Python tools for development [^1]. Reserve `.env/` to install
-# these tools in a local Python virtual environment.
-/.venv/
+variable "region" {
+  default = "us-central1"
+}
 
-.vscode
-
-# Ignore terraform files.
-.terraform/
-terraform.tfstate
+variable "zone" {
+  default = "us-central1-f"
+}

--- a/.gcb/integration.yaml
+++ b/.gcb/integration.yaml
@@ -21,10 +21,6 @@ options:
     - GOOGLE_CLOUD_RUST_TEST_SERVICE_ACCOUNT=set-iam-test-only@${PROJECT_ID}.iam.gserviceaccount.com
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'
 steps:
-  - name: 'bash'
-    script: |
-      #!/usr/bin/env bash
-      printenv
   - name: 'rust:1.82-bookworm'
     args: ['cargo', 'build']
   - name: 'rust:1.82-bookworm'

--- a/.gcb/integration.yaml
+++ b/.gcb/integration.yaml
@@ -17,22 +17,17 @@ options:
   substitutionOption: 'ALLOW_LOOSE'
   logging: CLOUD_LOGGING_ONLY
   env:
-  - GOOGLE_CLOUD_PROJECT=${PROJECT_ID}
-  - GOOGLE_CLOUD_RUST_TEST_SERVICE_ACCOUNT=set-iam-test-only@${PROJECT_ID}.iam.gserviceaccount.com
-
+    - GOOGLE_CLOUD_PROJECT=${PROJECT_ID}
+    - GOOGLE_CLOUD_RUST_TEST_SERVICE_ACCOUNT=set-iam-test-only@${PROJECT_ID}.iam.gserviceaccount.com
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'
-
 steps:
-- name: 'bash'
-  script: |
-    #!/usr/bin/env bash
-    printenv
-
-- name: 'rust:1.82-bookworm'
-  args: ['cargo', 'build' ]
-
-- name: 'rust:1.82-bookworm'
-  args: ['cargo', 'test', '--tests', '--bins', '--lib' ]
-
-- name: 'rust:1.82-bookworm'
-  args: ['cargo', 'test',  '--package', 'integration-tests', '--features', 'run-integration-tests' ]
+  - name: 'bash'
+    script: |
+      #!/usr/bin/env bash
+      printenv
+  - name: 'rust:1.82-bookworm'
+    args: ['cargo', 'build']
+  - name: 'rust:1.82-bookworm'
+    args: ['cargo', 'test', '--tests', '--bins', '--lib']
+  - name: 'rust:1.82-bookworm'
+    args: ['cargo', 'test', '--package', 'integration-tests', '--features', 'run-integration-tests']

--- a/.gcb/integration.yaml
+++ b/.gcb/integration.yaml
@@ -1,0 +1,38 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+options:
+  dynamic_substitutions: true
+  substitutionOption: 'ALLOW_LOOSE'
+  logging: CLOUD_LOGGING_ONLY
+  env:
+  - GOOGLE_CLOUD_PROJECT=${PROJECT_ID}
+  - GOOGLE_CLOUD_RUST_TEST_SERVICE_ACCOUNT=set-iam-test-only@${PROJECT_ID}.iam.gserviceaccount.com
+
+serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'
+
+steps:
+- name: 'bash'
+  script: |
+    #!/usr/bin/env bash
+    printenv
+
+- name: 'rust:1.82-bookworm'
+  args: ['cargo', 'build' ]
+
+- name: 'rust:1.82-bookworm'
+  args: ['cargo', 'test', '--tests', '--bins', '--lib' ]
+
+- name: 'rust:1.82-bookworm'
+  args: ['cargo', 'test',  '--package', 'integration-tests', '--features', 'run-integration-tests' ]

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -12,15 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Rust places its build artifacts in this directory
-/target/
+# A .ignore file for Google Cloud Build
 
-# We use a few Python tools for development [^1]. Reserve `.env/` to install
-# these tools in a local Python virtual environment.
-/.venv/
-
-.vscode
-
-# Ignore terraform files.
-.terraform/
-terraform.tfstate
+# Ignore anything ignored by `git`:
+#!include:.gitignore


### PR DESCRIPTION
This creates all the GCB (Google Cloud Build) configuration needed to
run the integration tests. There is a lot more Terraform than I would
like, but at least that can easily grow as we start needing more
resources.

The triggers for these builds are not created yet.