### PR TITLE
test: improve error messages for integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,6 +747,7 @@ dependencies = [
  "rand",
  "secretmanager-golden-gclient",
  "secretmanager-golden-openapi",
+ "serde_json",
  "tokio",
 ]
 

--- a/src/integration-tests/Cargo.toml
+++ b/src/integration-tests/Cargo.toml
@@ -23,14 +23,18 @@ publish           = ["prevent-accidental-publication"]
 run-integration-tests = ["dep:tokio"]
 
 [dependencies]
-tokio   = { version = "1.12", features = ["full", "macros"], optional = true }
-auth    = { path = "../../auth", package = "google-cloud-auth" }
-gax     = { path = "../../src/gax", package = "gcp-sdk-gax" }
-wkt     = { path = "../../src/wkt", package = "gcp-sdk-wkt" }
-iam_v1  = { path = "../../generator/testdata/rust/gclient/golden/iam/v1", package = "iam-v1-golden-gclient" }
-sm      = { path = "../../generator/testdata/rust/gclient/golden/secretmanager", package = "secretmanager-golden-gclient" }
-smo     = { path = "../../generator/testdata/rust/openapi/golden", package = "secretmanager-golden-openapi" }
-rand    = "0.8.5"
-futures = "0.3.31"
-bytes   = "1.8.0"
-crc32c  = "0.6.8"
+tokio      = { version = "1.12", features = ["full", "macros"], optional = true }
+auth       = { path = "../../auth", package = "google-cloud-auth" }
+gax        = { path = "../../src/gax", package = "gcp-sdk-gax" }
+wkt        = { path = "../../src/wkt", package = "gcp-sdk-wkt" }
+iam_v1     = { path = "../../generator/testdata/rust/gclient/golden/iam/v1", package = "iam-v1-golden-gclient" }
+sm         = { path = "../../generator/testdata/rust/gclient/golden/secretmanager", package = "secretmanager-golden-gclient" }
+smo        = { path = "../../generator/testdata/rust/openapi/golden", package = "secretmanager-golden-openapi" }
+rand       = "0.8.5"
+futures    = "0.3.31"
+bytes      = "1.8.0"
+crc32c     = "0.6.8"
+serde_json = "1.0.133"
+
+[dev-dependencies]
+tokio      = { version = "1.12", features = ["full", "macros"] }

--- a/src/integration-tests/Cargo.toml
+++ b/src/integration-tests/Cargo.toml
@@ -37,4 +37,4 @@ crc32c     = "0.6.8"
 serde_json = "1.0.133"
 
 [dev-dependencies]
-tokio      = { version = "1.12", features = ["full", "macros"] }
+tokio = { version = "1.12", features = ["full", "macros"] }

--- a/src/integration-tests/src/lib.rs
+++ b/src/integration-tests/src/lib.rs
@@ -12,20 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use std::error::Error;
-pub type Result<T> = std::result::Result<T, Box<dyn Error>>;
+use gax::error::Error;
+pub type Result<T> = std::result::Result<T, gax::error::Error>;
 pub mod secret_manager;
 
 pub const SECRET_ID_LENGTH: usize = 64;
 
 /// Returns the project id used for the integration tests.
 pub fn project_id() -> Result<String> {
-    let project_id = std::env::var("GOOGLE_CLOUD_PROJECT")?;
+    let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").map_err(Error::other)?;
     Ok(project_id)
 }
 
 /// Returns an existing, but disabled service account to test IAM RPCs.
 pub fn service_account_for_iam_tests() -> Result<String> {
-    let value = std::env::var("GOOGLE_CLOUD_RUST_TEST_SERVICE_ACCOUNT")?;
+    let value = std::env::var("GOOGLE_CLOUD_RUST_TEST_SERVICE_ACCOUNT").map_err(Error::other)?;
     Ok(value)
 }

--- a/src/integration-tests/src/secret_manager/openapi_locational.rs
+++ b/src/integration-tests/src/secret_manager/openapi_locational.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::Result;
+use gax::error::Error;
 use rand::{distributions::Alphanumeric, Rng};
 
 pub async fn run() -> Result<()> {
@@ -362,7 +363,9 @@ async fn cleanup_stale_secrets(
     location_id: &str,
 ) -> Result<()> {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
-    let stale_deadline = SystemTime::now().duration_since(UNIX_EPOCH)?;
+    let stale_deadline = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(Error::other)?;
     let stale_deadline = stale_deadline - Duration::from_secs(48 * 60 * 60);
     let stale_deadline = stale_deadline.as_secs() as i64;
 

--- a/src/integration-tests/tests/driver.rs
+++ b/src/integration-tests/tests/driver.rs
@@ -13,19 +13,31 @@
 // limitations under the License.
 
 #[cfg(all(test, feature = "run-integration-tests"))]
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn run_secretmanager_protobuf() -> integration_tests::Result<()> {
-    integration_tests::secret_manager::protobuf::run().await
-}
+mod driver {
+    use gax::error::*;
+    fn report(e: Error) -> Error {
+        println!("\nERROR {e}\n");
+        Error::other("test failed")
+    }
 
-#[cfg(all(test, feature = "run-integration-tests"))]
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn run_secretmanager_openapi() -> integration_tests::Result<()> {
-    integration_tests::secret_manager::openapi::run().await
-}
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn run_secretmanager_protobuf() -> integration_tests::Result<()> {
+        integration_tests::secret_manager::protobuf::run()
+            .await
+            .map_err(report)
+    }
 
-#[cfg(all(test, feature = "run-integration-tests"))]
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn run_secretmanager_openapi_locational() -> integration_tests::Result<()> {
-    integration_tests::secret_manager::openapi_locational::run().await
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn run_secretmanager_openapi() -> integration_tests::Result<()> {
+        integration_tests::secret_manager::openapi::run()
+            .await
+            .map_err(report)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn run_secretmanager_openapi_locational() -> integration_tests::Result<()> {
+        integration_tests::secret_manager::openapi_locational::run()
+            .await
+            .map_err(report)
+    }
 }


### PR DESCRIPTION
Use `gax::error::Error` so we can print better error messages on
failure.