### PR TITLE
ci(gcb): use pre-existing resources

### DIFF
--- a/.gcb/builds/main.tf
+++ b/.gcb/builds/main.tf
@@ -48,7 +48,7 @@ module "grants" {
 
 # Create the GCB triggers.
 module "triggers" {
-  depends_on = [module.services, module.resources, module.grants]
+  depends_on      = [module.services, module.resources, module.grants]
   source          = "./triggers"
   project         = var.project
   region          = var.region

--- a/.gcb/builds/resources/main.tf
+++ b/.gcb/builds/resources/main.tf
@@ -15,12 +15,3 @@
 variable "project" {
   type = string
 }
-
-# To test `SetIamPolicy()` calls we typically want to add bindings. We use this
-# account in such tests. The account is 
-# an existing account.
-resource "google_service_account" "set-iam-test-only" {
-  account_id   = "set-iam-test-only"
-  display_name = "Used in testing of set_iam_policy() and similar RPCs."
-  disabled     = true
-}


### PR DESCRIPTION
Creating project-wide grants in Terraform conflicts with the internal
Google Cloud project management tools. I moved the service account and
project-wide IAM permissions there, and use Terraform only for narrower
resources and permissions.
