### PR TITLE
impl(generator): global configuration for refresh

### DIFF
--- a/generator/sidekick/config.go
+++ b/generator/sidekick/config.go
@@ -37,21 +37,18 @@ type GeneralConfig struct {
 }
 
 func LoadRootConfig(filename string) (*Config, error) {
-	var config Config
+	config := &Config{
+		Codec:  map[string]string{},
+		Source: map[string]string{},
+	}
 	if contents, err := os.ReadFile(filename); err == nil {
 		err = toml.Unmarshal(contents, &config)
 		if err != nil {
 			return nil, fmt.Errorf("error reading top-level configuration: %w", err)
 		}
 	}
-	if config.Codec == nil {
-		config.Codec = map[string]string{}
-	}
-	if config.Source == nil {
-		config.Source = map[string]string{}
-	}
 	// Ignore errors reading the top-level file.
-	return &config, nil
+	return config, nil
 }
 
 func MergeConfig(rootConfig *Config, filename string) (*Config, error) {

--- a/generator/sidekick/config.go
+++ b/generator/sidekick/config.go
@@ -28,6 +28,8 @@ type Config struct {
 	Codec  map[string]string `toml:"codec"`
 }
 
+// Configuration parameters that affect Parsers and Codecs, including the
+// selection of parser and codec.
 type GeneralConfig struct {
 	Language            string `toml:"language"`
 	TemplateDir         string `toml:"template-dir"`

--- a/generator/sidekick/config.go
+++ b/generator/sidekick/config.go
@@ -14,6 +14,13 @@
 
 package main
 
+import (
+	"fmt"
+	"os"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
 type Config struct {
 	General GeneralConfig `toml:"general"`
 
@@ -22,9 +29,77 @@ type Config struct {
 }
 
 type GeneralConfig struct {
+	Language            string `toml:"language"`
+	TemplateDir         string `toml:"template-dir"`
 	SpecificationFormat string `toml:"specification-format"`
 	SpecificationSource string `toml:"specification-source"`
 	ServiceConfig       string `toml:"service-config"`
-	Language            string `toml:"language"`
-	TemplateDir         string `toml:"template-dir"`
+}
+
+func LoadRootConfig(filename string) (*Config, error) {
+	var config Config
+	if contents, err := os.ReadFile(filename); err == nil {
+		err = toml.Unmarshal(contents, &config)
+		if err != nil {
+			return nil, fmt.Errorf("error reading top-level configuration: %w", err)
+		}
+	}
+	if config.Codec == nil {
+		config.Codec = map[string]string{}
+	}
+	if config.Source == nil {
+		config.Source = map[string]string{}
+	}
+	// Ignore errors reading the top-level file.
+	return &config, nil
+}
+
+func MergeConfig(rootConfig *Config, filename string) (*Config, error) {
+	contents, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	var local Config
+	err = toml.Unmarshal(contents, &local)
+	if err != nil {
+		return nil, fmt.Errorf("error reading configuration %s: %w", filename, err)
+	}
+
+	merged := Config{
+		General: GeneralConfig{
+			Language:            rootConfig.General.Language,
+			TemplateDir:         rootConfig.General.TemplateDir,
+			SpecificationFormat: rootConfig.General.SpecificationFormat,
+		},
+		Source: map[string]string{},
+		Codec:  map[string]string{},
+	}
+	for k, v := range rootConfig.Codec {
+		merged.Codec[k] = v
+	}
+	for k, v := range rootConfig.Source {
+		merged.Source[k] = v
+	}
+
+	// Ignore `SpecificationSource` and `ServiceConfig` at the top-level
+	// configuration. It makes no sense to set those globally.
+	merged.General.SpecificationSource = local.General.SpecificationSource
+	merged.General.ServiceConfig = local.General.ServiceConfig
+	if local.General.SpecificationFormat != "" {
+		merged.General.SpecificationFormat = local.General.SpecificationFormat
+	}
+	if local.General.Language != "" {
+		merged.General.Language = local.General.Language
+	}
+	if local.General.TemplateDir != "" {
+		merged.General.TemplateDir = local.General.TemplateDir
+	}
+	for k, v := range local.Codec {
+		merged.Codec[k] = v
+	}
+	for k, v := range local.Source {
+		merged.Source[k] = v
+	}
+	// Ignore errors reading the top-level file.
+	return &merged, nil
 }

--- a/generator/sidekick/config_test.go
+++ b/generator/sidekick/config_test.go
@@ -1,0 +1,179 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+func TestMergeLocalForGeneral(t *testing.T) {
+	root := Config{
+		General: GeneralConfig{
+			Language:            "root-language",
+			TemplateDir:         "root-template-dir",
+			SpecificationFormat: "root-specification-format",
+		},
+	}
+
+	local := Config{
+		General: GeneralConfig{
+			Language:            "local-language",
+			TemplateDir:         "local-template-dir",
+			SpecificationFormat: "local-specification-format",
+			SpecificationSource: "local-specification-source",
+			ServiceConfig:       "local-service-config",
+		},
+	}
+
+	got, err := mergeTestConfigs(t, &root, &local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &Config{
+		General: GeneralConfig{
+			Language:            "local-language",
+			TemplateDir:         "local-template-dir",
+			SpecificationFormat: "local-specification-format",
+			SpecificationSource: "local-specification-source",
+			ServiceConfig:       "local-service-config",
+		},
+		Codec:  map[string]string{},
+		Source: map[string]string{},
+	}
+
+	if diff := cmp.Diff(want, got); len(diff) != 0 {
+		t.Errorf("mismatched merged config (-want, +got):\n%s", diff)
+	}
+}
+
+func TestMergeIgnoreRootSourceAndServiceConfig(t *testing.T) {
+	root := Config{
+		General: GeneralConfig{
+			Language:            "root-language",
+			TemplateDir:         "root-template-dir",
+			SpecificationFormat: "root-specification-format",
+			SpecificationSource: "root-specification-source",
+			ServiceConfig:       "root-service-config",
+		},
+	}
+
+	local := Config{
+		General: GeneralConfig{
+			Language:            "local-language",
+			TemplateDir:         "local-template-dir",
+			SpecificationFormat: "local-specification-format",
+		},
+	}
+
+	got, err := mergeTestConfigs(t, &root, &local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &Config{
+		General: GeneralConfig{
+			Language:            "local-language",
+			TemplateDir:         "local-template-dir",
+			SpecificationFormat: "local-specification-format",
+			SpecificationSource: "",
+			ServiceConfig:       "",
+		},
+		Codec:  map[string]string{},
+		Source: map[string]string{},
+	}
+
+	if diff := cmp.Diff(want, got); len(diff) != 0 {
+		t.Errorf("mismatched merged config (-want, +got):\n%s", diff)
+	}
+}
+
+func TestMergeCodecAndSource(t *testing.T) {
+	root := Config{
+		General: GeneralConfig{
+			Language:            "root-language",
+			TemplateDir:         "root-template-dir",
+			SpecificationFormat: "root-specification-format",
+		},
+		Codec: map[string]string{
+			"codec-a": "root-a-value",
+			"codec-b": "root-b-value",
+		},
+		Source: map[string]string{
+			"source-a": "root-a-value",
+			"source-b": "root-b-value",
+		},
+	}
+
+	local := Config{
+		General: GeneralConfig{
+			SpecificationSource: "local-specification-source",
+			ServiceConfig:       "local-service-config",
+		},
+		Codec: map[string]string{
+			"codec-b": "local-b-value",
+			"codec-c": "local-c-value",
+		},
+		Source: map[string]string{
+			"source-b": "local-b-value",
+			"source-c": "local-c-value",
+		},
+	}
+
+	got, err := mergeTestConfigs(t, &root, &local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &Config{
+		General: GeneralConfig{
+			Language:            "root-language",
+			TemplateDir:         "root-template-dir",
+			SpecificationFormat: "root-specification-format",
+			SpecificationSource: "local-specification-source",
+			ServiceConfig:       "local-service-config",
+		},
+		Codec: map[string]string{
+			"codec-a": "root-a-value",
+			"codec-b": "local-b-value",
+			"codec-c": "local-c-value",
+		},
+		Source: map[string]string{
+			"source-a": "root-a-value",
+			"source-b": "local-b-value",
+			"source-c": "local-c-value",
+		},
+	}
+
+	if diff := cmp.Diff(want, got); len(diff) != 0 {
+		t.Errorf("mismatched merged config (-want, +got):\n%s", diff)
+	}
+}
+
+func mergeTestConfigs(t *testing.T, root, local *Config) (*Config, error) {
+	t.Helper()
+	tempFile, err := os.CreateTemp(t.TempDir(), "sidekick.toml")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(tempFile.Name())
+	to := toml.NewEncoder(tempFile)
+	if err := to.Encode(local); err != nil {
+		return nil, err
+	}
+	tempFile.Close()
+	return MergeConfig(root, tempFile.Name())
+}

--- a/generator/sidekick/generate.go
+++ b/generator/sidekick/generate.go
@@ -28,7 +28,7 @@ import (
 
 // Generate takes some state and applies it to a template to create a client
 // library.
-func Generate(args []string) error {
+func Generate(rootConfig *Config, args []string) error {
 	fs := flag.NewFlagSet("generate", flag.ExitOnError)
 	var (
 		format        = fs.String("specification-format", "", "the specification format. Protobuf or OpenAPI v3.")
@@ -92,7 +92,7 @@ func Generate(args []string) error {
 	}
 
 	// Load the .sidekick.toml file and refresh the code.
-	return Refresh([]string{*output})
+	return Refresh(rootConfig, []string{*output})
 }
 
 func writeSidekickToml(outDir string, config Config) error {

--- a/generator/sidekick/refresh.go
+++ b/generator/sidekick/refresh.go
@@ -16,28 +16,21 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"path"
 
 	"github.com/googleapis/google-cloud-rust/generator/internal/genclient"
 	"github.com/googleapis/google-cloud-rust/generator/internal/genclient/language"
 	"github.com/googleapis/google-cloud-rust/generator/internal/genclient/parser"
-	toml "github.com/pelletier/go-toml/v2"
 )
 
 // Reruns the generator in one directory, using the configuration parameters
 // saved in its `.sidekick.toml` file.
-func Refresh(args []string) error {
+func Refresh(rootConfig *Config, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("expected the target directory")
 	}
 	outDir := args[0]
-	contents, err := os.ReadFile(path.Join(outDir, ".sidekick.toml"))
-	if err != nil {
-		return err
-	}
-	var config Config
-	err = toml.Unmarshal(contents, &config)
+	config, err := MergeConfig(rootConfig, path.Join(outDir, ".sidekick.toml"))
 	if err != nil {
 		return err
 	}

--- a/generator/sidekick/sidekick.go
+++ b/generator/sidekick/sidekick.go
@@ -36,17 +36,25 @@ func root() error {
 			return err
 		}
 	}
+
+	// Load the top-level configuration file. If there are any errors loading
+	// the file just run with the defaults.
+	config, err := LoadRootConfig(".sidekick.toml")
+	if err != nil {
+		return err
+	}
+
 	args := flag.Args()
-	if len(args) < 2 {
-		return fmt.Errorf("you must pass a subcommand")
+	if len(args) < 1 {
+		return fmt.Errorf("you must provide a subcommand")
 	}
 	switch args[0] {
 	case "generate":
-		if err := Generate(args[1:]); err != nil {
+		if err := Generate(config, args[1:]); err != nil {
 			return err
 		}
 	case "refresh":
-		if err := Refresh(args[1:]); err != nil {
+		if err := Refresh(config, args[1:]); err != nil {
 			return err
 		}
 	default:

--- a/generator/sidekick/sidekick_test.go
+++ b/generator/sidekick/sidekick_test.go
@@ -57,7 +57,7 @@ func TestRustFromOpenAPI(t *testing.T) {
 		"-codec-option", "package:gax=package=gcp-sdk-gax,path=src/gax,feature=sdk_client",
 		"-codec-option", "package:google-cloud-auth=package=google-cloud-auth,path=auth",
 	}
-	if err := Generate(args); err != nil {
+	if err := Generate(&Config{}, args); err != nil {
 		t.Fatal(err)
 	}
 
@@ -84,13 +84,13 @@ func TestRustFromProtobuf(t *testing.T) {
 	if err := os.Chdir(projectRoot); err != nil {
 		t.Fatal(err)
 	}
-	type Config struct {
+	type TestConfig struct {
 		Source       string
 		Name         string
 		ExtraOptions []string
 	}
 
-	configs := []Config{
+	configs := []TestConfig{
 		{
 			Source: "generator/testdata/googleapis/google/type",
 			Name:   "type",
@@ -137,7 +137,7 @@ func TestRustFromProtobuf(t *testing.T) {
 			"-codec-option", "package:google-cloud-auth=package=google-cloud-auth,path=auth",
 		}
 		args = append(args, config.ExtraOptions...)
-		if err := Generate(args); err != nil {
+		if err := Generate(&Config{}, args); err != nil {
 			t.Fatal(err)
 		}
 
@@ -205,7 +205,7 @@ func TestRustModuleFromProtobuf(t *testing.T) {
 		}
 		args = append(args, config.ExtraOptions...)
 
-		if err := Generate(args); err != nil {
+		if err := Generate(&Config{}, args); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -226,13 +226,13 @@ func TestGoFromProtobuf(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	type Config struct {
+	type TestConfig struct {
 		Source       string
 		Name         string
 		ExtraOptions []string
 		ModReplace   map[string]string
 	}
-	configs := []Config{
+	configs := []TestConfig{
 		{
 			Source: "generator/testdata/googleapis/google/type",
 			Name:   "typez",
@@ -269,7 +269,7 @@ func TestGoFromProtobuf(t *testing.T) {
 			"-codec-option", "package-name-override=github.com/google-cloud-rust/generator/testdata/go/gclient/golden/typez",
 		}
 		args = append(args, config.ExtraOptions...)
-		if err := Generate(args); err != nil {
+		if err := Generate(&Config{}, args); err != nil {
 			t.Fatal(err)
 		}
 

--- a/generator/testdata/go/gclient/golden/iam/v1/.sidekick.toml
+++ b/generator/testdata/go/gclient/golden/iam/v1/.sidekick.toml
@@ -13,11 +13,11 @@
 #  limitations under the License.
 
 [general]
+language = 'go'
+template-dir = 'generator/templates'
 specification-format = 'protobuf'
 specification-source = 'generator/testdata/googleapis/google/iam/v1'
 service-config = ''
-language = 'go'
-template-dir = 'generator/templates'
 
 [source]
 googleapis-root = 'generator/testdata/googleapis'

--- a/generator/testdata/go/gclient/golden/typez/.sidekick.toml
+++ b/generator/testdata/go/gclient/golden/typez/.sidekick.toml
@@ -13,11 +13,11 @@
 #  limitations under the License.
 
 [general]
+language = 'go'
+template-dir = 'generator/templates'
 specification-format = 'protobuf'
 specification-source = 'generator/testdata/googleapis/google/type'
 service-config = ''
-language = 'go'
-template-dir = 'generator/templates'
 
 [source]
 googleapis-root = 'generator/testdata/googleapis'

--- a/generator/testdata/rust/gclient/golden/iam/v1/.sidekick.toml
+++ b/generator/testdata/rust/gclient/golden/iam/v1/.sidekick.toml
@@ -13,11 +13,11 @@
 #  limitations under the License.
 
 [general]
+language = 'rust'
+template-dir = 'generator/templates'
 specification-format = 'protobuf'
 specification-source = 'generator/testdata/googleapis/google/iam/v1'
 service-config = ''
-language = 'rust'
-template-dir = 'generator/templates'
 
 [source]
 googleapis-root = 'generator/testdata/googleapis'

--- a/generator/testdata/rust/gclient/golden/location/.sidekick.toml
+++ b/generator/testdata/rust/gclient/golden/location/.sidekick.toml
@@ -13,11 +13,11 @@
 #  limitations under the License.
 
 [general]
+language = 'rust'
+template-dir = 'generator/templates'
 specification-format = 'protobuf'
 specification-source = 'generator/testdata/googleapis/google/cloud/location'
 service-config = 'generator/testdata/googleapis/google/cloud/location/cloud.yaml'
-language = 'rust'
-template-dir = 'generator/templates'
 
 [source]
 googleapis-root = 'generator/testdata/googleapis'

--- a/generator/testdata/rust/gclient/golden/module/rpc/.sidekick.toml
+++ b/generator/testdata/rust/gclient/golden/module/rpc/.sidekick.toml
@@ -13,11 +13,11 @@
 #  limitations under the License.
 
 [general]
+language = 'rust'
+template-dir = 'generator/templates'
 specification-format = 'protobuf'
 specification-source = 'generator/testdata/googleapis/google/rpc/error_details.proto'
 service-config = 'generator/testdata/googleapis/google/rpc/rpc_publish.yaml'
-language = 'rust'
-template-dir = 'generator/templates'
 
 [source]
 googleapis-root = 'generator/testdata/googleapis'

--- a/generator/testdata/rust/gclient/golden/module/type/.sidekick.toml
+++ b/generator/testdata/rust/gclient/golden/module/type/.sidekick.toml
@@ -13,11 +13,11 @@
 #  limitations under the License.
 
 [general]
+language = 'rust'
+template-dir = 'generator/templates'
 specification-format = 'protobuf'
 specification-source = 'generator/testdata/googleapis/google/type'
 service-config = 'generator/testdata/googleapis/google/type/type.yaml'
-language = 'rust'
-template-dir = 'generator/templates'
 
 [source]
 googleapis-root = 'generator/testdata/googleapis'

--- a/generator/testdata/rust/gclient/golden/secretmanager/.sidekick.toml
+++ b/generator/testdata/rust/gclient/golden/secretmanager/.sidekick.toml
@@ -13,11 +13,11 @@
 #  limitations under the License.
 
 [general]
+language = 'rust'
+template-dir = 'generator/templates'
 specification-format = 'protobuf'
 specification-source = 'generator/testdata/googleapis/google/cloud/secretmanager/v1'
 service-config = 'generator/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml'
-language = 'rust'
-template-dir = 'generator/templates'
 
 [source]
 googleapis-root = 'generator/testdata/googleapis'

--- a/generator/testdata/rust/gclient/golden/type/.sidekick.toml
+++ b/generator/testdata/rust/gclient/golden/type/.sidekick.toml
@@ -13,11 +13,11 @@
 #  limitations under the License.
 
 [general]
+language = 'rust'
+template-dir = 'generator/templates'
 specification-format = 'protobuf'
 specification-source = 'generator/testdata/googleapis/google/type'
 service-config = 'generator/testdata/googleapis/google/type/type.yaml'
-language = 'rust'
-template-dir = 'generator/templates'
 
 [source]
 googleapis-root = 'generator/testdata/googleapis'

--- a/generator/testdata/rust/openapi/golden/.sidekick.toml
+++ b/generator/testdata/rust/openapi/golden/.sidekick.toml
@@ -13,11 +13,11 @@
 #  limitations under the License.
 
 [general]
+language = 'rust'
+template-dir = 'generator/templates'
 specification-format = 'openapi'
 specification-source = 'generator/testdata/openapi/secretmanager_openapi_v1.json'
 service-config = 'generator/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml'
-language = 'rust'
-template-dir = 'generator/templates'
 
 [codec]
 copyright-year = '2024'


### PR DESCRIPTION
This change introduces support for an optional per-repository
configuration file, and starts using that file in the `refresh`
subcommand.

The motivation is to set the googleapis location in a single place and
to minimize the number of arguments that we need to provide in
`generate`.

Once the googleapis location is centralized, we can also start
downloading it from GitHub.

Fixes #261