### PR TITLE
impl(generator): helper functions for downloads

### DIFF
--- a/generator/go.mod
+++ b/generator/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/pb33f/libopenapi v0.18.6
 	github.com/pelletier/go-toml/v2 v2.2.3
+	github.com/walle/targz v0.0.0-20140417120357-57fe4206da5a
 	google.golang.org/genproto/googleapis/api v0.0.0-20241113202542-65e8d215514f
 	google.golang.org/protobuf v1.35.1
 )

--- a/generator/go.sum
+++ b/generator/go.sum
@@ -77,6 +77,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9NP674f9Hobk=
 github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
+github.com/walle/targz v0.0.0-20140417120357-57fe4206da5a h1:6cKSHLRphD9Fo1LJlISiulvgYCIafJ3QfKLimPYcAGc=
+github.com/walle/targz v0.0.0-20140417120357-57fe4206da5a/go.mod h1:nccQrXCnc5SjsThFLmL7hYbtT/mHJcuolPifzY5vJqE=
 github.com/wk8/go-ordered-map/v2 v2.1.9-0.20240815153524-6ea36470d1bd h1:dLuIF2kX9c+KknGJUdJi1Il1SDiTSK158/BB9kdgAew=
 github.com/wk8/go-ordered-map/v2 v2.1.9-0.20240815153524-6ea36470d1bd/go.mod h1:DbzwytT4g/odXquuOCqroKvtxxldI4nb3nuesHF/Exo=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/generator/sidekick/downloads_cache.go
+++ b/generator/sidekick/downloads_cache.go
@@ -1,0 +1,166 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/walle/targz"
+)
+
+func makeGoogleapisRoot(rootConfig *Config) (string, error) {
+	googleapisRoot, ok := rootConfig.Source["googleapis-root"]
+	if !ok {
+		return "", nil
+	}
+	if ok := isDirectory(googleapisRoot); ok {
+		return googleapisRoot, nil
+	}
+	if !requiresDownload(googleapisRoot) {
+		return "", fmt.Errorf("only directories and https URLs are supported for googleapis-root")
+	}
+	// Treat `googleapis-root` as a URL to download. We want to avoid downloads
+	// if possible, so we will first try to use a cache directory in $HOME.
+	// Only if that fails we try a new download.
+	googleapisSha256, ok := rootConfig.Source["googleapis-sha256"]
+	if !ok {
+		return "", fmt.Errorf("using an https:// URL for googleapis-root requires setting googleapis-sha256")
+	}
+	cacheDir, err := downloadsCacheDir(rootConfig)
+	if err != nil {
+		return "", err
+	}
+	target := path.Join(cacheDir, googleapisSha256)
+	if isDirectory(target) {
+		return target, nil
+	}
+	tgz := target + ".tar.gz"
+	if err := downloadGoogleapisRoot(tgz, googleapisRoot, googleapisSha256); err != nil {
+		return "", err
+	}
+
+	if err := targz.Extract(tgz, cacheDir); err != nil {
+		return "", err
+	}
+	name := extractedName(rootConfig, googleapisRoot)
+	if err := os.Rename(path.Join(cacheDir, name), target); err != nil {
+		return "", err
+	}
+	return target, nil
+}
+
+func extractedName(rootConfig *Config, googleapisRoot string) string {
+	name, ok := rootConfig.Source["googleapis-extracted-name"]
+	if ok {
+		return name
+	}
+	return "googleapis-" + filepath.Base(strings.TrimSuffix(googleapisRoot, ".tar.gz"))
+}
+
+func downloadGoogleapisRoot(target, source, sha256 string) error {
+	if fileExists(target) {
+		return nil
+	}
+	var err error
+	for range 3 {
+		if err = downloadAttempt(target, source, sha256); err == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("download failed after 3 attempts, last error=%w", err)
+}
+
+func downloadAttempt(target, source, expectedSha256 string) error {
+	if err := os.MkdirAll(filepath.Dir(target), 0777); err != nil {
+		return err
+	}
+	tempFile, err := os.CreateTemp(filepath.Dir(target), "temp-")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tempFile.Name())
+
+	response, err := http.Get(source)
+	if err != nil {
+		return err
+	}
+	if response.StatusCode >= 300 {
+		return fmt.Errorf("http error in download %s", response.Status)
+	}
+
+	if _, err := io.Copy(tempFile, response.Body); err != nil {
+		return err
+	}
+	if err := tempFile.Close(); err != nil {
+		return err
+	}
+	if err := response.Body.Close(); err != nil {
+		return err
+	}
+	file, err := os.Open(tempFile.Name())
+	if err != nil {
+		return err
+	}
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, file); err != nil {
+		return err
+	}
+	got := fmt.Sprintf("%x", hasher.Sum(nil))
+	if expectedSha256 != got {
+		return fmt.Errorf("mismatched hash on download, expected=%s, got=%s", expectedSha256, got)
+	}
+	return os.Rename(tempFile.Name(), target)
+}
+
+func fileExists(name string) bool {
+	stat, err := os.Stat(name)
+	if err != nil {
+		return false
+	}
+	return stat.Mode().IsRegular()
+}
+
+func isDirectory(name string) bool {
+	stat, err := os.Stat(name)
+	if err != nil {
+		return false
+	}
+	if !stat.IsDir() {
+		return false
+	}
+	return true
+}
+
+func downloadsCacheDir(rootConfig *Config) (string, error) {
+	cacheDir, ok := rootConfig.Source["cachedir"]
+	if !ok {
+		var err error
+		if cacheDir, err = os.UserCacheDir(); err != nil {
+			return "", err
+		}
+	}
+	return path.Join(cacheDir, "sidekick", "downloads"), nil
+}
+
+func requiresDownload(googleapisRoot string) bool {
+	return strings.HasPrefix(googleapisRoot, "https://") || strings.HasPrefix(googleapisRoot, "http://")
+}

--- a/generator/sidekick/downloads_cache_test.go
+++ b/generator/sidekick/downloads_cache_test.go
@@ -123,7 +123,7 @@ func TestTargetExists(t *testing.T) {
 		},
 	}
 
-	downloads, err := downloadsCacheDir(rootConfig)
+	downloads, err := getCacheDir(rootConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +280,7 @@ func TestExtractedNameOverride(t *testing.T) {
 }
 
 func TestDownloadsCacheDir(t *testing.T) {
-	dir, err := downloadsCacheDir(&Config{Source: map[string]string{"cachedir": "test-only"}})
+	dir, err := getCacheDir(&Config{Source: map[string]string{"cachedir": "test-only"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -290,7 +290,7 @@ func TestDownloadsCacheDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dir, err = downloadsCacheDir(&Config{Source: map[string]string{}})
+	dir, err = getCacheDir(&Config{Source: map[string]string{}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/generator/sidekick/downloads_cache_test.go
+++ b/generator/sidekick/downloads_cache_test.go
@@ -1,0 +1,308 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/walle/targz"
+)
+
+func TestExistingDirectory(t *testing.T) {
+	tmp, err := os.MkdirTemp(t.TempDir(), "sidekick-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp)
+	rootConfig := Config{
+		Source: map[string]string{
+			"googleapis-root": tmp,
+		},
+	}
+	root, err := makeGoogleapisRoot(&rootConfig)
+	if err != nil {
+		t.Error(err)
+	}
+	if root != tmp {
+		t.Errorf("mismatched root directory got=%s, want=%s", root, tmp)
+	}
+}
+
+func TestValidateConfig(t *testing.T) {
+	rootConfig := Config{
+		Source: map[string]string{
+			"googleapis-root": "https://unused",
+		},
+	}
+	_, err := makeGoogleapisRoot(&rootConfig)
+	if err == nil {
+		t.Errorf("expected error when missing `googleapis-sha256")
+	}
+}
+
+func TestWithDownload(t *testing.T) {
+	testDir, err := os.MkdirTemp(t.TempDir(), "sidekick-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(testDir)
+
+	simulatedSha := "2d08f07eab9bbe8300cd20b871d0811bbb693fab"
+	simulatedSubdir := fmt.Sprintf("googleapis-%s", simulatedSha)
+	simulatedPath := fmt.Sprintf("/archive/%s.tar.gz", simulatedSha)
+	tarball, err := makeTestTarball(t, testDir, simulatedSubdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// In this test we expect that a download is needed.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != simulatedPath {
+			t.Errorf("Expected to request '%s', got: %s", simulatedPath, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write(tarball.Contents)
+	}))
+	defer server.Close()
+
+	rootConfig := &Config{
+		Source: map[string]string{
+			"googleapis-root":   server.URL + simulatedPath,
+			"googleapis-sha256": tarball.Sha256,
+			"cachedir":          testDir,
+		},
+	}
+	got, err := makeGoogleapisRoot(rootConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(got, tarball.Sha256) {
+		t.Errorf("mismatched suffix in makeGoogleapisRoot want=%s, got=%s", tarball.Sha256, got)
+	}
+	if err := os.RemoveAll(got); err != nil {
+		t.Error(err)
+	}
+	if err := os.Remove(got + ".tar.gz"); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTargetExists(t *testing.T) {
+	testDir, err := os.MkdirTemp(t.TempDir(), "sidekick-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(testDir)
+
+	sha256 := "eb853d49313f20a096607fea87dfc10bd6a1b917ad17ad5db8a205b457a940e1"
+	rootConfig := &Config{
+		Source: map[string]string{
+			"googleapis-root":   "https://unused/path",
+			"googleapis-sha256": sha256,
+			"cachedir":          testDir,
+		},
+	}
+
+	downloads, err := downloadsCacheDir(rootConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(path.Join(downloads, sha256), 0755); err != nil {
+		t.Fatal(err)
+	}
+	got, err := makeGoogleapisRoot(rootConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(got, sha256) {
+		t.Errorf("mismatched suffix in makeGoogleapisRoot want=%s, got=%s", sha256, got)
+	}
+	if err := os.RemoveAll(got); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestDownloadGoogleapisRootTgzExists(t *testing.T) {
+	testDir, err := os.MkdirTemp(t.TempDir(), "sidekick-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(testDir)
+
+	tarball, err := makeTestContents(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// In this test we will create the download file with the right contents.
+	target := path.Join(testDir, "existing-file")
+	if err := os.WriteFile(target, tarball.Contents, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := downloadGoogleapisRoot(target, "https://unused/placeholder.tar.gz", tarball.Sha256); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestDownloadGoogleapisRootNeedsDownload(t *testing.T) {
+	testDir, err := os.MkdirTemp(t.TempDir(), "sidekick-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(testDir)
+
+	tarball, err := makeTestContents(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// In this test we expect that a download is needed.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/placeholder.tar.gz" {
+			t.Errorf("Expected to request '/placeholder.tar.gz', got: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write(tarball.Contents)
+	}))
+	defer server.Close()
+
+	expected := path.Join(testDir, "new-file")
+	if err := downloadGoogleapisRoot(expected, server.URL+"/placeholder.tar.gz", tarball.Sha256); err != nil {
+		t.Error(err)
+	}
+	got, err := os.ReadFile(expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(tarball.Contents, got); len(diff) != 0 {
+		t.Errorf("mismatched downloaded contents, (-want, +got):\n%s", diff)
+	}
+}
+
+type contents struct {
+	Sha256   string
+	Contents []byte
+}
+
+func makeTestContents(t *testing.T) (*contents, error) {
+	t.Helper()
+
+	hasher := sha256.New()
+	var data []byte
+	for i := range 10 {
+		line := []byte(fmt.Sprintf("%08d the quick brown fox jumps over the lazy dog\n", i))
+		data = append(data, line...)
+		hasher.Write(line)
+	}
+
+	return &contents{
+		Sha256:   fmt.Sprintf("%x", hasher.Sum(nil)),
+		Contents: data,
+	}, nil
+}
+
+func makeTestTarball(t *testing.T, tempDir, subdir string) (*contents, error) {
+	t.Helper()
+
+	top := path.Join(tempDir, subdir)
+	if err := os.MkdirAll(top, 0755); err != nil {
+		t.Fatal(err)
+	}
+	for i := range 3 {
+		name := fmt.Sprintf("file-%04d", i)
+		err := os.WriteFile(path.Join(top, name), []byte(fmt.Sprintf("%08d the quick brown fox jumps over the lazy dog\n", i)), 0644)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	tgz := path.Join(tempDir, "tarball.tgz")
+	defer os.Remove(tgz)
+
+	if err := targz.Compress(top, tgz); err != nil {
+		return nil, err
+	}
+
+	hasher := sha256.New()
+	data, err := os.ReadFile(tgz)
+	if err != nil {
+		return nil, err
+	}
+	hasher.Write(data)
+
+	return &contents{
+		Sha256:   fmt.Sprintf("%x", hasher.Sum(nil)),
+		Contents: data,
+	}, nil
+}
+
+func TestExtractedName(t *testing.T) {
+	var rootConfig Config
+	got := extractedName(&rootConfig, "https://github.com/googleapis/googleapis/archive/2d08f07eab9bbe8300cd20b871d0811bbb693fab.tar.gz")
+	want := "googleapis-2d08f07eab9bbe8300cd20b871d0811bbb693fab"
+	if got != want {
+		t.Errorf("mismatched extractedName, got=%s, want=%s", got, want)
+	}
+}
+
+func TestExtractedNameOverride(t *testing.T) {
+	want := "override"
+	rootConfig := Config{
+		Source: map[string]string{
+			"googleapis-extracted-name": want,
+		},
+	}
+	got := extractedName(&rootConfig, "https://github.com/googleapis/googleapis/archive/2d08f07eab9bbe8300cd20b871d0811bbb693fab.tar.gz")
+	if got != want {
+		t.Errorf("mismatched extractedName, got=%s, want=%s", got, want)
+	}
+}
+
+func TestDownloadsCacheDir(t *testing.T) {
+	dir, err := downloadsCacheDir(&Config{Source: map[string]string{"cachedir": "test-only"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkDownloadsCacheDir(t, dir, "test-only")
+
+	user, err := os.UserCacheDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir, err = downloadsCacheDir(&Config{Source: map[string]string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkDownloadsCacheDir(t, dir, user)
+}
+
+func checkDownloadsCacheDir(t *testing.T, got, root string) {
+	t.Helper()
+	if !strings.HasPrefix(got, root) {
+		t.Errorf("mismatched downloadsCacheDir, want=%s, got=%s", root, got)
+	}
+	if !strings.Contains(got, path.Join("sidekick", "downloads")) {
+		t.Errorf("mismatched downloadsCacheDir, want=%s, got=%s", "sidekick", root)
+	}
+}


### PR DESCRIPTION
To refresh all the directories we will need to download snapshots of
googleapis/googleapis from GitHub. This PR introduces a number of
helper functions to perform these downloads and keep a local cache in
$HOME.

The cache is content based, that is, the SHA256 of the complete tarball
is the index into the cache. The download fails if the contents do not
match the specified SHA256, and if the SHA256 is already in the cache
the functions skip the download.

Part of the work for #263