### PR TITLE
fix(generator/openapi): better service names

### DIFF
--- a/generator/testdata/rust/openapi/golden/src/lib.rs
+++ b/generator/testdata/rust/openapi/golden/src/lib.rs
@@ -73,11 +73,11 @@ struct NoBody {}
 /// Stores sensitive data such as API keys, passwords, and certificates.
 /// Provides convenience while improving security.
 #[derive(Clone)]
-pub struct GoogleCloudSecretmanagerV1SecretManagerServiceClient {
+pub struct SecretManagerServiceClient {
     inner: Arc<InnerClient>,
 }
 
-impl GoogleCloudSecretmanagerV1SecretManagerServiceClient {
+impl SecretManagerServiceClient {
     pub async fn new() -> Result<Self> {
         Self::new_with_config(ConfigBuilder::new()).await
     }

--- a/src/integration-tests/src/secret_manager/openapi.rs
+++ b/src/integration-tests/src/secret_manager/openapi.rs
@@ -23,7 +23,7 @@ pub async fn run() -> Result<()> {
         .map(char::from)
         .collect();
 
-    let client = smo::GoogleCloudSecretmanagerV1SecretManagerServiceClient::new().await?;
+    let client = smo::SecretManagerServiceClient::new().await?;
 
     println!("\nTesting create_secret()");
     let create = client
@@ -106,10 +106,7 @@ pub async fn run() -> Result<()> {
     Ok(())
 }
 
-async fn run_locations(
-    client: &smo::GoogleCloudSecretmanagerV1SecretManagerServiceClient,
-    project_id: &str,
-) -> Result<()> {
+async fn run_locations(client: &smo::SecretManagerServiceClient, project_id: &str) -> Result<()> {
     println!("\nTesting list_locations()");
     let locations = client
         .list_locations(smo::model::ListLocationsRequest::default().set_project(project_id))
@@ -142,7 +139,7 @@ async fn run_locations(
 }
 
 async fn run_iam(
-    client: &smo::GoogleCloudSecretmanagerV1SecretManagerServiceClient,
+    client: &smo::SecretManagerServiceClient,
     project_id: &str,
     secret_id: &str,
 ) -> Result<()> {
@@ -211,7 +208,7 @@ async fn run_iam(
 }
 
 async fn run_secret_versions(
-    client: &smo::GoogleCloudSecretmanagerV1SecretManagerServiceClient,
+    client: &smo::SecretManagerServiceClient,
     project_id: &str,
     secret_id: &str,
 ) -> Result<()> {
@@ -320,7 +317,7 @@ async fn run_secret_versions(
 }
 
 async fn get_all_secret_version_names(
-    client: &smo::GoogleCloudSecretmanagerV1SecretManagerServiceClient,
+    client: &smo::SecretManagerServiceClient,
     project_id: &str,
     secret_id: &str,
 ) -> Result<Vec<String>> {
@@ -349,7 +346,7 @@ async fn get_all_secret_version_names(
 }
 
 async fn get_all_secret_names(
-    client: &smo::GoogleCloudSecretmanagerV1SecretManagerServiceClient,
+    client: &smo::SecretManagerServiceClient,
     project_id: &str,
 ) -> Result<Vec<String>> {
     let mut names = Vec::new();

--- a/src/integration-tests/src/secret_manager/openapi_locational.rs
+++ b/src/integration-tests/src/secret_manager/openapi_locational.rs
@@ -26,12 +26,11 @@ pub async fn run() -> Result<()> {
 
     let location_id = "us-central1".to_string();
 
-    let client = smo::GoogleCloudSecretmanagerV1SecretManagerServiceClient::new_with_config(
-        smo::ConfigBuilder::new().set_endpoint(format!(
-            "https://secretmanager.{location_id}.rep.googleapis.com"
-        )),
-    )
-    .await?;
+    let client =
+        smo::SecretManagerServiceClient::new_with_config(smo::ConfigBuilder::new().set_endpoint(
+            format!("https://secretmanager.{location_id}.rep.googleapis.com"),
+        ))
+        .await?;
 
     cleanup_stale_secrets(&client, &project_id, &location_id).await?;
 
@@ -107,7 +106,7 @@ pub async fn run() -> Result<()> {
 }
 
 async fn run_iam(
-    client: &smo::GoogleCloudSecretmanagerV1SecretManagerServiceClient,
+    client: &smo::SecretManagerServiceClient,
     project_id: &str,
     location_id: &str,
     secret_id: &str,
@@ -180,7 +179,7 @@ async fn run_iam(
 }
 
 async fn run_secret_versions(
-    client: &smo::GoogleCloudSecretmanagerV1SecretManagerServiceClient,
+    client: &smo::SecretManagerServiceClient,
     project_id: &str,
     location_id: &str,
     secret_id: &str,
@@ -298,7 +297,7 @@ async fn run_secret_versions(
 }
 
 async fn get_all_secret_version_names(
-    client: &smo::GoogleCloudSecretmanagerV1SecretManagerServiceClient,
+    client: &smo::SecretManagerServiceClient,
     project_id: &str,
     location_id: &str,
     secret_id: &str,
@@ -329,7 +328,7 @@ async fn get_all_secret_version_names(
 }
 
 async fn get_all_secret_names(
-    client: &smo::GoogleCloudSecretmanagerV1SecretManagerServiceClient,
+    client: &smo::SecretManagerServiceClient,
     project_id: &str,
     location_id: &str,
 ) -> Result<Vec<String>> {
@@ -358,7 +357,7 @@ async fn get_all_secret_names(
 }
 
 async fn cleanup_stale_secrets(
-    client: &smo::GoogleCloudSecretmanagerV1SecretManagerServiceClient,
+    client: &smo::SecretManagerServiceClient,
     project_id: &str,
     location_id: &str,
 ) -> Result<()> {


### PR DESCRIPTION
OpenAPI does not have service names. We use the name from the service
config YAML file to get a name. This name includes the protobuf package.
With this change we strip the package name.

I also populated the package name in all the OpenAPI data structures,
mostly for consistency.

Fixes #235
