### PR TITLE
ci: treat `cargo clippy` warnings as errors

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -54,6 +54,6 @@ jobs:
         run: cargo version
       - name: Display rustc version
         run: rustc --version
-      - run: cargo clippy --fix
+      - run: cargo clippy -- --deny warnings
       - run: cargo fmt
       - run: git diff --exit-code


### PR DESCRIPTION
I finally figured out why `cargo clippy` was not stopping the build on
problems: warnings do not break the build. Eventually we may find some
clippy warnings to be false positives. I prefer to turn all of them on
and then turn off the bad ones vs. trying to pick the right ones.