### PR TITLE
feat(generator/rust): no mangling for setters

### DIFF
--- a/generator/internal/genclient/genclient.go
+++ b/generator/internal/genclient/genclient.go
@@ -84,6 +84,12 @@ type LanguageCodec interface {
 	// ToSnake converts a symbol name to `snake_case`, applying any mangling
 	// required by the language, e.g., to avoid clashes with reserved words.
 	ToSnake(string) string
+	// ToSnakeNoMangling converts a symbol name to `snake_case`, without any
+	// mangling to avoid reserved words. This is useful when the template is
+	// already going to mangle the name, e.g., by adding a prefix or suffix.
+	// Since the templates are language specific, their authors can determine
+	// when to use `ToSnake` or `ToSnakeNoMangling`.
+	ToSnakeNoMangling(string) string
 	// ToPascal converts a symbol name to `PascalCase`, applying any mangling
 	// required by the language, e.g., to avoid clashes with reserved words.
 	ToPascal(string) string

--- a/generator/internal/genclient/language/internal/golang/golang.go
+++ b/generator/internal/genclient/language/internal/golang/golang.go
@@ -243,7 +243,11 @@ func (c *Codec) QueryParams(m *genclient.Method, state *genclient.APIState) []*g
 	return queryParams
 }
 
-func (*Codec) ToSnake(symbol string) string {
+func (c *Codec) ToSnake(symbol string) string {
+	return EscapeKeyword(c.ToSnakeNoMangling(symbol))
+}
+
+func (*Codec) ToSnakeNoMangling(symbol string) string {
 	if strings.ToLower(symbol) == symbol {
 		return EscapeKeyword(symbol)
 	}

--- a/generator/internal/genclient/language/internal/rust/rust.go
+++ b/generator/internal/genclient/language/internal/rust/rust.go
@@ -540,11 +540,15 @@ func (c *Codec) QueryParams(m *genclient.Method, state *genclient.APIState) []*g
 // This type of conversion can easily introduce keywords. Consider
 //
 //	`ToSnake("True") -> "true"`
-func (*Codec) ToSnake(symbol string) string {
+func (c *Codec) ToSnake(symbol string) string {
+	return EscapeKeyword(c.ToSnakeNoMangling(symbol))
+}
+
+func (*Codec) ToSnakeNoMangling(symbol string) string {
 	if strings.ToLower(symbol) == symbol {
-		return EscapeKeyword(symbol)
+		return symbol
 	}
-	return EscapeKeyword(strcase.ToSnake(symbol))
+	return strcase.ToSnake(symbol)
 }
 
 // Convert a name to `PascalCase`.  Strangley, the `strcase` package calls this

--- a/generator/internal/genclient/templatedata.go
+++ b/generator/internal/genclient/templatedata.go
@@ -381,6 +381,10 @@ func (f *field) NameToSnake() string {
 	return f.c.ToSnake(f.s.Name)
 }
 
+func (f *field) NameToSnakeNoMangling() string {
+	return f.c.ToSnakeNoMangling(f.s.Name)
+}
+
 // NameToCamel converts a Name to camelCase.
 func (f *field) NameToCamel() string {
 	return f.c.ToCamel(f.s.Name)
@@ -422,6 +426,10 @@ func (o *oneOf) NameToPascal() string {
 
 func (o *oneOf) NameToSnake() string {
 	return o.c.ToSnake(o.s.Name)
+}
+
+func (o *oneOf) NameToSnakeNoMangling() string {
+	return o.c.ToSnakeNoMangling(o.s.Name)
 }
 
 func (o *oneOf) FieldType() string {

--- a/generator/templates/rust/common/message.mustache
+++ b/generator/templates/rust/common/message.mustache
@@ -50,7 +50,7 @@ impl {{Name}} {
     {{#BasicFields}}
 
     /// Sets the value of `{{NameToSnake}}`.
-    pub fn set_{{NameToSnake}}<T: Into<{{{FieldType}}}>>(mut self, v: T) -> Self {
+    pub fn set_{{NameToSnakeNoMangling}}<T: Into<{{{FieldType}}}>>(mut self, v: T) -> Self {
         self.{{NameToSnake}} = v.into();
         self
     }
@@ -58,7 +58,7 @@ impl {{Name}} {
     {{#ExplicitOneOfs}}
 
     /// Sets the value of `{{NameToSnake}}`.
-    pub fn set_{{NameToSnake}}<T: Into<Option<{{{FieldType}}}>>>(mut self, v: T) ->Self {
+    pub fn set_{{NameToSnakeNoMangling}}<T: Into<Option<{{{FieldType}}}>>>(mut self, v: T) ->Self {
         self.{{NameToSnake}} = v.into();
         self
     }

--- a/generator/testdata/rust/gclient/golden/module/rpc/mod.rs
+++ b/generator/testdata/rust/gclient/golden/module/rpc/mod.rs
@@ -280,7 +280,7 @@ pub mod precondition_failure {
     impl Violation {
 
         /// Sets the value of `r#type`.
-        pub fn set_r#type<T: Into<String>>(mut self, v: T) -> Self {
+        pub fn set_type<T: Into<String>>(mut self, v: T) -> Self {
             self.r#type = v.into();
             self
         }


### PR DESCRIPTION
The setters are already mangled: they start with `set_` and no reserved
word has that prefix.

Part of the work for #283 
