### PR TITLE
feat(generator): refreshall subcommand

### DIFF
--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -17,5 +17,5 @@ language     = 'rust'
 template-dir = 'generator/templates'
 
 [source]
-googleapis-root = 'https://github.com/googleapis/googleapis/archive/2d08f07eab9bbe8300cd20b871d0811bbb693fab.tar.gz'
+googleapis-root   = 'https://github.com/googleapis/googleapis/archive/2d08f07eab9bbe8300cd20b871d0811bbb693fab.tar.gz'
 googleapis-sha256 = 'eb853d49313f20a096607fea87dfc10bd6a1b917ad17ad5db8a205b457a940e1'

--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 [general]
-language = "rust"
+language     = 'rust'
+template-dir = 'generator/templates'
 
-[[packages]]
-name = "gax"
-path = "../../.."
+[source]
+googleapis-root = 'https://github.com/googleapis/googleapis/archive/2d08f07eab9bbe8300cd20b871d0811bbb693fab.tar.gz'
+googleapis-sha256 = 'eb853d49313f20a096607fea87dfc10bd6a1b917ad17ad5db8a205b457a940e1'

--- a/generator/sidekick/generate.go
+++ b/generator/sidekick/generate.go
@@ -59,12 +59,6 @@ func Generate(rootConfig *Config, args []string) error {
 	})
 	fs.Parse(args)
 
-	if *format == "" {
-		return fmt.Errorf("must provide specification-format")
-	}
-	if *source == "" {
-		return fmt.Errorf("must provide source")
-	}
 	config := Config{
 		General: GeneralConfig{
 			SpecificationFormat: *format,

--- a/generator/sidekick/refresh.go
+++ b/generator/sidekick/refresh.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"path"
 
@@ -26,6 +27,12 @@ import (
 // Reruns the generator in one directory, using the configuration parameters
 // saved in its `.sidekick.toml` file.
 func Refresh(rootConfig *Config, args []string) error {
+	fs := flag.NewFlagSet("refreshall", flag.ExitOnError)
+	var (
+		dryrun = fs.Bool("dry-run", false, "do a dry-run: find and report directories, but do not execute any changes.")
+	)
+	fs.Parse(args)
+	args = fs.Args()
 	if len(args) != 1 {
 		return fmt.Errorf("expected the target directory")
 	}
@@ -33,6 +40,12 @@ func Refresh(rootConfig *Config, args []string) error {
 	config, err := MergeConfig(rootConfig, path.Join(outDir, ".sidekick.toml"))
 	if err != nil {
 		return err
+	}
+	if config.General.SpecificationFormat == "" {
+		return fmt.Errorf("must provide general.specification-format")
+	}
+	if config.General.SpecificationSource == "" {
+		return fmt.Errorf("must provide general.specification-source")
 	}
 
 	specFormat := config.General.SpecificationFormat
@@ -71,6 +84,9 @@ func Refresh(rootConfig *Config, args []string) error {
 		Codec:       codec,
 		OutDir:      copts.OutDir,
 		TemplateDir: copts.TemplateDir,
+	}
+	if *dryrun {
+		return nil
 	}
 	return genclient.Generate(request)
 }

--- a/generator/sidekick/refresh.go
+++ b/generator/sidekick/refresh.go
@@ -27,9 +27,9 @@ import (
 // Reruns the generator in one directory, using the configuration parameters
 // saved in its `.sidekick.toml` file.
 func Refresh(rootConfig *Config, args []string) error {
-	fs := flag.NewFlagSet("refreshall", flag.ExitOnError)
+	fs := flag.NewFlagSet("refresh", flag.ExitOnError)
 	var (
-		dryrun = fs.Bool("dry-run", false, "do a dry-run: find and report directories, but do not execute any changes.")
+		dryrun = fs.Bool("dry-run", false, "do a dry-run: load the configuration, but do not perform any changes.")
 	)
 	fs.Parse(args)
 	args = fs.Args()

--- a/generator/sidekick/refreshall.go
+++ b/generator/sidekick/refreshall.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -42,11 +43,9 @@ func RefreshAll(rootConfig *Config, args []string) error {
 	}
 
 	override := *rootConfig
-	if override.Source == nil {
-		override.Source = map[string]string{"googleapis-root": root}
-	} else {
-		override.Source["googleapis-root"] = root
-	}
+	override.Codec = maps.Clone(rootConfig.Codec)
+	override.Source = maps.Clone(rootConfig.Source)
+	override.Source["googleapis-root"] = root
 
 	type result struct {
 		dir string

--- a/generator/sidekick/refreshall.go
+++ b/generator/sidekick/refreshall.go
@@ -1,0 +1,107 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+func RefreshAll(rootConfig *Config, args []string) error {
+	fs := flag.NewFlagSet("refreshall", flag.ExitOnError)
+	var (
+		dryrun = fs.Bool("dry-run", false, "do a dry-run: find and report directories, but do not execute any changes.")
+	)
+	fs.Parse(args)
+
+	root, err := makeGoogleapisRoot(rootConfig)
+	if err != nil {
+		return err
+	}
+	directories, err := findAllDirectories(rootConfig)
+	if err != nil {
+		return err
+	}
+
+	override := *rootConfig
+	if override.Source == nil {
+		override.Source = map[string]string{"googleapis-root": root}
+	} else {
+		override.Source["googleapis-root"] = root
+	}
+
+	type result struct {
+		dir string
+		err error
+	}
+	results := make(chan result)
+	var wg sync.WaitGroup
+	for _, dir := range directories {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var err error
+			if *dryrun {
+				fmt.Printf("refreshing directory %s\n", dir)
+				err = Refresh(&override, []string{"-dry-run", dir})
+			} else {
+				err = Refresh(&override, []string{dir})
+			}
+			results <- result{dir: dir, err: err}
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+	var failures []error
+	for e := range results {
+		if e.err != nil {
+			failures = append(failures, fmt.Errorf("error refreshing directory %s: %w", e.dir, e.err))
+		}
+	}
+	if failures == nil {
+		return nil
+	}
+	return errors.Join(failures...)
+}
+
+func findAllDirectories(_ *Config) ([]string, error) {
+	var result []string
+	err := fs.WalkDir(os.DirFS("."), ".", func(path string, d fs.DirEntry, _ error) error {
+		if d.IsDir() {
+			return nil
+		}
+		dir := filepath.Dir(path)
+		if strings.Contains(dir, "/testdata/go/") {
+			// Skip these directories. They are intended for testing only.
+			return nil
+		}
+		if d.Name() == ".sidekick.toml" && dir != "." {
+			result = append(result, dir)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/generator/sidekick/refreshall.go
+++ b/generator/sidekick/refreshall.go
@@ -28,7 +28,7 @@ import (
 func RefreshAll(rootConfig *Config, args []string) error {
 	fs := flag.NewFlagSet("refreshall", flag.ExitOnError)
 	var (
-		dryrun = fs.Bool("dry-run", false, "do a dry-run: find and report directories, but do not execute any changes.")
+		dryrun = fs.Bool("dry-run", false, "do a dry-run: find and report directories, but do not perform any changes.")
 	)
 	fs.Parse(args)
 

--- a/generator/sidekick/refreshall_test.go
+++ b/generator/sidekick/refreshall_test.go
@@ -20,16 +20,12 @@ import (
 )
 
 func TestRefreshAll(t *testing.T) {
-	const (
-		projectRoot = "../.."
-	)
-
 	cwd, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.Chdir(cwd)
-	if err := os.Chdir(projectRoot); err != nil {
+	if err := os.Chdir("../.."); err != nil {
 		t.Fatal(err)
 	}
 	rootConfig, err := LoadRootConfig(".sidekick.toml")

--- a/generator/sidekick/refreshall_test.go
+++ b/generator/sidekick/refreshall_test.go
@@ -1,0 +1,42 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestRefreshAll(t *testing.T) {
+	const (
+		projectRoot = "../.."
+	)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(cwd)
+	if err := os.Chdir(projectRoot); err != nil {
+		t.Fatal(err)
+	}
+	rootConfig, err := LoadRootConfig(".sidekick.toml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := RefreshAll(rootConfig, []string{"-dry-run"}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/generator/sidekick/sidekick.go
+++ b/generator/sidekick/sidekick.go
@@ -57,6 +57,10 @@ func root() error {
 		if err := Refresh(config, args[1:]); err != nil {
 			return err
 		}
+	case "refresh-all", "refreshall":
+		if err := RefreshAll(config, args[1:]); err != nil {
+			return err
+		}
 	default:
 		return fmt.Errorf("unknown subcommand %s", os.Args[1])
 	}

--- a/generator/sidekick/sidekick.go
+++ b/generator/sidekick/sidekick.go
@@ -46,7 +46,7 @@ func root() error {
 
 	args := flag.Args()
 	if len(args) < 1 {
-		return fmt.Errorf("you must provide a subcommand")
+		return fmt.Errorf("you must provide a subcommand, either `generate`, `refresh`, or `refreshall`")
 	}
 	switch args[0] {
 	case "generate":


### PR DESCRIPTION
This introduces the `refreshall` subcommand. This subcommand runs the
`refresh` subcommand for all the directories that happen to have a
`.sidekick.toml` file.

The intent is to keep a pinned version of googleapis/googleapis
configured in the top-level directory. This pinned version is downloaded
to the sidekick cache (if needed) and all the subdirectories use the
version in the cache.

This subcommand is intended to handle changes in the mustache templates
or the generator itself. We will introduce a separate subcommand to
update the googleapis/googleapis pinned SHA.

Fixes #263, fixes #270
