### PR TITLE
refactor(generator): consolidated command line args

### DIFF
--- a/generator/sidekick/cmdline.go
+++ b/generator/sidekick/cmdline.go
@@ -1,0 +1,109 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Represents the arguments received from the command line.
+type CommandLine struct {
+	Command             string
+	ProjectRoot         string
+	SpecificationFormat string
+	SpecificationSource string
+	ServiceConfig       string
+	Source              map[string]string
+	Output              string
+	TemplateDir         string
+	Language            string
+	Codec               map[string]string
+	DryRun              bool
+}
+
+func ParseArgs() (*CommandLine, error) {
+	return ParseArgsExplicit(os.Args[1:])
+}
+
+func ParseArgsExplicit(args []string) (*CommandLine, error) {
+	fs := flag.NewFlagSet("sidekick", flag.ContinueOnError)
+	var (
+		projectRoot   = fs.String("project-root", "", "the root of the output project")
+		format        = fs.String("specification-format", "", "the specification format. Protobuf or OpenAPI v3.")
+		source        = fs.String("specification-source", "", "the path to the input data")
+		serviceConfig = fs.String("service-config", "", "path to service config")
+		sourceOpts    = map[string]string{}
+		output        = fs.String("output", "generated", "the path within project-root to put generated files")
+		templateDir   = fs.String("template-dir", "templates/", "the path to the template directory")
+		language      = fs.String("language", "", "the generated language")
+		codecOpts     = map[string]string{}
+		dryrun        = fs.Bool("dry-run", false, "do a dry-run: load the configuration, but do not perform any changes.")
+	)
+
+	fs.Func("source-option", "source options", func(opt string) error {
+		components := strings.SplitN(opt, "=", 2)
+		if len(components) != 2 {
+			return fmt.Errorf("invalid source option, must be in key=value format (%s)", opt)
+		}
+		sourceOpts[components[0]] = components[1]
+		return nil
+	})
+	fs.Func("codec-option", "codec options", func(opt string) error {
+		components := strings.SplitN(opt, "=", 2)
+		if len(components) != 2 {
+			return fmt.Errorf("invalid codec option, must be in key=value format (%s)", opt)
+		}
+		codecOpts[components[0]] = components[1]
+		return nil
+	})
+	fs.Usage = func() {
+		fmt.Println("Usage: sidekick [options] <command (generate|refresh|refreshall)>")
+		fs.PrintDefaults()
+	}
+	fs.Parse(args)
+
+	args = fs.Args()
+	var command string
+	switch len(args) {
+	case 0:
+		return nil, fmt.Errorf("missing command")
+	case 1:
+		command = args[0]
+	default:
+		return nil, fmt.Errorf("unrecognized arguments %v", args)
+	}
+
+	if command == "help" {
+		fs.Usage()
+		os.Exit(0)
+	}
+
+	return &CommandLine{
+		Command:             command,
+		ProjectRoot:         *projectRoot,
+		SpecificationFormat: *format,
+		SpecificationSource: *source,
+		ServiceConfig:       *serviceConfig,
+		Source:              sourceOpts,
+		Language:            *language,
+		Output:              *output,
+		TemplateDir:         *templateDir,
+		Codec:               codecOpts,
+		DryRun:              *dryrun,
+	}, nil
+}

--- a/generator/sidekick/cmdline_test.go
+++ b/generator/sidekick/cmdline_test.go
@@ -1,0 +1,67 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseArgs(t *testing.T) {
+	args := []string{
+		"-project-root", "../..",
+		"-specification-format", "openapi",
+		"-specification-source", "generator/testdata/openapi/secretmanager_openapi_v1.json",
+		"-service-config", "generator/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml",
+		"-source-option", "googleapis-root=generator/testdata/googleapis",
+		"-language", "rust",
+		"-output", "generator/testdata/test-only",
+		"-template-dir", "generator/templates",
+		"-codec-option", "copyright-year=2024",
+		"-codec-option", "package-name-override=secretmanager-golden-openapi",
+		"-codec-option", "package:wkt=package=gcp-sdk-wkt,path=src/wkt,source=google.protobuf",
+		"-codec-option", "package:gax=package=gcp-sdk-gax,path=src/gax,feature=sdk_client",
+		"-codec-option", "package:google-cloud-auth=package=google-cloud-auth,path=auth",
+		"generate",
+	}
+	got, err := ParseArgsExplicit(args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &CommandLine{
+		Command:             "generate",
+		ProjectRoot:         "../..",
+		SpecificationFormat: "openapi",
+		SpecificationSource: "generator/testdata/openapi/secretmanager_openapi_v1.json",
+		ServiceConfig:       "generator/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml",
+		Source: map[string]string{
+			"googleapis-root": "generator/testdata/googleapis",
+		},
+		Language:    "rust",
+		Output:      "generator/testdata/test-only",
+		TemplateDir: "generator/templates",
+		Codec: map[string]string{
+			"copyright-year":            "2024",
+			"package-name-override":     "secretmanager-golden-openapi",
+			"package:wkt":               "package=gcp-sdk-wkt,path=src/wkt,source=google.protobuf",
+			"package:gax":               "package=gcp-sdk-gax,path=src/gax,feature=sdk_client",
+			"package:google-cloud-auth": "package=google-cloud-auth,path=auth",
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatched merged config (-want, +got):\n%s", diff)
+	}
+}

--- a/generator/sidekick/config.go
+++ b/generator/sidekick/config.go
@@ -53,7 +53,7 @@ func LoadRootConfig(filename string) (*Config, error) {
 	return config, nil
 }
 
-func MergeConfig(rootConfig *Config, filename string) (*Config, error) {
+func MergeConfigAndFile(rootConfig *Config, filename string) (*Config, error) {
 	contents, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
@@ -63,7 +63,10 @@ func MergeConfig(rootConfig *Config, filename string) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error reading configuration %s: %w", filename, err)
 	}
+	return MergeConfigs(rootConfig, &local)
+}
 
+func MergeConfigs(rootConfig, local *Config) (*Config, error) {
 	merged := Config{
 		General: GeneralConfig{
 			Language:            rootConfig.General.Language,

--- a/generator/sidekick/config_test.go
+++ b/generator/sidekick/config_test.go
@@ -278,5 +278,5 @@ func mergeTestConfigs(t *testing.T, root, local *Config) (*Config, error) {
 		return nil, err
 	}
 	tempFile.Close()
-	return MergeConfig(root, tempFile.Name())
+	return MergeConfigAndFile(root, tempFile.Name())
 }

--- a/generator/sidekick/refresh.go
+++ b/generator/sidekick/refresh.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"path"
 
@@ -26,18 +25,8 @@ import (
 
 // Reruns the generator in one directory, using the configuration parameters
 // saved in its `.sidekick.toml` file.
-func Refresh(rootConfig *Config, args []string) error {
-	fs := flag.NewFlagSet("refresh", flag.ExitOnError)
-	var (
-		dryrun = fs.Bool("dry-run", false, "do a dry-run: load the configuration, but do not perform any changes.")
-	)
-	fs.Parse(args)
-	args = fs.Args()
-	if len(args) != 1 {
-		return fmt.Errorf("expected the target directory")
-	}
-	outDir := args[0]
-	config, err := MergeConfig(rootConfig, path.Join(outDir, ".sidekick.toml"))
+func Refresh(rootConfig *Config, cmdLine *CommandLine, output string) error {
+	config, err := MergeConfigAndFile(rootConfig, path.Join(output, ".sidekick.toml"))
 	if err != nil {
 		return err
 	}
@@ -57,7 +46,7 @@ func Refresh(rootConfig *Config, args []string) error {
 
 	copts := &genclient.CodecOptions{
 		Language:    config.General.Language,
-		OutDir:      outDir,
+		OutDir:      output,
 		TemplateDir: config.General.TemplateDir,
 		Options:     config.Codec,
 	}
@@ -85,7 +74,7 @@ func Refresh(rootConfig *Config, args []string) error {
 		OutDir:      copts.OutDir,
 		TemplateDir: copts.TemplateDir,
 	}
-	if *dryrun {
+	if cmdLine.DryRun {
 		return nil
 	}
 	return genclient.Generate(request)

--- a/generator/sidekick/refreshall.go
+++ b/generator/sidekick/refreshall.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"io/fs"
 	"maps"
@@ -26,13 +25,7 @@ import (
 	"sync"
 )
 
-func RefreshAll(rootConfig *Config, args []string) error {
-	fs := flag.NewFlagSet("refreshall", flag.ExitOnError)
-	var (
-		dryrun = fs.Bool("dry-run", false, "do a dry-run: find and report directories, but do not perform any changes.")
-	)
-	fs.Parse(args)
-
+func RefreshAll(rootConfig *Config, cmdLine *CommandLine) error {
 	root, err := makeGoogleapisRoot(rootConfig)
 	if err != nil {
 		return err
@@ -57,13 +50,8 @@ func RefreshAll(rootConfig *Config, args []string) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			var err error
-			if *dryrun {
-				fmt.Printf("refreshing directory %s\n", dir)
-				err = Refresh(&override, []string{"-dry-run", dir})
-			} else {
-				err = Refresh(&override, []string{dir})
-			}
+			fmt.Printf("refreshing directory %s\n", dir)
+			err := Refresh(&override, cmdLine, dir)
 			results <- result{dir: dir, err: err}
 		}()
 	}

--- a/generator/sidekick/refreshall_test.go
+++ b/generator/sidekick/refreshall_test.go
@@ -14,25 +14,15 @@
 
 package main
 
-import (
-	"os"
-	"testing"
-)
+import "testing"
 
 func TestRefreshAll(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
+	cmdLine := &CommandLine{
+		Command:     "refreshall",
+		ProjectRoot: "../..",
+		DryRun:      true,
 	}
-	defer os.Chdir(cwd)
-	if err := os.Chdir("../.."); err != nil {
-		t.Fatal(err)
-	}
-	rootConfig, err := LoadRootConfig(".sidekick.toml")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := RefreshAll(rootConfig, []string{"-dry-run"}); err != nil {
+	if err := root(cmdLine); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Parse the command-line arguments in a single place, so `sidekick -h`
works as expected.

Introduce a new subcommand to just print the help message.

Fixes #285 