### PR TITLE
feat(generator/rust): configurable module paths

### DIFF
--- a/generator/internal/genclient/language/internal/rust/rust_test.go
+++ b/generator/internal/genclient/language/internal/rust/rust_test.go
@@ -32,6 +32,7 @@ func testCodec() *Codec {
 	}
 
 	return &Codec{
+		ModulePath:    "model",
 		ExtraPackages: []*RustPackage{wkt},
 		PackageMapping: map[string]*RustPackage{
 			"google.protobuf": wkt,
@@ -61,6 +62,7 @@ func TestParseOptions(t *testing.T) {
 	want := &Codec{
 		PackageNameOverride: "test-only",
 		GenerationYear:      "2035",
+		ModulePath:          "model",
 		ExtraPackages: []*RustPackage{
 			gp,
 			{
@@ -248,7 +250,7 @@ func TestMethodInOut(t *testing.T) {
 		Parent: message,
 	}
 	api := genclient.NewTestAPI([]*genclient.Message{message, nested}, []*genclient.Enum{}, []*genclient.Service{})
-	c := &Codec{}
+	c := testCodec()
 	c.LoadWellKnownTypes(api.State)
 
 	want := "crate::model::Target"
@@ -965,7 +967,7 @@ func TestMessageNames(t *testing.T) {
 
 	api := genclient.NewTestAPI([]*genclient.Message{message, nested}, []*genclient.Enum{}, []*genclient.Service{})
 
-	c := &Codec{}
+	c := testCodec()
 	if got := c.MessageName(message, api.State); got != "Replication" {
 		t.Errorf("mismatched message name, got=%s, want=Replication", got)
 	}
@@ -1003,7 +1005,7 @@ func TestEnumNames(t *testing.T) {
 
 	api := genclient.NewTestAPI([]*genclient.Message{message}, []*genclient.Enum{nested}, []*genclient.Service{})
 
-	c := &Codec{}
+	c := testCodec()
 	if got := c.EnumName(nested, api.State); got != "State" {
 		t.Errorf("mismatched message name, got=%s, want=Automatic", got)
 	}

--- a/generator/sidekick/sidekick_test.go
+++ b/generator/sidekick/sidekick_test.go
@@ -180,6 +180,7 @@ func TestRustModuleFromProtobuf(t *testing.T) {
 			Name:   "rpc",
 			ExtraOptions: []string{
 				"-service-config", "generator/testdata/googleapis/google/rpc/rpc_publish.yaml",
+				"-codec-option", "module-path=error::rpc::generated",
 				"-codec-option", "package:wkt=package=gcp-sdk-wkt,path=src/wkt,source=google.protobuf",
 			},
 		},

--- a/generator/testdata/rust/gclient/golden/module/rpc/.sidekick.toml
+++ b/generator/testdata/rust/gclient/golden/module/rpc/.sidekick.toml
@@ -25,4 +25,5 @@ googleapis-root = 'generator/testdata/googleapis'
 [codec]
 copyright-year = '2024'
 generate-module = 'true'
+module-path = 'error::rpc::generated'
 'package:wkt' = 'package=gcp-sdk-wkt,path=src/wkt,source=google.protobuf'

--- a/generator/testdata/rust/gclient/golden/module/rpc/mod.rs
+++ b/generator/testdata/rust/gclient/golden/module/rpc/mod.rs
@@ -171,13 +171,13 @@ impl DebugInfo {
 pub struct QuotaFailure {
 
     /// Describes all quota violations.
-    pub violations: Vec<crate::model::quota_failure::Violation>,
+    pub violations: Vec<crate::error::rpc::generated::quota_failure::Violation>,
 }
 
 impl QuotaFailure {
 
     /// Sets the value of `violations`.
-    pub fn set_violations<T: Into<Vec<crate::model::quota_failure::Violation>>>(mut self, v: T) -> Self {
+    pub fn set_violations<T: Into<Vec<crate::error::rpc::generated::quota_failure::Violation>>>(mut self, v: T) -> Self {
         self.violations = v.into();
         self
     }
@@ -237,13 +237,13 @@ pub mod quota_failure {
 pub struct PreconditionFailure {
 
     /// Describes all precondition violations.
-    pub violations: Vec<crate::model::precondition_failure::Violation>,
+    pub violations: Vec<crate::error::rpc::generated::precondition_failure::Violation>,
 }
 
 impl PreconditionFailure {
 
     /// Sets the value of `violations`.
-    pub fn set_violations<T: Into<Vec<crate::model::precondition_failure::Violation>>>(mut self, v: T) -> Self {
+    pub fn set_violations<T: Into<Vec<crate::error::rpc::generated::precondition_failure::Violation>>>(mut self, v: T) -> Self {
         self.violations = v.into();
         self
     }
@@ -308,13 +308,13 @@ pub mod precondition_failure {
 pub struct BadRequest {
 
     /// Describes all violations in a client request.
-    pub field_violations: Vec<crate::model::bad_request::FieldViolation>,
+    pub field_violations: Vec<crate::error::rpc::generated::bad_request::FieldViolation>,
 }
 
 impl BadRequest {
 
     /// Sets the value of `field_violations`.
-    pub fn set_field_violations<T: Into<Vec<crate::model::bad_request::FieldViolation>>>(mut self, v: T) -> Self {
+    pub fn set_field_violations<T: Into<Vec<crate::error::rpc::generated::bad_request::FieldViolation>>>(mut self, v: T) -> Self {
         self.field_violations = v.into();
         self
     }
@@ -489,13 +489,13 @@ impl ResourceInfo {
 pub struct Help {
 
     /// URL(s) pointing to additional information on handling the current error.
-    pub links: Vec<crate::model::help::Link>,
+    pub links: Vec<crate::error::rpc::generated::help::Link>,
 }
 
 impl Help {
 
     /// Sets the value of `links`.
-    pub fn set_links<T: Into<Vec<crate::model::help::Link>>>(mut self, v: T) -> Self {
+    pub fn set_links<T: Into<Vec<crate::error::rpc::generated::help::Link>>>(mut self, v: T) -> Self {
         self.links = v.into();
         self
     }


### PR DESCRIPTION
Generated modules embedded on a hand-crafted library may not be in the `crate::model::` path. Recall that the generator uses paths anchored to `crate::`, as relative paths do not work well with nested messages and their corresponding nested modules. With this PR, the module path is configurable.

Part of the work for #283 