### PR TITLE
feat(generator/rust): configurable mod serialization

### DIFF
--- a/generator/internal/genclient/genclient.go
+++ b/generator/internal/genclient/genclient.go
@@ -46,6 +46,9 @@ type LanguageCodec interface {
 	// The name of a message type ID when used as an input or output argument
 	// in the client methods.
 	MethodInOutTypeName(id string, state *APIState) string
+	// Returns a (possibly empty) list of "attributes" included immediately
+	// before the message definition.
+	MessageAttributes(m *Message, state *APIState) []string
 	// The (unqualified) message name, as used when defining the type to
 	// represent it.
 	MessageName(m *Message, state *APIState) string

--- a/generator/internal/genclient/language/internal/golang/golang.go
+++ b/generator/internal/genclient/language/internal/golang/golang.go
@@ -152,6 +152,10 @@ func (c *Codec) MethodInOutTypeName(id string, s *genclient.APIState) string {
 	return strcase.ToCamel(m.Name)
 }
 
+func (*Codec) MessageAttributes(*genclient.Message, *genclient.APIState) []string {
+	return []string{}
+}
+
 func (c *Codec) MessageName(m *genclient.Message, state *genclient.APIState) string {
 	if m.Parent != nil {
 		return c.MessageName(m.Parent, state) + "_" + strcase.ToCamel(m.Name)

--- a/generator/internal/genclient/language/internal/rust/rust.go
+++ b/generator/internal/genclient/language/internal/rust/rust.go
@@ -31,11 +31,12 @@ import (
 func NewCodec(copts *genclient.CodecOptions) (*Codec, error) {
 	year, _, _ := time.Now().Date()
 	codec := &Codec{
-		GenerationYear:  fmt.Sprintf("%04d", year),
-		OutputDirectory: copts.OutDir,
-		ModulePath:      "model",
-		ExtraPackages:   []*RustPackage{},
-		PackageMapping:  map[string]*RustPackage{},
+		GenerationYear:           fmt.Sprintf("%04d", year),
+		OutputDirectory:          copts.OutDir,
+		ModulePath:               "model",
+		DeserializeWithdDefaults: true,
+		ExtraPackages:            []*RustPackage{},
+		PackageMapping:           map[string]*RustPackage{},
 	}
 	for key, definition := range copts.Options {
 		switch key {
@@ -51,6 +52,12 @@ func NewCodec(copts *genclient.CodecOptions) (*Codec, error) {
 			continue
 		case "module-path":
 			codec.ModulePath = definition
+		case "deserialize-with-defaults":
+			value, err := strconv.ParseBool(definition)
+			if err != nil {
+				return nil, err
+			}
+			codec.DeserializeWithdDefaults = value
 			continue
 		case "copyright-year":
 			codec.GenerationYear = definition
@@ -109,6 +116,9 @@ type Codec struct {
 	// Note that using `self` does not work, as the generated code may contain
 	// nested modules for nested messages.
 	ModulePath string
+	// If true, the deserialization functions will accept default values in
+	// messages. In almost all cases this should be `true`, but
+	DeserializeWithdDefaults bool
 	// Additional Rust packages imported by this module. The Mustache template
 	// hardcodes a number of packages, but some are configured via the
 	// command-line.
@@ -406,6 +416,19 @@ func (c *Codec) rustPackage(packageName string) string {
 		return mapped.Name
 	}
 	return mapped.Name + "::model"
+}
+
+func (c *Codec) MessageAttributes(*genclient.Message, *genclient.APIState) []string {
+	serde := `#[serde(default, rename_all = "camelCase")]`
+	if !c.DeserializeWithdDefaults {
+		serde = `#[serde(rename_all = "camelCase")]`
+	}
+	return []string{
+		`#[serde_with::serde_as]`,
+		`#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]`,
+		serde,
+		`#[non_exhaustive]`,
+	}
 }
 
 func (c *Codec) MessageName(m *genclient.Message, state *genclient.APIState) string {

--- a/generator/internal/genclient/language/internal/rust/rust_test.go
+++ b/generator/internal/genclient/language/internal/rust/rust_test.go
@@ -46,6 +46,7 @@ func TestParseOptions(t *testing.T) {
 		Options: map[string]string{
 			"package-name-override": "test-only",
 			"copyright-year":        "2035",
+			"module-path":           "alternative::generated",
 			"package:wkt":           "package=types,path=src/wkt,source=google.protobuf,source=test-only",
 			"package:gax":           "package=gax,path=src/gax,feature=sdk_client",
 		},
@@ -60,9 +61,10 @@ func TestParseOptions(t *testing.T) {
 		Path:    "src/wkt",
 	}
 	want := &Codec{
-		PackageNameOverride: "test-only",
-		GenerationYear:      "2035",
-		ModulePath:          "model",
+		PackageNameOverride:      "test-only",
+		GenerationYear:           "2035",
+		ModulePath:               "alternative::generated",
+		DeserializeWithdDefaults: true,
 		ExtraPackages: []*RustPackage{
 			gp,
 			{
@@ -938,7 +940,7 @@ func TestFormatDocCommentsBullets(t *testing.T) {
 		"///   value in the third email_addresses message.)",
 	}
 
-	c := &Codec{}
+	c := testCodec()
 	got := c.FormatDocComments(input)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)

--- a/generator/internal/genclient/templatedata.go
+++ b/generator/internal/genclient/templatedata.go
@@ -283,6 +283,10 @@ func (m *message) Enums() []*enum {
 	})
 }
 
+func (m *message) MessageAttributes() []string {
+	return m.c.MessageAttributes(m.s, m.state)
+}
+
 func (m *message) Name() string {
 	return m.c.MessageName(m.s, m.state)
 }

--- a/generator/sidekick/sidekick_test.go
+++ b/generator/sidekick/sidekick_test.go
@@ -181,6 +181,7 @@ func TestRustModuleFromProtobuf(t *testing.T) {
 			ExtraOptions: []string{
 				"-service-config", "generator/testdata/googleapis/google/rpc/rpc_publish.yaml",
 				"-codec-option", "module-path=error::rpc::generated",
+				"-codec-option", "deserialize-with-defaults=false",
 				"-codec-option", "package:wkt=package=gcp-sdk-wkt,path=src/wkt,source=google.protobuf",
 			},
 		},

--- a/generator/templates/rust/common/message.mustache
+++ b/generator/templates/rust/common/message.mustache
@@ -18,10 +18,9 @@ limitations under the License.
 {{#DocLines}}
 {{{.}}}
 {{/DocLines}}
-#[serde_with::serde_as]
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(default, rename_all = "camelCase")]
-#[non_exhaustive]
+{{#MessageAttributes}}
+{{{.}}}
+{{/MessageAttributes}}
 pub struct {{Name}} {
     {{#BasicFields}}
 

--- a/generator/testdata/rust/gclient/golden/module/rpc/.sidekick.toml
+++ b/generator/testdata/rust/gclient/golden/module/rpc/.sidekick.toml
@@ -24,6 +24,7 @@ googleapis-root = 'generator/testdata/googleapis'
 
 [codec]
 copyright-year = '2024'
+deserialize-with-defaults = 'false'
 generate-module = 'true'
 module-path = 'error::rpc::generated'
 'package:wkt' = 'package=gcp-sdk-wkt,path=src/wkt,source=google.protobuf'

--- a/generator/testdata/rust/gclient/golden/module/rpc/mod.rs
+++ b/generator/testdata/rust/gclient/golden/module/rpc/mod.rs
@@ -40,7 +40,7 @@
 ///     }
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(default, rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ErrorInfo {
 
@@ -107,7 +107,7 @@ impl ErrorInfo {
 /// reached.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(default, rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct RetryInfo {
 
@@ -127,7 +127,7 @@ impl RetryInfo {
 /// Describes additional debugging info.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(default, rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct DebugInfo {
 
@@ -166,7 +166,7 @@ impl DebugInfo {
 /// quota failure.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(default, rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct QuotaFailure {
 
@@ -190,7 +190,7 @@ pub mod quota_failure {
     /// daily quota or a custom quota that was exceeded.
     #[serde_with::serde_as]
     #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-    #[serde(default, rename_all = "camelCase")]
+    #[serde(rename_all = "camelCase")]
     #[non_exhaustive]
     pub struct Violation {
 
@@ -232,7 +232,7 @@ pub mod quota_failure {
 /// PreconditionFailure message.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(default, rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct PreconditionFailure {
 
@@ -255,7 +255,7 @@ pub mod precondition_failure {
     /// A message type used to describe a single precondition failure.
     #[serde_with::serde_as]
     #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-    #[serde(default, rename_all = "camelCase")]
+    #[serde(rename_all = "camelCase")]
     #[non_exhaustive]
     pub struct Violation {
 
@@ -303,7 +303,7 @@ pub mod precondition_failure {
 /// syntactic aspects of the request.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(default, rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct BadRequest {
 
@@ -326,7 +326,7 @@ pub mod bad_request {
     /// A message type used to describe a single bad request field.
     #[serde_with::serde_as]
     #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-    #[serde(default, rename_all = "camelCase")]
+    #[serde(rename_all = "camelCase")]
     #[non_exhaustive]
     pub struct FieldViolation {
 
@@ -393,7 +393,7 @@ pub mod bad_request {
 /// or providing other forms of feedback.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(default, rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct RequestInfo {
 
@@ -424,7 +424,7 @@ impl RequestInfo {
 /// Describes the resource that is being accessed.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(default, rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ResourceInfo {
 
@@ -484,7 +484,7 @@ impl ResourceInfo {
 /// directly to the right place in the developer console to flip the bit.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(default, rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Help {
 
@@ -507,7 +507,7 @@ pub mod help {
     /// Describes a URL link.
     #[serde_with::serde_as]
     #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-    #[serde(default, rename_all = "camelCase")]
+    #[serde(rename_all = "camelCase")]
     #[non_exhaustive]
     pub struct Link {
 
@@ -538,7 +538,7 @@ pub mod help {
 /// which can be attached to an RPC error.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(default, rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct LocalizedMessage {
 


### PR DESCRIPTION
In the generated module for `gax/error/rpc` we need to tweak message
serialization to *only* accept JSON objects with all the message fields.
This PR adds an option to support this case. I expect the option will
see little use beyond that, but custom  options to bootstrap the
libraries are (I think) to be expected.

Part of the work for #283 