### PR TITLE
feat(generator): cleaner `.sidekick.toml` files

### DIFF
--- a/generator/sidekick/config.go
+++ b/generator/sidekick/config.go
@@ -24,18 +24,18 @@ import (
 type Config struct {
 	General GeneralConfig `toml:"general"`
 
-	Source map[string]string `toml:"source"`
-	Codec  map[string]string `toml:"codec"`
+	Source map[string]string `toml:"source,omitempty"`
+	Codec  map[string]string `toml:"codec,omitempty"`
 }
 
 // Configuration parameters that affect Parsers and Codecs, including the
 // selection of parser and codec.
 type GeneralConfig struct {
-	Language            string `toml:"language"`
-	TemplateDir         string `toml:"template-dir"`
-	SpecificationFormat string `toml:"specification-format"`
-	SpecificationSource string `toml:"specification-source"`
-	ServiceConfig       string `toml:"service-config"`
+	Language            string `toml:"language,omitempty"`
+	TemplateDir         string `toml:"template-dir,omitempty"`
+	SpecificationFormat string `toml:"specification-format,omitempty"`
+	SpecificationSource string `toml:"specification-source,omitempty"`
+	ServiceConfig       string `toml:"service-config,omitempty"`
 }
 
 func LoadRootConfig(filename string) (*Config, error) {

--- a/generator/sidekick/config_test.go
+++ b/generator/sidekick/config_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"testing"
 
@@ -232,6 +233,33 @@ func TestMergeCodecAndSource(t *testing.T) {
 			"source-c": "local-c-value",
 		},
 	}
+
+	if diff := cmp.Diff(want, got); len(diff) != 0 {
+		t.Errorf("mismatched merged config (-want, +got):\n%s", diff)
+	}
+}
+
+func TestSaveOmitEmpty(t *testing.T) {
+	input := Config{
+		General: GeneralConfig{
+			SpecificationSource: "test-only-source",
+			ServiceConfig:       "test-only-config",
+		},
+		Codec:  map[string]string{},
+		Source: map[string]string{},
+	}
+	output := bytes.Buffer{}
+
+	to := toml.NewEncoder(&output)
+	if err := to.Encode(input); err != nil {
+		t.Fatal(err)
+	}
+
+	got := output.String()
+	want := `[general]
+specification-source = 'test-only-source'
+service-config = 'test-only-config'
+`
 
 	if diff := cmp.Diff(want, got); len(diff) != 0 {
 		t.Errorf("mismatched merged config (-want, +got):\n%s", diff)

--- a/generator/testdata/go/gclient/golden/iam/v1/.sidekick.toml
+++ b/generator/testdata/go/gclient/golden/iam/v1/.sidekick.toml
@@ -17,7 +17,6 @@ language = 'go'
 template-dir = 'generator/templates'
 specification-format = 'protobuf'
 specification-source = 'generator/testdata/googleapis/google/iam/v1'
-service-config = ''
 
 [source]
 googleapis-root = 'generator/testdata/googleapis'

--- a/generator/testdata/go/gclient/golden/typez/.sidekick.toml
+++ b/generator/testdata/go/gclient/golden/typez/.sidekick.toml
@@ -17,7 +17,6 @@ language = 'go'
 template-dir = 'generator/templates'
 specification-format = 'protobuf'
 specification-source = 'generator/testdata/googleapis/google/type'
-service-config = ''
 
 [source]
 googleapis-root = 'generator/testdata/googleapis'

--- a/generator/testdata/rust/gclient/golden/iam/v1/.sidekick.toml
+++ b/generator/testdata/rust/gclient/golden/iam/v1/.sidekick.toml
@@ -17,7 +17,6 @@ language = 'rust'
 template-dir = 'generator/templates'
 specification-format = 'protobuf'
 specification-source = 'generator/testdata/googleapis/google/iam/v1'
-service-config = ''
 
 [source]
 googleapis-root = 'generator/testdata/googleapis'


### PR DESCRIPTION
Most `.sidekick.toml` files will have only a few items set, with most of
the configuration saved in the top-level configuration file. With this
change, only non-empty values are saved.

Part of the work for #284 