### PR TITLE
feat(generator): search paths for inputs

### DIFF
--- a/generator/internal/genclient/parser/openapi/openapi.go
+++ b/generator/internal/genclient/parser/openapi/openapi.go
@@ -60,7 +60,7 @@ func (t *Parser) Parse(opts genclient.ParserOptions) (*genclient.API, error) {
 	}
 	var serviceConfig *serviceconfig.Service
 	if opts.ServiceConfig != "" {
-		cfg, err := genclient.ReadServiceConfig(opts.ServiceConfig)
+		cfg, err := genclient.ReadServiceConfig(genclient.FindServiceConfigPath(opts))
 		if err != nil {
 			return nil, err
 		}

--- a/generator/internal/genclient/parser/protobuf/protobuf_test.go
+++ b/generator/internal/genclient/parser/protobuf/protobuf_test.go
@@ -1015,7 +1015,7 @@ func newTestCodeGeneratorRequest(t *testing.T, filename string) *pluginpb.CodeGe
 		Source: filename,
 		Options: map[string]string{
 			"googleapis-root": "../../../../testdata/googleapis",
-			"input-root":      "testdata",
+			"test-root":       "testdata",
 		},
 	}
 	request, err := NewCodeGeneratorRequest(popts)

--- a/generator/sidekick/sidekick_test.go
+++ b/generator/sidekick/sidekick_test.go
@@ -164,8 +164,8 @@ func TestRustModuleFromProtobuf(t *testing.T) {
 	}
 	configs := []TestConfig{
 		{
-			Source:        "generator/testdata/googleapis/google/rpc/error_details.proto",
-			ServiceConfig: "generator/testdata/googleapis/google/rpc/rpc_publish.yaml",
+			Source:        "google/rpc/error_details.proto",
+			ServiceConfig: "google/rpc/rpc_publish.yaml",
 			Name:          "rpc",
 			ExtraOptions: map[string]string{
 				"module-path":               "error::rpc::generated",
@@ -174,8 +174,8 @@ func TestRustModuleFromProtobuf(t *testing.T) {
 			},
 		},
 		{
-			Source:        "generator/testdata/googleapis/google/type",
-			ServiceConfig: "generator/testdata/googleapis/google/type/type.yaml",
+			Source:        "google/type",
+			ServiceConfig: "google/type/type.yaml",
 			Name:          "type",
 		},
 	}

--- a/generator/testdata/rust/gclient/golden/module/rpc/.sidekick.toml
+++ b/generator/testdata/rust/gclient/golden/module/rpc/.sidekick.toml
@@ -16,8 +16,8 @@
 language = 'rust'
 template-dir = 'generator/templates'
 specification-format = 'protobuf'
-specification-source = 'generator/testdata/googleapis/google/rpc/error_details.proto'
-service-config = 'generator/testdata/googleapis/google/rpc/rpc_publish.yaml'
+specification-source = 'google/rpc/error_details.proto'
+service-config = 'google/rpc/rpc_publish.yaml'
 
 [source]
 googleapis-root = 'generator/testdata/googleapis'

--- a/generator/testdata/rust/gclient/golden/module/type/.sidekick.toml
+++ b/generator/testdata/rust/gclient/golden/module/type/.sidekick.toml
@@ -16,8 +16,8 @@
 language = 'rust'
 template-dir = 'generator/templates'
 specification-format = 'protobuf'
-specification-source = 'generator/testdata/googleapis/google/type'
-service-config = 'generator/testdata/googleapis/google/type/type.yaml'
+specification-source = 'google/type'
+service-config = 'google/type/type.yaml'
 
 [source]
 googleapis-root = 'generator/testdata/googleapis'


### PR DESCRIPTION
It is more ergonomic to specify the inputs into the parsers relative to
`googleapis-root` (or some such configuration). That allows us to keep
the root configured in a single place, and even dynamically download
the right googleapis version where needed.

For now, we use `test-root` and `googleapis-root` as search paths, and
fall back to searching in `$PWD` if those do not work. In the future we
may want to add other `*-root` search paths, e.g. if all the discovery
docs are committed to a different directory.


Part of the work for #284
