### PR TITLE
fix(generator): fewer defaults for cmdline arguments

### DIFF
--- a/generator/sidekick/cmdline.go
+++ b/generator/sidekick/cmdline.go
@@ -48,8 +48,8 @@ func ParseArgsExplicit(args []string) (*CommandLine, error) {
 		source        = fs.String("specification-source", "", "the path to the input data")
 		serviceConfig = fs.String("service-config", "", "path to service config")
 		sourceOpts    = map[string]string{}
-		output        = fs.String("output", "generated", "the path within project-root to put generated files")
-		templateDir   = fs.String("template-dir", "templates/", "the path to the template directory")
+		output        = fs.String("output", "", "the path within project-root to put generated files")
+		templateDir   = fs.String("template-dir", "", "the path to the template directory")
 		language      = fs.String("language", "", "the generated language")
 		codecOpts     = map[string]string{}
 		dryrun        = fs.Bool("dry-run", false, "do a dry-run: load the configuration, but do not perform any changes.")

--- a/generator/sidekick/cmdline_test.go
+++ b/generator/sidekick/cmdline_test.go
@@ -65,3 +65,24 @@ func TestParseArgs(t *testing.T) {
 		t.Errorf("mismatched merged config (-want, +got):\n%s", diff)
 	}
 }
+
+func TestDefaults(t *testing.T) {
+	root := t.TempDir()
+	args := []string{
+		"-project-root", root,
+		"generate",
+	}
+	got, err := ParseArgsExplicit(args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &CommandLine{
+		Command:     "generate",
+		ProjectRoot: root,
+		Source:      map[string]string{},
+		Codec:       map[string]string{},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatched merged config (-want, +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
The defaults (if any) should be saved in the top-level configuration file.

Part of the work for #284 