### PR TITLE
feat(generator): `generate` can download googleapis

### DIFF
--- a/generator/sidekick/generate.go
+++ b/generator/sidekick/generate.go
@@ -46,8 +46,17 @@ func Generate(rootConfig *Config, cmdLine *CommandLine) error {
 		return err
 	}
 
+	root, err := makeGoogleapisRoot(rootConfig)
+	if err != nil {
+		return err
+	}
+	override := *rootConfig
+	override.Codec = maps.Clone(rootConfig.Codec)
+	override.Source = maps.Clone(rootConfig.Source)
+	override.Source["googleapis-root"] = root
+
 	// Load the .sidekick.toml file and refresh the code.
-	return Refresh(rootConfig, cmdLine, cmdLine.Output)
+	return Refresh(&override, cmdLine, cmdLine.Output)
 }
 
 func writeSidekickToml(outDir string, config *Config) error {


### PR DESCRIPTION
`generate` is the command to create new client libraries. The top-level
`.sidekick.toml` configuration may require use of a pinned SHA from
GitHub. In such case `generate` needs to download googleapis, and
override the configuration to use the downlead copy.

Recall that such downloads are cached, so most of the time this would
not be very slow, and may not even involve any network traffic. Also,
the tests use a local directory, so unit tests and CI tests do not
involve network traffic either.

Part of the work for #284
