### PR TITLE
feat(generator): improve default rust crate name

### DIFF
--- a/generator/internal/genclient/language/common/common.go
+++ b/generator/internal/genclient/language/common/common.go
@@ -1,0 +1,31 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import "strings"
+
+func SplitApiName(name string) (string, string) {
+	li := strings.LastIndex(name, ".")
+	if li == -1 {
+		return "", name
+	}
+	return name[:li], name[li+1:]
+}
+
+func WellKnownMixin(apiName string) bool {
+	return strings.HasPrefix(apiName, "google.cloud.location.Location") ||
+		strings.HasPrefix(apiName, "google.longrunning.Operations") ||
+		strings.HasPrefix(apiName, "google.iam.v1.IAMPolicy")
+}

--- a/generator/internal/genclient/language/internal/rust/rust.go
+++ b/generator/internal/genclient/language/internal/rust/rust.go
@@ -671,7 +671,10 @@ func (c *Codec) PackageName(api *genclient.API) string {
 	if len(c.PackageNameOverride) > 0 {
 		return c.PackageNameOverride
 	}
-	return api.Name
+	name := strings.TrimPrefix(api.PackageName, "google.cloud.")
+	name = strings.TrimPrefix(name, "google.")
+	name = strings.ReplaceAll(name, ".", "-")
+	return "gcp-sdk-" + name
 }
 
 func (c *Codec) validatePackageName(newPackage, elementName string) error {

--- a/generator/internal/genclient/language/internal/rust/rust.go
+++ b/generator/internal/genclient/language/internal/rust/rust.go
@@ -674,6 +674,9 @@ func (c *Codec) PackageName(api *genclient.API) string {
 	name := strings.TrimPrefix(api.PackageName, "google.cloud.")
 	name = strings.TrimPrefix(name, "google.")
 	name = strings.ReplaceAll(name, ".", "-")
+	if name == "" {
+		name = api.Name
+	}
 	return "gcp-sdk-" + name
 }
 

--- a/generator/internal/genclient/language/internal/rust/rust_test.go
+++ b/generator/internal/genclient/language/internal/rust/rust_test.go
@@ -146,7 +146,7 @@ func TestPackageName(t *testing.T) {
 			"package-name-override": "test-only-overridden",
 		},
 	})
-	packageNameImpl(t, "test-only-default", &genclient.CodecOptions{
+	packageNameImpl(t, "gcp-sdk-service-v3", &genclient.CodecOptions{
 		Language: "rust",
 	})
 
@@ -155,7 +155,8 @@ func TestPackageName(t *testing.T) {
 func packageNameImpl(t *testing.T, want string, copts *genclient.CodecOptions) {
 	t.Helper()
 	api := &genclient.API{
-		Name: "test-only-default",
+		Name:        "test-only-name",
+		PackageName: "google.cloud.service.v3",
 	}
 	codec, err := NewCodec(copts)
 	if err != nil {

--- a/generator/internal/genclient/language/internal/rust/rust_test.go
+++ b/generator/internal/genclient/language/internal/rust/rust_test.go
@@ -145,19 +145,26 @@ func TestPackageName(t *testing.T) {
 		Options: map[string]string{
 			"package-name-override": "test-only-overridden",
 		},
+	}, &genclient.API{
+		Name:        "test-only-name",
+		PackageName: "google.cloud.service.v3",
 	})
 	packageNameImpl(t, "gcp-sdk-service-v3", &genclient.CodecOptions{
 		Language: "rust",
-	})
-
-}
-
-func packageNameImpl(t *testing.T, want string, copts *genclient.CodecOptions) {
-	t.Helper()
-	api := &genclient.API{
+	}, &genclient.API{
 		Name:        "test-only-name",
 		PackageName: "google.cloud.service.v3",
-	}
+	})
+	packageNameImpl(t, "gcp-sdk-type", &genclient.CodecOptions{
+		Language: "rust",
+	}, &genclient.API{
+		Name:        "type",
+		PackageName: "",
+	})
+}
+
+func packageNameImpl(t *testing.T, want string, copts *genclient.CodecOptions, api *genclient.API) {
+	t.Helper()
 	codec, err := NewCodec(copts)
 	if err != nil {
 		t.Fatal(err)

--- a/generator/internal/genclient/model.go
+++ b/generator/internal/genclient/model.go
@@ -52,6 +52,9 @@ const (
 type API struct {
 	// Name of the API (e.g. secretmanager).
 	Name string
+	// Name of the package name in the source specification format. For Protobuf
+	// this may be `google.cloud.secretmanager.v1`.
+	PackageName string
 	// The API Title (e.g. "Secret Manager API" or "Cloud Spanner API").
 	Title string
 	// The API Description

--- a/generator/internal/genclient/parser/openapi/openapi.go
+++ b/generator/internal/genclient/parser/openapi/openapi.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/google-cloud-rust/generator/internal/genclient"
+	"github.com/googleapis/google-cloud-rust/generator/internal/genclient/language/common"
 	"github.com/pb33f/libopenapi"
 	"github.com/pb33f/libopenapi/datamodel/high/base"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
@@ -108,9 +109,9 @@ func makeAPI(serviceConfig *serviceconfig.Service, model *libopenapi.DocumentMod
 	packageName := ""
 	if serviceConfig != nil {
 		for _, api := range serviceConfig.Apis {
-			packageName, serviceName = splitApiName(api.Name)
+			packageName, serviceName = common.SplitApiName(api.Name)
 			// Keep searching after well-known mixin services.
-			if !wellKnownMixin(api.Name) {
+			if !common.WellKnownMixin(api.Name) {
 				break
 			}
 		}
@@ -143,20 +144,6 @@ func makeAPI(serviceConfig *serviceconfig.Service, model *libopenapi.DocumentMod
 		return nil, err
 	}
 	return api, nil
-}
-
-func wellKnownMixin(apiName string) bool {
-	return strings.HasPrefix(apiName, "google.cloud.location.Location") ||
-		strings.HasPrefix(apiName, "google.longrunning.Operations") ||
-		strings.HasPrefix(apiName, "google.iam.v1.IAMPolicy")
-}
-
-func splitApiName(name string) (string, string) {
-	li := strings.LastIndex(name, ".")
-	if li == -1 {
-		return "", name
-	}
-	return name[:li], name[li+1:]
 }
 
 func makeServices(api *genclient.API, model *libopenapi.DocumentModel[v3.Document], packageName, serviceName string) error {


### PR DESCRIPTION
By default, the rust crate name should be something like
`gcp-sdk-secretmanager-v1`. This change makes it so. We can still
override the name in crates that need it.

Part of the work for #284, fixes #172 
