### PR TITLE
fix(generator/protobuf): limit .proto search depth

### DIFF
--- a/generator/internal/genclient/parser/protobuf/protobuf.go
+++ b/generator/internal/genclient/parser/protobuf/protobuf.go
@@ -163,10 +163,18 @@ func determineInputFiles(config genclient.ParserOptions) ([]string, error) {
 			break
 		}
 	}
+	const maxDepth = 1
 	var files []string
 	err := filepath.Walk(source, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
+		}
+		depth := strings.Count(filepath.ToSlash(strings.TrimPrefix(path, source)), "/")
+		if info.IsDir() && depth >= maxDepth {
+			return filepath.SkipDir
+		}
+		if depth > maxDepth {
+			return nil
 		}
 		if filepath.Ext(path) == ".proto" {
 			files = append(files, path)


### PR DESCRIPTION
Most APIs include multiple `.proto` files from the same directory. But
some services also include `logging/` and other subdirectories we do not
want: the symbols are in a different protobuf package, and they are not
needed to use the service.

In the future we may want more flexibility, maybe specify multiple
directories, or many manually list multiple files. I think this approach
will serve us well for the next few services we choose to generate.

Part of the work for #284 