### PR TITLE
ci: skip formatting of generated toml files

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Format TOML files
         run: |
           cargo install taplo-cli --version 0.9.3
-          git ls-files -z -- '*.toml' ':!:**/testdata/**' | \
+          git ls-files -z -- '*.toml' ':!:**/testdata/**' ':!:src/generated/**' | \
             xargs -0 taplo fmt
       - name: Check for changes
         run: git diff --exit-code


### PR DESCRIPTION
Motivated by #284

It seems silly to format generated files that we should never look at, and it creates additional work when adding new generated crates.