### PR TITLE
feat(wkt): implement `TryFrom` for `Duration`

### DIFF
--- a/src/wkt/src/duration.rs
+++ b/src/wkt/src/duration.rs
@@ -125,7 +125,10 @@ impl std::convert::TryFrom<std::time::Duration> for Duration {
         if value.subsec_nanos() > (i32::MAX as u32) {
             return Err("sub-second nanos are out of range");
         }
-        Ok(Self { seconds: value.as_secs() as i64, nanos: value.subsec_nanos() as i32 })
+        Ok(Self {
+            seconds: value.as_secs() as i64,
+            nanos: value.subsec_nanos() as i32,
+        })
     }
 }
 

--- a/src/wkt/src/duration.rs
+++ b/src/wkt/src/duration.rs
@@ -115,6 +115,34 @@ impl Duration {
     }
 }
 
+impl std::convert::TryFrom<std::time::Duration> for Duration {
+    type Error = &'static str;
+
+    fn try_from(value: std::time::Duration) -> std::result::Result<Self, Self::Error> {
+        if value.as_secs() > (i64::MAX as u64) {
+            return Err("seconds are out of range");
+        }
+        if value.subsec_nanos() > (i32::MAX as u32) {
+            return Err("sub-second nanos are out of range");
+        }
+        Ok(Self { seconds: value.as_secs() as i64, nanos: value.subsec_nanos() as i32 })
+    }
+}
+
+impl std::convert::TryFrom<Duration> for std::time::Duration {
+    type Error = &'static str;
+
+    fn try_from(value: Duration) -> std::result::Result<Self, Self::Error> {
+        if value.seconds < 0 {
+            return Err("seconds are out of range");
+        }
+        if value.nanos < 0 {
+            return Err("sub-second nanos are out of range");
+        }
+        Ok(Self::new(value.seconds as u64, value.nanos as u32))
+    }
+}
+
 /// Implement [`serde`](::serde) serialization for Duration.
 impl serde::ser::Serialize for Duration {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>

--- a/src/wkt/tests/duration.rs
+++ b/src/wkt/tests/duration.rs
@@ -77,3 +77,36 @@ fn compare() {
     assert_eq!(ts0.partial_cmp(&ts1), Some(std::cmp::Ordering::Less));
     assert_eq!(ts2.partial_cmp(&ts3), Some(std::cmp::Ordering::Less));
 }
+
+#[test]
+fn from_std_time_duration() -> Result {
+    let std_d = std::time::Duration::new(123, 456789012);
+    let got = Duration::try_from(std_d)?;
+    let want = Duration::new(123, 456789012);
+    assert_eq!(got, want);
+
+    let std_d = std::time::Duration::new(i64::MAX as u64 + 2, 0);
+    let got = Duration::try_from(std_d);
+    assert!(got.is_err(), "expected error converting from out of range value got={got:?}");
+
+    Ok(())
+}
+
+
+#[test]
+fn std_from_duration() -> Result {
+    let dur = Duration::new(123, 456789012);
+    let got = std::time::Duration::try_from(dur)?;
+    let want = std::time::Duration::new(123, 456789012);
+    assert_eq!(got, want);
+
+    let dur = Duration::new(-10, 0);
+    let got = std::time::Duration::try_from(dur);
+    assert!(got.is_err(), "expected error converting from out of range value got={got:?}");
+
+    let dur = Duration::new(0, -10);
+    let got = std::time::Duration::try_from(dur);
+    assert!(got.is_err(), "expected error converting from out of range value got={got:?}");
+
+    Ok(())
+}

--- a/src/wkt/tests/duration.rs
+++ b/src/wkt/tests/duration.rs
@@ -87,11 +87,13 @@ fn from_std_time_duration() -> Result {
 
     let std_d = std::time::Duration::new(i64::MAX as u64 + 2, 0);
     let got = Duration::try_from(std_d);
-    assert!(got.is_err(), "expected error converting from out of range value got={got:?}");
+    assert!(
+        got.is_err(),
+        "expected error converting from out of range value got={got:?}"
+    );
 
     Ok(())
 }
-
 
 #[test]
 fn std_from_duration() -> Result {
@@ -102,11 +104,17 @@ fn std_from_duration() -> Result {
 
     let dur = Duration::new(-10, 0);
     let got = std::time::Duration::try_from(dur);
-    assert!(got.is_err(), "expected error converting from out of range value got={got:?}");
+    assert!(
+        got.is_err(),
+        "expected error converting from out of range value got={got:?}"
+    );
 
     let dur = Duration::new(0, -10);
     let got = std::time::Duration::try_from(dur);
-    assert!(got.is_err(), "expected error converting from out of range value got={got:?}");
+    assert!(
+        got.is_err(),
+        "expected error converting from out of range value got={got:?}"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
We cannot safely convert from `std::time::Duration` to the
`wkt::Duration` because Rust has higher maximum value.

We cannot safely convert from `wkt::Duration` to `std::time::Duration`
because `wkt::Duration`s can be negative, while Rust supports only
positive intervals.

But in the normal case somethin like `Duration::try_from(x)?` should
work in both directions.

Fixes #50 