### PR TITLE
impl(internal/parser): remove unused code and rename functions

### DIFF
--- a/generator/internal/parser/parser.go
+++ b/generator/internal/parser/parser.go
@@ -16,7 +16,6 @@ package parser
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/googleapis/google-cloud-rust/generator/internal/genclient"
 	"github.com/googleapis/google-cloud-rust/generator/internal/parser/openapi"
@@ -32,26 +31,10 @@ func knownParsers() map[string]newParser {
 	}
 }
 
-func NewParser(parserID string) (genclient.Parser, error) {
+func New(parserID string) (genclient.Parser, error) {
 	create, ok := knownParsers()[parserID]
 	if !ok {
 		return nil, fmt.Errorf("unknown parser %q", parserID)
 	}
 	return create(), nil
-}
-
-func Help() string {
-	var help []string
-	for name, fact := range knownParsers() {
-		parser := fact()
-		help = append(help, fmt.Sprintf("%s: %s", name, parser.Help()))
-		options := parser.OptionDescriptions()
-		if len(options) > 0 {
-			help = append(help, "  Options")
-		}
-		for opt, description := range parser.OptionDescriptions() {
-			help = append(help, fmt.Sprintf("    %s: %s", opt, description))
-		}
-	}
-	return strings.Join(help, "\n")
 }

--- a/generator/internal/parser/protobuf/protobuf.go
+++ b/generator/internal/parser/protobuf/protobuf.go
@@ -65,7 +65,7 @@ func (t *Parser) Parse(opts genclient.ParserOptions) (*genclient.API, error) {
 		}
 		serviceConfig = cfg
 	}
-	return MakeAPI(serviceConfig, request), nil
+	return makeAPI(serviceConfig, request), nil
 }
 
 func NewCodeGeneratorRequest(opts genclient.ParserOptions) (*pluginpb.CodeGeneratorRequest, error) {
@@ -220,7 +220,7 @@ const (
 	enumDescriptorValue = 2
 )
 
-func MakeAPI(serviceConfig *serviceconfig.Service, req *pluginpb.CodeGeneratorRequest) *genclient.API {
+func makeAPI(serviceConfig *serviceconfig.Service, req *pluginpb.CodeGeneratorRequest) *genclient.API {
 	var mixinFileDesc []*descriptorpb.FileDescriptorProto
 	var enabledMixinMethods mixinMethods = make(map[string]bool)
 	state := &genclient.APIState{

--- a/generator/internal/parser/protobuf/protobuf_test.go
+++ b/generator/internal/parser/protobuf/protobuf_test.go
@@ -36,7 +36,7 @@ func TestInfo(t *testing.T) {
 		},
 	}
 
-	api := MakeAPI(serviceConfig, newTestCodeGeneratorRequest(t, "scalar.proto"))
+	api := makeAPI(serviceConfig, newTestCodeGeneratorRequest(t, "scalar.proto"))
 	if api.Name != "secretmanager" {
 		t.Errorf("want = %q; got = %q", "secretmanager", api.Name)
 	}
@@ -49,7 +49,7 @@ func TestInfo(t *testing.T) {
 }
 
 func TestScalar(t *testing.T) {
-	api := MakeAPI(nil, newTestCodeGeneratorRequest(t, "scalar.proto"))
+	api := makeAPI(nil, newTestCodeGeneratorRequest(t, "scalar.proto"))
 
 	message, ok := api.State.MessageByID[".test.Fake"]
 	if !ok {
@@ -171,7 +171,7 @@ func TestScalar(t *testing.T) {
 }
 
 func TestScalarArray(t *testing.T) {
-	api := MakeAPI(nil, newTestCodeGeneratorRequest(t, "scalar_array.proto"))
+	api := makeAPI(nil, newTestCodeGeneratorRequest(t, "scalar_array.proto"))
 
 	message, ok := api.State.MessageByID[".test.Fake"]
 	if !ok {
@@ -220,7 +220,7 @@ func TestScalarArray(t *testing.T) {
 }
 
 func TestScalarOptional(t *testing.T) {
-	api := MakeAPI(nil, newTestCodeGeneratorRequest(t, "scalar_optional.proto"))
+	api := makeAPI(nil, newTestCodeGeneratorRequest(t, "scalar_optional.proto"))
 
 	message, ok := api.State.MessageByID[".test.Fake"]
 	if !ok {
@@ -269,7 +269,7 @@ func TestScalarOptional(t *testing.T) {
 }
 
 func TestSkipExternalMessages(t *testing.T) {
-	api := MakeAPI(nil, newTestCodeGeneratorRequest(t, "with_import.proto"))
+	api := makeAPI(nil, newTestCodeGeneratorRequest(t, "with_import.proto"))
 
 	// Both `ImportedMessage` and `LocalMessage` should be in the index:
 	_, ok := api.State.MessageByID[".away.ImportedMessage"]
@@ -315,7 +315,7 @@ func TestSkipExternalMessages(t *testing.T) {
 }
 
 func TestSkipExternaEnums(t *testing.T) {
-	api := MakeAPI(nil, newTestCodeGeneratorRequest(t, "with_import.proto"))
+	api := makeAPI(nil, newTestCodeGeneratorRequest(t, "with_import.proto"))
 
 	// Both `ImportedEnum` and `LocalEnum` should be in the index:
 	_, ok := api.State.EnumByID[".away.ImportedEnum"]
@@ -354,7 +354,7 @@ func TestSkipExternaEnums(t *testing.T) {
 }
 
 func TestComments(t *testing.T) {
-	api := MakeAPI(nil, newTestCodeGeneratorRequest(t, "comments.proto"))
+	api := makeAPI(nil, newTestCodeGeneratorRequest(t, "comments.proto"))
 
 	message, ok := api.State.MessageByID[".test.Request"]
 	if !ok {
@@ -451,7 +451,7 @@ func TestComments(t *testing.T) {
 }
 
 func TestOneOfs(t *testing.T) {
-	api := MakeAPI(nil, newTestCodeGeneratorRequest(t, "oneofs.proto"))
+	api := makeAPI(nil, newTestCodeGeneratorRequest(t, "oneofs.proto"))
 	message, ok := api.State.MessageByID[".test.Fake"]
 	if !ok {
 		t.Fatalf("Cannot find message %s in API State", ".test.Request")
@@ -522,7 +522,7 @@ func TestOneOfs(t *testing.T) {
 }
 
 func TestObjectFields(t *testing.T) {
-	api := MakeAPI(nil, newTestCodeGeneratorRequest(t, "object_fields.proto"))
+	api := makeAPI(nil, newTestCodeGeneratorRequest(t, "object_fields.proto"))
 
 	message, ok := api.State.MessageByID[".test.Fake"]
 	if !ok {
@@ -556,7 +556,7 @@ func TestObjectFields(t *testing.T) {
 }
 
 func TestWellKnownTypeFields(t *testing.T) {
-	api := MakeAPI(nil, newTestCodeGeneratorRequest(t, "wkt_fields.proto"))
+	api := makeAPI(nil, newTestCodeGeneratorRequest(t, "wkt_fields.proto"))
 
 	message, ok := api.State.MessageByID[".test.Fake"]
 	if !ok {
@@ -620,7 +620,7 @@ func TestWellKnownTypeFields(t *testing.T) {
 }
 
 func TestMapFields(t *testing.T) {
-	api := MakeAPI(nil, newTestCodeGeneratorRequest(t, "map_fields.proto"))
+	api := makeAPI(nil, newTestCodeGeneratorRequest(t, "map_fields.proto"))
 
 	message, ok := api.State.MessageByID[".test.Fake"]
 	if !ok {
@@ -674,7 +674,7 @@ func TestMapFields(t *testing.T) {
 }
 
 func TestService(t *testing.T) {
-	api := MakeAPI(nil, newTestCodeGeneratorRequest(t, "test_service.proto"))
+	api := makeAPI(nil, newTestCodeGeneratorRequest(t, "test_service.proto"))
 
 	service, ok := api.State.ServiceByID[".test.TestService"]
 	if !ok {
@@ -725,7 +725,7 @@ func TestService(t *testing.T) {
 }
 
 func TestQueryParameters(t *testing.T) {
-	api := MakeAPI(nil, newTestCodeGeneratorRequest(t, "query_parameters.proto"))
+	api := makeAPI(nil, newTestCodeGeneratorRequest(t, "query_parameters.proto"))
 
 	service, ok := api.State.ServiceByID[".test.TestService"]
 	if !ok {
@@ -777,7 +777,7 @@ func TestQueryParameters(t *testing.T) {
 }
 
 func TestEnum(t *testing.T) {
-	api := MakeAPI(nil, newTestCodeGeneratorRequest(t, "enum.proto"))
+	api := makeAPI(nil, newTestCodeGeneratorRequest(t, "enum.proto"))
 	e, ok := api.State.EnumByID[".test.Code"]
 	if !ok {
 		t.Fatalf("Cannot find enum %s in API State", ".test.Code")
@@ -851,7 +851,7 @@ func TestLocationMixin(t *testing.T) {
 			},
 		},
 	}
-	api := MakeAPI(serviceConfig, newTestCodeGeneratorRequest(t, "test_service.proto"))
+	api := makeAPI(serviceConfig, newTestCodeGeneratorRequest(t, "test_service.proto"))
 	service, ok := api.State.ServiceByID[".google.cloud.location.Locations"]
 	if !ok {
 		t.Fatalf("Cannot find service %s in API State", ".google.cloud.location.Locations")
@@ -910,7 +910,7 @@ func TestIAMMixin(t *testing.T) {
 			},
 		},
 	}
-	api := MakeAPI(serviceConfig, newTestCodeGeneratorRequest(t, "test_service.proto"))
+	api := makeAPI(serviceConfig, newTestCodeGeneratorRequest(t, "test_service.proto"))
 	service, ok := api.State.ServiceByID[".google.iam.v1.IAMPolicy"]
 	if !ok {
 		t.Fatalf("Cannot find service %s in API State", ".google.iam.v1.IAMPolicy")
@@ -977,7 +977,7 @@ func TestOperationMixin(t *testing.T) {
 			},
 		},
 	}
-	api := MakeAPI(serviceConfig, newTestCodeGeneratorRequest(t, "test_service.proto"))
+	api := makeAPI(serviceConfig, newTestCodeGeneratorRequest(t, "test_service.proto"))
 	service, ok := api.State.ServiceByID[".google.longrunning.Operations"]
 	if !ok {
 		t.Fatalf("Cannot find service %s in API State", ".google.longrunning.Operations")

--- a/generator/internal/sidekick/refresh.go
+++ b/generator/internal/sidekick/refresh.go
@@ -51,7 +51,7 @@ func refresh(rootConfig *Config, cmdLine *CommandLine, output string) error {
 		Options:     config.Codec,
 	}
 
-	parser, err := parser.NewParser(specFormat)
+	parser, err := parser.New(specFormat)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* Unexport functions that do not need to be exported.
* Deleted unused code
* Rename parser.NewParser to parser.New to remove redundancy