### PR TITLE
impl(internal/genclient): remove unused CodecOptions and TemplateDir

### DIFF
--- a/generator/internal/genclient/genclient.go
+++ b/generator/internal/genclient/genclient.go
@@ -138,12 +138,8 @@ type ParserOptions struct {
 }
 
 type CodecOptions struct {
-	// The location where the specification can be found.
-	Language string
 	// The output location within ProjectRoot.
 	OutDir string
-	// The directory containing all mustache templates.
-	TemplateDir string
 	// Additional options.
 	Options map[string]string
 }

--- a/generator/internal/language/rust/rust_test.go
+++ b/generator/internal/language/rust/rust_test.go
@@ -42,7 +42,6 @@ func testCodec() *Codec {
 
 func TestParseOptions(t *testing.T) {
 	copts := &genclient.CodecOptions{
-		Language: "rust",
 		Options: map[string]string{
 			"package-name-override": "test-only",
 			"copyright-year":        "2035",
@@ -92,8 +91,7 @@ func TestParseOptions(t *testing.T) {
 
 func TestRequiredPackages(t *testing.T) {
 	copts := &genclient.CodecOptions{
-		Language: "rust",
-		OutDir:   "src/generated/newlib",
+		OutDir: "src/generated/newlib",
 		Options: map[string]string{
 			"package:gtype": "package=types,path=src/generated/type,source=google.type,source=test-only",
 			"package:gax":   "package=gax,path=src/gax,version=1.2.3",
@@ -119,8 +117,7 @@ func TestRequiredPackagesLocal(t *testing.T) {
 	// This is not a thing we expect to do in the Rust repository, but the
 	// behavior is consistent.
 	copts := &genclient.CodecOptions{
-		Language: "rust",
-		OutDir:   "",
+		OutDir: "",
 		Options: map[string]string{
 			"package:gtype": "package=types,path=src/generated/type,source=google.type,source=test-only",
 		},
@@ -141,7 +138,6 @@ func TestRequiredPackagesLocal(t *testing.T) {
 
 func TestPackageName(t *testing.T) {
 	packageNameImpl(t, "test-only-overridden", &genclient.CodecOptions{
-		Language: "rust",
 		Options: map[string]string{
 			"package-name-override": "test-only-overridden",
 		},
@@ -149,15 +145,11 @@ func TestPackageName(t *testing.T) {
 		Name:        "test-only-name",
 		PackageName: "google.cloud.service.v3",
 	})
-	packageNameImpl(t, "gcp-sdk-service-v3", &genclient.CodecOptions{
-		Language: "rust",
-	}, &genclient.API{
+	packageNameImpl(t, "gcp-sdk-service-v3", &genclient.CodecOptions{}, &genclient.API{
 		Name:        "test-only-name",
 		PackageName: "google.cloud.service.v3",
 	})
-	packageNameImpl(t, "gcp-sdk-type", &genclient.CodecOptions{
-		Language: "rust",
-	}, &genclient.API{
+	packageNameImpl(t, "gcp-sdk-type", &genclient.CodecOptions{}, &genclient.API{
 		Name:        "type",
 		PackageName: "",
 	})
@@ -889,7 +881,7 @@ func TestFormatDocComments(t *testing.T) {
 	input := `Some comments describing the thing.
 
 The next line has some extra trailing whitespace:
-    
+
 We want to respect whitespace at the beginning, because it important in Markdown:
 - A thing
   - A nested thing

--- a/generator/internal/language/rust/rust_test.go
+++ b/generator/internal/language/rust/rust_test.go
@@ -880,7 +880,7 @@ func TestToPascal(t *testing.T) {
 func TestFormatDocComments(t *testing.T) {
 	input := `Some comments describing the thing.
 
-The next line has some extra trailing whitespace:
+The next line has some extra trailing whitespace:` + "   " + `
 
 We want to respect whitespace at the beginning, because it important in Markdown:
 - A thing

--- a/generator/internal/sidekick/refresh.go
+++ b/generator/internal/sidekick/refresh.go
@@ -46,13 +46,6 @@ func refresh(rootConfig *Config, cmdLine *CommandLine, output string) error {
 		Options:       config.Source,
 	}
 
-	copts := &genclient.CodecOptions{
-		Language:    config.General.Language,
-		OutDir:      output,
-		TemplateDir: config.General.TemplateDir,
-		Options:     config.Codec,
-	}
-
 	var api *genclient.API
 	switch specFormat {
 	case "openapi":
@@ -66,27 +59,33 @@ func refresh(rootConfig *Config, cmdLine *CommandLine, output string) error {
 		return err
 	}
 
-	var codec genclient.LanguageCodec
-	switch copts.Language {
+	var (
+		codec genclient.LanguageCodec
+		copts = &genclient.CodecOptions{
+			OutDir:  output,
+			Options: config.Codec,
+		}
+	)
+	switch config.General.Language {
 	case "rust":
 		codec, err = rust.NewCodec(copts)
 	case "go":
 		codec, err = golang.NewCodec(copts)
 	default:
-		return fmt.Errorf("unknown language: %s", copts.Language)
+		return fmt.Errorf("unknown language: %s", config.General.Language)
 	}
 	if err != nil {
 		return err
 	}
-
 	if err := codec.Validate(api); err != nil {
 		return err
 	}
+
 	request := &genclient.GenerateRequest{
 		API:         api,
 		Codec:       codec,
-		OutDir:      copts.OutDir,
-		TemplateDir: copts.TemplateDir,
+		OutDir:      output,
+		TemplateDir: config.General.TemplateDir,
 	}
 	if cmdLine.DryRun {
 		return nil


### PR DESCRIPTION
Remove unused genclient.CodecOptions and genclient.TemplateDir fields.