### PR TITLE
feat(wkt): enforce range limits in `Duration`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "test-case",
+ "thiserror",
  "time",
 ]
 

--- a/src/gax/src/error/rpc/mod.rs
+++ b/src/gax/src/error/rpc/mod.rs
@@ -364,7 +364,7 @@ mod test {
                     description: "desc".to_string(),
                 }),
                 StatusDetails::RetryInfo(RetryInfo {
-                    retry_delay: Some(wkt::Duration::from_seconds(1)),
+                    retry_delay: Some(wkt::Duration::clamp(1, 0)),
                 }),
             ],
         };
@@ -460,7 +460,7 @@ mod test {
                     description: "desc".to_string(),
                 }),
                 StatusDetails::RetryInfo(RetryInfo {
-                    retry_delay: Some(wkt::Duration::from_seconds(1)),
+                    retry_delay: Some(wkt::Duration::clamp(1, 0)),
                 }),
             ],
         };

--- a/src/gax/src/query_parameter.rs
+++ b/src/gax/src/query_parameter.rs
@@ -149,7 +149,7 @@ mod tests {
 
     #[test]
     fn duration() -> Result {
-        let d = wkt::Duration::new(12, 345_678_900);
+        let d = wkt::Duration::new(12, 345_678_900)?;
         let builder = reqwest::Client::builder()
             .build()?
             .get("https://test.googleapis.com/v1/unused");

--- a/src/gax/src/request_parameter.rs
+++ b/src/gax/src/request_parameter.rs
@@ -103,7 +103,7 @@ mod tests {
 
     #[test]
     fn duration() -> Result {
-        let d = wkt::Duration::new(12, 345_678_900);
+        let d = wkt::Duration::new(12, 345_678_900)?;
         let f = RequestParameter::format(&d)?;
         assert_eq!("12.345678900s", f);
         Ok(())

--- a/src/gax/tests/query_parameters.rs
+++ b/src/gax/tests/query_parameters.rs
@@ -130,7 +130,7 @@ fn with_duration() -> Result<()> {
     // Create a basic request.
     let request = FakeRequest {
         parent: "projects/test-only-invalid".into(),
-        ttl: Some(wkt::Duration::new(12, 345_678_900)),
+        ttl: Some(wkt::Duration::clamp(12, 345_678_900)),
         ..Default::default()
     };
     let builder = with_query_parameters(&request)?;
@@ -189,7 +189,7 @@ fn with_repeated_int32() -> Result<()> {
 fn with_repeated_duration() -> Result<()> {
     let request = FakeRequest {
         parent: "projects/test-only-invalid".into(),
-        repeated_duration: [2, 3, 5].map(wkt::Duration::from_seconds).to_vec(),
+        repeated_duration: [2, 3, 5].map(|s| wkt::Duration::clamp(s, 0)).to_vec(),
         ..Default::default()
     };
     let builder = with_query_parameters(&request)?;

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -28,6 +28,7 @@ serde      = { version = "1.0.214", features = ["serde_derive"] }
 serde_with = { version = "3.11.0" }
 serde_json = "1.0.132"
 time       = { version = "0.3.36", features = ["formatting", "parsing"] }
+thiserror  = "2"
 bytes      = { version = "1.8.0", features = ["serde"] }
 
 [dev-dependencies]

--- a/src/wkt/src/duration.rs
+++ b/src/wkt/src/duration.rs
@@ -39,7 +39,7 @@ pub struct Duration {
     /// Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these
     /// bounds are computed from:
     ///     60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
-    pub seconds: i64,
+    seconds: i64,
 
     /// Signed fractions of a second at nanosecond resolution of the span
     /// of time.
@@ -49,73 +49,97 @@ pub struct Duration {
     /// of one second or more, a non-zero value for the `nanos` field must be
     /// of the same sign as the `seconds` field. Must be from -999,999,999
     /// to +999,999,999 inclusive.
-    pub nanos: i32,
+    nanos: i32,
 }
 
-impl Duration {
-    /// Set the `seconds` field.
-    pub fn set_seconds(mut self, v: i64) -> Self {
-        self.seconds = v;
-        self
-    }
-
-    /// Set the `nanos` field.
-    pub fn set_nanos(mut self, v: i32) -> Self {
-        self.nanos = v;
-        self
-    }
+#[derive(thiserror::Error, Debug)]
+pub enum DurationError {
+    #[error("seconds and/or nanoseconds out of range")]
+    OutOfRange(),
+    #[error("if seconds and nanoseconds are not zero, they must have the same sign")]
+    MismatchedSigns(),
 }
 
-const NS: i32 = 1_000_000_000;
+type Error = DurationError;
 
 impl Duration {
-    /// Create a normalized Duration.
+    const NS: i32 = 1_000_000_000;
+
+    pub const MAX_SECONDS: i64 = 315_576_000_000;
+    pub const MIN_SECONDS: i64 = -Self::MAX_SECONDS;
+    pub const MAX_NANOS: i32 = Self::NS - 1;
+    pub const MIN_NANOS: i32 = -Self::MAX_NANOS;
+
+    /// Create a [Duration].
     ///
     /// Durations must have the same sign in the seconds and nanos field. This
     /// function creates a normalized value.
     ///
     /// `seconds` - the seconds in the interval.
     /// `nanos` - the nanoseconds *added* to the interval.
-    pub fn new(seconds: i64, nanos: i32) -> Self {
-        Self::saturated_add(Self::from_seconds(seconds), Self::from_nanos(nanos))
-    }
-
-    /// Creates a new [Duration] from the specified number of nanoseconds.
-    pub fn from_nanos(nanos: i32) -> Self {
-        Self {
-            seconds: (nanos / NS) as i64,
-            nanos: nanos % NS,
+    pub fn new(seconds: i64, nanos: i32) -> std::result::Result<Self, Error> {
+        if seconds < Self::MIN_SECONDS || seconds > Self::MAX_SECONDS {
+            return Err(Error::OutOfRange());
         }
+        if nanos < Self::MIN_NANOS || nanos > Self::MAX_NANOS {
+            return Err(Error::OutOfRange());
+        }
+        if (seconds != 0 && nanos != 0) && ((seconds < 0) != (nanos < 0)) {
+            return Err(Error::MismatchedSigns());
+        }
+        Ok(Self { seconds, nanos })
     }
 
-    /// Creates a new [Duration] from the specified number of seconds.
-    pub fn from_seconds(seconds: i64) -> Self {
-        Self { seconds, nanos: 0 }
-    }
-
-    fn saturated_add(a: Duration, b: Duration) -> Self {
-        let mut seconds = a.seconds + b.seconds;
-        let mut nanos = a.nanos + b.nanos;
-
-        seconds += (nanos / NS) as i64;
-        nanos %= NS;
+    /// Create a normalized, clamped [Duration].
+    ///
+    /// Durations must be in the [-10_000, +10_000] year range, the nanoseconds
+    /// field must be in the [-999_999_999, +999_999_999] range, and the seconds
+    /// and nanosecond fields must have the same sign. This function creates a
+    /// new [Duration] instance clamped to those ranges.
+    ///
+    /// The function effectively adds the nanoseconds part (with carry) to the
+    /// seconds part, with saturation.
+    ///
+    /// `seconds` - the seconds in the interval.
+    /// `nanos` - the nanoseconds *added* to the interval.
+    pub fn clamp(seconds: i64, nanos: i32) -> Self {
+        let mut seconds = seconds;
+        seconds = seconds.saturating_add((nanos / Self::NS) as i64);
+        let mut nanos = nanos % Self::NS;
         if seconds > 0 && nanos < 0 {
+            seconds = seconds.saturating_sub(1);
+            nanos = Self::NS + nanos;
+        } else if seconds < 0 && nanos > 0 {
+            seconds = seconds.saturating_add(1);
+            nanos = -(Self::NS - nanos);
+        }
+        if seconds > Self::MAX_SECONDS {
             return Self {
-                seconds: seconds - 1,
-                nanos: NS + nanos,
+                seconds: Self::MAX_SECONDS,
+                nanos: 0,
             };
         }
-        if seconds < 0 && nanos > 0 {
+        if seconds < Self::MIN_SECONDS {
             return Self {
-                seconds: seconds + 1,
-                nanos: -(NS - nanos),
+                seconds: Self::MIN_SECONDS,
+                nanos: 0,
             };
         }
-        Self { seconds, nanos }
+        return Self { seconds, nanos };
+    }
+
+    /// Returns the seconds part of the duration.
+    pub fn seconds(&self) -> i64 {
+        self.seconds
+    }
+
+    /// Returns the sub-second part of the duration.
+    pub fn nanos(&self) -> i32 {
+        self.nanos
     }
 }
 
-/// Implement [`serde`](::serde) serialization for Duration.
+/// Implement [`serde`](::serde) serialization for [Duration].
 impl serde::ser::Serialize for Duration {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
@@ -173,14 +197,15 @@ impl<'de> serde::de::Visitor<'de> for DurationVisitor {
             .transpose()
             .map_err(Error::custom)?;
 
-        Ok(Duration {
-            seconds: sign * seconds.unwrap_or(0),
-            nanos: sign as i32 * nanos.unwrap_or(0),
-        })
+        let d = Duration::new(
+            sign * seconds.unwrap_or(0),
+            sign as i32 * nanos.unwrap_or(0),
+        ).map_err(E::custom)?;
+        Ok(d)
     }
 }
 
-/// Implement [`serde`](::serde) deserialization for timestamps.
+/// Implement [`serde`](::serde) deserialization for [`Duration`].
 impl<'de> serde::de::Deserialize<'de> for Duration {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -212,7 +237,62 @@ mod test {
         Ok(())
     }
 
-    // Verify 0 converts as expected.
+    // Google assumes all minutes have 60 seconds. Leap seconds are handled via
+    // smearing.
+    const SECONDS_IN_DAY: i64 = 24 * 60 * 60;
+    // For the purposes of this Duration type, Google ignores the subtleties of
+    // leap years on multiples of 100 and 400.
+    const SECONDS_IN_YEAR: i64 = 365 * SECONDS_IN_DAY + SECONDS_IN_DAY / 4;
+
+    #[test_case(10_000 * SECONDS_IN_YEAR , 0 ; "exactly 10,000 years")]
+    #[test_case(- 10_000 * SECONDS_IN_YEAR , 0 ; "exactly negative 10,000 years")]
+    #[test_case(10_000 * SECONDS_IN_YEAR , 999_999_999 ; "exactly 10,000 years and 999,999,999 nanos")]
+    #[test_case(- 10_000 * SECONDS_IN_YEAR , -999_999_999 ; "exactly negative 10,000 years and 999,999,999 nanos")]
+    #[test_case(0, 999_999_999 ; "exactly 999,999,999 nanos")]
+    #[test_case(0 , -999_999_999 ; "exactly negative 999,999,999 nanos")]
+    fn edge_of_range(seconds: i64, nanos: i32) -> Result {
+        let d = Duration::new(seconds, nanos)?;
+        assert_eq!(seconds, d.seconds());
+        assert_eq!(nanos, d.nanos());
+        Ok(())
+    }
+
+    #[test_case(10_000 * SECONDS_IN_YEAR + 1, 0 ; "more seconds than in 10,000 years")]
+    #[test_case(- 10_000 * SECONDS_IN_YEAR - 1, 0 ; "more negative seconds than in -10,000 years")]
+    #[test_case(0, 1_000_000_000 ; "too many positive nanoseconds")]
+    #[test_case(0, -1_000_000_000 ; "too many negative nanoseconds")]
+    fn out_of_range(seconds: i64, nanos: i32) -> Result {
+        let d = Duration::new(seconds, nanos);
+        assert!(d.is_err());
+        match d.as_ref().err().unwrap() {
+            Error::OutOfRange() => {}
+            _ => {
+                assert!(false, "expected an OutOfRange error, got={:?}", d);
+            }
+        }
+        Ok(())
+    }
+
+    #[test_case(1 , -1 ; "mismatched sign case 1")]
+    #[test_case(-1 , 1 ; "mismatched sign case 2")]
+    fn mismatched_sign(seconds: i64, nanos: i32) -> Result {
+        let d = Duration::new(seconds, nanos);
+        assert!(d.is_err());
+        match d.as_ref().err().unwrap() {
+            Error::MismatchedSigns() => {}
+            _ => {
+                assert!(false, "expected an MismatchedSigns error, got={:?}", d);
+            }
+        }
+        Ok(())
+    }
+
+    #[test_case(20_000 * SECONDS_IN_YEAR, 0, 10_000 * SECONDS_IN_YEAR, 0 ; "too many positive seconds")]
+    #[test_case(-20_000 * SECONDS_IN_YEAR, 0, -10_000 * SECONDS_IN_YEAR, 0 ; "too many negative seconds")]
+    #[test_case(10_000 * SECONDS_IN_YEAR - 1, 1_999_999_999, 10_000 * SECONDS_IN_YEAR, 999_999_999 ; "upper edge of range")]
+    #[test_case(-10_000 * SECONDS_IN_YEAR + 1, -1_999_999_999, -10_000 * SECONDS_IN_YEAR, -999_999_999 ; "lower edge of range")]
+    #[test_case(10_000 * SECONDS_IN_YEAR - 1 , 2 * 1_000_000_000_i32, 10_000 * SECONDS_IN_YEAR, 0 ; "nanos push over 10,000 years")]
+    #[test_case(-10_000 * SECONDS_IN_YEAR + 1, -2 * 1_000_000_000_i32, -10_000 * SECONDS_IN_YEAR, 0 ; "one push under -10,000 years")]
     #[test_case(0, 0, 0, 0 ; "all inputs are zero")]
     #[test_case(1, 0, 1, 0 ; "positive seconds and zero nanos")]
     #[test_case(1, 200_000, 1, 200_000 ; "positive seconds and nanos")]
@@ -220,28 +300,17 @@ mod test {
     #[test_case(-1, -500_000_000, -1, -500_000_000; "negative seconds and nanos")]
     #[test_case(2, -400_000_000, 1, 600_000_000; "positive seconds and negative nanos")]
     #[test_case(-2, 400_000_000, -1, -600_000_000; "negative seconds and positive nanos")]
-    fn normalize(seconds: i64, nanos: i32, want_seconds: i64, want_nanos: i32) {
-        let got = Duration::new(seconds, nanos);
+    fn clamp(seconds: i64, nanos: i32, want_seconds: i64, want_nanos: i32) -> Result {
+        let got = Duration::clamp(seconds, nanos);
         let want = Duration {
             seconds: want_seconds,
             nanos: want_nanos,
         };
         assert_eq!(want, got);
+        Ok(())
     }
 
-    #[test_case(0, 0, 0; "zero nanos")]
-    #[test_case(1_000_000_000, 1, 0; "one second")]
-    #[test_case(1_200_000_000, 1, 200_000_000; "one second and 200ms")]
-    #[test_case(-1_200_000_000, -1, -200_000_000; "minus one second and 200ms")]
-    fn from_nanos(nanos: i32, want_seconds: i64, want_nanos: i32) {
-        let got = Duration::from_nanos(nanos);
-        let want = Duration {
-            seconds: want_seconds,
-            nanos: want_nanos,
-        };
-        assert_eq!(want, got);
-    }
-
+    // Verify durations can roundtrip from string -> struct -> string without loss.
     #[test_case(0, 0, "0s" ; "zero")]
     #[test_case(12, 0, "12s"; "round positive seconds")]
     #[test_case(12, 123, "12.000000123s"; "positive seconds and nanos")]
@@ -253,30 +322,27 @@ mod test {
     #[test_case(-12, -123_000, "-12.000123000s"; "negative seconds and micros")]
     #[test_case(-12, -123_000_000, "-12.123000000s"; "negative seconds and millis")]
     #[test_case(-12, -123_456_789, "-12.123456789s"; "negative seconds and full nanos")]
-    fn serialize(seconds: i64, nanos: i32, want: &str) -> Result {
-        let got = serde_json::to_value(Duration { seconds, nanos })?
+    #[test_case(-10_000 * SECONDS_IN_YEAR, -999_999_999, "-315576000000.999999999s"; "range edge start")]
+    #[test_case(10_000 * SECONDS_IN_YEAR, 999_999_999, "315576000000.999999999s"; "range edge end")]
+    fn roundtrip(seconds: i64, nanos: i32, want: &str) -> Result {
+        let input = Duration::new(seconds, nanos)?;
+        let got = serde_json::to_value(&input)?
             .as_str()
             .map(str::to_string)
             .ok_or("cannot convert value to string")?;
         assert_eq!(want, got);
+
+        let rt = serde_json::from_value::<Duration>(serde_json::Value::String(got))?;
+        assert_eq!(input, rt);
         Ok(())
     }
 
-    // Verify durations can roundtrip from string -> struct -> string without loss.
-    #[test]
-    fn roundtrip() -> Result {
-        let inputs = vec!["-315576000000.999999999s", "315576000000.999999999s"];
-
-        for input in inputs {
-            let json = serde_json::Value::String(input.to_string());
-            let timestamp = serde_json::from_value::<Duration>(json)?;
-            let roundtrip = serde_json::to_string(&timestamp)?;
-            assert_eq!(
-                format!("\"{input}\""),
-                roundtrip,
-                "mismatched value for input={input}"
-            );
-        }
+    #[test_case("-315576000001s"; "range edge start")]
+    #[test_case("315576000001s"; "range edge end")]
+    fn deserialize_out_of_range(input: &str) -> Result {
+        let value = serde_json::to_value(&input)?;
+        let got = serde_json::from_value::<Duration>(value);
+        assert!(got.is_err());
         Ok(())
     }
 }

--- a/src/wkt/src/duration.rs
+++ b/src/wkt/src/duration.rs
@@ -200,7 +200,8 @@ impl<'de> serde::de::Visitor<'de> for DurationVisitor {
         let d = Duration::new(
             sign * seconds.unwrap_or(0),
             sign as i32 * nanos.unwrap_or(0),
-        ).map_err(E::custom)?;
+        )
+        .map_err(E::custom)?;
         Ok(d)
     }
 }

--- a/src/wkt/tests/any.rs
+++ b/src/wkt/tests/any.rs
@@ -41,7 +41,7 @@ fn roundtrip_generic() -> Result {
 
 #[test]
 fn roundtrip_duration() -> Result {
-    let input = Duration::new(12, 3456);
+    let input = Duration::new(12, 3456)?;
     let any = Any::from(&input)?;
     let json = serde_json::to_value(any)?;
     let any = serde_json::from_value::<Any>(json)?;

--- a/src/wkt/tests/duration.rs
+++ b/src/wkt/tests/duration.rs
@@ -32,15 +32,12 @@ fn access() {
 
 #[test]
 fn serialize_in_struct() -> Result {
-    let input = Helper {
-        ..Default::default()
-    };
+    let input = Helper::default();
     let json = serde_json::to_value(input)?;
     assert_eq!(json, json!({}));
 
     let input = Helper {
         time_to_live: Some(Duration::clamp(12, 345678900)),
-        ..Default::default()
     };
 
     let json = serde_json::to_value(input)?;
@@ -51,16 +48,13 @@ fn serialize_in_struct() -> Result {
 #[test]
 fn deserialize_in_struct() -> Result {
     let input = json!({});
-    let want = Helper {
-        ..Default::default()
-    };
+    let want = Helper::default();
     let got = serde_json::from_value::<Helper>(input)?;
     assert_eq!(want, got);
 
     let input = json!({ "timeToLive": "12.345678900s" });
     let want = Helper {
         time_to_live: Some(Duration::clamp(12, 345678900)),
-        ..Default::default()
     };
     let got = serde_json::from_value::<Helper>(input)?;
     assert_eq!(want, got);

--- a/src/wkt/tests/duration.rs
+++ b/src/wkt/tests/duration.rs
@@ -26,8 +26,8 @@ pub struct Helper {
 #[test]
 fn access() {
     let d = Duration::default();
-    assert_eq!(d.nanos, 0);
-    assert_eq!(d.seconds, 0);
+    assert_eq!(d.nanos(), 0);
+    assert_eq!(d.seconds(), 0);
 }
 
 #[test]
@@ -39,7 +39,7 @@ fn serialize_in_struct() -> Result {
     assert_eq!(json, json!({}));
 
     let input = Helper {
-        time_to_live: Some(Duration::new(12, 345678900)),
+        time_to_live: Some(Duration::clamp(12, 345678900)),
         ..Default::default()
     };
 
@@ -59,7 +59,7 @@ fn deserialize_in_struct() -> Result {
 
     let input = json!({ "timeToLive": "12.345678900s" });
     let want = Helper {
-        time_to_live: Some(Duration::new(12, 345678900)),
+        time_to_live: Some(Duration::clamp(12, 345678900)),
         ..Default::default()
     };
     let got = serde_json::from_value::<Helper>(input)?;
@@ -70,9 +70,9 @@ fn deserialize_in_struct() -> Result {
 #[test]
 fn compare() {
     let ts0 = Duration::default();
-    let ts1 = Duration::default().set_seconds(1).set_nanos(100);
-    let ts2 = Duration::default().set_seconds(1).set_nanos(200);
-    let ts3 = Duration::default().set_seconds(2);
+    let ts1 = Duration::clamp(1, 100);
+    let ts2 = Duration::clamp(1, 200);
+    let ts3 = Duration::clamp(2, 0);
     assert_eq!(ts0.partial_cmp(&ts0), Some(std::cmp::Ordering::Equal));
     assert_eq!(ts0.partial_cmp(&ts1), Some(std::cmp::Ordering::Less));
     assert_eq!(ts2.partial_cmp(&ts3), Some(std::cmp::Ordering::Less));


### PR DESCRIPTION
The `Duration` type only supports values in the range
`[-10_000, 10_000]` years (plus 10^9-1 nanos). Any other values result
in undefined behavior. It seems worthwhile to enforce this restriction,
as opposed to letting things fail on serialization or (worse) silently
convert to an invalid duration.

Part of the work for #328 