### PR TITLE
feat(wkt): enforce range limits in `Timestamp`

### DIFF
--- a/src/gax/tests/query_parameters.rs
+++ b/src/gax/tests/query_parameters.rs
@@ -147,11 +147,7 @@ fn with_timestamp() -> Result<()> {
     // Create a basic request.
     let request = FakeRequest {
         parent: "projects/test-only-invalid".into(),
-        expiration: Some(
-            wkt::Timestamp::default()
-                .set_seconds(12)
-                .set_nanos(345_678_900),
-        ),
+        expiration: Some(wkt::Timestamp::new(12, 345_678_900)?),
         ..Default::default()
     };
     let builder = with_query_parameters(&request)?;

--- a/src/integration-tests/src/secret_manager/openapi_locational.rs
+++ b/src/integration-tests/src/secret_manager/openapi_locational.rs
@@ -366,7 +366,7 @@ async fn cleanup_stale_secrets(
         .duration_since(UNIX_EPOCH)
         .map_err(Error::other)?;
     let stale_deadline = stale_deadline - Duration::from_secs(48 * 60 * 60);
-    let stale_deadline = wkt::Timestamp::default().set_seconds(stale_deadline.as_secs() as i64);
+    let stale_deadline = wkt::Timestamp::clamp(stale_deadline.as_secs() as i64, 0);
 
     let mut stale_secrets = Vec::new();
     let mut page_token = None::<String>;

--- a/src/integration-tests/src/secret_manager/protobuf.rs
+++ b/src/integration-tests/src/secret_manager/protobuf.rs
@@ -334,7 +334,7 @@ async fn cleanup_stale_secrets(
         .duration_since(UNIX_EPOCH)
         .map_err(Error::other)?;
     let stale_deadline = stale_deadline - Duration::from_secs(48 * 60 * 60);
-    let stale_deadline = wkt::Timestamp::default().set_seconds(stale_deadline.as_secs() as i64);
+    let stale_deadline = wkt::Timestamp::clamp(stale_deadline.as_secs() as i64, 0);
 
     let mut stale_secrets = Vec::new();
     let mut list_request =

--- a/src/wkt/tests/timestamp.rs
+++ b/src/wkt/tests/timestamp.rs
@@ -39,8 +39,7 @@ fn serialize_in_struct() -> Result {
     assert_eq!(json, json!({}));
 
     let input = Helper {
-        create_time: Some(Timestamp::default().set_seconds(12).set_nanos(345_678_900)),
-        ..Default::default()
+        create_time: Some(Timestamp::new(12, 345_678_900)?),
     };
 
     let json = serde_json::to_value(input)?;
@@ -62,8 +61,7 @@ fn deserialize_in_struct() -> Result {
 
     let input = json!({ "createTime": "1970-01-01T00:00:12.3456789Z" });
     let want = Helper {
-        create_time: Some(Timestamp::default().set_seconds(12).set_nanos(345678900)),
-        ..Default::default()
+        create_time: Some(Timestamp::new(12, 345678900)?),
     };
     let got = serde_json::from_value::<Helper>(input)?;
     assert_eq!(want, got);
@@ -71,12 +69,13 @@ fn deserialize_in_struct() -> Result {
 }
 
 #[test]
-fn compare() {
+fn compare() -> Result {
     let ts0 = Timestamp::default();
-    let ts1 = Timestamp::default().set_seconds(1).set_nanos(100);
-    let ts2 = Timestamp::default().set_seconds(1).set_nanos(200);
-    let ts3 = Timestamp::default().set_seconds(2);
+    let ts1 = Timestamp::new(1, 100)?;
+    let ts2 = Timestamp::new(1, 200)?;
+    let ts3 = Timestamp::new(2, 0)?;
     assert_eq!(ts0.partial_cmp(&ts0), Some(std::cmp::Ordering::Equal));
     assert_eq!(ts0.partial_cmp(&ts1), Some(std::cmp::Ordering::Less));
     assert_eq!(ts2.partial_cmp(&ts3), Some(std::cmp::Ordering::Less));
+    Ok(())
 }


### PR DESCRIPTION
The `Timestamp` type only supports values in the range
`[0001-01-01T00:00:00Z, 9999-12-31T23:59:59.999999999Z]`. Any other
values result in undefined behavior. It seems worthwhile to enforce this
restriction, as opposed to leeting things fail on serialization or
(worse) silently convert to an invalid timestamp.

Fixes #328 