### PR TITLE
impl(internal/parser): move genclient.SplitApiName and genclient.WellKnownMixin

### DIFF
--- a/generator/internal/parser/common.go
+++ b/generator/internal/parser/common.go
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package genclient
+package parser
 
 import "strings"
 
-func SplitApiName(name string) (string, string) {
+func splitApiName(name string) (string, string) {
 	li := strings.LastIndex(name, ".")
 	if li == -1 {
 		return "", name
@@ -24,7 +24,7 @@ func SplitApiName(name string) (string, string) {
 	return name[:li], name[li+1:]
 }
 
-func WellKnownMixin(apiName string) bool {
+func wellKnownMixin(apiName string) bool {
 	return strings.HasPrefix(apiName, "google.cloud.location.Location") ||
 		strings.HasPrefix(apiName, "google.longrunning.Operations") ||
 		strings.HasPrefix(apiName, "google.iam.v1.IAMPolicy")

--- a/generator/internal/parser/openapi.go
+++ b/generator/internal/parser/openapi.go
@@ -89,9 +89,9 @@ func makeAPIForOpenAPI(serviceConfig *serviceconfig.Service, model *libopenapi.D
 	packageName := ""
 	if serviceConfig != nil {
 		for _, api := range serviceConfig.Apis {
-			packageName, serviceName = genclient.SplitApiName(api.Name)
+			packageName, serviceName = splitApiName(api.Name)
 			// Keep searching after well-known mixin services.
-			if !genclient.WellKnownMixin(api.Name) {
+			if !wellKnownMixin(api.Name) {
 				break
 			}
 		}

--- a/generator/internal/parser/protobuf.go
+++ b/generator/internal/parser/protobuf.go
@@ -224,9 +224,9 @@ func makeAPIForProtobuf(serviceConfig *serviceconfig.Service, req *pluginpb.Code
 		enabledMixinMethods, mixinFileDesc = loadMixins(serviceConfig)
 		packageName := ""
 		for _, api := range serviceConfig.Apis {
-			packageName, _ = genclient.SplitApiName(api.Name)
+			packageName, _ = splitApiName(api.Name)
 			// Keep searching after well-known mixin services.
-			if !genclient.WellKnownMixin(api.Name) {
+			if !wellKnownMixin(api.Name) {
 				break
 			}
 		}


### PR DESCRIPTION
Now that protobuf and openapi are in the same package, move genclient.SplitApiName and genclient.WellKnownMixin to package parser and unexport them, since that is the open place these function are used.