### PR TITLE
impl(internal/parser): remove ParserOptions

### DIFF
--- a/generator/internal/parser/openapi.go
+++ b/generator/internal/parser/openapi.go
@@ -30,8 +30,8 @@ import (
 	"google.golang.org/genproto/googleapis/api/serviceconfig"
 )
 
-func ParseOpenAPI(opts ParserOptions) (*api.API, error) {
-	contents, err := os.ReadFile(opts.Source)
+func ParseOpenAPI(source, serviceConfigFile string, options map[string]string) (*api.API, error) {
+	contents, err := os.ReadFile(source)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +40,8 @@ func ParseOpenAPI(opts ParserOptions) (*api.API, error) {
 		return nil, err
 	}
 	var serviceConfig *serviceconfig.Service
-	if opts.ServiceConfig != "" {
-		cfg, err := readServiceConfig(findServiceConfigPath(opts))
+	if serviceConfigFile != "" {
+		cfg, err := readServiceConfig(findServiceConfigPath(serviceConfigFile, options))
 		if err != nil {
 			return nil, err
 		}

--- a/generator/internal/parser/parser.go
+++ b/generator/internal/parser/parser.go
@@ -16,15 +16,6 @@ package parser
 
 import "strings"
 
-type ParserOptions struct {
-	// The location where the specification can be found.
-	Source string
-	// The location of the service configuration file.
-	ServiceConfig string
-	// Additional options.
-	Options map[string]string
-}
-
 func splitApiName(name string) (string, string) {
 	li := strings.LastIndex(name, ".")
 	if li == -1 {

--- a/generator/internal/parser/protobuf_test.go
+++ b/generator/internal/parser/protobuf_test.go
@@ -999,14 +999,11 @@ func TestProtobuf_OperationMixin(t *testing.T) {
 
 func newTestCodeGeneratorRequest(t *testing.T, filename string) *pluginpb.CodeGeneratorRequest {
 	t.Helper()
-	popts := ParserOptions{
-		Source: filename,
-		Options: map[string]string{
-			"googleapis-root": "../../testdata/googleapis",
-			"test-root":       "testdata",
-		},
+	options := map[string]string{
+		"googleapis-root": "../../testdata/googleapis",
+		"test-root":       "testdata",
 	}
-	request, err := newCodeGeneratorRequest(popts)
+	request, err := newCodeGeneratorRequest(filename, options)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/generator/internal/parser/service_config.go
+++ b/generator/internal/parser/service_config.go
@@ -53,14 +53,14 @@ func readServiceConfig(serviceConfigPath string) (*serviceconfig.Service, error)
 // The service config files are specified as relative to the `googleapis-root`
 // path (or `test-root` when set). This finds the right path given a
 // configuration
-func findServiceConfigPath(config ParserOptions) string {
+func findServiceConfigPath(serviceConfigFile string, options map[string]string) string {
 	for _, opt := range []string{"test-root", "googleapis-root"} {
-		dir, ok := config.Options[opt]
+		dir, ok := options[opt]
 		if !ok {
 			// Ignore options that are not set
 			continue
 		}
-		location := path.Join(dir, config.ServiceConfig)
+		location := path.Join(dir, serviceConfigFile)
 		stat, err := os.Stat(location)
 		if err == nil && stat.Mode().IsRegular() {
 			return location
@@ -68,5 +68,5 @@ func findServiceConfigPath(config ParserOptions) string {
 	}
 	// Fallback to the current directory, it may fail but that is detected
 	// elsewhere.
-	return config.ServiceConfig
+	return serviceConfigFile
 }

--- a/generator/internal/sidekick/refresh.go
+++ b/generator/internal/sidekick/refresh.go
@@ -37,21 +37,14 @@ func refresh(rootConfig *Config, cmdLine *CommandLine, output string) error {
 		return fmt.Errorf("must provide general.specification-source")
 	}
 
-	specFormat := config.General.SpecificationFormat
-	popts := &parser.ParserOptions{
-		Source:        config.General.SpecificationSource,
-		ServiceConfig: config.General.ServiceConfig,
-		Options:       config.Source,
-	}
-
 	var a *api.API
-	switch specFormat {
+	switch config.General.SpecificationFormat {
 	case "openapi":
-		a, err = parser.ParseOpenAPI(*popts)
+		a, err = parser.ParseOpenAPI(config.General.SpecificationSource, config.General.ServiceConfig, config.Source)
 	case "protobuf":
-		a, err = parser.ParseProtobuf(*popts)
+		a, err = parser.ParseProtobuf(config.General.SpecificationSource, config.General.ServiceConfig, config.Source)
 	default:
-		return fmt.Errorf("unknown parser %q", specFormat)
+		return fmt.Errorf("unknown parser %q", config.General.SpecificationFormat)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
parser.ParserOptions has been removed because it only contained a few fields and created an extra level of indirection. These fields are now passed directly as arguments to the functions where they are needed.