### PR TITLE
fix(gax): wrong package name in code snippet

### DIFF
--- a/src/gax/src/error/core_error.rs
+++ b/src/gax/src/error/core_error.rs
@@ -67,8 +67,8 @@ impl Error {
     /// # Examples
     ///
     /// ```
-    /// # use gax::error::Error;
-    /// # use gax::error::HttpError;
+    /// # use gcp_sdk_gax::error::Error;
+    /// # use gcp_sdk_gax::error::HttpError;
     /// # use std::collections::HashMap;
     /// let error: Error = HttpError::new(404, HashMap::new(), None).into();
     /// if let Some(e) = error.as_inner::<HttpError>() {


### PR DESCRIPTION
The code snippet could not compile because it used the wrong package
name. This went undetected, as we disabled the documentation tests
(see #92 for details).

