### PR TITLE
feat(wkt): convert traits for `Timestamp`

### DIFF
--- a/src/wkt/tests/timestamp.rs
+++ b/src/wkt/tests/timestamp.rs
@@ -79,3 +79,23 @@ fn compare() -> Result {
     assert_eq!(ts2.partial_cmp(&ts3), Some(std::cmp::Ordering::Less));
     Ok(())
 }
+
+#[test]
+fn convert_from_time() -> Result {
+    let ts =
+        time::OffsetDateTime::from_unix_timestamp(123)? + time::Duration::nanoseconds(456789012);
+    let got = Timestamp::try_from(ts)?;
+    let want = Timestamp::new(123, 456789012)?;
+    assert_eq!(got, want);
+    Ok(())
+}
+
+#[test]
+fn convert_to_time() -> Result {
+    let ts = Timestamp::new(123, 456789012)?;
+    let got = time::OffsetDateTime::try_from(ts)?;
+    let want =
+        time::OffsetDateTime::from_unix_timestamp(123)? + time::Duration::nanoseconds(456789012);
+    assert_eq!(got, want);
+    Ok(())
+}


### PR DESCRIPTION
`Timestamp` objects can be converted to `tim::OffsetDateTime`. These
traits are only enabled if the `time` feature is enabled. The `time`
crate is not (yet) 1.0, we do not want to expose these in our API
by default.

We do not provide conversion to `std::time::Instant`. Those are often
used with timers and other deadlines. Semantically they represent
different things, or at least different use-cases for the same thing.

Fixes #51