### PR TITLE
ci: enable docs testing

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -33,9 +33,7 @@ jobs:
         run: cargo version
       - name: Display rustc version
         run: rustc --version
-        # TODO(#92) - disable the doc tests because the generated code contains non-rusty blockquotes
-      - run: cargo test --lib --bins --tests
-      - run: cargo test --package gcp-sdk-wkt --package google-cloud-auth --package check-copyright
+      - run: cargo test
   lint:
     runs-on: ubuntu-24.04
     strategy:


### PR DESCRIPTION
The generator protects enough code blocks to enable these tests.