### PR TITLE
feat(wkt): conversion traits for `Duration`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,7 @@ name = "gcp-sdk-wkt"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "gcp-sdk-wkt",
  "serde",
  "serde_json",
  "serde_with",

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -23,6 +23,9 @@ repository.workspace = true
 keywords.workspace   = true
 categories.workspace = true
 
+[features]
+time = []
+
 [dependencies]
 serde      = { version = "1.0.214", features = ["serde_derive"] }
 serde_with = { version = "3.11.0" }
@@ -35,3 +38,4 @@ bytes      = { version = "1.8.0", features = ["serde"] }
 test-case  = "3.3.1"
 bytes      = { version = "1.8.0", features = ["serde"] }
 serde_with = { version = "3.11.0", features = ["base64"] }
+wkt        = { path = ".", package = "gcp-sdk-wkt", features = ["time"] }

--- a/src/wkt/tests/duration.rs
+++ b/src/wkt/tests/duration.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use gcp_sdk_wkt::Duration;
+use gcp_sdk_wkt::{Duration, DurationError};
 use serde_json::json;
 type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
@@ -70,4 +70,36 @@ fn compare() {
     assert_eq!(ts0.partial_cmp(&ts0), Some(std::cmp::Ordering::Equal));
     assert_eq!(ts0.partial_cmp(&ts1), Some(std::cmp::Ordering::Less));
     assert_eq!(ts2.partial_cmp(&ts3), Some(std::cmp::Ordering::Less));
+}
+
+#[test]
+fn from_std_time_duration() -> Result {
+    let std_d = std::time::Duration::new(123, 456789012);
+    let got = Duration::try_from(std_d)?;
+    let want = Duration::new(123, 456789012)?;
+    assert_eq!(got, want);
+
+    let std_d = std::time::Duration::new(i64::MAX as u64 + 2, 0);
+    let got = Duration::try_from(std_d);
+    assert_eq!(got, Err(DurationError::OutOfRange()));
+
+    Ok(())
+}
+
+#[test]
+fn std_from_duration() -> Result {
+    let dur = Duration::new(123, 456789012)?;
+    let got = std::time::Duration::try_from(dur)?;
+    let want = std::time::Duration::new(123, 456789012);
+    assert_eq!(got, want);
+
+    let dur = Duration::new(-10, 0)?;
+    let got = std::time::Duration::try_from(dur);
+    assert_eq!(got, Err(DurationError::OutOfRange()));
+
+    let dur = Duration::new(0, -10)?;
+    let got = std::time::Duration::try_from(dur);
+    assert_eq!(got, Err(DurationError::OutOfRange()));
+
+    Ok(())
 }


### PR DESCRIPTION
Implement traits to convert `Duration` to `std::time::Duration` (and
vice-versa) and traits to convert `Duration` to `time::Duration` (and
vice-versa). The latter are protected by a feature.

We cannot safely convert from `std::time::Duration` to the
`wkt::Duration` because Rust has higher maximum value.

We cannot safely convert from `wkt::Duration` to `std::time::Duration`
because `wkt::Duration`s can be negative, while Rust supports only
positive intervals.

But in the normal case something like `Duration::try_from(x)?` should
work in both directions.

It is always safe to convert `Duration` to `time::Duration`, but not in the
opposite direction.

Finally, `time::Duration` is protected by a feature because the `time` crate is
not 1.0, and we should avoid unstable APIs in our own APIs.

Fixes #50 