### PR TITLE
fix: need `sdk_client` feature with gax

### DIFF
--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -22,6 +22,6 @@ googleapis-root   = 'https://github.com/googleapis/googleapis/archive/2d08f07eab
 googleapis-sha256 = 'eb853d49313f20a096607fea87dfc10bd6a1b917ad17ad5db8a205b457a940e1'
 
 [codec]
-'package:gax'               = 'package=gcp-sdk-gax,path=src/gax'
+'package:gax'               = 'package=gcp-sdk-gax,path=src/gax,feature=sdk_client'
 'package:wkt'               = 'package=gcp-sdk-wkt,path=src/wkt,source=google.protobuf'
 'package:google-cloud-auth' = 'package=google-cloud-auth,path=auth'

--- a/src/generated/cloud/location/Cargo.toml
+++ b/src/generated/cloud/location/Cargo.toml
@@ -32,6 +32,6 @@ serde_json = "1.0.132"
 time       = { version = "0.3.36", features = ["formatting", "parsing"] }
 reqwest    = { version = "0.12.9", features = ["json"] }
 bytes      = { version = "1.8.0", features = ["serde"] }
-gax        = { path = "../../../../src/gax", package = "gcp-sdk-gax" }
+gax        = { path = "../../../../src/gax", package = "gcp-sdk-gax", features = ["sdk_client"] }
 google-cloud-auth = { path = "../../../../auth", package = "google-cloud-auth" }
 wkt        = { path = "../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/cloud/secretmanager/v1/Cargo.toml
+++ b/src/generated/cloud/secretmanager/v1/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1.0.132"
 time       = { version = "0.3.36", features = ["formatting", "parsing"] }
 reqwest    = { version = "0.12.9", features = ["json"] }
 bytes      = { version = "1.8.0", features = ["serde"] }
-gax        = { path = "../../../../../src/gax", package = "gcp-sdk-gax" }
+gax        = { path = "../../../../../src/gax", package = "gcp-sdk-gax", features = ["sdk_client"] }
 google-cloud-auth = { path = "../../../../../auth", package = "google-cloud-auth" }
 iam_v1     = { path = "../../../../../src/generated/iam/v1", package = "gcp-sdk-iam-v1" }
 location   = { path = "../../../../../src/generated/cloud/location", package = "gcp-sdk-location" }

--- a/src/generated/iam/v1/Cargo.toml
+++ b/src/generated/iam/v1/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1.0.132"
 time       = { version = "0.3.36", features = ["formatting", "parsing"] }
 reqwest    = { version = "0.12.9", features = ["json"] }
 bytes      = { version = "1.8.0", features = ["serde"] }
-gax        = { path = "../../../../src/gax", package = "gcp-sdk-gax" }
+gax        = { path = "../../../../src/gax", package = "gcp-sdk-gax", features = ["sdk_client"] }
 google-cloud-auth = { path = "../../../../auth", package = "google-cloud-auth" }
 gtype      = { path = "../../../../src/generated/type", package = "gcp-sdk-type" }
 wkt        = { path = "../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/type/Cargo.toml
+++ b/src/generated/type/Cargo.toml
@@ -32,6 +32,6 @@ serde_json = "1.0.132"
 time       = { version = "0.3.36", features = ["formatting", "parsing"] }
 reqwest    = { version = "0.12.9", features = ["json"] }
 bytes      = { version = "1.8.0", features = ["serde"] }
-gax        = { path = "../../../src/gax", package = "gcp-sdk-gax" }
+gax        = { path = "../../../src/gax", package = "gcp-sdk-gax", features = ["sdk_client"] }
 google-cloud-auth = { path = "../../../auth", package = "google-cloud-auth" }
 wkt        = { path = "../../../src/wkt", package = "gcp-sdk-wkt" }


### PR DESCRIPTION
Almost all generated crates will need this feature, and without them
the packages do not compile.

Motivated by #353
