### PR TITLE
cleanup(wkt): prepare for Rust 1.83

### DIFF
--- a/src/wkt/src/duration.rs
+++ b/src/wkt/src/duration.rs
@@ -215,7 +215,7 @@ impl serde::ser::Serialize for Duration {
 
 struct DurationVisitor;
 
-impl<'de> serde::de::Visitor<'de> for DurationVisitor {
+impl serde::de::Visitor<'_> for DurationVisitor {
     type Value = Duration;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/src/wkt/src/field_mask.rs
+++ b/src/wkt/src/field_mask.rs
@@ -275,7 +275,7 @@ where
     deserializer.deserialize_str(PathVisitor)
 }
 
-impl<'de> serde::de::Visitor<'de> for PathVisitor {
+impl serde::de::Visitor<'_> for PathVisitor {
     type Value = Vec<String>;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/src/wkt/src/timestamp.rs
+++ b/src/wkt/src/timestamp.rs
@@ -157,7 +157,7 @@ impl serde::ser::Serialize for Timestamp {
 
 struct TimestampVisitor;
 
-impl<'de> serde::de::Visitor<'de> for TimestampVisitor {
+impl serde::de::Visitor<'_> for TimestampVisitor {
     type Value = Timestamp;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {


### PR DESCRIPTION
The next version of clippy simplified some of our code.
