### PR TITLE
feat(generator): mark messages as pageable responses

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -210,6 +210,9 @@ type Message struct {
 	// The Protobuf package this message belongs to.
 	Package string
 	IsMap   bool
+	// IsPageableResponse indicated that this Message is returned by a standard
+	// List RPC and conforms to [AIP-4233](https://google.aip.dev/client-libraries/4233).
+	IsPageableResponse bool
 }
 
 // Enum defines a message used in request/response handling.

--- a/generator/internal/parser/openapi_test.go
+++ b/generator/internal/parser/openapi_test.go
@@ -617,6 +617,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 				Optional:      true,
 			},
 		},
+		IsPageableResponse: true,
 	})
 
 	// This is a synthetic message, the OpenAPI spec does not contain requests
@@ -893,6 +894,32 @@ func TestOpenAPI_Pagination(t *testing.T) {
 					QueryParameters: map[string]bool{"pageSize": true, "pageToken": true},
 				},
 				IsPageable: true,
+			},
+		},
+	})
+	resp, ok := test.State.MessageByID["..ListFoosResponse"]
+	if !ok {
+		t.Errorf("missing message (ListFoosResponse) in MessageByID index")
+		return
+	}
+	checkMessage(t, *resp, api.Message{
+		Name:               "ListFoosResponse",
+		ID:                 "..ListFoosResponse",
+		IsPageableResponse: true,
+		Fields: []*api.Field{
+			{
+				Name:     "nextPageToken",
+				Typez:    9,
+				TypezID:  "string",
+				JSONName: "nextPageToken",
+				Optional: true,
+			},
+			{
+				Name:     "secrets",
+				Typez:    11,
+				TypezID:  "..Foo",
+				JSONName: "secrets",
+				Repeated: true,
 			},
 		},
 	})

--- a/generator/internal/parser/pagination.go
+++ b/generator/internal/parser/pagination.go
@@ -72,5 +72,6 @@ func updateMethodPagination(a *api.API) {
 			continue
 		}
 		m.IsPageable = true
+		respMsg.IsPageableResponse = true
 	}
 }

--- a/generator/internal/parser/protobuf_test.go
+++ b/generator/internal/parser/protobuf_test.go
@@ -1021,6 +1021,40 @@ func TestProtobuf_Pagination(t *testing.T) {
 			},
 		},
 	})
+
+	resp, ok := test.State.MessageByID[".test.ListFooResponse"]
+	if !ok {
+		t.Errorf("missing message (ListFooResponse) in MessageByID index")
+		return
+	}
+	checkMessage(t, *resp, api.Message{
+		Name:               "ListFooResponse",
+		ID:                 ".test.ListFooResponse",
+		Package:            "test",
+		IsPageableResponse: true,
+		Fields: []*api.Field{
+			{
+				Name:     "next_page_token",
+				ID:       ".test.ListFooResponse.next_page_token",
+				Typez:    9,
+				JSONName: "nextPageToken",
+			},
+			{
+				Name:     "foos",
+				ID:       ".test.ListFooResponse.foos",
+				Typez:    11,
+				TypezID:  ".test.Foo",
+				JSONName: "foos",
+				Repeated: true,
+			},
+			{
+				Name:     "total_size",
+				ID:       ".test.ListFooResponse.total_size",
+				Typez:    5,
+				JSONName: "totalSize",
+			},
+		},
+	})
 }
 
 func TestProtobuf_OperationMixin(t *testing.T) {

--- a/generator/internal/sidekick/templatedata.go
+++ b/generator/internal/sidekick/templatedata.go
@@ -53,18 +53,19 @@ type Service struct {
 }
 
 type Message struct {
-	Fields            []*Field
-	BasicFields       []*Field
-	ExplicitOneOfs    []*OneOf
-	NestedMessages    []*Message
-	Enums             []*Enum
-	MessageAttributes []string
-	Name              string
-	QualifiedName     string
-	NameSnakeCase     string
-	HasNestedTypes    bool
-	DocLines          []string
-	IsMap             bool
+	Fields             []*Field
+	BasicFields        []*Field
+	ExplicitOneOfs     []*OneOf
+	NestedMessages     []*Message
+	Enums              []*Enum
+	MessageAttributes  []string
+	Name               string
+	QualifiedName      string
+	NameSnakeCase      string
+	HasNestedTypes     bool
+	DocLines           []string
+	IsMap              bool
+	IsPageableResponse bool
 }
 
 type Method struct {
@@ -81,6 +82,7 @@ type Method struct {
 	QueryParams       []*Field
 	HasBody           bool
 	BodyAccessor      string
+	IsPageable        bool
 }
 
 type OneOf struct {
@@ -206,8 +208,9 @@ func newMessage(m *api.Message, c language.Codec, state *api.APIState) *Message 
 			}
 			return false
 		}(),
-		DocLines: c.FormatDocComments(m.Documentation),
-		IsMap:    m.IsMap,
+		DocLines:           c.FormatDocComments(m.Documentation),
+		IsMap:              m.IsMap,
+		IsPageableResponse: m.IsPageableResponse,
 	}
 }
 
@@ -228,6 +231,7 @@ func newMethod(m *api.Method, c language.Codec, state *api.APIState) *Method {
 		QueryParams: mapSlice(c.QueryParams(m, state), func(s *api.Field) *Field {
 			return newField(s, c, state)
 		}),
+		IsPageable: m.IsPageable,
 	}
 }
 


### PR DESCRIPTION
These message types will need to implement a trait to be used with the Paginator type. This means we need to mark them as such in advance. 
Also prep template to start using this data.

Updates: #297