### PR TITLE
cleanup: consistent "do-not-publish" annotation

### DIFF
--- a/src/integration-tests/Cargo.toml
+++ b/src/integration-tests/Cargo.toml
@@ -17,7 +17,7 @@ name              = "integration-tests"
 description       = "Integration tests for google-cloud-rust."
 version           = "0.0.0"
 edition.workspace = true
-publish           = ["prevent-accidental-publication"]
+publish           = false
 
 [features]
 run-integration-tests = ["dep:tokio"]


### PR DESCRIPTION
Use the same annotation in this hand-crafted crate vs. the generated
crates.