### PR TITLE
cleanup: remove stale TODO entries

### DIFF
--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -216,19 +216,6 @@ pub struct Credential {
     source: Box<dyn Source + Send + Sync>,
 }
 
-// TODO(codyoss): This is currently needed to make generated code easier to generate. Not
-//       great that it is an empty cred. Either this should do a partial ADC lookup
-//       or we should find a different way and remove this. If we did not need
-//       an api call for compute credentials this could just work. But today we
-//       need to make async network requests.
-impl Default for Credential {
-    fn default() -> Self {
-        Self {
-            source: Box::new(NoOpSource {}),
-        }
-    }
-}
-
 impl Credential {
     /// Fetches a [AccessToken] based on environment and/or configuration settings.
     pub async fn access_token(&self) -> Result<AccessToken> {

--- a/auth/src/metadata.rs
+++ b/auth/src/metadata.rs
@@ -25,10 +25,6 @@ const GCE_METADATA_HOST_ENV: &str = "GCE_METADATA_HOST";
 const DEFAULT_GCE_METADATA_HOST: &str = "169.254.169.254";
 const GCE_METADATA_HOST_DNS: &str = "metadata.google.internal";
 
-// TODO(codyoss): cache a client
-// TODO(codyoss): funcs could take &str or impl Into<String>?
-
-// TODO: Create a wrapper for reuse that caches useful values.
 fn new_metadata_client() -> Client {
     let mut headers = HeaderMap::with_capacity(2);
     headers.insert("Metadata-Flavor", "Google".parse().unwrap());


### PR DESCRIPTION
We are never going to fix these TODO entries, the code is going away. In
the interim, they just pollute any search for things to do.