### PR TITLE
cleanup: published dependencies need versions

### DIFF
--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -22,6 +22,6 @@ googleapis-root   = 'https://github.com/googleapis/googleapis/archive/2d08f07eab
 googleapis-sha256 = 'eb853d49313f20a096607fea87dfc10bd6a1b917ad17ad5db8a205b457a940e1'
 
 [codec]
-'package:gax'               = 'package=gcp-sdk-gax,path=src/gax,feature=sdk_client'
-'package:wkt'               = 'package=gcp-sdk-wkt,path=src/wkt,source=google.protobuf'
-'package:google-cloud-auth' = 'package=google-cloud-auth,path=auth'
+'package:gax'               = 'package=gcp-sdk-gax,path=src/gax,feature=sdk_client,version=0.1.0'
+'package:wkt'               = 'package=gcp-sdk-wkt,path=src/wkt,source=google.protobuf,version=0.1.0'
+'package:google-cloud-auth' = 'package=google-cloud-auth,path=auth,version=0.1.0'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ version = "0.0.0"
 
 [[package]]
 name = "gcp-sdk-gax"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "bytes",
  "futures",

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -22,6 +22,7 @@ repository  = "https://github.com/googleapis/google-cloud-rust/tree/main/auth"
 keywords    = ["auth", "google", "google-cloud"]
 categories  = ["authentication", "web-programming"]
 edition     = "2021"
+publish     = false
 
 [dependencies]
 base64         = "0.22"

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name                 = "gcp-sdk-gax"
-version              = "0.0.0"
+version              = "0.1.0"
 description          = "Google Cloud SDK for Rust"
 edition.workspace    = true
 authors.workspace    = true
@@ -33,7 +33,7 @@ serde       = "1.0.214"
 serde_json  = "1.0.133"
 serde_with  = "3.11.0"
 thiserror   = "2.0.3"
-wkt         = { path = "../wkt", package = "gcp-sdk-wkt" }
+wkt         = { version = "0.1.0", path = "../wkt", package = "gcp-sdk-wkt" }
 
 [dev-dependencies]
 serde = { version = "1.0.214", features = ["serde_derive"] }

--- a/src/generated/cloud/location/Cargo.toml
+++ b/src/generated/cloud/location/Cargo.toml
@@ -32,6 +32,6 @@ serde_json = "1.0.132"
 time       = { version = "0.3.36", features = ["formatting", "parsing"] }
 reqwest    = { version = "0.12.9", features = ["json"] }
 bytes      = { version = "1.8.0", features = ["serde"] }
-gax        = { path = "../../../../src/gax", package = "gcp-sdk-gax", features = ["sdk_client"] }
-google-cloud-auth = { path = "../../../../auth", package = "google-cloud-auth" }
-wkt        = { path = "../../../../src/wkt", package = "gcp-sdk-wkt" }
+gax        = { version = "0.1.0", path = "../../../../src/gax", package = "gcp-sdk-gax", features = ["sdk_client"] }
+google-cloud-auth = { version = "0.1.0", path = "../../../../auth", package = "google-cloud-auth" }
+wkt        = { version = "0.1.0", path = "../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/cloud/secretmanager/v1/.sidekick.toml
+++ b/src/generated/cloud/secretmanager/v1/.sidekick.toml
@@ -18,5 +18,5 @@ service-config = 'google/cloud/secretmanager/v1/secretmanager_v1.yaml'
 
 [codec]
 copyright-year = '2024'
-'package:iam_v1' = 'package=gcp-sdk-iam-v1,source=google.iam.v1,path=src/generated/iam/v1'
-'package:location' = 'package=gcp-sdk-location,source=google.cloud.location,path=src/generated/cloud/location'
+'package:iam_v1' = 'package=gcp-sdk-iam-v1,source=google.iam.v1,path=src/generated/iam/v1,version=0.1.0'
+'package:location' = 'package=gcp-sdk-location,source=google.cloud.location,path=src/generated/cloud/location,version=0.1.0'

--- a/src/generated/cloud/secretmanager/v1/Cargo.toml
+++ b/src/generated/cloud/secretmanager/v1/Cargo.toml
@@ -32,8 +32,8 @@ serde_json = "1.0.132"
 time       = { version = "0.3.36", features = ["formatting", "parsing"] }
 reqwest    = { version = "0.12.9", features = ["json"] }
 bytes      = { version = "1.8.0", features = ["serde"] }
-gax        = { path = "../../../../../src/gax", package = "gcp-sdk-gax", features = ["sdk_client"] }
-google-cloud-auth = { path = "../../../../../auth", package = "google-cloud-auth" }
-iam_v1     = { path = "../../../../../src/generated/iam/v1", package = "gcp-sdk-iam-v1" }
-location   = { path = "../../../../../src/generated/cloud/location", package = "gcp-sdk-location" }
-wkt        = { path = "../../../../../src/wkt", package = "gcp-sdk-wkt" }
+gax        = { version = "0.1.0", path = "../../../../../src/gax", package = "gcp-sdk-gax", features = ["sdk_client"] }
+google-cloud-auth = { version = "0.1.0", path = "../../../../../auth", package = "google-cloud-auth" }
+iam_v1     = { version = "0.1.0", path = "../../../../../src/generated/iam/v1", package = "gcp-sdk-iam-v1" }
+location   = { version = "0.1.0", path = "../../../../../src/generated/cloud/location", package = "gcp-sdk-location" }
+wkt        = { version = "0.1.0", path = "../../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/iam/v1/.sidekick.toml
+++ b/src/generated/iam/v1/.sidekick.toml
@@ -18,4 +18,4 @@ service-config = 'google/iam/v1/iam_meta_api.yaml'
 
 [codec]
 copyright-year = '2024'
-'package:gtype' = 'package=gcp-sdk-type,source=google.type,path=src/generated/type'
+'package:gtype' = 'package=gcp-sdk-type,source=google.type,path=src/generated/type,version=0.1.0'

--- a/src/generated/iam/v1/Cargo.toml
+++ b/src/generated/iam/v1/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1.0.132"
 time       = { version = "0.3.36", features = ["formatting", "parsing"] }
 reqwest    = { version = "0.12.9", features = ["json"] }
 bytes      = { version = "1.8.0", features = ["serde"] }
-gax        = { path = "../../../../src/gax", package = "gcp-sdk-gax", features = ["sdk_client"] }
-google-cloud-auth = { path = "../../../../auth", package = "google-cloud-auth" }
-gtype      = { path = "../../../../src/generated/type", package = "gcp-sdk-type" }
-wkt        = { path = "../../../../src/wkt", package = "gcp-sdk-wkt" }
+gax        = { version = "0.1.0", path = "../../../../src/gax", package = "gcp-sdk-gax", features = ["sdk_client"] }
+google-cloud-auth = { version = "0.1.0", path = "../../../../auth", package = "google-cloud-auth" }
+gtype      = { version = "0.1.0", path = "../../../../src/generated/type", package = "gcp-sdk-type" }
+wkt        = { version = "0.1.0", path = "../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/type/Cargo.toml
+++ b/src/generated/type/Cargo.toml
@@ -32,6 +32,6 @@ serde_json = "1.0.132"
 time       = { version = "0.3.36", features = ["formatting", "parsing"] }
 reqwest    = { version = "0.12.9", features = ["json"] }
 bytes      = { version = "1.8.0", features = ["serde"] }
-gax        = { path = "../../../src/gax", package = "gcp-sdk-gax", features = ["sdk_client"] }
-google-cloud-auth = { path = "../../../auth", package = "google-cloud-auth" }
-wkt        = { path = "../../../src/wkt", package = "gcp-sdk-wkt" }
+gax        = { version = "0.1.0", path = "../../../src/gax", package = "gcp-sdk-gax", features = ["sdk_client"] }
+google-cloud-auth = { version = "0.1.0", path = "../../../auth", package = "google-cloud-auth" }
+wkt        = { version = "0.1.0", path = "../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/tools/check-copyright/Cargo.toml
+++ b/tools/check-copyright/Cargo.toml
@@ -16,6 +16,7 @@
 name    = "check-copyright"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 regex = "1.11.1"


### PR DESCRIPTION
Any package we intend to publish should include a version for each of its
dependencies. This PR marks a few more crates as `publish = false`, and marks
all the dependencies with a specific version.
