### PR TITLE
fix(wkt): `Timestamp` fields should be private

### DIFF
--- a/src/wkt/src/timestamp.rs
+++ b/src/wkt/src/timestamp.rs
@@ -49,13 +49,13 @@ pub struct Timestamp {
     /// Represents seconds of UTC time since Unix epoch
     /// 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
     /// 9999-12-31T23:59:59Z inclusive.
-    pub seconds: i64,
+    seconds: i64,
 
     /// Non-negative fractions of a second at nanosecond resolution. Negative
     /// second values with fractions must still have non-negative nanos values
     /// that count forward in time. Must be from 0 to 999,999,999
     /// inclusive.
-    pub nanos: i32,
+    nanos: i32,
 }
 
 #[derive(thiserror::Error, Debug, PartialEq)]

--- a/src/wkt/tests/timestamp.rs
+++ b/src/wkt/tests/timestamp.rs
@@ -26,8 +26,8 @@ pub struct Helper {
 #[test]
 fn access() {
     let ts = Timestamp::default();
-    assert_eq!(ts.nanos, 0);
-    assert_eq!(ts.seconds, 0);
+    assert_eq!(ts.nanos(), 0);
+    assert_eq!(ts.seconds(), 0);
 }
 
 #[test]


### PR DESCRIPTION
I accidentally left these fields are public when the type gained some
invariants.