### PR TITLE
feat(generator/rust): use `client::*` as public API

### DIFF
--- a/generator/templates/rust/crate/src/client.rs.mustache
+++ b/generator/templates/rust/crate/src/client.rs.mustache
@@ -51,7 +51,7 @@ impl {{NameToPascal}} {
     /// Creates a new client with the specified configuration.
     pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
         Ok(Self { 
-            inner: Arc::new(crate::transport::{{NameToPascal}}::new_with_config(conf).await?)
+            inner: Arc::new(crate::transport::{{NameToPascal}}::new(conf).await?)
         })
     }
 }

--- a/generator/templates/rust/crate/src/lib.rs.mustache
+++ b/generator/templates/rust/crate/src/lib.rs.mustache
@@ -71,8 +71,3 @@ impl ConfigBuilder {
 }
 
 {{/HasServices}}
-{{#Services}}
-{{! TODO(#370) - remove once the new structure is fully in place }}
-pub type {{NameToPascal}}Client = crate::transport::{{NameToPascal}};
-
-{{/Services}}

--- a/generator/templates/rust/crate/src/traits/dyntraits.rs.mustache
+++ b/generator/templates/rust/crate/src/traits/dyntraits.rs.mustache
@@ -49,4 +49,5 @@ impl<T: crate::traits::{{NameToPascal}}> {{NameToPascal}} for T {
 
     {{/Methods}}
 }
+
 {{/Services}}

--- a/generator/templates/rust/crate/src/transport.rs.mustache
+++ b/generator/templates/rust/crate/src/transport.rs.mustache
@@ -21,9 +21,9 @@ limitations under the License.
 
 use gax::error::{Error, HttpError};
 use crate::{Credential, Result};
-use std::sync::Arc;
 
 // Shared implementation across clients.
+#[derive(Clone)]
 struct InnerClient {
     http_client: reqwest::Client,
     cred: Credential,
@@ -41,7 +41,7 @@ struct NoBody {}
 {{/DocLines}}
 #[derive(Clone)]
 pub struct {{NameToPascal}} {
-    inner: Arc<InnerClient>,
+    inner: InnerClient,
 }
 
 impl std::fmt::Debug for {{NameToPascal}} {
@@ -51,21 +51,16 @@ impl std::fmt::Debug for {{NameToPascal}} {
 }
 
 impl {{NameToPascal}} {
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(crate::ConfigBuilder::default()).await
-    }
-
-    pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
+    pub async fn new(conf: crate::ConfigBuilder) -> Result<Self> {
+        let cred = conf
+                .cred
+                .unwrap_or(crate::ConfigBuilder::default_credential().await?); 
         let inner = InnerClient {
             http_client: conf.client.unwrap_or(crate::ConfigBuilder::default_client()),
-            cred: conf
-                .cred
-                .unwrap_or(crate::ConfigBuilder::default_credential().await?),
+            cred,
             endpoint: conf.endpoint.unwrap_or(crate::DEFAULT_HOST.to_string()),
         };
-        Ok(Self {
-            inner: Arc::new(inner),
-        })
+        Ok(Self { inner })
     }
 
     async fn fetch_token(&self) -> Result<String> {
@@ -105,11 +100,10 @@ impl crate::traits::{{NameToPascal}} for {{NameToPascal}} {
     {{{.}}}
     {{/DocLines}}
     async fn {{NameToSnake}}(&self, req: {{InputTypeName}}) -> Result<{{OutputTypeName}}> {
-        let inner_client = self.inner.clone();
-        let builder = inner_client.http_client
+        let builder = self.inner.http_client
             .{{HTTPMethodToLower}}(format!(
                "{}{{HTTPPathFmt}}",
-               inner_client.endpoint,
+               self.inner.endpoint,
                {{#HTTPPathArgs}}
                {{{.}}},
                {{/HTTPPathArgs}}

--- a/generator/testdata/rust/gclient/golden/iam/v1/src/client.rs
+++ b/generator/testdata/rust/gclient/golden/iam/v1/src/client.rs
@@ -66,7 +66,7 @@ impl Iampolicy {
     /// Creates a new client with the specified configuration.
     pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
         Ok(Self { 
-            inner: Arc::new(crate::transport::Iampolicy::new_with_config(conf).await?)
+            inner: Arc::new(crate::transport::Iampolicy::new(conf).await?)
         })
     }
 }

--- a/generator/testdata/rust/gclient/golden/iam/v1/src/lib.rs
+++ b/generator/testdata/rust/gclient/golden/iam/v1/src/lib.rs
@@ -65,5 +65,3 @@ impl ConfigBuilder {
     }
 }
 
-pub type IampolicyClient = crate::transport::Iampolicy;
-

--- a/generator/testdata/rust/gclient/golden/iam/v1/src/traits/dyntraits.rs
+++ b/generator/testdata/rust/gclient/golden/iam/v1/src/traits/dyntraits.rs
@@ -79,3 +79,4 @@ impl<T: crate::traits::Iampolicy> Iampolicy for T {
     }
 
 }
+

--- a/generator/testdata/rust/gclient/golden/location/src/client.rs
+++ b/generator/testdata/rust/gclient/golden/location/src/client.rs
@@ -44,7 +44,7 @@ impl Locations {
     /// Creates a new client with the specified configuration.
     pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
         Ok(Self { 
-            inner: Arc::new(crate::transport::Locations::new_with_config(conf).await?)
+            inner: Arc::new(crate::transport::Locations::new(conf).await?)
         })
     }
 }

--- a/generator/testdata/rust/gclient/golden/location/src/lib.rs
+++ b/generator/testdata/rust/gclient/golden/location/src/lib.rs
@@ -65,5 +65,3 @@ impl ConfigBuilder {
     }
 }
 
-pub type LocationsClient = crate::transport::Locations;
-

--- a/generator/testdata/rust/gclient/golden/location/src/traits/dyntraits.rs
+++ b/generator/testdata/rust/gclient/golden/location/src/traits/dyntraits.rs
@@ -53,3 +53,4 @@ impl<T: crate::traits::Locations> Locations for T {
     }
 
 }
+

--- a/generator/testdata/rust/gclient/golden/location/src/transport.rs
+++ b/generator/testdata/rust/gclient/golden/location/src/transport.rs
@@ -16,9 +16,9 @@
 
 use gax::error::{Error, HttpError};
 use crate::{Credential, Result};
-use std::sync::Arc;
 
 // Shared implementation across clients.
+#[derive(Clone)]
 struct InnerClient {
     http_client: reqwest::Client,
     cred: Credential,
@@ -34,7 +34,7 @@ struct NoBody {}
 /// [Location.metadata][google.cloud.location.Location.metadata] field.
 #[derive(Clone)]
 pub struct Locations {
-    inner: Arc<InnerClient>,
+    inner: InnerClient,
 }
 
 impl std::fmt::Debug for Locations {
@@ -44,21 +44,16 @@ impl std::fmt::Debug for Locations {
 }
 
 impl Locations {
-    pub async fn new() -> Result<Self> {
-        Self::new_with_config(crate::ConfigBuilder::default()).await
-    }
-
-    pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
+    pub async fn new(conf: crate::ConfigBuilder) -> Result<Self> {
+        let cred = conf
+                .cred
+                .unwrap_or(crate::ConfigBuilder::default_credential().await?); 
         let inner = InnerClient {
             http_client: conf.client.unwrap_or(crate::ConfigBuilder::default_client()),
-            cred: conf
-                .cred
-                .unwrap_or(crate::ConfigBuilder::default_credential().await?),
+            cred,
             endpoint: conf.endpoint.unwrap_or(crate::DEFAULT_HOST.to_string()),
         };
-        Ok(Self {
-            inner: Arc::new(inner),
-        })
+        Ok(Self { inner })
     }
 
     async fn fetch_token(&self) -> Result<String> {
@@ -95,11 +90,10 @@ impl Locations {
 impl crate::traits::Locations for Locations {
     /// Lists information about the supported locations for this service.
     async fn list_locations(&self, req: crate::model::ListLocationsRequest) -> Result<crate::model::ListLocationsResponse> {
-        let inner_client = self.inner.clone();
-        let builder = inner_client.http_client
+        let builder = self.inner.http_client
             .get(format!(
                "{}/v1/{}",
-               inner_client.endpoint,
+               self.inner.endpoint,
                req.name,
             ))
             .query(&[("alt", "json")]);
@@ -112,11 +106,10 @@ impl crate::traits::Locations for Locations {
 
     /// Gets information about a location.
     async fn get_location(&self, req: crate::model::GetLocationRequest) -> Result<crate::model::Location> {
-        let inner_client = self.inner.clone();
-        let builder = inner_client.http_client
+        let builder = self.inner.http_client
             .get(format!(
                "{}/v1/{}",
-               inner_client.endpoint,
+               self.inner.endpoint,
                req.name,
             ))
             .query(&[("alt", "json")]);

--- a/generator/testdata/rust/gclient/golden/secretmanager/src/client.rs
+++ b/generator/testdata/rust/gclient/golden/secretmanager/src/client.rs
@@ -48,7 +48,7 @@ impl SecretManagerService {
     /// Creates a new client with the specified configuration.
     pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
         Ok(Self { 
-            inner: Arc::new(crate::transport::SecretManagerService::new_with_config(conf).await?)
+            inner: Arc::new(crate::transport::SecretManagerService::new(conf).await?)
         })
     }
 }
@@ -195,7 +195,7 @@ impl Locations {
     /// Creates a new client with the specified configuration.
     pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
         Ok(Self { 
-            inner: Arc::new(crate::transport::Locations::new_with_config(conf).await?)
+            inner: Arc::new(crate::transport::Locations::new(conf).await?)
         })
     }
 }

--- a/generator/testdata/rust/gclient/golden/secretmanager/src/lib.rs
+++ b/generator/testdata/rust/gclient/golden/secretmanager/src/lib.rs
@@ -65,7 +65,3 @@ impl ConfigBuilder {
     }
 }
 
-pub type SecretManagerServiceClient = crate::transport::SecretManagerService;
-
-pub type LocationsClient = crate::transport::Locations;
-

--- a/generator/testdata/rust/gclient/golden/secretmanager/src/traits/dyntraits.rs
+++ b/generator/testdata/rust/gclient/golden/secretmanager/src/traits/dyntraits.rs
@@ -288,6 +288,7 @@ impl<T: crate::traits::SecretManagerService> SecretManagerService for T {
 
 }
 
+
 /// A dyn-compatible, crate-private version of `Locations`.
 #[async_trait::async_trait]
 pub trait Locations: Send + Sync {
@@ -327,3 +328,4 @@ impl<T: crate::traits::Locations> Locations for T {
     }
 
 }
+

--- a/generator/testdata/rust/openapi/golden/src/client.rs
+++ b/generator/testdata/rust/openapi/golden/src/client.rs
@@ -43,7 +43,7 @@ impl SecretManagerService {
     /// Creates a new client with the specified configuration.
     pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
         Ok(Self { 
-            inner: Arc::new(crate::transport::SecretManagerService::new_with_config(conf).await?)
+            inner: Arc::new(crate::transport::SecretManagerService::new(conf).await?)
         })
     }
 }

--- a/generator/testdata/rust/openapi/golden/src/lib.rs
+++ b/generator/testdata/rust/openapi/golden/src/lib.rs
@@ -65,5 +65,3 @@ impl ConfigBuilder {
     }
 }
 
-pub type SecretManagerServiceClient = crate::transport::SecretManagerService;
-

--- a/generator/testdata/rust/openapi/golden/src/traits/dyntraits.rs
+++ b/generator/testdata/rust/openapi/golden/src/traits/dyntraits.rs
@@ -561,3 +561,4 @@ impl<T: crate::traits::SecretManagerService> SecretManagerService for T {
     }
 
 }
+

--- a/src/generated/cloud/location/src/client.rs
+++ b/src/generated/cloud/location/src/client.rs
@@ -44,7 +44,7 @@ impl Locations {
     /// Creates a new client with the specified configuration.
     pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
         Ok(Self {
-            inner: Arc::new(crate::transport::Locations::new_with_config(conf).await?),
+            inner: Arc::new(crate::transport::Locations::new(conf).await?),
         })
     }
 }

--- a/src/generated/cloud/location/src/lib.rs
+++ b/src/generated/cloud/location/src/lib.rs
@@ -64,5 +64,3 @@ impl ConfigBuilder {
             .map_err(Error::authentication)
     }
 }
-
-pub type LocationsClient = crate::transport::Locations;

--- a/src/generated/cloud/secretmanager/v1/src/client.rs
+++ b/src/generated/cloud/secretmanager/v1/src/client.rs
@@ -48,7 +48,7 @@ impl SecretManagerService {
     /// Creates a new client with the specified configuration.
     pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
         Ok(Self {
-            inner: Arc::new(crate::transport::SecretManagerService::new_with_config(conf).await?),
+            inner: Arc::new(crate::transport::SecretManagerService::new(conf).await?),
         })
     }
 }
@@ -236,7 +236,7 @@ impl Locations {
     /// Creates a new client with the specified configuration.
     pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
         Ok(Self {
-            inner: Arc::new(crate::transport::Locations::new_with_config(conf).await?),
+            inner: Arc::new(crate::transport::Locations::new(conf).await?),
         })
     }
 }

--- a/src/generated/cloud/secretmanager/v1/src/lib.rs
+++ b/src/generated/cloud/secretmanager/v1/src/lib.rs
@@ -64,7 +64,3 @@ impl ConfigBuilder {
             .map_err(Error::authentication)
     }
 }
-
-pub type SecretManagerServiceClient = crate::transport::SecretManagerService;
-
-pub type LocationsClient = crate::transport::Locations;

--- a/src/generated/iam/v1/src/client.rs
+++ b/src/generated/iam/v1/src/client.rs
@@ -66,7 +66,7 @@ impl Iampolicy {
     /// Creates a new client with the specified configuration.
     pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
         Ok(Self {
-            inner: Arc::new(crate::transport::Iampolicy::new_with_config(conf).await?),
+            inner: Arc::new(crate::transport::Iampolicy::new(conf).await?),
         })
     }
 }

--- a/src/generated/iam/v1/src/lib.rs
+++ b/src/generated/iam/v1/src/lib.rs
@@ -64,5 +64,3 @@ impl ConfigBuilder {
             .map_err(Error::authentication)
     }
 }
-
-pub type IampolicyClient = crate::transport::Iampolicy;

--- a/src/generated/openapi-validation/src/client.rs
+++ b/src/generated/openapi-validation/src/client.rs
@@ -43,7 +43,7 @@ impl SecretManagerService {
     /// Creates a new client with the specified configuration.
     pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
         Ok(Self {
-            inner: Arc::new(crate::transport::SecretManagerService::new_with_config(conf).await?),
+            inner: Arc::new(crate::transport::SecretManagerService::new(conf).await?),
         })
     }
 }

--- a/src/generated/openapi-validation/src/lib.rs
+++ b/src/generated/openapi-validation/src/lib.rs
@@ -64,5 +64,3 @@ impl ConfigBuilder {
             .map_err(Error::authentication)
     }
 }
-
-pub type SecretManagerServiceClient = crate::transport::SecretManagerService;

--- a/src/integration-tests/src/secret_manager/openapi.rs
+++ b/src/integration-tests/src/secret_manager/openapi.rs
@@ -24,7 +24,7 @@ pub async fn run() -> Result<()> {
         .map(char::from)
         .collect();
 
-    let client = smo::SecretManagerServiceClient::new().await?;
+    let client = smo::client::SecretManagerService::new().await?;
 
     println!("\nTesting create_secret()");
     let create = client
@@ -107,7 +107,7 @@ pub async fn run() -> Result<()> {
     Ok(())
 }
 
-async fn run_locations(client: &smo::SecretManagerServiceClient, project_id: &str) -> Result<()> {
+async fn run_locations(client: &smo::client::SecretManagerService, project_id: &str) -> Result<()> {
     println!("\nTesting list_locations()");
     let locations = client
         .list_locations(smo::model::ListLocationsRequest::default().set_project(project_id))
@@ -140,7 +140,7 @@ async fn run_locations(client: &smo::SecretManagerServiceClient, project_id: &st
 }
 
 async fn run_iam(
-    client: &smo::SecretManagerServiceClient,
+    client: &smo::client::SecretManagerService,
     project_id: &str,
     secret_id: &str,
 ) -> Result<()> {
@@ -209,7 +209,7 @@ async fn run_iam(
 }
 
 async fn run_secret_versions(
-    client: &smo::SecretManagerServiceClient,
+    client: &smo::client::SecretManagerService,
     project_id: &str,
     secret_id: &str,
 ) -> Result<()> {
@@ -318,7 +318,7 @@ async fn run_secret_versions(
 }
 
 async fn get_all_secret_version_names(
-    client: &smo::SecretManagerServiceClient,
+    client: &smo::client::SecretManagerService,
     project_id: &str,
     secret_id: &str,
 ) -> Result<Vec<String>> {
@@ -347,7 +347,7 @@ async fn get_all_secret_version_names(
 }
 
 async fn get_all_secret_names(
-    client: &smo::SecretManagerServiceClient,
+    client: &smo::client::SecretManagerService,
     project_id: &str,
 ) -> Result<Vec<String>> {
     let mut names = Vec::new();

--- a/src/integration-tests/src/secret_manager/openapi_locational.rs
+++ b/src/integration-tests/src/secret_manager/openapi_locational.rs
@@ -28,7 +28,7 @@ pub async fn run() -> Result<()> {
     let location_id = "us-central1".to_string();
 
     let client =
-        smo::SecretManagerServiceClient::new_with_config(smo::ConfigBuilder::new().set_endpoint(
+        smo::client::SecretManagerService::new_with_config(smo::ConfigBuilder::new().set_endpoint(
             format!("https://secretmanager.{location_id}.rep.googleapis.com"),
         ))
         .await?;
@@ -107,7 +107,7 @@ pub async fn run() -> Result<()> {
 }
 
 async fn run_iam(
-    client: &smo::SecretManagerServiceClient,
+    client: &smo::client::SecretManagerService,
     project_id: &str,
     location_id: &str,
     secret_id: &str,
@@ -180,7 +180,7 @@ async fn run_iam(
 }
 
 async fn run_secret_versions(
-    client: &smo::SecretManagerServiceClient,
+    client: &smo::client::SecretManagerService,
     project_id: &str,
     location_id: &str,
     secret_id: &str,
@@ -298,7 +298,7 @@ async fn run_secret_versions(
 }
 
 async fn get_all_secret_version_names(
-    client: &smo::SecretManagerServiceClient,
+    client: &smo::client::SecretManagerService,
     project_id: &str,
     location_id: &str,
     secret_id: &str,
@@ -329,7 +329,7 @@ async fn get_all_secret_version_names(
 }
 
 async fn get_all_secret_names(
-    client: &smo::SecretManagerServiceClient,
+    client: &smo::client::SecretManagerService,
     project_id: &str,
     location_id: &str,
 ) -> Result<Vec<String>> {
@@ -358,7 +358,7 @@ async fn get_all_secret_names(
 }
 
 async fn cleanup_stale_secrets(
-    client: &smo::SecretManagerServiceClient,
+    client: &smo::client::SecretManagerService,
     project_id: &str,
     location_id: &str,
 ) -> Result<()> {

--- a/src/integration-tests/src/secret_manager/protobuf.rs
+++ b/src/integration-tests/src/secret_manager/protobuf.rs
@@ -26,8 +26,8 @@ pub async fn run() -> Result<()> {
         .map(char::from)
         .collect();
 
-    let client = sm::SecretManagerServiceClient::new().await?;
-    let location_client = sm::LocationsClient::new().await?;
+    let client = sm::client::SecretManagerService::new().await?;
+    let location_client = sm::client::Locations::new().await?;
 
     cleanup_stale_secrets(&client, &project_id, &secret_id).await?;
 
@@ -104,7 +104,7 @@ pub async fn run() -> Result<()> {
     Ok(())
 }
 
-async fn run_locations(client: &sm::LocationsClient, project_id: &str) -> Result<()> {
+async fn run_locations(client: &sm::client::Locations, project_id: &str) -> Result<()> {
     println!("\nTesting list_locations()");
     let locations = client
         .list_locations(
@@ -137,7 +137,7 @@ async fn run_locations(client: &sm::LocationsClient, project_id: &str) -> Result
     Ok(())
 }
 
-async fn run_iam(client: &sm::SecretManagerServiceClient, secret_name: &str) -> Result<()> {
+async fn run_iam(client: &sm::client::SecretManagerService, secret_name: &str) -> Result<()> {
     let service_account = crate::service_account_for_iam_tests()?;
 
     println!("\nTesting get_iam_policy()");
@@ -197,7 +197,7 @@ async fn run_iam(client: &sm::SecretManagerServiceClient, secret_name: &str) -> 
 }
 
 async fn run_secret_versions(
-    client: &sm::SecretManagerServiceClient,
+    client: &sm::client::SecretManagerService,
     secret_name: &str,
 ) -> Result<()> {
     println!("\nTesting create_secret_version()");
@@ -275,7 +275,7 @@ async fn run_secret_versions(
 }
 
 async fn get_all_secret_version_names(
-    client: &sm::SecretManagerServiceClient,
+    client: &sm::client::SecretManagerService,
     secret_name: &str,
 ) -> Result<Vec<String>> {
     let mut names = Vec::new();
@@ -301,7 +301,7 @@ async fn get_all_secret_version_names(
 }
 
 async fn get_all_secret_names(
-    client: &sm::SecretManagerServiceClient,
+    client: &sm::client::SecretManagerService,
     project_id: &str,
 ) -> Result<Vec<String>> {
     let mut names = Vec::new();
@@ -327,7 +327,7 @@ async fn get_all_secret_names(
 }
 
 async fn cleanup_stale_secrets(
-    client: &sm::SecretManagerServiceClient,
+    client: &sm::client::SecretManagerService,
     project_id: &str,
     secret_id: &str,
 ) -> Result<()> {


### PR DESCRIPTION
Use the generated `client::*` types as the public API of each SDK.

Part of the work for #370 