### PR TITLE
feat(generator): new cmd to update googleapis-root

### DIFF
--- a/generator/internal/sidekick/sidekick.go
+++ b/generator/internal/sidekick/sidekick.go
@@ -61,19 +61,14 @@ func runSidekick(cmdLine *CommandLine) error {
 
 	switch cmdLine.Command {
 	case "generate":
-		if err := generate(config, cmdLine); err != nil {
-			return err
-		}
+		return generate(config, cmdLine)
 	case "refresh":
-		if err := refresh(config, cmdLine, cmdLine.Output); err != nil {
-			return err
-		}
+		return refresh(config, cmdLine, cmdLine.Output)
 	case "refresh-all", "refreshall":
-		if err := refreshAll(config, cmdLine); err != nil {
-			return err
-		}
+		return refreshAll(config, cmdLine)
+	case "update":
+		return update(config, cmdLine)
 	default:
 		return fmt.Errorf("unknown subcommand %s", cmdLine.Command)
 	}
-	return nil
 }

--- a/generator/internal/sidekick/update.go
+++ b/generator/internal/sidekick/update.go
@@ -1,0 +1,152 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sidekick
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"os"
+	"strings"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+const (
+	defaultGitHubApi = "https://api.github.com"
+	defaultGitHub    = "https://github.com"
+	repo             = "googleapis/googleapis"
+	branch           = "master"
+)
+
+func update(rootConfig *Config, cmdLine *CommandLine) error {
+	if err := updateRootConfig(rootConfig); err != nil {
+		return err
+	}
+	// Reload the freshly minted configuration.
+	rootConfig, err := loadRootConfig(".sidekick.toml")
+	if err != nil {
+		return err
+	}
+	return refreshAll(rootConfig, cmdLine)
+}
+
+func updateRootConfig(rootConfig *Config) error {
+	gitHubApi, ok := rootConfig.Source["github-api"]
+	if !ok {
+		gitHubApi = defaultGitHubApi
+	}
+	gitHub, ok := rootConfig.Source["github"]
+	if !ok {
+		gitHub = defaultGitHub
+	}
+
+	query := fmt.Sprintf("%s/repos/%s/commits/%s", gitHubApi, repo, branch)
+	fmt.Printf("getting latest SHA from %q\n", query)
+	latestSha, err := getLatestSha(query)
+	if err != nil {
+		return err
+	}
+
+	newRoot := fmt.Sprintf("%s/%s/archive/%s.tar.gz", gitHub, repo, latestSha)
+	fmt.Printf("computing SHA256 for %q\n", newRoot)
+	newSha256, err := getSha256(newRoot)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("updating .sidekick.toml\n")
+
+	newConfig := Config{
+		General: rootConfig.General,
+		Source:  maps.Clone(rootConfig.Source),
+		Codec:   maps.Clone(rootConfig.Codec),
+	}
+	newConfig.Source["googleapis-root"] = newRoot
+	newConfig.Source["googleapis-sha256"] = newSha256
+
+	contents, err := os.ReadFile(".sidekick.toml")
+	if err != nil {
+		// If the file does not exist just fallback on an empty boilerplate.
+		contents = []byte{}
+	}
+	var boilerPlate []string
+	for _, line := range strings.Split(string(contents), "\n") {
+		if !strings.HasPrefix(line, "#") {
+			break
+		}
+		boilerPlate = append(boilerPlate, line)
+	}
+
+	cwd, _ := os.Getwd()
+	fmt.Printf("%s\n", cwd)
+	f, err := os.Create(".sidekick.toml")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	t := toml.NewEncoder(f)
+	for _, line := range boilerPlate {
+		f.Write([]byte(line))
+		f.Write([]byte("\n"))
+	}
+	f.Write([]byte("\n"))
+	if err := t.Encode(newConfig); err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+func getLatestSha(query string) (string, error) {
+	client := &http.Client{}
+	request, err := http.NewRequest(http.MethodGet, query, nil)
+	if err != nil {
+		return "", err
+	}
+	request.Header.Set("Accept", "application/vnd.github.VERSION.sha")
+	response, err := client.Do(request)
+	if err != nil {
+		return "", err
+	}
+	if response.StatusCode >= 300 {
+		return "", fmt.Errorf("http error in download %s", response.Status)
+	}
+	defer response.Body.Close()
+	contents, err := io.ReadAll(response.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(contents), nil
+}
+
+func getSha256(query string) (string, error) {
+	response, err := http.Get(query)
+	if err != nil {
+		return "", err
+	}
+	if response.StatusCode >= 300 {
+		return "", fmt.Errorf("http error in download %s", response.Status)
+	}
+	defer response.Body.Close()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, response.Body); err != nil {
+		return "", err
+	}
+	got := fmt.Sprintf("%x", hasher.Sum(nil))
+	return got, nil
+}

--- a/generator/internal/sidekick/update_test.go
+++ b/generator/internal/sidekick/update_test.go
@@ -1,0 +1,110 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sidekick
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+func TestUpdateRootConfig(t *testing.T) {
+	// update() normally writes `.sidekick.toml` to cwd. We need to change to a
+	// temporary directory to avoid changing the actual configuration, and any
+	// conflicts with other tests running at the same time.
+	tempDir := t.TempDir()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(cwd)
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatal(err)
+	}
+
+	const (
+		getLatestShaPath      = "/repos/googleapis/googleapis/commits/master"
+		latestSha             = "5d5b1bf126485b0e2c972bac41b376438601e266"
+		tarballPath           = "/googleapis/googleapis/archive/5d5b1bf126485b0e2c972bac41b376438601e266.tar.gz"
+		latestShaContents     = "The quick brown fox jumps over the lazy dog"
+		latestShaContentsHash = "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592"
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case getLatestShaPath:
+			got := r.Header.Get("Accept")
+			want := "application/vnd.github.VERSION.sha"
+			if got != want {
+				t.Fatalf("mismatched Accept header for %q, got=%q, want=%s", r.URL.Path, got, want)
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(latestSha))
+		case tarballPath:
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(latestShaContents))
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	rootConfig := &Config{
+		General: GeneralConfig{
+			Language:            "rust",
+			TemplateDir:         "generator/templates",
+			SpecificationFormat: "protobuf",
+		},
+		Source: map[string]string{
+			"github-api":        server.URL,
+			"github":            server.URL,
+			"googleapis-root":   fmt.Sprintf("%s/googleapis/googleapis/archive/old.tar.gz", server.URL),
+			"googleapis-sha256": "old-sha-unused",
+		},
+		Codec: map[string]string{},
+	}
+
+	if err := updateRootConfig(rootConfig); err != nil {
+		t.Fatal(err)
+	}
+
+	got := &Config{}
+	contents, err := os.ReadFile(path.Join(tempDir, ".sidekick.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := toml.Unmarshal(contents, got); err != nil {
+		t.Fatal("error reading top-level configuration: %w", err)
+	}
+	want := &Config{
+		General: rootConfig.General,
+		Source: map[string]string{
+			"github-api":        server.URL,
+			"github":            server.URL,
+			"googleapis-root":   fmt.Sprintf("%s/googleapis/googleapis/archive/%s.tar.gz", server.URL, latestSha),
+			"googleapis-sha256": latestShaContentsHash,
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch in loaded root config (-want, +got)\n:%s", diff)
+	}
+}


### PR DESCRIPTION
The `update` command updates the `googleapis-root` SHA and then
refreshes all the generated code.

Fixes #271
