### PR TITLE
feat(gax): support full `Status` message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "test-case",
  "thiserror 2.0.3",
  "tokio",
  "warp",

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -39,11 +39,11 @@ wkt         = { version = "0.1.0", path = "../wkt", package = "gcp-sdk-wkt" }
 [dev-dependencies]
 # This is a workaround to integration test features of this crate. Open issue
 # https://github.com/rust-lang/cargo/issues/2911.
-gax   = { path = ".", package = "gcp-sdk-gax", features = ["unstable-sdk-client", "stream"] }
-serde = { version = "1.0.214", features = ["serde_derive"] }
+gax       = { path = ".", package = "gcp-sdk-gax", features = ["unstable-sdk-client", "stream"] }
+serde     = { version = "1.0.214", features = ["serde_derive"] }
 test-case = "3.3.1"
-tokio = { version = "1.41.1", features = ["macros"] }
-warp  = "0.3.7"
+tokio     = { version = "1.41.1", features = ["macros"] }
+warp      = "0.3.7"
 
 [features]
 unstable-sdk-client = ["dep:reqwest", "dep:auth"]

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -41,6 +41,7 @@ wkt         = { version = "0.1.0", path = "../wkt", package = "gcp-sdk-wkt" }
 # https://github.com/rust-lang/cargo/issues/2911.
 gax   = { path = ".", package = "gcp-sdk-gax", features = ["unstable-sdk-client", "stream"] }
 serde = { version = "1.0.214", features = ["serde_derive"] }
+test-case = "3.3.1"
 tokio = { version = "1.41.1", features = ["macros"] }
 warp  = "0.3.7"
 


### PR DESCRIPTION
We were missing the `status` field from the JSON encoding.

Fixes #255
