### PR TITLE
feat(gax): `x-goog-api-client` header formatter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c360505aed52b7ec96a3636c3f039d99103c37d1d9b4f7a8c743d3ea9ffcd03b"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +474,7 @@ version = "0.0.0"
 name = "gcp-sdk-gax"
 version = "0.1.0"
 dependencies = [
+ "built",
  "bytes",
  "futures",
  "gcp-sdk-gax",

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -16,6 +16,7 @@
 name                 = "gcp-sdk-gax"
 version              = "0.1.0"
 description          = "Google Cloud SDK for Rust"
+build                = "build.rs"
 edition.workspace    = true
 authors.workspace    = true
 license.workspace    = true
@@ -43,6 +44,9 @@ gax   = { path = ".", package = "gcp-sdk-gax", features = ["unstable-sdk-client"
 serde = { version = "1.0.214", features = ["serde_derive"] }
 tokio = { version = "1.41.1", features = ["macros"] }
 warp  = "0.3.7"
+
+[build-dependencies]
+built = "0.7"
 
 [features]
 unstable-sdk-client = ["dep:reqwest", "dep:auth"]

--- a/src/gax/build.rs
+++ b/src/gax/build.rs
@@ -1,0 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn main() {
+    built::write_built_file().expect("Failed to acquire build-time information");
+}

--- a/src/gax/src/api_header.rs
+++ b/src/gax/src/api_header.rs
@@ -1,0 +1,93 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Generated libraries create one static instance of this struct and use it
+/// to lazy initialize (via [std::sync::LazyLock]) the x-goog-api-client header
+/// value.
+#[derive(Debug, PartialEq)]
+pub struct XGoogApiClient {
+    name: &'static str,
+    library_type: &'static str,
+    version: &'static str,
+}
+
+pub const GAPIC: &str = "gapic";
+pub const GCCL: &str = "gccl";
+
+mod built_info {
+    // The file has been placed there by the build script.
+    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+
+impl XGoogApiClient {
+    /// Format the struct as needed for the `x-goog-api-client` header.
+    pub fn header_value(&self) -> String {
+        // Strip out the initial "rustc " string from `RUSTC_VERSION`. If not
+        // found, leave RUSTC_VERSION unchanged.
+        let rustc_version = built_info::RUSTC_VERSION;
+        let rustc_version = rustc_version
+            .strip_prefix("rustc ")
+            .unwrap_or(built_info::RUSTC_VERSION);
+
+        // Capture the gax version too.
+        let gax_version = built_info::PKG_VERSION;
+
+        format!(
+            "gl-rust/{rustc_version} gax/{gax_version} {}/{}",
+            self.library_type, self.version
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn breakdown(formatted: &str) -> HashMap<String, String> {
+        formatted
+            .split(" ")
+            .filter_map(|v| v.find('/').map(|i| v.split_at(i)))
+            .map(|(k, v)| (k, &v[1..]))
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn test_format() {
+        let header = XGoogApiClient {
+            name: "unused",
+            version: "1.2.3",
+            library_type: GCCL,
+        };
+        let fields = breakdown(header.header_value().as_str());
+
+        let got = fields.get(GCCL).map(String::to_owned);
+        assert_eq!(got.as_deref(), Some("1.2.3"));
+
+        let got = fields.get("gax").map(String::to_owned);
+        assert_eq!(got.as_deref(), Some(built_info::PKG_VERSION));
+
+        let got = fields.get("gl-rust").map(String::to_owned);
+        let want = built_info::RUSTC_VERSION;
+        assert!(
+            got.as_ref()
+                .map(|s| want.contains(s) && s != "")
+                .unwrap_or(false),
+            "mismatched rustc version {} and {:?}",
+            want,
+            got
+        );
+    }
+}

--- a/src/gax/src/api_header.rs
+++ b/src/gax/src/api_header.rs
@@ -17,9 +17,9 @@
 /// value.
 #[derive(Debug, PartialEq)]
 pub struct XGoogApiClient {
-    name: &'static str,
-    library_type: &'static str,
-    version: &'static str,
+    pub name: &'static str,
+    pub library_type: &'static str,
+    pub version: &'static str,
 }
 
 pub const GAPIC: &str = "gapic";

--- a/src/gax/src/lib.rs
+++ b/src/gax/src/lib.rs
@@ -69,6 +69,11 @@ pub mod path_parameter;
 #[doc(hidden)]
 mod request_parameter;
 
+/// Implements helpers to create telemetry headers.
+#[cfg(feature = "unstable-sdk-client")]
+#[doc(hidden)]
+pub mod api_header;
+
 /// The core error types used by generated clients.
 pub mod error;
 


### PR DESCRIPTION
Part of the work for #249