### PR TITLE
fix: Update return type of  get_universe_domain to Result

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -67,5 +67,5 @@ pub trait Credential: Send + Sync {
     ) -> impl Future<Output = Result<Vec<(HeaderName, HeaderValue)>>> + Send;
 
     /// Retrieves the universe domain associated with the credential, if any.
-    fn get_universe_domain(&self) -> impl Future<Output = Option<String>> + Send;
+    fn get_universe_domain(&self) -> impl Future<Output = Result<String>> + Send;
 }


### PR DESCRIPTION
For MDS based creds, universe domain needs to be obtained via a call to MDS endpoint. Since there is a possibility of a failure, changing return type from Option to Result.