### PR TITLE
fix(generator): correct rustdoc link for `Arc`

### DIFF
--- a/generator/templates/rust/crate/src/client.rs.mustache
+++ b/generator/templates/rust/crate/src/client.rs.mustache
@@ -31,7 +31,7 @@ use std::sync::Arc;
 ///
 /// `{{NameToPascal}}` holds a connection pool internally, it is advised to
 /// create one and the reuse it.  You do not need to wrap `{{NameToPascal}}` in
-/// an [Rc](std::sync::Rc) or [Arc](std::async::Arc) to reuse it, because it
+/// an [Rc](std::sync::Rc) or [Arc](std::sync::Arc) to reuse it, because it
 /// already uses an `Arc` internally.
 ///
 {{#DocLines}}

--- a/generator/testdata/rust/gclient/golden/iam/v1/src/client.rs
+++ b/generator/testdata/rust/gclient/golden/iam/v1/src/client.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 ///
 /// `Iampolicy` holds a connection pool internally, it is advised to
 /// create one and the reuse it.  You do not need to wrap `Iampolicy` in
-/// an [Rc](std::sync::Rc) or [Arc](std::async::Arc) to reuse it, because it
+/// an [Rc](std::sync::Rc) or [Arc](std::sync::Arc) to reuse it, because it
 /// already uses an `Arc` internally.
 ///
 /// API Overview

--- a/generator/testdata/rust/gclient/golden/location/src/client.rs
+++ b/generator/testdata/rust/gclient/golden/location/src/client.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 ///
 /// `Locations` holds a connection pool internally, it is advised to
 /// create one and the reuse it.  You do not need to wrap `Locations` in
-/// an [Rc](std::sync::Rc) or [Arc](std::async::Arc) to reuse it, because it
+/// an [Rc](std::sync::Rc) or [Arc](std::sync::Arc) to reuse it, because it
 /// already uses an `Arc` internally.
 ///
 /// An abstract interface that provides location-related information for

--- a/generator/testdata/rust/gclient/golden/secretmanager/src/client.rs
+++ b/generator/testdata/rust/gclient/golden/secretmanager/src/client.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 ///
 /// `SecretManagerService` holds a connection pool internally, it is advised to
 /// create one and the reuse it.  You do not need to wrap `SecretManagerService` in
-/// an [Rc](std::sync::Rc) or [Arc](std::async::Arc) to reuse it, because it
+/// an [Rc](std::sync::Rc) or [Arc](std::sync::Arc) to reuse it, because it
 /// already uses an `Arc` internally.
 ///
 /// Secret Manager Service
@@ -191,7 +191,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
 ///
 /// `Locations` holds a connection pool internally, it is advised to
 /// create one and the reuse it.  You do not need to wrap `Locations` in
-/// an [Rc](std::sync::Rc) or [Arc](std::async::Arc) to reuse it, because it
+/// an [Rc](std::sync::Rc) or [Arc](std::sync::Arc) to reuse it, because it
 /// already uses an `Arc` internally.
 ///
 /// Manages location-related information with an API service.

--- a/generator/testdata/rust/openapi/golden/src/client.rs
+++ b/generator/testdata/rust/openapi/golden/src/client.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 ///
 /// `SecretManagerService` holds a connection pool internally, it is advised to
 /// create one and the reuse it.  You do not need to wrap `SecretManagerService` in
-/// an [Rc](std::sync::Rc) or [Arc](std::async::Arc) to reuse it, because it
+/// an [Rc](std::sync::Rc) or [Arc](std::sync::Arc) to reuse it, because it
 /// already uses an `Arc` internally.
 ///
 /// Stores sensitive data such as API keys, passwords, and certificates.

--- a/src/generated/cloud/location/src/client.rs
+++ b/src/generated/cloud/location/src/client.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 ///
 /// `Locations` holds a connection pool internally, it is advised to
 /// create one and the reuse it.  You do not need to wrap `Locations` in
-/// an [Rc](std::sync::Rc) or [Arc](std::async::Arc) to reuse it, because it
+/// an [Rc](std::sync::Rc) or [Arc](std::sync::Arc) to reuse it, because it
 /// already uses an `Arc` internally.
 ///
 /// An abstract interface that provides location-related information for

--- a/src/generated/cloud/secretmanager/v1/src/client.rs
+++ b/src/generated/cloud/secretmanager/v1/src/client.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 ///
 /// `SecretManagerService` holds a connection pool internally, it is advised to
 /// create one and the reuse it.  You do not need to wrap `SecretManagerService` in
-/// an [Rc](std::sync::Rc) or [Arc](std::async::Arc) to reuse it, because it
+/// an [Rc](std::sync::Rc) or [Arc](std::sync::Arc) to reuse it, because it
 /// already uses an `Arc` internally.
 ///
 /// Secret Manager Service
@@ -240,7 +240,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
 ///
 /// `Locations` holds a connection pool internally, it is advised to
 /// create one and the reuse it.  You do not need to wrap `Locations` in
-/// an [Rc](std::sync::Rc) or [Arc](std::async::Arc) to reuse it, because it
+/// an [Rc](std::sync::Rc) or [Arc](std::sync::Arc) to reuse it, because it
 /// already uses an `Arc` internally.
 ///
 /// Manages location-related information with an API service.

--- a/src/generated/iam/v1/src/client.rs
+++ b/src/generated/iam/v1/src/client.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 ///
 /// `Iampolicy` holds a connection pool internally, it is advised to
 /// create one and the reuse it.  You do not need to wrap `Iampolicy` in
-/// an [Rc](std::sync::Rc) or [Arc](std::async::Arc) to reuse it, because it
+/// an [Rc](std::sync::Rc) or [Arc](std::sync::Arc) to reuse it, because it
 /// already uses an `Arc` internally.
 ///
 /// API Overview

--- a/src/generated/openapi-validation/src/client.rs
+++ b/src/generated/openapi-validation/src/client.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 ///
 /// `SecretManagerService` holds a connection pool internally, it is advised to
 /// create one and the reuse it.  You do not need to wrap `SecretManagerService` in
-/// an [Rc](std::sync::Rc) or [Arc](std::async::Arc) to reuse it, because it
+/// an [Rc](std::sync::Rc) or [Arc](std::sync::Arc) to reuse it, because it
 /// already uses an `Arc` internally.
 ///
 /// Stores sensitive data such as API keys, passwords, and certificates.


### PR DESCRIPTION
Part of the work for #403
