### PR TITLE
cleanup: fewer references to `generator/`

### DIFF
--- a/generator/internal/sidekick/cmdline_test.go
+++ b/generator/internal/sidekick/cmdline_test.go
@@ -30,7 +30,7 @@ func TestParseArgs(t *testing.T) {
 		"-source-option", fmt.Sprintf("googleapis-root=%s", googleapisRoot),
 		"-language", "rust",
 		"-output", outputDir,
-		"-template-dir", "generator/templates",
+		"-template-dir", "templates",
 		"-codec-option", "copyright-year=2024",
 		"-codec-option", "package-name-override=secretmanager-golden-openapi",
 		"-codec-option", "package:wkt=package=gcp-sdk-wkt,path=src/wkt,source=google.protobuf",

--- a/generator/internal/sidekick/refreshall.go
+++ b/generator/internal/sidekick/refreshall.go
@@ -78,9 +78,14 @@ func findAllDirectories(_ *Config) ([]string, error) {
 			return nil
 		}
 		dir := filepath.Dir(path)
-		if strings.Contains(dir, "/testdata/go/") {
-			// Skip these directories. They are intended for testing only.
-			return nil
+		ignored := []string{
+			"target/package/",     // The output from `cargo package`
+			"generator/testdata/", // Testing
+		}
+		for _, candidate := range ignored {
+			if strings.Contains(dir, candidate) {
+				return nil
+			}
 		}
 		if d.Name() == ".sidekick.toml" && dir != "." {
 			result = append(result, dir)

--- a/generator/internal/sidekick/sidekick_test.go
+++ b/generator/internal/sidekick/sidekick_test.go
@@ -29,9 +29,9 @@ import (
 const (
 	// projectRoot is the root of the google-cloud-rust. The golden files for
 	// these tests depend on code in ../../auth and ../../src/gax.
-	projectRoot = "../../.."
-	templateDir = "generator/templates"
-	testdataDir = "generator/testdata"
+	projectRoot = "../.."
+	templateDir = "templates"
+	testdataDir = "testdata"
 )
 
 var (
@@ -39,7 +39,7 @@ var (
 	outputDir                  = fmt.Sprintf("%s/test-only", testdataDir)
 	secretManagerServiceConfig = "googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml"
 	specificationSource        = fmt.Sprintf("%s/openapi/secretmanager_openapi_v1.json", testdataDir)
-	testdataImportPath         = fmt.Sprintf("github.com/google-cloud-rust/%s", testdataDir)
+	testdataImportPath         = fmt.Sprintf("github.com/google-cloud-rust/generator/%s", testdataDir)
 )
 
 func TestRustFromOpenAPI(t *testing.T) {
@@ -57,9 +57,9 @@ func TestRustFromOpenAPI(t *testing.T) {
 			"not-for-publication":       "true",
 			"copyright-year":            "2024",
 			"package-name-override":     "secretmanager-golden-openapi",
-			"package:wkt":               "package=gcp-sdk-wkt,path=src/wkt,source=google.protobuf",
-			"package:gax":               "package=gcp-sdk-gax,path=src/gax,feature=unstable-sdk-client",
-			"package:google-cloud-auth": "package=google-cloud-auth,path=auth",
+			"package:wkt":               "package=gcp-sdk-wkt,path=../src/wkt,source=google.protobuf",
+			"package:gax":               "package=gcp-sdk-gax,path=../src/gax,feature=unstable-sdk-client",
+			"package:google-cloud-auth": "package=google-cloud-auth,path=../auth",
 		},
 	}
 	if err := runSidekick(cmdLine); err != nil {
@@ -128,9 +128,9 @@ func TestRustFromProtobuf(t *testing.T) {
 				"not-for-publication":       "true",
 				"copyright-year":            "2024",
 				"package-name-override":     strings.Replace(config.Name, "/", "-", -1) + "-golden-gclient",
-				"package:wkt":               "package=gcp-sdk-wkt,path=src/wkt,source=google.protobuf",
-				"package:gax":               "package=gcp-sdk-gax,path=src/gax,feature=unstable-sdk-client",
-				"package:google-cloud-auth": "package=google-cloud-auth,path=auth",
+				"package:wkt":               "package=gcp-sdk-wkt,path=../src/wkt,source=google.protobuf",
+				"package:gax":               "package=gcp-sdk-gax,path=../src/gax,feature=unstable-sdk-client",
+				"package:google-cloud-auth": "package=google-cloud-auth,path=../auth",
 			},
 		}
 		for k, v := range config.ExtraOptions {

--- a/generator/testdata/go/gclient/golden/iam/v1/.sidekick.toml
+++ b/generator/testdata/go/gclient/golden/iam/v1/.sidekick.toml
@@ -14,12 +14,12 @@
 
 [general]
 language = 'go'
-template-dir = 'generator/templates'
+template-dir = 'templates'
 specification-format = 'protobuf'
-specification-source = 'generator/testdata/googleapis/google/iam/v1'
+specification-source = 'testdata/googleapis/google/iam/v1'
 
 [source]
-googleapis-root = 'generator/testdata/googleapis'
+googleapis-root = 'testdata/googleapis'
 
 [codec]
 copyright-year = '2024'

--- a/generator/testdata/go/gclient/golden/typez/.sidekick.toml
+++ b/generator/testdata/go/gclient/golden/typez/.sidekick.toml
@@ -14,12 +14,12 @@
 
 [general]
 language = 'go'
-template-dir = 'generator/templates'
+template-dir = 'templates'
 specification-format = 'protobuf'
-specification-source = 'generator/testdata/googleapis/google/type'
+specification-source = 'testdata/googleapis/google/type'
 
 [source]
-googleapis-root = 'generator/testdata/googleapis'
+googleapis-root = 'testdata/googleapis'
 
 [codec]
 copyright-year = '2024'

--- a/generator/testdata/rust/gclient/golden/iam/v1/.sidekick.toml
+++ b/generator/testdata/rust/gclient/golden/iam/v1/.sidekick.toml
@@ -14,18 +14,18 @@
 
 [general]
 language = 'rust'
-template-dir = 'generator/templates'
+template-dir = 'templates'
 specification-format = 'protobuf'
-specification-source = 'generator/testdata/googleapis/google/iam/v1'
+specification-source = 'testdata/googleapis/google/iam/v1'
 
 [source]
-googleapis-root = 'generator/testdata/googleapis'
+googleapis-root = 'testdata/googleapis'
 
 [codec]
 copyright-year = '2024'
 not-for-publication = 'true'
 package-name-override = 'iam-v1-golden-gclient'
-'package:gax' = 'package=gcp-sdk-gax,path=src/gax,feature=unstable-sdk-client'
-'package:google-cloud-auth' = 'package=google-cloud-auth,path=auth'
-'package:gtype' = 'package=type-golden-gclient,path=generator/testdata/rust/gclient/golden/type,source=google.type'
-'package:wkt' = 'package=gcp-sdk-wkt,path=src/wkt,source=google.protobuf'
+'package:gax' = 'package=gcp-sdk-gax,path=../src/gax,feature=unstable-sdk-client'
+'package:google-cloud-auth' = 'package=google-cloud-auth,path=../auth'
+'package:gtype' = 'package=type-golden-gclient,path=testdata/rust/gclient/golden/type,source=google.type'
+'package:wkt' = 'package=gcp-sdk-wkt,path=../src/wkt,source=google.protobuf'

--- a/generator/testdata/rust/gclient/golden/iam/v1/Cargo.toml
+++ b/generator/testdata/rust/gclient/golden/iam/v1/Cargo.toml
@@ -38,5 +38,5 @@ reqwest    = { version = "0.12.9", features = ["json"] }
 bytes      = { version = "1.8.0", features = ["serde"] }
 gax        = { path = "../../../../../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
 google-cloud-auth = { path = "../../../../../../../auth", package = "google-cloud-auth" }
-gtype      = { path = "../../../../../../../generator/testdata/rust/gclient/golden/type", package = "type-golden-gclient" }
+gtype      = { path = "../../../../../../testdata/rust/gclient/golden/type", package = "type-golden-gclient" }
 wkt        = { path = "../../../../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/generator/testdata/rust/gclient/golden/location/.sidekick.toml
+++ b/generator/testdata/rust/gclient/golden/location/.sidekick.toml
@@ -14,18 +14,18 @@
 
 [general]
 language = 'rust'
-template-dir = 'generator/templates'
+template-dir = 'templates'
 specification-format = 'protobuf'
-specification-source = 'generator/testdata/googleapis/google/cloud/location'
-service-config = 'generator/testdata/googleapis/google/cloud/location/cloud.yaml'
+specification-source = 'testdata/googleapis/google/cloud/location'
+service-config = 'testdata/googleapis/google/cloud/location/cloud.yaml'
 
 [source]
-googleapis-root = 'generator/testdata/googleapis'
+googleapis-root = 'testdata/googleapis'
 
 [codec]
 copyright-year = '2024'
 not-for-publication = 'true'
 package-name-override = 'location-golden-gclient'
-'package:gax' = 'package=gcp-sdk-gax,path=src/gax,feature=unstable-sdk-client'
-'package:google-cloud-auth' = 'package=google-cloud-auth,path=auth'
-'package:wkt' = 'package=gcp-sdk-wkt,path=src/wkt,source=google.protobuf'
+'package:gax' = 'package=gcp-sdk-gax,path=../src/gax,feature=unstable-sdk-client'
+'package:google-cloud-auth' = 'package=google-cloud-auth,path=../auth'
+'package:wkt' = 'package=gcp-sdk-wkt,path=../src/wkt,source=google.protobuf'

--- a/generator/testdata/rust/gclient/golden/module/rpc/.sidekick.toml
+++ b/generator/testdata/rust/gclient/golden/module/rpc/.sidekick.toml
@@ -14,13 +14,13 @@
 
 [general]
 language = 'rust'
-template-dir = 'generator/templates'
+template-dir = 'templates'
 specification-format = 'protobuf'
 specification-source = 'google/rpc/error_details.proto'
 service-config = 'google/rpc/rpc_publish.yaml'
 
 [source]
-googleapis-root = 'generator/testdata/googleapis'
+googleapis-root = 'testdata/googleapis'
 
 [codec]
 copyright-year = '2024'

--- a/generator/testdata/rust/gclient/golden/module/type/.sidekick.toml
+++ b/generator/testdata/rust/gclient/golden/module/type/.sidekick.toml
@@ -14,13 +14,13 @@
 
 [general]
 language = 'rust'
-template-dir = 'generator/templates'
+template-dir = 'templates'
 specification-format = 'protobuf'
 specification-source = 'google/type'
 service-config = 'google/type/type.yaml'
 
 [source]
-googleapis-root = 'generator/testdata/googleapis'
+googleapis-root = 'testdata/googleapis'
 
 [codec]
 copyright-year = '2024'

--- a/generator/testdata/rust/gclient/golden/secretmanager/.sidekick.toml
+++ b/generator/testdata/rust/gclient/golden/secretmanager/.sidekick.toml
@@ -14,20 +14,20 @@
 
 [general]
 language = 'rust'
-template-dir = 'generator/templates'
+template-dir = 'templates'
 specification-format = 'protobuf'
-specification-source = 'generator/testdata/googleapis/google/cloud/secretmanager/v1'
-service-config = 'generator/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml'
+specification-source = 'testdata/googleapis/google/cloud/secretmanager/v1'
+service-config = 'testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml'
 
 [source]
-googleapis-root = 'generator/testdata/googleapis'
+googleapis-root = 'testdata/googleapis'
 
 [codec]
 copyright-year = '2024'
 not-for-publication = 'true'
 package-name-override = 'secretmanager-golden-gclient'
-'package:gax' = 'package=gcp-sdk-gax,path=src/gax,feature=unstable-sdk-client'
-'package:google-cloud-auth' = 'package=google-cloud-auth,path=auth'
-'package:iam' = 'package=iam-v1-golden-gclient,path=generator/testdata/rust/gclient/golden/iam/v1,source=google.iam.v1'
-'package:location' = 'package=location-golden-gclient,path=generator/testdata/rust/gclient/golden/location,source=google.cloud.location'
-'package:wkt' = 'package=gcp-sdk-wkt,path=src/wkt,source=google.protobuf'
+'package:gax' = 'package=gcp-sdk-gax,path=../src/gax,feature=unstable-sdk-client'
+'package:google-cloud-auth' = 'package=google-cloud-auth,path=../auth'
+'package:iam' = 'package=iam-v1-golden-gclient,path=testdata/rust/gclient/golden/iam/v1,source=google.iam.v1'
+'package:location' = 'package=location-golden-gclient,path=testdata/rust/gclient/golden/location,source=google.cloud.location'
+'package:wkt' = 'package=gcp-sdk-wkt,path=../src/wkt,source=google.protobuf'

--- a/generator/testdata/rust/gclient/golden/secretmanager/Cargo.toml
+++ b/generator/testdata/rust/gclient/golden/secretmanager/Cargo.toml
@@ -38,6 +38,6 @@ reqwest    = { version = "0.12.9", features = ["json"] }
 bytes      = { version = "1.8.0", features = ["serde"] }
 gax        = { path = "../../../../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
 google-cloud-auth = { path = "../../../../../../auth", package = "google-cloud-auth" }
-iam        = { path = "../../../../../../generator/testdata/rust/gclient/golden/iam/v1", package = "iam-v1-golden-gclient" }
-location   = { path = "../../../../../../generator/testdata/rust/gclient/golden/location", package = "location-golden-gclient" }
+iam        = { path = "../../../../../testdata/rust/gclient/golden/iam/v1", package = "iam-v1-golden-gclient" }
+location   = { path = "../../../../../testdata/rust/gclient/golden/location", package = "location-golden-gclient" }
 wkt        = { path = "../../../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/generator/testdata/rust/gclient/golden/type/.sidekick.toml
+++ b/generator/testdata/rust/gclient/golden/type/.sidekick.toml
@@ -14,18 +14,18 @@
 
 [general]
 language = 'rust'
-template-dir = 'generator/templates'
+template-dir = 'templates'
 specification-format = 'protobuf'
-specification-source = 'generator/testdata/googleapis/google/type'
-service-config = 'generator/testdata/googleapis/google/type/type.yaml'
+specification-source = 'testdata/googleapis/google/type'
+service-config = 'testdata/googleapis/google/type/type.yaml'
 
 [source]
-googleapis-root = 'generator/testdata/googleapis'
+googleapis-root = 'testdata/googleapis'
 
 [codec]
 copyright-year = '2024'
 not-for-publication = 'true'
 package-name-override = 'type-golden-gclient'
-'package:gax' = 'package=gcp-sdk-gax,path=src/gax,feature=unstable-sdk-client'
-'package:google-cloud-auth' = 'package=google-cloud-auth,path=auth'
-'package:wkt' = 'package=gcp-sdk-wkt,path=src/wkt,source=google.protobuf'
+'package:gax' = 'package=gcp-sdk-gax,path=../src/gax,feature=unstable-sdk-client'
+'package:google-cloud-auth' = 'package=google-cloud-auth,path=../auth'
+'package:wkt' = 'package=gcp-sdk-wkt,path=../src/wkt,source=google.protobuf'

--- a/generator/testdata/rust/openapi/golden/.sidekick.toml
+++ b/generator/testdata/rust/openapi/golden/.sidekick.toml
@@ -14,15 +14,15 @@
 
 [general]
 language = 'rust'
-template-dir = 'generator/templates'
+template-dir = 'templates'
 specification-format = 'openapi'
-specification-source = 'generator/testdata/openapi/secretmanager_openapi_v1.json'
-service-config = 'generator/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml'
+specification-source = 'testdata/openapi/secretmanager_openapi_v1.json'
+service-config = 'testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml'
 
 [codec]
 copyright-year = '2024'
 not-for-publication = 'true'
 package-name-override = 'secretmanager-golden-openapi'
-'package:gax' = 'package=gcp-sdk-gax,path=src/gax,feature=unstable-sdk-client'
-'package:google-cloud-auth' = 'package=google-cloud-auth,path=auth'
-'package:wkt' = 'package=gcp-sdk-wkt,path=src/wkt,source=google.protobuf'
+'package:gax' = 'package=gcp-sdk-gax,path=../src/gax,feature=unstable-sdk-client'
+'package:google-cloud-auth' = 'package=google-cloud-auth,path=../auth'
+'package:wkt' = 'package=gcp-sdk-wkt,path=../src/wkt,source=google.protobuf'


### PR DESCRIPTION
This separates the generator tests from the `google-cloud-rust`
configuration. I want to make changes to the top-level `.sidekick.toml`
without impacting the generator golden files.

It also helps (I think) with an eventual move of the generator to a new
repository.
