### PR TITLE
feat(generator/rust): make URLs rustdoc-friendly

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -54,6 +54,9 @@ jobs:
         run: rustc --version
       - run: cargo clippy -- --deny warnings
       - run: cargo fmt
+      - run: cargo doc
+        env:
+          RUSTDOCFLAGS: "-D warnings"
       - run: git diff --exit-code
   regenerate:
     # Verifies the generated code has not been tampered with. Or maybe that the

--- a/generator/testdata/rust/gclient/golden/module/rpc/mod.rs
+++ b/generator/testdata/rust/gclient/golden/module/rpc/mod.rs
@@ -557,7 +557,7 @@ pub mod help {
 pub struct LocalizedMessage {
 
     /// The locale used following the specification defined at
-    /// https://www.rfc-editor.org/rfc/bcp/bcp47.txt.
+    /// <https://www.rfc-editor.org/rfc/bcp/bcp47.txt>.
     /// Examples are: "en-US", "fr-CH", "es-MX"
     pub locale: String,
 

--- a/generator/testdata/rust/gclient/golden/module/type/mod.rs
+++ b/generator/testdata/rust/gclient/golden/module/type/mod.rs
@@ -19,7 +19,7 @@
 
 /// Represents a textual expression in the Common Expression Language (CEL)
 /// syntax. CEL is a C-like expression language. The syntax and semantics of CEL
-/// are documented at https://github.com/google/cel-spec.
+/// are documented at <https://github.com/google/cel-spec>.
 ///
 /// Example (Comparison):
 ///

--- a/generator/testdata/rust/gclient/golden/secretmanager/src/model.rs
+++ b/generator/testdata/rust/gclient/golden/secretmanager/src/model.rs
@@ -955,7 +955,7 @@ pub struct SecretPayload {
     ///
     /// The CRC32C value is encoded as a Int64 for compatibility, and can be
     /// safely downconverted to uint32 in languages that support this type.
-    /// https://cloud.google.com/apis/design/design_patterns#integer_types
+    /// <https://cloud.google.com/apis/design/design_patterns#integer_types>
     ///
     /// [google.cloud.secretmanager.v1.SecretManagerService]: crate::traits::SecretManagerService
     /// [google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion]: crate::traits::SecretManagerService::access_secret_version

--- a/generator/testdata/rust/gclient/golden/type/src/model.rs
+++ b/generator/testdata/rust/gclient/golden/type/src/model.rs
@@ -19,7 +19,7 @@
 
 /// Represents a textual expression in the Common Expression Language (CEL)
 /// syntax. CEL is a C-like expression language. The syntax and semantics of CEL
-/// are documented at https://github.com/google/cel-spec.
+/// are documented at <https://github.com/google/cel-spec>.
 ///
 /// Example (Comparison):
 ///

--- a/generator/testdata/rust/openapi/golden/src/model.rs
+++ b/generator/testdata/rust/openapi/golden/src/model.rs
@@ -620,7 +620,7 @@ pub struct SecretPayload {
     ///
     /// The CRC32C value is encoded as a Int64 for compatibility, and can be
     /// safely downconverted to uint32 in languages that support this type.
-    /// https://cloud.google.com/apis/design/design_patterns#integer_types
+    /// <https://cloud.google.com/apis/design/design_patterns#integer_types>
     #[serde(rename = "dataCrc32c")]
     #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
     pub data_crc_32_c: Option<i64>,
@@ -1557,7 +1557,7 @@ impl Binding {
 
 /// Represents a textual expression in the Common Expression Language (CEL)
 /// syntax. CEL is a C-like expression language. The syntax and semantics of CEL
-/// are documented at https://github.com/google/cel-spec.
+/// are documented at <https://github.com/google/cel-spec>.
 ///
 /// Example (Comparison):
 ///

--- a/src/gax/src/error/rpc/generated/mod.rs
+++ b/src/gax/src/error/rpc/generated/mod.rs
@@ -549,7 +549,7 @@ pub mod help {
 #[non_exhaustive]
 pub struct LocalizedMessage {
     /// The locale used following the specification defined at
-    /// https://www.rfc-editor.org/rfc/bcp/bcp47.txt.
+    /// <https://www.rfc-editor.org/rfc/bcp/bcp47.txt>.
     /// Examples are: "en-US", "fr-CH", "es-MX"
     pub locale: String,
 

--- a/src/generated/cloud/secretmanager/v1/src/model.rs
+++ b/src/generated/cloud/secretmanager/v1/src/model.rs
@@ -984,7 +984,7 @@ pub struct SecretPayload {
     ///
     /// The CRC32C value is encoded as a Int64 for compatibility, and can be
     /// safely downconverted to uint32 in languages that support this type.
-    /// https://cloud.google.com/apis/design/design_patterns#integer_types
+    /// <https://cloud.google.com/apis/design/design_patterns#integer_types>
     ///
     /// [google.cloud.secretmanager.v1.SecretManagerService]: crate::traits::SecretManagerService
     /// [google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion]: crate::traits::SecretManagerService::access_secret_version

--- a/src/generated/iam/v1/src/model.rs
+++ b/src/generated/iam/v1/src/model.rs
@@ -813,7 +813,7 @@ pub mod audit_config_delta {
 #[non_exhaustive]
 pub struct ResourcePolicyMember {
     /// IAM policy binding member referring to a Google Cloud resource by
-    /// user-assigned name (https://google.aip.dev/122). If a resource is deleted
+    /// user-assigned name (<https://google.aip.dev/122>). If a resource is deleted
     /// and recreated with the same name, the binding will be applicable to the new
     /// resource.
     ///
@@ -822,7 +822,7 @@ pub struct ResourcePolicyMember {
     pub iam_policy_name_principal: String,
 
     /// IAM policy binding member referring to a Google Cloud resource by
-    /// system-assigned unique identifier (https://google.aip.dev/148#uid). If a
+    /// system-assigned unique identifier (<https://google.aip.dev/148#uid>). If a
     /// resource is deleted and recreated with the same name, the binding will not
     /// be applicable to the new resource
     ///

--- a/src/generated/openapi-validation/src/model.rs
+++ b/src/generated/openapi-validation/src/model.rs
@@ -616,7 +616,7 @@ pub struct SecretPayload {
     ///
     /// The CRC32C value is encoded as a Int64 for compatibility, and can be
     /// safely downconverted to uint32 in languages that support this type.
-    /// https://cloud.google.com/apis/design/design_patterns#integer_types
+    /// <https://cloud.google.com/apis/design/design_patterns#integer_types>
     #[serde(rename = "dataCrc32c")]
     #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
     pub data_crc_32_c: Option<i64>,
@@ -1543,7 +1543,7 @@ impl Binding {
 
 /// Represents a textual expression in the Common Expression Language (CEL)
 /// syntax. CEL is a C-like expression language. The syntax and semantics of CEL
-/// are documented at https://github.com/google/cel-spec.
+/// are documented at <https://github.com/google/cel-spec>.
 ///
 /// Example (Comparison):
 ///

--- a/src/generated/type/src/model.rs
+++ b/src/generated/type/src/model.rs
@@ -445,7 +445,7 @@ impl TimeZone {
 /// Python's [decimal.Decimal][].
 ///
 /// [BigDecimal]:
-/// https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/math/BigDecimal.html
+/// <https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/math/BigDecimal.html>
 /// [decimal.Decimal]: https://docs.python.org/3/library/decimal.html
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -535,7 +535,7 @@ impl Decimal {
 
 /// Represents a textual expression in the Common Expression Language (CEL)
 /// syntax. CEL is a C-like expression language. The syntax and semantics of CEL
-/// are documented at https://github.com/google/cel-spec.
+/// are documented at <https://github.com/google/cel-spec>.
 ///
 /// Example (Comparison):
 ///
@@ -692,7 +692,7 @@ impl Interval {
 /// An object that represents a latitude/longitude pair. This is expressed as a
 /// pair of doubles to represent degrees latitude and degrees longitude. Unless
 /// specified otherwise, this must conform to the
-/// <a href="http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf">WGS84
+/// <a href="<http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf>">WGS84
 /// standard</a>. Values must be within normalized ranges.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -732,7 +732,7 @@ pub struct LocalizedText {
     /// The text's BCP-47 language code, such as "en-US" or "sr-Latn".
     ///
     /// For more information, see
-    /// http://www.unicode.org/reports/tr35/#Unicode_locale_identifier.
+    /// <http://www.unicode.org/reports/tr35/#Unicode_locale_identifier>.
     pub language_code: String,
 }
 
@@ -824,7 +824,7 @@ impl Money {
 ///    }
 ///
 ///  Reference(s):
-///   - https://github.com/google/libphonenumber
+///   - <https://github.com/google/libphonenumber>
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -883,7 +883,7 @@ pub mod phone_number {
         /// short code can be made, such as "US" and "BB".
         ///
         /// Reference(s):
-        ///  - http://www.unicode.org/reports/tr35/#unicode_region_subtag
+        ///  - <http://www.unicode.org/reports/tr35/#unicode_region_subtag>
         pub region_code: String,
 
         /// Required. The short code digits, without a leading plus ('+') or country
@@ -924,14 +924,14 @@ pub mod phone_number {
         /// National-only numbers are not allowed.
         ///
         /// References:
-        ///  - https://www.itu.int/rec/T-REC-E.164-201011-I
-        ///  - https://en.wikipedia.org/wiki/E.164.
-        ///  - https://en.wikipedia.org/wiki/List_of_country_calling_codes
+        ///  - <https://www.itu.int/rec/T-REC-E.164-201011-I>
+        ///  - <https://en.wikipedia.org/wiki/E.164>.
+        ///  - <https://en.wikipedia.org/wiki/List_of_country_calling_codes>
         E164Number { e164_number: String },
         /// A short code.
         ///
         /// Reference(s):
-        ///  - https://en.wikipedia.org/wiki/Short_code
+        ///  - <https://en.wikipedia.org/wiki/Short_code>
         ShortCode(crate::model::phone_number::ShortCode),
     }
 }
@@ -947,12 +947,12 @@ pub mod phone_number {
 ///
 /// Advice on address input / editing:
 ///  - Use an i18n-ready address widget such as
-///    https://github.com/google/libaddressinput)
+///    <https://github.com/google/libaddressinput>)
 /// - Users should not be presented with UI elements for input or editing of
 ///   fields outside countries where that field is used.
 ///
 /// For more guidance on how to use this schema, please see:
-/// https://support.google.com/business/answer/6397478
+/// <https://support.google.com/business/answer/6397478>
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -966,8 +966,8 @@ pub struct PostalAddress {
 
     /// Required. CLDR region code of the country/region of the address. This
     /// is never inferred and it is up to the user to ensure the value is
-    /// correct. See http://cldr.unicode.org/ and
-    /// http://www.unicode.org/cldr/charts/30/supplemental/territory_information.html
+    /// correct. See <http://cldr.unicode.org/> and
+    /// <http://www.unicode.org/cldr/charts/30/supplemental/territory_information.html>
     /// for details. Example: "CH" for Switzerland.
     pub region_code: String,
 
@@ -1120,13 +1120,13 @@ impl PostalAddress {
 
 /// A quaternion is defined as the quotient of two directed lines in a
 /// three-dimensional space or equivalently as the quotient of two Euclidean
-/// vectors (https://en.wikipedia.org/wiki/Quaternion).
+/// vectors (<https://en.wikipedia.org/wiki/Quaternion>).
 ///
 /// Quaternions are often used in calculations involving three-dimensional
-/// rotations (https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation),
+/// rotations (<https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation>),
 /// as they provide greater mathematical robustness by avoiding the gimbal lock
 /// problems that can be encountered when using Euler angles
-/// (https://en.wikipedia.org/wiki/Gimbal_lock).
+/// (<https://en.wikipedia.org/wiki/Gimbal_lock>).
 ///
 /// Quaternions are generally represented in this form:
 ///
@@ -1170,7 +1170,7 @@ impl PostalAddress {
 /// quaternion maintains the same direction, but has a norm of 1, i.e. it moves
 /// on the unit sphere. This is generally necessary for rotation and orientation
 /// quaternions, to avoid rounding errors:
-/// https://en.wikipedia.org/wiki/Rotation_formalisms_in_three_dimensions
+/// <https://en.wikipedia.org/wiki/Rotation_formalisms_in_three_dimensions>
 ///
 /// Note that `(x, y, z, w)` and `(-x, -y, -z, -w)` represent the same rotation,
 /// but normalization would be even more useful, e.g. for comparison purposes, if


### PR DESCRIPTION
Rustdoc requires URLs to be in angle brackets, it warns if they are not,
and does not autolink them. The comments in most proto files assume
autolinking.

Fixes #403