### PR TITLE
chore: keep TOML arrays sorted

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 [formatting]
-align_entries = true
-column_width  = 120
+align_entries  = true
+column_width   = 120
+reorder_arrays = true
 
 # The CI builds exclude these explicitly. Having them here makes it easier to
 # format everything we care about. 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,21 +17,21 @@ resolver = "2"
 
 members = [
   "auth",
-  "tools/check-copyright",
-  "src/root",
-  "src/base",
   "src/auth",
+  "src/base",
   "src/gax",
-  "src/wkt",
-  "src/generated/longrunning",
-  "src/generated/type",
+  "src/generated/api",
+  "src/generated/cloud/common",
   "src/generated/cloud/location",
   "src/generated/cloud/secretmanager/v1",
-  "src/generated/cloud/common",
   "src/generated/iam/v1",
-  "src/generated/api",
+  "src/generated/longrunning",
   "src/generated/openapi-validation",
+  "src/generated/type",
   "src/integration-tests",
+  "src/root",
+  "src/wkt",
+  "tools/check-copyright",
 ]
 
 [workspace.package]
@@ -40,5 +40,5 @@ authors     = ["Google LLC"]
 description = "Google Cloud SDK for Rust"
 license     = "Apache-2.0"
 repository  = "https://github.com/googleapis/google-cloud-rust/tree/main"
-keywords    = ["google-cloud", "google-cloud-rust", "gcp", "sdk"]
+keywords    = ["gcp", "google-cloud", "google-cloud-rust", "sdk"]
 categories  = ["network-programming"]

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -40,7 +40,7 @@ wkt         = { version = "0.1.0", path = "../wkt", package = "gcp-sdk-wkt" }
 [dev-dependencies]
 # This is a workaround to integration test features of this crate. Open issue
 # https://github.com/rust-lang/cargo/issues/2911.
-gax       = { path = ".", package = "gcp-sdk-gax", features = ["unstable-sdk-client", "stream"] }
+gax       = { path = ".", package = "gcp-sdk-gax", features = ["stream", "unstable-sdk-client"] }
 serde     = { version = "1.0.214", features = ["serde_derive"] }
 test-case = "3.3.1"
 tokio     = { version = "1.41.1", features = ["macros"] }
@@ -50,5 +50,5 @@ warp      = "0.3.7"
 built = "0.7"
 
 [features]
-unstable-sdk-client = ["dep:reqwest", "dep:auth"]
+unstable-sdk-client = ["dep:auth", "dep:reqwest"]
 stream              = ["dep:futures", "dep:pin-project"]


### PR DESCRIPTION
This is mostly to make maintenance of the top-level `Cargo.toml` file
easier. When `sidekick generate` a new crate it gets into the right
place, and that minimizes conflicts if two developers add different
crates.