### PR TITLE
impl(gax): support for per-request options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,7 @@ dependencies = [
  "gcp-sdk-wkt",
  "google-cloud-auth",
  "http",
+ "lazy_static",
  "pin-project",
  "reqwest",
  "serde",

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -28,6 +28,7 @@ categories.workspace = true
 bytes       = "1.8.0"
 futures     = { version = "0.3.31", optional = true }
 http        = "1.1.0"
+lazy_static = "1.5.0"
 pin-project = { version = "1.1.7", optional = true }
 reqwest     = { version = "0.12.9", optional = true }
 serde       = "1.0.214"

--- a/src/gax/src/api_header.rs
+++ b/src/gax/src/api_header.rs
@@ -24,6 +24,11 @@ pub struct XGoogApiClient {
 
 pub const GAPIC: &str = "gapic";
 pub const GCCL: &str = "gccl";
+lazy_static::lazy_static! {
+    pub(crate) static ref USER_AGENT: String = {
+        user_agent()
+    };
+}
 
 mod built_info {
     // The file has been placed there by the build script.
@@ -33,21 +38,26 @@ mod built_info {
 impl XGoogApiClient {
     /// Format the struct as needed for the `x-goog-api-client` header.
     pub fn header_value(&self) -> String {
-        // Strip out the initial "rustc " string from `RUSTC_VERSION`. If not
-        // found, leave RUSTC_VERSION unchanged.
-        let rustc_version = built_info::RUSTC_VERSION;
-        let rustc_version = rustc_version
-            .strip_prefix("rustc ")
-            .unwrap_or(built_info::RUSTC_VERSION);
-
-        // Capture the gax version too.
-        let gax_version = built_info::PKG_VERSION;
-
         format!(
-            "gl-rust/{rustc_version} gax/{gax_version} {}/{}",
-            self.library_type, self.version
+            "{}/{} {}",
+            self.library_type,
+            self.version,
+            USER_AGENT.as_str()
         )
     }
+}
+
+pub(crate) fn user_agent() -> String {
+    // Strip out the initial "rustc " string from `RUSTC_VERSION`. If not
+    // found, leave RUSTC_VERSION unchanged.
+    let rustc_version = built_info::RUSTC_VERSION;
+    let rustc_version = rustc_version
+        .strip_prefix("rustc ")
+        .unwrap_or(built_info::RUSTC_VERSION);
+
+    // Capture the gax version too.
+    let gax_version = built_info::PKG_VERSION;
+    format!("gax/{gax_version} gl-rust/{rustc_version}")
 }
 
 #[cfg(test)]

--- a/src/gax/src/lib.rs
+++ b/src/gax/src/lib.rs
@@ -86,3 +86,6 @@ pub mod paginator;
 #[cfg(feature = "unstable-sdk-client")]
 #[doc(hidden)]
 pub mod http_client;
+
+/// Defines traits and helpers to set options on requests.
+pub mod options;

--- a/src/gax/src/options/mod.rs
+++ b/src/gax/src/options/mod.rs
@@ -1,0 +1,132 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+
+// The number of options tends to grow rather quickly. Keep them in separate
+// modules to avoid overly large files and make these easier to find.
+mod request_timeout;
+pub use request_timeout::*;
+mod user_agent_prefix;
+pub use user_agent_prefix::*;
+
+pub trait RequestOption: 'static
+where
+    Self::Type: Any + Clone + Send,
+{
+    /// The type of the option.
+    type Type;
+}
+
+/// A set of options configuring a single request.
+///
+/// Some applications need to override the default settings on a per-request
+/// basis. For example, they may want to change the RPC timeout, or the retry
+/// policy on different requests.
+///
+/// The client RPCs accept an (optional) set of options applicable to the
+/// request.
+///
+/// Example:
+/// ```
+/// fn WithDefaults(client: &Client, req: ListFoosRequest) {
+///     client.list_foos(req, None)
+/// }
+///
+/// fn WithOptions(client: &Client, req: ListFoosRequest) {
+///     use std::time::Duration;
+///     let options = RequestOptions::new().set::<RequestTimeout>(Duration::from_secs(60));
+///     client.list_foos(req, options.into())
+/// }
+///
+/// fn Get(options: &RequestOptions) {
+///     let value = options.get::<RequestTimeout>();
+///     println!("current timeout set to {value:?}");
+/// }
+/// # struct ListFoosRequest;
+/// # struct Client {};
+/// # impl Client { pub fn list_foos(&self, req: ListFoosRequest, options: Option<RequestOptions>) {} }
+/// # use gcp_sdk_gax::options::RequestOptions;
+/// # use gcp_sdk_gax::options::RequestTimeout;
+/// ```
+#[derive(Debug, Default)]
+pub struct RequestOptions {
+    options: HashMap<TypeId, Box<dyn Any + Send>>,
+}
+
+impl RequestOptions {
+    /// Create a new (empty) set of options.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the option `O` to the value in `value`.
+    ///
+    /// # Parameters
+    /// * `value` - the new value for the option.
+    /// * `O` - the name of the option being set.
+    pub fn set<O>(mut self, value: impl Into<O::Type>) -> Self
+    where
+        O: RequestOption,
+    {
+        self.options
+            .insert(TypeId::of::<O>(), Box::new(value.into()));
+        self
+    }
+
+    /// Adds all the options from `values` to this collection of options.
+    ///
+    /// If both collections have the same option set, the value from `new` takes
+    /// precedence.
+    ///
+    /// # Parameters
+    /// * `new` - the new options values.
+    pub fn extend(mut self, new: RequestOptions) -> Self {
+        self.options.extend(new.options);
+        self
+    }
+
+    /// Retrieves the value for option `O`, or `None`if it is not set.
+    ///
+    /// #Parameters
+    /// * `O` - the name of the option to retrieve.
+    pub fn get<O: RequestOption>(&self) -> Option<O::Type> {
+        self.options
+            .get(&TypeId::of::<O>())
+            .and_then(|v| v.downcast_ref::<O::Type>())
+            .cloned()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn test_set_get() {
+        let options = RequestOptions::new()
+            .set::<RequestTimeout>(Duration::from_secs(123))
+            .set::<UserAgentPrefix>("myapp/3.4.5");
+        assert_eq!(
+            options.get::<RequestTimeout>(),
+            Some(Duration::from_secs(123))
+        );
+        assert_eq!(
+            options.get::<UserAgentPrefix>(),
+            Some("myapp/3.4.5".to_string())
+        );
+    }
+}

--- a/src/gax/src/options/request_timeout.rs
+++ b/src/gax/src/options/request_timeout.rs
@@ -1,0 +1,24 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Sets the timeout for requests.
+///
+/// RPCs can stall, applications can use this option to configure the maximum
+/// time allowed for an RPC. When retries are
+#[derive(Debug)]
+pub struct RequestTimeout;
+
+impl super::RequestOption for RequestTimeout {
+    type Type = std::time::Duration;
+}

--- a/src/gax/src/options/user_agent_prefix.rs
+++ b/src/gax/src/options/user_agent_prefix.rs
@@ -1,0 +1,20 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[derive(Debug)]
+pub struct UserAgentPrefix;
+
+impl super::RequestOption for UserAgentPrefix {
+    type Type = String;
+}

--- a/src/gax/tests/echo_server.rs
+++ b/src/gax/tests/echo_server.rs
@@ -1,0 +1,96 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Defines helpers functions to run ReqwestClient integration tests.
+//!
+//! Setting up integration tests is a bit complicated. So we refactor that code
+//! to some helper functions.
+
+use axum::{
+    extract::Query,
+    http::{HeaderMap, StatusCode},
+};
+use serde_json::json;
+use std::collections::HashMap;
+use tokio::task::JoinHandle;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+pub async fn start() -> Result<(String, JoinHandle<()>)> {
+    let app = axum::Router::new().route("/echo", axum::routing::get(echo));
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await?;
+    let addr = listener.local_addr()?;
+    let server = tokio::spawn(async {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    Ok((format!("http://{}:{}", addr.ip(), addr.port()), server))
+}
+
+#[allow(dead_code)]
+pub fn get_query_value(response: &serde_json::Value, name: &str) -> Option<String> {
+    response
+        .as_object()
+        .map(|o| o.get("query"))
+        .flatten()
+        .map(|h| h.get(name))
+        .flatten()
+        .map(|v| v.as_str())
+        .flatten()
+        .map(str::to_string)
+}
+
+async fn echo(
+    Query(query): Query<HashMap<String, String>>,
+    headers: HeaderMap,
+) -> (http::StatusCode, String) {
+    let response = echo_impl(query, headers).await;
+    match response {
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
+        Ok(s) => (StatusCode::OK, s),
+    }
+}
+
+async fn echo_impl(query: HashMap<String, String>, headers: HeaderMap) -> Result<String> {
+    let query = serde_json::Value::Object(
+        query
+            .into_iter()
+            .map(|(k, v)| (k, serde_json::Value::String(v)))
+            .collect(),
+    );
+    let headers = headers_to_json(headers)?;
+    let object = json!({
+        "headers": headers,
+        "query": query,
+    });
+    let body = serde_json::to_string(&object)?;
+    Ok(body)
+}
+
+fn headers_to_json(headers: HeaderMap) -> Result<serde_json::Value> {
+    let to_dyn = |e| -> Box<dyn std::error::Error + 'static> { Box::new(e) };
+    let headers = headers
+        .into_iter()
+        .map(|(k, v)| {
+            (
+                k.map(|h| h.to_string()).unwrap_or("__status__".to_string()),
+                v.to_str().map(|s| serde_json::Value::String(s.to_string())),
+            )
+        })
+        .map(|(k, v)| v.map(|s| (k, s)))
+        .map(|r| r.map_err(to_dyn))
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(serde_json::Value::Object(headers.into_iter().collect()))
+}

--- a/src/gax/tests/request_options.rs
+++ b/src/gax/tests/request_options.rs
@@ -1,0 +1,40 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use gcp_sdk_gax::options::{RequestOptions, RequestTimeout, UserAgentPrefix};
+use std::time::Duration;
+
+#[test]
+fn test_setall() {
+    let options = RequestOptions::new().set::<UserAgentPrefix>("myapp/4.5.6");
+    assert_eq!(
+        options.get::<UserAgentPrefix>(),
+        Some("myapp/4.5.6".to_string())
+    );
+    assert_eq!(options.get::<RequestTimeout>(), None);
+
+    let options = options.extend(
+        RequestOptions::new()
+            .set::<RequestTimeout>(Duration::from_secs(123))
+            .set::<UserAgentPrefix>("myapp/3.4.5"),
+    );
+    assert_eq!(
+        options.get::<RequestTimeout>(),
+        Some(Duration::from_secs(123))
+    );
+    assert_eq!(
+        options.get::<UserAgentPrefix>(),
+        Some("myapp/3.4.5".to_string())
+    );
+}

--- a/src/gax/tests/user_agent.rs
+++ b/src/gax/tests/user_agent.rs
@@ -1,0 +1,99 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use gax::http_client::*;
+use gax::options::*;
+use gcp_sdk_gax as gax;
+use serde_json::json;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+mod echo_server;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_user_agent() -> Result<()> {
+    let (endpoint, _server) = echo_server::start().await?;
+
+    let config = ClientConfig::default().set_credential(auth::Credential::test_credentials());
+    let client = ReqwestClient::new(config, &endpoint).await?;
+
+    let builder = client.builder(reqwest::Method::GET, "/echo".into());
+    let body = json!({});
+    let response = client
+        .execute_with_options::<serde_json::Value, serde_json::Value>(
+            builder,
+            Some(body),
+            RequestOptions::new(),
+        )
+        .await?;
+    let got = get_header_value(&response, "user-agent");
+    assert!(
+        got.as_ref().map(|v| v.contains("gax/")).unwrap_or(false),
+        "missing 'gax/' in {got:?}"
+    );
+    assert!(
+        got.as_ref()
+            .map(|v| v.contains("gl-rust/"))
+            .unwrap_or(false),
+        "missing 'gl-rust/' in {got:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_user_agent_with_prefix() -> Result<()> {
+    let (endpoint, _server) = echo_server::start().await?;
+
+    let config = ClientConfig::default().set_credential(auth::Credential::test_credentials());
+    let client = ReqwestClient::new(config, &endpoint).await?;
+
+    let builder = client.builder(reqwest::Method::GET, "/echo".into());
+    let body = json!({});
+    let prefix = "test-prefix/1.2.3";
+    let response = client
+        .execute_with_options::<serde_json::Value, serde_json::Value>(
+            builder,
+            Some(body),
+            RequestOptions::new().set::<UserAgentPrefix>(prefix),
+        )
+        .await?;
+    let got = get_header_value(&response, "user-agent");
+    assert!(
+        got.as_ref().map(|v| v.starts_with(prefix)).unwrap_or(false),
+        "missing prefix '{prefix}' in {got:?}"
+    );
+    assert!(
+        got.as_ref().map(|v| v.contains("gax/")).unwrap_or(false),
+        "missing 'gax/' in {got:?}"
+    );
+    assert!(
+        got.as_ref()
+            .map(|v| v.contains("gl-rust/"))
+            .unwrap_or(false),
+        "missing 'gl-rust/' in {got:?}"
+    );
+    Ok(())
+}
+
+fn get_header_value(response: &serde_json::Value, name: &str) -> Option<String> {
+    response
+        .as_object()
+        .map(|o| o.get("headers"))
+        .flatten()
+        .map(|h| h.get(name))
+        .flatten()
+        .map(|v| v.as_str())
+        .flatten()
+        .map(str::to_string)
+}


### PR DESCRIPTION
This introduces a mechanism to pass arbitrary options into the gax
`ReqwestClient`. I use `UserAgentPrefix` to show how these would work,
but I anticipate many more options (timeouts, retry loop policies, HTTP
version strings, proxy configuration?). And in the hand-crafted
libraries we will have even more options, many of them service specific.

Also introduced an echo server to simplify testing of the
`ReqwestClient`.