### PR TITLE
cleanup(generator/rust): no fixed packages templates

### DIFF
--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -21,7 +21,22 @@ googleapis-root   = 'https://github.com/googleapis/googleapis/archive/5285c0c325
 googleapis-sha256 = 'e076d2c608c9a2bcdb347e696eb4e536d28b9bd5b9d99153e8f5f8c0b3bdce1c'
 
 [codec]
-version                     = "0.1.0"
+# The default version for all crates. This can be overridden in the crate's
+# `.sidekick.toml` file.
+version = "0.1.0"
+# These are external (not part of `google-cloud-rust`) crates used by (nearly
+# all) generated crates. 
+'package:async-trait' = 'force-used=true,package=async-trait,version=0.1.83'
+'package:bytes'       = 'force-used=true,package=bytes,version=1.8.0,feature=serde'
+'package:lazy_static' = 'force-used=true,package=lazy_static,version=1.5.0'
+'package:reqwest'     = 'force-used=true,package=reqwest,version=0.12.9,feature=json'
+'package:serde'       = 'force-used=true,package=serde,version=1.0.214,feature=serde_derive'
+'package:serde_json'  = 'force-used=true,package=serde_json,version=1.0.132'
+'package:serde_with'  = 'force-used=true,package=serde_with,version=3.11.0,feature=base64'
+'package:time'        = 'force-used=true,package=time,version=0.3.36,feature=formatting,feature=parsing'
+'package:tracing'     = 'force-used=true,package=tracing,version=0.1.41'
+# These are crates in `google-cloud-rust`. If not used, `sidekick` prunes them
+# from the list of depedencies.
 'package:gtype'             = 'package=gcp-sdk-type,source=google.type,path=src/generated/type,version=0.1.0'
 'package:gax'               = 'package=gcp-sdk-gax,path=src/gax,feature=unstable-sdk-client,version=0.1.0'
 'package:google-cloud-auth' = 'package=google-cloud-auth,path=auth,version=0.1.0'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -26,7 +26,7 @@ publish     = false
 
 [dependencies]
 base64         = "0.22"
-chrono         = { version = "0.4", features = ["serde"] }
+chrono         = { version = "0.4.39", features = ["serde"] }
 reqwest        = { version = "0.12", features = ["json"] }
 rustls         = "0.20"
 rustls-pemfile = "0.2"

--- a/generator/internal/language/rust.go
+++ b/generator/internal/language/rust.go
@@ -950,7 +950,7 @@ func (c *RustCodec) RequiredPackages() []string {
 		if pkg.Path != "" {
 			components = append(components, fmt.Sprintf("path = %q", path.Join(c.projectRoot(), pkg.Path)))
 		}
-		if pkg.Package != "" {
+		if pkg.Package != "" && pkg.Name != pkg.Package {
 			components = append(components, fmt.Sprintf("package = %q", pkg.Package))
 		}
 		if len(pkg.Features) > 0 {

--- a/generator/internal/language/rust_test.go
+++ b/generator/internal/language/rust_test.go
@@ -92,9 +92,10 @@ func TestRust_ParseOptions(t *testing.T) {
 func TestRust_RequiredPackages(t *testing.T) {
 	outdir := "src/generated/newlib"
 	options := map[string]string{
-		"package:gtype": "package=types,path=src/generated/type,source=google.type,source=test-only",
-		"package:gax":   "package=gax,path=src/gax,version=1.2.3,force-used=true",
-		"package:auth":  "ignore=true",
+		"package:async-trait": "package=async-trait,version=0.1.83,force-used=true",
+		"package:gtype":       "package=gcp-sdk-type,path=src/generated/type,source=google.type,source=test-only",
+		"package:gax":         "package=gcp-sdk-gax,path=src/gax,version=1.2.3,force-used=true",
+		"package:auth":        "ignore=true",
 	}
 	codec, err := NewRustCodec(outdir, options)
 	if err != nil {
@@ -102,7 +103,8 @@ func TestRust_RequiredPackages(t *testing.T) {
 	}
 	got := codec.RequiredPackages()
 	want := []string{
-		"gax        = { version = \"1.2.3\", path = \"../../../src/gax\", package = \"gax\" }",
+		"async-trait = { version = \"0.1.83\" }",
+		"gax        = { version = \"1.2.3\", path = \"../../../src/gax\", package = \"gcp-sdk-gax\" }",
 	}
 	less := func(a, b string) bool { return a < b }
 	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {

--- a/generator/internal/language/templates/rust/crate/Cargo.toml.mustache
+++ b/generator/internal/language/templates/rust/crate/Cargo.toml.mustache
@@ -33,15 +33,6 @@ publish              = false
 {{/NotForPublication}}
 
 [dependencies]
-async-trait = "0.1.83"
-lazy_static = "1.5.0"
-tracing     = "0.1.41"
-serde      = { version = "1.0.214", features = ["serde_derive"] }
-serde_with = { version = "3.11.0", features = ["base64"] }
-serde_json = "1.0.132"
-time       = { version = "0.3.36", features = ["formatting", "parsing"] }
-reqwest    = { version = "0.12.9", features = ["json"] }
-bytes      = { version = "1.8.0", features = ["serde"] }
 {{#RequiredPackages}}
 {{{.}}}
 {{/RequiredPackages}}

--- a/generator/testdata/rust/gclient/golden/iam/v1/Cargo.toml
+++ b/generator/testdata/rust/gclient/golden/iam/v1/Cargo.toml
@@ -27,15 +27,6 @@ categories.workspace = true
 publish              = false
 
 [dependencies]
-async-trait = "0.1.83"
-lazy_static = "1.5.0"
-tracing     = "0.1.41"
-serde      = { version = "1.0.214", features = ["serde_derive"] }
-serde_with = { version = "3.11.0", features = ["base64"] }
-serde_json = "1.0.132"
-time       = { version = "0.3.36", features = ["formatting", "parsing"] }
-reqwest    = { version = "0.12.9", features = ["json"] }
-bytes      = { version = "1.8.0", features = ["serde"] }
 gax        = { path = "../../../../../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
 gtype      = { path = "../../../../../../testdata/rust/gclient/golden/type", package = "type-golden-gclient" }
 wkt        = { path = "../../../../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/generator/testdata/rust/gclient/golden/location/Cargo.toml
+++ b/generator/testdata/rust/gclient/golden/location/Cargo.toml
@@ -27,14 +27,5 @@ categories.workspace = true
 publish              = false
 
 [dependencies]
-async-trait = "0.1.83"
-lazy_static = "1.5.0"
-tracing     = "0.1.41"
-serde      = { version = "1.0.214", features = ["serde_derive"] }
-serde_with = { version = "3.11.0", features = ["base64"] }
-serde_json = "1.0.132"
-time       = { version = "0.3.36", features = ["formatting", "parsing"] }
-reqwest    = { version = "0.12.9", features = ["json"] }
-bytes      = { version = "1.8.0", features = ["serde"] }
 gax        = { path = "../../../../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
 wkt        = { path = "../../../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/generator/testdata/rust/gclient/golden/secretmanager/Cargo.toml
+++ b/generator/testdata/rust/gclient/golden/secretmanager/Cargo.toml
@@ -27,15 +27,6 @@ categories.workspace = true
 publish              = false
 
 [dependencies]
-async-trait = "0.1.83"
-lazy_static = "1.5.0"
-tracing     = "0.1.41"
-serde      = { version = "1.0.214", features = ["serde_derive"] }
-serde_with = { version = "3.11.0", features = ["base64"] }
-serde_json = "1.0.132"
-time       = { version = "0.3.36", features = ["formatting", "parsing"] }
-reqwest    = { version = "0.12.9", features = ["json"] }
-bytes      = { version = "1.8.0", features = ["serde"] }
 gax        = { path = "../../../../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
 iam        = { path = "../../../../../testdata/rust/gclient/golden/iam/v1", package = "iam-v1-golden-gclient" }
 location   = { path = "../../../../../testdata/rust/gclient/golden/location", package = "location-golden-gclient" }

--- a/generator/testdata/rust/gclient/golden/type/Cargo.toml
+++ b/generator/testdata/rust/gclient/golden/type/Cargo.toml
@@ -27,12 +27,3 @@ categories.workspace = true
 publish              = false
 
 [dependencies]
-async-trait = "0.1.83"
-lazy_static = "1.5.0"
-tracing     = "0.1.41"
-serde      = { version = "1.0.214", features = ["serde_derive"] }
-serde_with = { version = "3.11.0", features = ["base64"] }
-serde_json = "1.0.132"
-time       = { version = "0.3.36", features = ["formatting", "parsing"] }
-reqwest    = { version = "0.12.9", features = ["json"] }
-bytes      = { version = "1.8.0", features = ["serde"] }

--- a/generator/testdata/rust/openapi/golden/Cargo.toml
+++ b/generator/testdata/rust/openapi/golden/Cargo.toml
@@ -27,14 +27,5 @@ categories.workspace = true
 publish              = false
 
 [dependencies]
-async-trait = "0.1.83"
-lazy_static = "1.5.0"
-tracing     = "0.1.41"
-serde      = { version = "1.0.214", features = ["serde_derive"] }
-serde_with = { version = "3.11.0", features = ["base64"] }
-serde_json = "1.0.132"
-time       = { version = "0.3.36", features = ["formatting", "parsing"] }
-reqwest    = { version = "0.12.9", features = ["json"] }
-bytes      = { version = "1.8.0", features = ["serde"] }
 gax        = { path = "../../../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
 wkt        = { path = "../../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/cloud/location/Cargo.toml
+++ b/src/generated/cloud/location/Cargo.toml
@@ -26,14 +26,14 @@ keywords.workspace   = true
 categories.workspace = true
 
 [dependencies]
-async-trait = "0.1.83"
-lazy_static = "1.5.0"
-tracing     = "0.1.41"
-serde      = { version = "1.0.214", features = ["serde_derive"] }
-serde_with = { version = "3.11.0", features = ["base64"] }
-serde_json = "1.0.132"
-time       = { version = "0.3.36", features = ["formatting", "parsing"] }
-reqwest    = { version = "0.12.9", features = ["json"] }
+async-trait = { version = "0.1.83" }
 bytes      = { version = "1.8.0", features = ["serde"] }
 gax        = { version = "0.1.0", path = "../../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
+lazy_static = { version = "1.5.0" }
+reqwest    = { version = "0.12.9", features = ["json"] }
+serde      = { version = "1.0.214", features = ["serde_derive"] }
+serde_json = { version = "1.0.132" }
+serde_with = { version = "3.11.0", features = ["base64"] }
+time       = { version = "0.3.36", features = ["formatting", "parsing"] }
+tracing    = { version = "0.1.41" }
 wkt        = { version = "0.1.0", path = "../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/cloud/secretmanager/v1/Cargo.toml
+++ b/src/generated/cloud/secretmanager/v1/Cargo.toml
@@ -26,16 +26,16 @@ keywords.workspace   = true
 categories.workspace = true
 
 [dependencies]
-async-trait = "0.1.83"
-lazy_static = "1.5.0"
-tracing     = "0.1.41"
-serde      = { version = "1.0.214", features = ["serde_derive"] }
-serde_with = { version = "3.11.0", features = ["base64"] }
-serde_json = "1.0.132"
-time       = { version = "0.3.36", features = ["formatting", "parsing"] }
-reqwest    = { version = "0.12.9", features = ["json"] }
+async-trait = { version = "0.1.83" }
 bytes      = { version = "1.8.0", features = ["serde"] }
 gax        = { version = "0.1.0", path = "../../../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
 iam_v1     = { version = "0.1.0", path = "../../../../../src/generated/iam/v1", package = "gcp-sdk-iam-v1" }
+lazy_static = { version = "1.5.0" }
 location   = { version = "0.1.0", path = "../../../../../src/generated/cloud/location", package = "gcp-sdk-location" }
+reqwest    = { version = "0.12.9", features = ["json"] }
+serde      = { version = "1.0.214", features = ["serde_derive"] }
+serde_json = { version = "1.0.132" }
+serde_with = { version = "3.11.0", features = ["base64"] }
+time       = { version = "0.3.36", features = ["formatting", "parsing"] }
+tracing    = { version = "0.1.41" }
 wkt        = { version = "0.1.0", path = "../../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/iam/v1/Cargo.toml
+++ b/src/generated/iam/v1/Cargo.toml
@@ -26,15 +26,15 @@ keywords.workspace   = true
 categories.workspace = true
 
 [dependencies]
-async-trait = "0.1.83"
-lazy_static = "1.5.0"
-tracing     = "0.1.41"
-serde      = { version = "1.0.214", features = ["serde_derive"] }
-serde_with = { version = "3.11.0", features = ["base64"] }
-serde_json = "1.0.132"
-time       = { version = "0.3.36", features = ["formatting", "parsing"] }
-reqwest    = { version = "0.12.9", features = ["json"] }
+async-trait = { version = "0.1.83" }
 bytes      = { version = "1.8.0", features = ["serde"] }
 gax        = { version = "0.1.0", path = "../../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
 gtype      = { version = "0.1.0", path = "../../../../src/generated/type", package = "gcp-sdk-type" }
+lazy_static = { version = "1.5.0" }
+reqwest    = { version = "0.12.9", features = ["json"] }
+serde      = { version = "1.0.214", features = ["serde_derive"] }
+serde_json = { version = "1.0.132" }
+serde_with = { version = "3.11.0", features = ["base64"] }
+time       = { version = "0.3.36", features = ["formatting", "parsing"] }
+tracing    = { version = "0.1.41" }
 wkt        = { version = "0.1.0", path = "../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/openapi-validation/Cargo.toml
+++ b/src/generated/openapi-validation/Cargo.toml
@@ -27,14 +27,14 @@ categories.workspace = true
 publish              = false
 
 [dependencies]
-async-trait = "0.1.83"
-lazy_static = "1.5.0"
-tracing     = "0.1.41"
-serde      = { version = "1.0.214", features = ["serde_derive"] }
-serde_with = { version = "3.11.0", features = ["base64"] }
-serde_json = "1.0.132"
-time       = { version = "0.3.36", features = ["formatting", "parsing"] }
-reqwest    = { version = "0.12.9", features = ["json"] }
+async-trait = { version = "0.1.83" }
 bytes      = { version = "1.8.0", features = ["serde"] }
 gax        = { version = "0.1.0", path = "../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
+lazy_static = { version = "1.5.0" }
+reqwest    = { version = "0.12.9", features = ["json"] }
+serde      = { version = "1.0.214", features = ["serde_derive"] }
+serde_json = { version = "1.0.132" }
+serde_with = { version = "3.11.0", features = ["base64"] }
+time       = { version = "0.3.36", features = ["formatting", "parsing"] }
+tracing    = { version = "0.1.41" }
 wkt        = { version = "0.1.0", path = "../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/type/Cargo.toml
+++ b/src/generated/type/Cargo.toml
@@ -26,13 +26,13 @@ keywords.workspace   = true
 categories.workspace = true
 
 [dependencies]
-async-trait = "0.1.83"
-lazy_static = "1.5.0"
-tracing     = "0.1.41"
-serde      = { version = "1.0.214", features = ["serde_derive"] }
-serde_with = { version = "3.11.0", features = ["base64"] }
-serde_json = "1.0.132"
-time       = { version = "0.3.36", features = ["formatting", "parsing"] }
-reqwest    = { version = "0.12.9", features = ["json"] }
+async-trait = { version = "0.1.83" }
 bytes      = { version = "1.8.0", features = ["serde"] }
+lazy_static = { version = "1.5.0" }
+reqwest    = { version = "0.12.9", features = ["json"] }
+serde      = { version = "1.0.214", features = ["serde_derive"] }
+serde_json = { version = "1.0.132" }
+serde_with = { version = "3.11.0", features = ["base64"] }
+time       = { version = "0.3.36", features = ["formatting", "parsing"] }
+tracing    = { version = "0.1.41" }
 wkt        = { version = "0.1.0", path = "../../../src/wkt", package = "gcp-sdk-wkt" }


### PR DESCRIPTION
Remove all hard-coded packages from `Cargo.toml.mustache`. Having the
list on the template file would require changing the  generator when
a new version of these packages is needed. We can keep this list of
packages in the top-level `.sidekick.toml` file, which is easier to
manually change when needed (and then just `sidekick refreshall`).