### PR TITLE
impl(auth): credential traits in modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,6 +565,7 @@ version = "0.0.0"
 name = "gcp-sdk-auth"
 version = "0.0.0"
 dependencies = [
+ "async-trait",
  "http",
  "thiserror",
  "time",

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -24,6 +24,7 @@ keywords.workspace   = true
 categories.workspace = true
 
 [dependencies]
-thiserror = "2"
-http      = "1.2.0"
-time      = "0.3.37"
+async-trait = "0.1.83"
+thiserror   = "2"
+http        = "1.2.0"
+time        = "0.3.37"

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -17,6 +17,8 @@ use std::future::Future;
 
 type Result<T> = std::result::Result<T, crate::errors::CredentialError>;
 
+/// An implementation of [crate::credentials::traits::Credential].
+///
 /// Represents a [Credential] used to obtain auth [Token][crate::token::Token]s
 /// and the corresponding request headers.
 ///
@@ -38,9 +40,9 @@ type Result<T> = std::result::Result<T, crate::errors::CredentialError>;
 /// only when used from a given machine (virtual or not). Further limiting the
 /// risks associated with any leaks of these tokens.
 ///
-/// This trait also abstracts token sources that are not backed by an specific
+/// This struct also abstracts token sources that are not backed by a specific
 /// digital object. The canonical example is the [Metadata Service]. This
-/// service available in many Google Cloud environments, including
+/// service is available in many Google Cloud environments, including
 /// [Google Compute Engine], and [Google Kubernetes Engine].
 ///
 /// [credentials-link]: https://cloud.google.com/docs/authentication#credentials
@@ -73,6 +75,45 @@ pub mod traits {
     use super::Result;
     use super::{HeaderName, HeaderValue};
 
+    /// Represents a [Credential] used to obtain auth
+    /// [Token][crate::token::Token]s and the corresponding request headers.
+    ///
+    /// In general, [Credentials][credentials-link] are "digital object that
+    /// provide proof of identity", the archetype may be a username and password
+    /// combination, but a private RSA key may be a better example.
+    ///
+    /// Modern authentication protocols do not send the credentials to
+    /// authenticate with a service. Even when sent over encrypted transports,
+    /// the credentials may be accidentally exposed via logging or may be
+    /// captured if there are errors in the transport encryption. Because the
+    /// credentials are often long-lived, that risk of exposure is also
+    /// long-lived.
+    ///
+    /// Instead, modern authentication protocols exchange the credentials for a
+    /// time-limited [Token][token-link], a digital object that shows the caller
+    /// was in possession of the credentials. Because tokens are time limited,
+    /// risk of misuse is also time limited. Tokens may be further restricted to
+    /// only a certain subset of the RPCs in the service, or even to specific
+    /// resources, or only when used from a given machine (virtual or not).
+    /// Further limiting the risks associated with any leaks of these tokens.
+    ///
+    /// This struct also abstracts token sources that are not backed by a
+    /// specific digital object. The canonical example is the [Metadata
+    /// Service]. This service is available in many Google Cloud environments,
+    /// including [Google Compute Engine], and [Google Kubernetes Engine].
+    ///
+    /// # Notes
+    ///
+    /// Application developers who directly use the Auth SDK can use this trait
+    /// to mock the credentials. Application developers who use the Google Cloud
+    /// Rust SDK directly should not need this functionality.
+    ///
+    /// [credentials-link]:
+    /// https://cloud.google.com/docs/authentication#credentials [token-link]:
+    /// https://cloud.google.com/docs/authentication#token [Metadata Service]:
+    /// https://cloud.google.com/compute/docs/metadata/overview [Google Compute
+    /// Engine]: https://cloud.google.com/products/compute [Google Kubernetes
+    /// Engine]: https://cloud.google.com/kubernetes-engine
     pub trait Credential {
         /// Asynchronously retrieves a token.
         ///
@@ -95,7 +136,7 @@ pub mod traits {
         fn get_universe_domain(&mut self) -> impl Future<Output = Option<String>> + Send;
     }
 
-    pub mod dynamic {
+    pub(crate) mod dynamic {
         use super::Result;
         use super::{HeaderName, HeaderValue};
 

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -98,9 +98,10 @@ pub mod traits {
     /// Further limiting the risks associated with any leaks of these tokens.
     ///
     /// This struct also abstracts token sources that are not backed by a
-    /// specific digital object. The canonical example is the [Metadata
-    /// Service]. This service is available in many Google Cloud environments,
-    /// including [Google Compute Engine], and [Google Kubernetes Engine].
+    /// specific digital object. The canonical example is the
+    /// [Metadata Service]. This service is available in many Google Cloud
+    /// environments, including [Google Compute Engine], and
+    /// [Google Kubernetes Engine].
     ///
     /// # Notes
     ///
@@ -108,12 +109,11 @@ pub mod traits {
     /// to mock the credentials. Application developers who use the Google Cloud
     /// Rust SDK directly should not need this functionality.
     ///
-    /// [credentials-link]:
-    /// https://cloud.google.com/docs/authentication#credentials [token-link]:
-    /// https://cloud.google.com/docs/authentication#token [Metadata Service]:
-    /// https://cloud.google.com/compute/docs/metadata/overview [Google Compute
-    /// Engine]: https://cloud.google.com/products/compute [Google Kubernetes
-    /// Engine]: https://cloud.google.com/kubernetes-engine
+    /// [credentials-link]: https://cloud.google.com/docs/authentication#credentials
+    /// [token-link]: https://cloud.google.com/docs/authentication#token
+    /// [Metadata Service]: https://cloud.google.com/compute/docs/metadata/overview
+    /// [Google Compute Engine]: https://cloud.google.com/products/compute
+    /// [Google Kubernetes Engine]: https://cloud.google.com/kubernetes-engine
     pub trait Credential {
         /// Asynchronously retrieves a token.
         ///


### PR DESCRIPTION
Part of the work for #442 

Move around the definitions for the Credential trait, as per the design. The crate version is `0.0.0`, this is fine.

Let me know what all needs documenting. Anything `pub`?

And whether I need/want unit tests for `impl traits::Credential for Credential`