### PR TITLE
ci: update mdformat version and reformat

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "pip"
-    directory: "/ci"
-    schedule:
-      interval: "weekly"

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -15,7 +15,7 @@
 # A requirements file to install Python-based development tools. Using a file
 # makes these dependencies visible to robots like dependabot and renovatebot.
 
-mdformat==0.7.18
+mdformat==0.7.19
 mdformat-gfm==0.4.1
 mdformat-frontmatter==2.0.8
 mdformat-footnote==0.1.1

--- a/generator/README.md
+++ b/generator/README.md
@@ -61,7 +61,7 @@ we suggest two approaches:
 - The Protobuf team ships easy to install binaries with each release. In the
   [latest Protobuf release][protobuf-latest] you can find a `.zip` file for
   your platform. Download and extract such that the `bin/` subdirectory is in
-  your path.  For example:
+  your path. For example:
 
   ```shell
   curl -fSSL -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protoc-28.3-linux-x86_64.zip


### PR DESCRIPTION
Also remove this tooling from dependabot automatic updates. We don't
care that much about keeping the tools up to date, and I care more about
stable CI and tooling.

