### PR TITLE
impl(auth): introduce `TokenProvider`, `UserCredentials`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +392,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +469,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "fs_extra"
@@ -567,6 +585,7 @@ version = "0.1.0-rc2"
 dependencies = [
  "async-trait",
  "http",
+ "mockall",
  "test-case",
  "thiserror",
  "time",
@@ -1259,6 +1278,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,6 +1506,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -1987,6 +2058,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-case"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,8 +567,10 @@ version = "0.1.0-rc2"
 dependencies = [
  "async-trait",
  "http",
+ "test-case",
  "thiserror",
  "time",
+ "tokio",
 ]
 
 [[package]]

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -28,3 +28,7 @@ async-trait = "0.1.83"
 thiserror   = "2"
 http        = "1.2.0"
 time        = "0.3.37"
+
+[dev-dependencies]
+test-case = "3.3.1"
+tokio     = { version = "1.41.1", features = ["macros"] }

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -30,5 +30,6 @@ http        = "1.2.0"
 time        = "0.3.37"
 
 [dev-dependencies]
+mockall   = "0.13.1"
 test-case = "3.3.1"
-tokio     = { version = "1.41.1", features = ["macros"] }
+tokio     = { version = "1.42", features = ["macros", "test-util"] }

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub(crate) mod user_credential;
+
 use crate::Result;
 use http::header::{HeaderName, HeaderValue};
 use std::future::Future;

--- a/src/auth/src/credentials/user_credential.rs
+++ b/src/auth/src/credentials/user_credential.rs
@@ -1,0 +1,103 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::credentials::traits::dynamic::Credential;
+use crate::credentials::Result;
+use crate::errors::{BoxError, CredentialError};
+use crate::token::{Token, TokenProvider};
+use http::header::{HeaderName, HeaderValue};
+
+/// Data model for a UserCredential
+#[allow(dead_code)] // TODO(#442) - implementation in progress
+pub(crate) struct UserCredential {
+    token_provider: Box<dyn TokenProvider>,
+}
+
+#[async_trait::async_trait]
+impl Credential for UserCredential {
+    async fn get_token(&mut self) -> Result<Token> {
+        self.token_provider.get_token().await
+    }
+
+    async fn get_headers(&mut self) -> Result<Vec<(HeaderName, HeaderValue)>> {
+        // TODO(#442) - implementation in progress
+        Err(CredentialError::new(false, BoxError::from("unimplemented")))
+    }
+
+    async fn get_universe_domain(&mut self) -> Option<String> {
+        Some("googleapis.com".to_string())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    struct TestTokenProvider {
+        token: Token,
+    }
+
+    #[async_trait::async_trait]
+    impl TokenProvider for TestTokenProvider {
+        async fn get_token(&mut self) -> Result<Token> {
+            Ok(self.token.clone())
+        }
+    }
+
+    struct TestErrorProvider {
+        is_retryable: bool,
+        message: String,
+    }
+
+    #[async_trait::async_trait]
+    impl TokenProvider for TestErrorProvider {
+        async fn get_token(&mut self) -> Result<Token> {
+            Err(CredentialError::new(
+                self.is_retryable,
+                BoxError::from(self.message.clone()),
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn get_token_success() {
+        let expected = Token {
+            token: "test-token".to_string(),
+            token_type: "Bearer".to_string(),
+            expires_at: None,
+            metadata: None,
+        };
+
+        let tp = TestTokenProvider {
+            token: expected.clone(),
+        };
+        let mut uc = UserCredential {
+            token_provider: Box::new(tp),
+        };
+        let actual = uc.get_token().await.unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[tokio::test]
+    async fn get_token_failure() {
+        let tp = TestErrorProvider {
+            is_retryable: false,
+            message: "fail".to_string(),
+        };
+        let mut uc = UserCredential {
+            token_provider: Box::new(tp),
+        };
+        assert!(uc.get_token().await.is_err());
+    }
+}

--- a/src/auth/src/errors.rs
+++ b/src/auth/src/errors.rs
@@ -15,7 +15,7 @@
 use std::error::Error;
 use std::fmt::{Display, Formatter, Result};
 
-type BoxError = Box<dyn Error + Send + Sync>;
+pub(crate) type BoxError = Box<dyn Error + Send + Sync>;
 
 /// Represents an error creating or using a [Credential](crate::credentials::Credential).
 ///

--- a/src/auth/src/token.rs
+++ b/src/auth/src/token.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::credentials::Result;
+
 /// Represents an auth token.
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Token {
     /// The actual token string.
     ///
@@ -35,4 +37,10 @@ pub struct Token {
     ///
     /// This might include information like granted scopes or other claims.
     pub metadata: Option<std::collections::HashMap<String, String>>,
+}
+
+#[async_trait::async_trait]
+#[allow(dead_code)] // TODO(#442) - implementation in progress
+pub(crate) trait TokenProvider: Send + Sync {
+    async fn get_token(&mut self) -> Result<Token>;
 }

--- a/src/auth/src/token.rs
+++ b/src/auth/src/token.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::credentials::Result;
+use crate::Result;
 
 /// Represents an auth token.
 #[derive(Clone, Debug, PartialEq)]
@@ -43,4 +43,18 @@ pub struct Token {
 #[allow(dead_code)] // TODO(#442) - implementation in progress
 pub(crate) trait TokenProvider: Send + Sync {
     async fn get_token(&mut self) -> Result<Token>;
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use super::*;
+
+    mockall::mock! {
+        pub TokenProvider { }
+
+        #[async_trait::async_trait]
+        impl TokenProvider for TokenProvider {
+            async fn get_token(&mut self) -> Result<Token>;
+        }
+    }
 }


### PR DESCRIPTION
Part of the work for #442 

Introduce the (internal) `TokenProvider`, and (internal) `UserCredential` types.

My intention is to mock the `TokenProvider` in the test cases. It looks like unit tests for internal classes belong in the same file as the implementation, so that is what I did for `user_credential.rs`.

Q: Should unit tests return `Result`s?

I decided to cut off the PR early (without implementing `get_headers()`) because I have probably made too many mistakes already.

Note that `CredentialError` is using a `Box`, so we cannot clone it. That prevents me from using code like this in my test. Maybe it should use an `Arc`?

```rs
struct TestTokenProvider {
  token: Result<Token>,
}
```