### PR TITLE
chore: prepare for 0.1.0-rc2

### DIFF
--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -23,7 +23,7 @@ googleapis-sha256 = 'e076d2c608c9a2bcdb347e696eb4e536d28b9bd5b9d99153e8f5f8c0b3b
 [codec]
 # The default version for all crates. This can be overridden in the crate's
 # `.sidekick.toml` file.
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 # These are external (not part of `google-cloud-rust`) crates used by (nearly
 # all) generated crates. 
 'package:async-trait' = 'force-used=true,package=async-trait,version=0.1.83'
@@ -37,9 +37,9 @@ version = "0.1.0-rc1"
 'package:tracing'     = 'force-used=true,package=tracing,version=0.1.41'
 # These are crates in `google-cloud-rust`. If not used, `sidekick` prunes them
 # from the list of depedencies.
-'package:gtype'             = 'package=gcp-sdk-type,source=google.type,path=src/generated/type,version=0.1.0-rc1'
-'package:gax'               = 'package=gcp-sdk-gax,path=src/gax,feature=unstable-sdk-client,version=0.1.0-rc1'
-'package:google-cloud-auth' = 'package=google-cloud-auth,path=auth,version=0.1.0-rc1'
-'package:wkt'               = 'package=gcp-sdk-wkt,path=src/wkt,source=google.protobuf,version=0.1.0-rc1'
-'package:iam_v1'            = 'package=gcp-sdk-iam-v1,source=google.iam.v1,path=src/generated/iam/v1,version=0.1.0-rc1'
-'package:location'          = 'package=gcp-sdk-location,source=google.cloud.location,path=src/generated/cloud/location,version=0.1.0-rc1'
+'package:gtype'             = 'package=gcp-sdk-type,source=google.type,path=src/generated/type,version=0.1.0-rc2'
+'package:gax'               = 'package=gcp-sdk-gax,path=src/gax,feature=unstable-sdk-client,version=0.1.0-rc2'
+'package:google-cloud-auth' = 'package=google-cloud-auth,path=auth,version=0.1.0-rc2'
+'package:wkt'               = 'package=gcp-sdk-wkt,path=src/wkt,source=google.protobuf,version=0.1.0-rc2'
+'package:iam_v1'            = 'package=gcp-sdk-iam-v1,source=google.iam.v1,path=src/generated/iam/v1,version=0.1.0-rc2'
+'package:location'          = 'package=gcp-sdk-location,source=google.cloud.location,path=src/generated/cloud/location,version=0.1.0-rc2'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,7 +563,7 @@ version = "0.0.0"
 
 [[package]]
 name = "gcp-sdk-auth"
-version = "0.0.0"
+version = "0.1.0-rc2"
 dependencies = [
  "async-trait",
  "http",
@@ -581,7 +581,7 @@ version = "0.0.0"
 
 [[package]]
 name = "gcp-sdk-gax"
-version = "0.1.0"
+version = "0.1.0-rc2"
 dependencies = [
  "axum",
  "built",
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "gcp-sdk-iam-v1"
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "gcp-sdk-location"
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -642,7 +642,7 @@ version = "0.0.0"
 
 [[package]]
 name = "gcp-sdk-secretmanager-v1"
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "gcp-sdk-type"
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "gcp-sdk-wkt"
-version = "0.1.0"
+version = "0.1.0-rc2"
 dependencies = [
  "bytes",
  "gcp-sdk-wkt",
@@ -1720,7 +1720,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secretmanager-openapi-v1"
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 dependencies = [
  "async-trait",
  "bytes",

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name                 = "gcp-sdk-auth"
-version              = "0.0.0"
+version              = "0.1.0-rc2"
 description          = "Google Cloud SDK for Rust"
 edition.workspace    = true
 authors.workspace    = true

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name                 = "gcp-sdk-gax"
-version              = "0.1.0"
+version              = "0.1.0-rc2"
 description          = "Google Cloud SDK for Rust"
 build                = "build.rs"
 edition.workspace    = true
@@ -35,7 +35,7 @@ serde_json  = "1.0.133"
 serde_with  = { version = "3.11.0", default-features = false, features = ["base64", "macros"] }
 thiserror   = "2.0.3"
 auth        = { version = "0.1.0", path = "../../auth", package = "google-cloud-auth", optional = true }
-wkt         = { version = "0.1.0", path = "../wkt", package = "gcp-sdk-wkt" }
+wkt         = { version = "0.1.0-rc2", path = "../wkt", package = "gcp-sdk-wkt" }
 
 [dev-dependencies]
 # This is a workaround to integration test features of this crate. Open issue

--- a/src/generated/cloud/location/Cargo.toml
+++ b/src/generated/cloud/location/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                 = "gcp-sdk-location"
-version              = "0.1.0-rc1"
+version              = "0.1.0-rc2"
 description          = "Google Cloud SDK for Rust - Cloud Metadata API"
 edition.workspace    = true
 authors.workspace    = true
@@ -28,7 +28,7 @@ categories.workspace = true
 [dependencies]
 async-trait = { version = "0.1.83" }
 bytes      = { version = "1.8.0", features = ["serde"] }
-gax        = { version = "0.1.0-rc1", path = "../../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
+gax        = { version = "0.1.0-rc2", path = "../../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1.5.0" }
 reqwest    = { version = "0.12.9", features = ["json"] }
 serde      = { version = "1.0.214", features = ["serde_derive"] }
@@ -36,4 +36,4 @@ serde_json = { version = "1.0.132" }
 serde_with = { version = "3.11.0", default-features = false, features = ["base64", "macros", "std"] }
 time       = { version = "0.3.36", features = ["formatting", "parsing"] }
 tracing    = { version = "0.1.41" }
-wkt        = { version = "0.1.0-rc1", path = "../../../../src/wkt", package = "gcp-sdk-wkt" }
+wkt        = { version = "0.1.0-rc2", path = "../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/cloud/secretmanager/v1/Cargo.toml
+++ b/src/generated/cloud/secretmanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                 = "gcp-sdk-secretmanager-v1"
-version              = "0.1.0-rc1"
+version              = "0.1.0-rc2"
 description          = "Google Cloud SDK for Rust - Secret Manager API"
 edition.workspace    = true
 authors.workspace    = true
@@ -28,14 +28,14 @@ categories.workspace = true
 [dependencies]
 async-trait = { version = "0.1.83" }
 bytes      = { version = "1.8.0", features = ["serde"] }
-gax        = { version = "0.1.0-rc1", path = "../../../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
-iam_v1     = { version = "0.1.0-rc1", path = "../../../../../src/generated/iam/v1", package = "gcp-sdk-iam-v1" }
+gax        = { version = "0.1.0-rc2", path = "../../../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
+iam_v1     = { version = "0.1.0-rc2", path = "../../../../../src/generated/iam/v1", package = "gcp-sdk-iam-v1" }
 lazy_static = { version = "1.5.0" }
-location   = { version = "0.1.0-rc1", path = "../../../../../src/generated/cloud/location", package = "gcp-sdk-location" }
+location   = { version = "0.1.0-rc2", path = "../../../../../src/generated/cloud/location", package = "gcp-sdk-location" }
 reqwest    = { version = "0.12.9", features = ["json"] }
 serde      = { version = "1.0.214", features = ["serde_derive"] }
 serde_json = { version = "1.0.132" }
 serde_with = { version = "3.11.0", default-features = false, features = ["base64", "macros", "std"] }
 time       = { version = "0.3.36", features = ["formatting", "parsing"] }
 tracing    = { version = "0.1.41" }
-wkt        = { version = "0.1.0-rc1", path = "../../../../../src/wkt", package = "gcp-sdk-wkt" }
+wkt        = { version = "0.1.0-rc2", path = "../../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/iam/v1/Cargo.toml
+++ b/src/generated/iam/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                 = "gcp-sdk-iam-v1"
-version              = "0.1.0-rc1"
+version              = "0.1.0-rc2"
 description          = "Google Cloud SDK for Rust - IAM Meta API"
 edition.workspace    = true
 authors.workspace    = true
@@ -28,8 +28,8 @@ categories.workspace = true
 [dependencies]
 async-trait = { version = "0.1.83" }
 bytes      = { version = "1.8.0", features = ["serde"] }
-gax        = { version = "0.1.0-rc1", path = "../../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
-gtype      = { version = "0.1.0-rc1", path = "../../../../src/generated/type", package = "gcp-sdk-type" }
+gax        = { version = "0.1.0-rc2", path = "../../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
+gtype      = { version = "0.1.0-rc2", path = "../../../../src/generated/type", package = "gcp-sdk-type" }
 lazy_static = { version = "1.5.0" }
 reqwest    = { version = "0.12.9", features = ["json"] }
 serde      = { version = "1.0.214", features = ["serde_derive"] }
@@ -37,4 +37,4 @@ serde_json = { version = "1.0.132" }
 serde_with = { version = "3.11.0", default-features = false, features = ["base64", "macros", "std"] }
 time       = { version = "0.3.36", features = ["formatting", "parsing"] }
 tracing    = { version = "0.1.41" }
-wkt        = { version = "0.1.0-rc1", path = "../../../../src/wkt", package = "gcp-sdk-wkt" }
+wkt        = { version = "0.1.0-rc2", path = "../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/openapi-validation/Cargo.toml
+++ b/src/generated/openapi-validation/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                 = "secretmanager-openapi-v1"
-version              = "0.1.0-rc1"
+version              = "0.1.0-rc2"
 description          = "Google Cloud SDK for Rust - Secret Manager API"
 edition.workspace    = true
 authors.workspace    = true
@@ -29,7 +29,7 @@ publish              = false
 [dependencies]
 async-trait = { version = "0.1.83" }
 bytes      = { version = "1.8.0", features = ["serde"] }
-gax        = { version = "0.1.0-rc1", path = "../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
+gax        = { version = "0.1.0-rc2", path = "../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1.5.0" }
 reqwest    = { version = "0.12.9", features = ["json"] }
 serde      = { version = "1.0.214", features = ["serde_derive"] }
@@ -37,4 +37,4 @@ serde_json = { version = "1.0.132" }
 serde_with = { version = "3.11.0", default-features = false, features = ["base64", "macros", "std"] }
 time       = { version = "0.3.36", features = ["formatting", "parsing"] }
 tracing    = { version = "0.1.41" }
-wkt        = { version = "0.1.0-rc1", path = "../../../src/wkt", package = "gcp-sdk-wkt" }
+wkt        = { version = "0.1.0-rc2", path = "../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/type/Cargo.toml
+++ b/src/generated/type/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                 = "gcp-sdk-type"
-version              = "0.1.0-rc1"
+version              = "0.1.0-rc2"
 description          = "Google Cloud SDK for Rust - Common Types"
 edition.workspace    = true
 authors.workspace    = true
@@ -35,4 +35,4 @@ serde_json = { version = "1.0.132" }
 serde_with = { version = "3.11.0", default-features = false, features = ["base64", "macros", "std"] }
 time       = { version = "0.3.36", features = ["formatting", "parsing"] }
 tracing    = { version = "0.1.41" }
-wkt        = { version = "0.1.0-rc1", path = "../../../src/wkt", package = "gcp-sdk-wkt" }
+wkt        = { version = "0.1.0-rc2", path = "../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name                 = "gcp-sdk-wkt"
-version              = "0.1.0"
+version              = "0.1.0-rc2"
 description          = "Google Cloud SDK for Rust - Well Known Types"
 edition.workspace    = true
 authors.workspace    = true


### PR DESCRIPTION
Missed the hand-crafted libraries (wkt, gax, auth) in the *-rc1
versions.