### PR TITLE
refactor(auth): move `Result` definition

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::Result;
 use http::header::{HeaderName, HeaderValue};
 use std::future::Future;
-
-type Result<T> = std::result::Result<T, crate::errors::CredentialError>;
 
 /// An implementation of [crate::credentials::traits::Credential].
 ///

--- a/src/auth/src/lib.rs
+++ b/src/auth/src/lib.rs
@@ -41,3 +41,5 @@ pub mod credentials;
 ///
 /// [Tokens]: https://cloud.google.com/docs/authentication#token
 pub mod token;
+
+pub(crate) type Result<T> = std::result::Result<T, crate::errors::CredentialError>;

--- a/src/auth/src/lib.rs
+++ b/src/auth/src/lib.rs
@@ -42,4 +42,6 @@ pub mod credentials;
 /// [Tokens]: https://cloud.google.com/docs/authentication#token
 pub mod token;
 
+/// A `Result` alias where the `Err` case is
+/// `gcp-sdk-auth::errors::CredentialError`.
 pub(crate) type Result<T> = std::result::Result<T, crate::errors::CredentialError>;


### PR DESCRIPTION
Re: https://github.com/googleapis/google-cloud-rust/pull/455#discussion_r1887541999