### PR TITLE
fix: make paginator Send and align feature names

### DIFF
--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -40,7 +40,7 @@ wkt         = { version = "0.1.0", path = "../wkt", package = "gcp-sdk-wkt" }
 [dev-dependencies]
 # This is a workaround to integration test features of this crate. Open issue
 # https://github.com/rust-lang/cargo/issues/2911.
-gax       = { path = ".", package = "gcp-sdk-gax", features = ["stream", "unstable-sdk-client"] }
+gax       = { path = ".", package = "gcp-sdk-gax", features = ["unstable-sdk-client", "unstable-stream"] }
 axum      = "0.7.9"
 serde     = { version = "1.0.214", features = ["serde_derive"] }
 test-case = "3.3.1"
@@ -51,4 +51,4 @@ built = "0.7"
 
 [features]
 unstable-sdk-client = ["dep:auth", "dep:reqwest"]
-stream              = ["dep:futures", "dep:pin-project"]
+unstable-stream     = ["dep:futures", "dep:pin-project"]

--- a/src/gax/src/lib.rs
+++ b/src/gax/src/lib.rs
@@ -79,7 +79,7 @@ pub mod error;
 
 /// Defines some types and traits to convert and use List RPCs as a Stream.
 /// Async streams are not yet stable, so neither is the use of this feature.
-#[cfg(feature = "stream")]
+#[cfg(feature = "unstable-stream")]
 pub mod paginator;
 
 /// Defines traits and helpers for HTTP client implementations.


### PR DESCRIPTION
- We need to make this type fully Send so we can satisfy our dyntraits. 
- Align the feature name to be consistent with other unstable features.
- Impl Debug so tracing will work with the returned type

Updates: #297