### PR TITLE
feat(sidekick): source field behavior annotations in proto clients 

### DIFF
--- a/generator/internal/parser/protobuf.go
+++ b/generator/internal/parser/protobuf.go
@@ -482,7 +482,7 @@ func processMessage(state *api.APIState, m *descriptorpb.DescriptorProto, mFQN, 
 			Name:     mf.GetName(),
 			ID:       mFQN + "." + mf.GetName(),
 			JSONName: mf.GetJsonName(),
-			Optional: isProtoOptional,
+			Optional: isProtoOptional && !isFieldRequired(mf),
 			Repeated: mf.Label != nil && *mf.Label == descriptorpb.FieldDescriptorProto_LABEL_REPEATED,
 			IsOneOf:  mf.OneofIndex != nil && !isProtoOptional,
 		}

--- a/generator/internal/parser/protobuf_annotations.go
+++ b/generator/internal/parser/protobuf_annotations.go
@@ -130,3 +130,18 @@ func parseDefaultHost(m proto.Message) string {
 	}
 	return defaultHost
 }
+
+func isFieldRequired(field *descriptorpb.FieldDescriptorProto) bool {
+	name := field.GetName()
+	_ = name
+	fb, ok := proto.GetExtension(field.GetOptions(), annotations.E_FieldBehavior).([]annotations.FieldBehavior)
+	if !ok {
+		return false
+	}
+	for _, b := range fb {
+		if annotations.FieldBehavior(b.Number()) == annotations.FieldBehavior_REQUIRED {
+			return true
+		}
+	}
+	return false
+}

--- a/generator/internal/parser/protobuf_test.go
+++ b/generator/internal/parser/protobuf_test.go
@@ -297,7 +297,6 @@ func TestProtobuf_SkipExternalMessages(t *testing.T) {
 				Documentation: "This field uses an imported enum.",
 				Typez:         api.ENUM_TYPE,
 				TypezID:       ".away.ImportedEnum",
-				Optional:      false,
 			},
 		},
 	})


### PR DESCRIPTION
This relates to https://google.aip.dev/203. If a field is not labeled
required we should consider it optional. This field behavior annotations
are traditionally only one request messages which in turn makes almost
everything optional on response messages. This change should make clients
generated from proto and openapi have closer req/resp models.

Updates: https://github.com/googleapis/google-cloud-rust/issues/27