### PR TITLE
cleanup(gax): fix (or silence) clippy warnings

### DIFF
--- a/src/gax/src/api_header.rs
+++ b/src/gax/src/api_header.rs
@@ -83,7 +83,7 @@ mod test {
         let want = built_info::RUSTC_VERSION;
         assert!(
             got.as_ref()
-                .map(|s| want.contains(s) && s != "")
+                .map(|s| want.contains(s) && !s.is_empty())
                 .unwrap_or(false),
             "mismatched rustc version {} and {:?}",
             want,

--- a/src/gax/src/error/rpc/mod.rs
+++ b/src/gax/src/error/rpc/mod.rs
@@ -590,7 +590,7 @@ mod test {
     #[test_case("UNAUTHENTICATED")]
     fn code_roundtrip(input: &str) {
         let code = Code::try_from(input);
-        let output: Result<String, _> = code.map(|c| From::from(c));
+        let output: Result<String, _> = code.map(From::from);
         assert_eq!(output, Ok(input.to_string()));
     }
 }

--- a/src/gax/src/paginator.rs
+++ b/src/gax/src/paginator.rs
@@ -53,7 +53,8 @@ where
                     ControlFlow::Continue(token) => token,
                     ControlFlow::Break(_) => return None,
                 };
-                let resp = match execute(token).await {
+
+                match execute(token).await {
                     Ok(page_resp) => {
                         let tok = page_resp.next_page_token();
                         let next_state = if tok.is_empty() {
@@ -64,8 +65,7 @@ where
                         Some((Ok(page_resp), next_state))
                     }
                     Err(e) => Some((Err(e), ControlFlow::Break(()))),
-                };
-                resp
+                }
             }
         });
         Self {
@@ -74,6 +74,7 @@ where
     }
 
     /// Returns the next mutation of the wrapped stream.
+    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> futures::stream::Next<'_, Self> {
         StreamExt::next(self)
     }

--- a/src/gax/tests/paginator.rs
+++ b/src/gax/tests/paginator.rs
@@ -35,14 +35,10 @@ async fn test_paginator() -> Result<()> {
     let mut page_token = String::default();
     let mut items = Vec::new();
     loop {
-        let response = client
-            .list(ListFoosRequest {
-                page_token: page_token,
-            })
-            .await?;
+        let response = client.list(ListFoosRequest { page_token }).await?;
         response.items.into_iter().for_each(|s| items.push(s.name));
         page_token = response.next_page_token;
-        if page_token == "" {
+        if page_token.is_empty() {
             break;
         }
     }
@@ -100,7 +96,7 @@ impl Client {
             .inner
             .builder(reqwest::Method::GET, "/pagination".to_string())
             .query(&[("alt", "json")]);
-        if "" != req.page_token {
+        if !req.page_token.is_empty() {
             builder = builder.query(&[("pageToken", req.page_token)]);
         }
         self.inner.execute(builder, None::<NoBody>).await
@@ -127,7 +123,7 @@ async fn handle_page(Query(params): Query<HashMap<String, String>>) -> (StatusCo
     };
 
     let page_token = params.get("pageToken").map(String::as_str).unwrap_or("");
-    let response = if page_token == "" {
+    let response = if page_token.is_empty() {
         ListFoosResponse {
             items: to_items(&["f1", "f2"]),
             next_page_token: "abc123".to_string(),


### PR DESCRIPTION
I for one welcome our clippy overlords.

The only controversial thing may be silencing the warning around
`next()`. Clippy thinks we should be implementing the `Iterator` trait
or think of a better method name.  Clippy is wrong, neither suggestion
applies here.