### PR TITLE
feat(generator): extra downloadable proto sources

### DIFF
--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -17,8 +17,11 @@ language             = 'rust'
 specification-format = 'protobuf'
 
 [source]
-googleapis-root   = 'https://github.com/googleapis/googleapis/archive/5285c0c32504691588201fd2d8b100c2cab6eca7.tar.gz'
-googleapis-sha256 = 'e076d2c608c9a2bcdb347e696eb4e536d28b9bd5b9d99153e8f5f8c0b3bdce1c'
+googleapis-root             = 'https://github.com/googleapis/googleapis/archive/5285c0c32504691588201fd2d8b100c2cab6eca7.tar.gz'
+googleapis-sha256           = 'e076d2c608c9a2bcdb347e696eb4e536d28b9bd5b9d99153e8f5f8c0b3bdce1c'
+extra-protos-root           = 'https://github.com/googleapis/gapic-showcase/archive/refs/tags/v0.35.5.tar.gz'
+extra-protos-sha256         = 'fd3c1b33080a75987433db924a576d576fa622aff4f14eee86b1dc959e7aef63'
+extra-protos-extracted-name = 'gapic-showcase-0.35.5'
 
 [codec]
 # The default version for all crates. This can be overridden in the crate's

--- a/generator/internal/parser/protobuf.go
+++ b/generator/internal/parser/protobuf.go
@@ -105,7 +105,7 @@ func protoc(tempFile string, files []string, options map[string]string) ([]byte,
 		"--retain_options",
 		"--descriptor_set_out", tempFile,
 	}
-	for _, name := range []string{"test-root", "googleapis-root"} {
+	for _, name := range []string{"extra-protos-root", "googleapis-root"} {
 		if path, ok := options[name]; ok {
 			args = append(args, "--proto_path")
 			args = append(args, path)
@@ -119,14 +119,14 @@ func protoc(tempFile string, files []string, options map[string]string) ([]byte,
 	cmd.Stderr = &stderr
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("error calling protoc\ndetails:\n%s\n: %w", stderr.String(), err)
+		return nil, fmt.Errorf("error calling protoc\ndetails:\n%s\nargs:\n%v\n: %w", stderr.String(), args, err)
 	}
 
 	return os.ReadFile(tempFile)
 }
 
 func determineInputFiles(source string, options map[string]string) ([]string, error) {
-	// `config.Source` is relative to the `googleapis-root` (or `test-root`) if
+	// `config.Source` is relative to the `googleapis-root` (or `extra-protos-root`) if
 	// that is set. When it is a single file, this is easy, just return the
 	// filename and `protoc` will find it.
 
@@ -136,7 +136,7 @@ func determineInputFiles(source string, options map[string]string) ([]string, er
 		return []string{source}, nil
 	}
 
-	for _, opt := range []string{"test-root", "googleapis-root"} {
+	for _, opt := range []string{"extra-protos-root", "googleapis-root"} {
 		location, ok := options[opt]
 		if !ok {
 			// Ignore options that are not set

--- a/generator/internal/parser/protobuf_test.go
+++ b/generator/internal/parser/protobuf_test.go
@@ -1126,8 +1126,8 @@ func TestProtobuf_OperationMixin(t *testing.T) {
 func newTestCodeGeneratorRequest(t *testing.T, filename string) *pluginpb.CodeGeneratorRequest {
 	t.Helper()
 	options := map[string]string{
-		"googleapis-root": "../../testdata/googleapis",
-		"test-root":       "testdata",
+		"googleapis-root":   "../../testdata/googleapis",
+		"extra-protos-root": "testdata",
 	}
 	request, err := newCodeGeneratorRequest(filename, options)
 	if err != nil {

--- a/generator/internal/parser/service_config.go
+++ b/generator/internal/parser/service_config.go
@@ -51,10 +51,10 @@ func readServiceConfig(serviceConfigPath string) (*serviceconfig.Service, error)
 // Finds the service config path for the current parser configuration.
 //
 // The service config files are specified as relative to the `googleapis-root`
-// path (or `test-root` when set). This finds the right path given a
+// path (or `extra-protos-root` when set). This finds the right path given a
 // configuration
 func findServiceConfigPath(serviceConfigFile string, options map[string]string) string {
-	for _, opt := range []string{"test-root", "googleapis-root"} {
+	for _, opt := range []string{"extra-protos-root", "googleapis-root"} {
 		dir, ok := options[opt]
 		if !ok {
 			// Ignore options that are not set

--- a/generator/internal/sidekick/downloads_cache_test.go
+++ b/generator/internal/sidekick/downloads_cache_test.go
@@ -39,7 +39,7 @@ func TestExistingDirectory(t *testing.T) {
 			"googleapis-root": tmp,
 		},
 	}
-	root, err := makeGoogleapisRoot(&rootConfig)
+	root, err := makeSourceRoot(&rootConfig, "googleapis")
 	if err != nil {
 		t.Error(err)
 	}
@@ -54,7 +54,7 @@ func TestValidateConfig(t *testing.T) {
 			"googleapis-root": "https://unused",
 		},
 	}
-	_, err := makeGoogleapisRoot(&rootConfig)
+	_, err := makeSourceRoot(&rootConfig, "googleapis")
 	if err == nil {
 		t.Errorf("expected error when missing `googleapis-sha256")
 	}
@@ -92,12 +92,12 @@ func TestWithDownload(t *testing.T) {
 			"cachedir":          testDir,
 		},
 	}
-	got, err := makeGoogleapisRoot(rootConfig)
+	got, err := makeSourceRoot(rootConfig, "googleapis")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !strings.HasSuffix(got, tarball.Sha256) {
-		t.Errorf("mismatched suffix in makeGoogleapisRoot want=%s, got=%s", tarball.Sha256, got)
+		t.Errorf("mismatched suffix in makeSourceRoot want=%s, got=%s", tarball.Sha256, got)
 	}
 	if err := os.RemoveAll(got); err != nil {
 		t.Error(err)
@@ -130,12 +130,12 @@ func TestTargetExists(t *testing.T) {
 	if err := os.MkdirAll(path.Join(downloads, sha256), 0755); err != nil {
 		t.Fatal(err)
 	}
-	got, err := makeGoogleapisRoot(rootConfig)
+	got, err := makeSourceRoot(rootConfig, "googleapis")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !strings.HasSuffix(got, sha256) {
-		t.Errorf("mismatched suffix in makeGoogleapisRoot want=%s, got=%s", sha256, got)
+		t.Errorf("mismatched suffix in makeSourceRoot want=%s, got=%s", sha256, got)
 	}
 	if err := os.RemoveAll(got); err != nil {
 		t.Error(err)
@@ -160,7 +160,7 @@ func TestDownloadGoogleapisRootTgzExists(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := downloadGoogleapisRoot(target, "https://unused/placeholder.tar.gz", tarball.Sha256); err != nil {
+	if err := downloadSourceRoot(target, "https://unused/placeholder.tar.gz", tarball.Sha256); err != nil {
 		t.Error(err)
 	}
 }
@@ -188,7 +188,7 @@ func TestDownloadGoogleapisRootNeedsDownload(t *testing.T) {
 	defer server.Close()
 
 	expected := path.Join(testDir, "new-file")
-	if err := downloadGoogleapisRoot(expected, server.URL+"/placeholder.tar.gz", tarball.Sha256); err != nil {
+	if err := downloadSourceRoot(expected, server.URL+"/placeholder.tar.gz", tarball.Sha256); err != nil {
 		t.Error(err)
 	}
 	got, err := os.ReadFile(expected)
@@ -259,7 +259,7 @@ func makeTestTarball(t *testing.T, tempDir, subdir string) (*contents, error) {
 
 func TestExtractedName(t *testing.T) {
 	var rootConfig Config
-	got := extractedName(&rootConfig, "https://github.com/googleapis/googleapis/archive/2d08f07eab9bbe8300cd20b871d0811bbb693fab.tar.gz")
+	got := extractedName(&rootConfig, "https://github.com/googleapis/googleapis/archive/2d08f07eab9bbe8300cd20b871d0811bbb693fab.tar.gz", "googleapis")
 	want := "googleapis-2d08f07eab9bbe8300cd20b871d0811bbb693fab"
 	if got != want {
 		t.Errorf("mismatched extractedName, got=%s, want=%s", got, want)
@@ -273,7 +273,7 @@ func TestExtractedNameOverride(t *testing.T) {
 			"googleapis-extracted-name": want,
 		},
 	}
-	got := extractedName(&rootConfig, "https://github.com/googleapis/googleapis/archive/2d08f07eab9bbe8300cd20b871d0811bbb693fab.tar.gz")
+	got := extractedName(&rootConfig, "https://github.com/googleapis/googleapis/archive/2d08f07eab9bbe8300cd20b871d0811bbb693fab.tar.gz", "googleapis")
 	if got != want {
 		t.Errorf("mismatched extractedName, got=%s, want=%s", got, want)
 	}

--- a/generator/internal/sidekick/generate.go
+++ b/generator/internal/sidekick/generate.go
@@ -44,17 +44,13 @@ func generate(rootConfig *Config, cmdLine *CommandLine) error {
 		return err
 	}
 
-	root, err := makeGoogleapisRoot(rootConfig)
+	override, err := overrideSources(rootConfig)
 	if err != nil {
 		return err
 	}
-	override := *rootConfig
-	override.Codec = maps.Clone(rootConfig.Codec)
-	override.Source = maps.Clone(rootConfig.Source)
-	override.Source["googleapis-root"] = root
 
 	// Load the .sidekick.toml file and refresh the code.
-	return refresh(&override, cmdLine, cmdLine.Output)
+	return refresh(override, cmdLine, cmdLine.Output)
 }
 
 func writeSidekickToml(outDir string, config *Config) error {

--- a/src/generated/showcase/.not-working-sidekick.toml
+++ b/src/generated/showcase/.not-working-sidekick.toml
@@ -1,0 +1,26 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[general]
+language = 'rust'
+specification-source = 'schema/google/showcase/v1beta1'
+service-config = 'schema/google/showcase/v1beta1/showcase_v1beta1.yaml'
+
+[codec]
+copyright-year = '2024'
+not-for-publication = 'true'
+package-name-override = 'secretmanager-golden-openapi'
+'package:gax' = 'package=gcp-sdk-gax,path=../src/gax,feature=unstable-sdk-client'
+'package:google-cloud-auth' = 'package=google-cloud-auth,path=../auth'
+'package:wkt' = 'package=gcp-sdk-wkt,path=../src/wkt,source=google.protobuf'


### PR DESCRIPTION
Eventually we will want to download and compile the showcase protos.
That require an "extra" proto source that is also downloadable. This
PR introduces that source, but does not enable it, as the comments in
showcase break the parser.