### PR TITLE
refactor: pass API to codec.AdditionalContext and stub out Rust context

### DIFF
--- a/generator/internal/language/codec.go
+++ b/generator/internal/language/codec.go
@@ -118,7 +118,7 @@ type Codec interface {
 	// Prefer using specific methods when the information is applicable to most
 	// (or many) languages. Use this method when the information is application
 	// to only one language.
-	AdditionalContext() any
+	AdditionalContext(api *api.API) any
 	// Imports to add.
 	Imports() []string
 	// Some packages are not intended for publication. For example, they may be

--- a/generator/internal/language/golang.go
+++ b/generator/internal/language/golang.go
@@ -369,7 +369,7 @@ type GoContext struct {
 	GoPackage string
 }
 
-func (c *GoCodec) AdditionalContext() any {
+func (c *GoCodec) AdditionalContext(*api.API) any {
 	return GoContext{
 		GoPackage: c.GoPackageName,
 	}

--- a/generator/internal/language/rust.go
+++ b/generator/internal/language/rust.go
@@ -1037,7 +1037,10 @@ func (c *RustCodec) Validate(api *api.API) error {
 	return nil
 }
 
-func (c *RustCodec) AdditionalContext() any {
+// RustContext contains Rust specific data that can be referenced in templates.
+type RustContext struct{}
+
+func (c *RustCodec) AdditionalContext(*api.API) any {
 	return nil
 }
 

--- a/generator/internal/sidekick/genclient.go
+++ b/generator/internal/sidekick/genclient.go
@@ -58,8 +58,8 @@ func generateClient(req *generateClientRequest) error {
 	data := newTemplateData(req.API, req.Codec)
 	var context []any
 	context = append(context, data)
-	if req.Codec.AdditionalContext() != nil {
-		context = append(context, req.Codec.AdditionalContext())
+	if languageContext := req.Codec.AdditionalContext(req.API); languageContext != nil {
+		context = append(context, languageContext)
 	}
 
 	provider := req.Codec.TemplatesProvider()


### PR DESCRIPTION
This will be used in a future PR for iterator support.