### PR TITLE
cleanup(generator): link method to service

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -118,6 +118,7 @@ type Method struct {
 	// IsPageable is true if the method conforms to standard defined by
 	// [AIP-4233](https://google.aip.dev/client-libraries/4233).
 	IsPageable bool
+	Parent     *Service
 }
 
 // Normalized request path information.

--- a/generator/internal/parser/openapi.go
+++ b/generator/internal/parser/openapi.go
@@ -149,6 +149,9 @@ func makeServices(a *api.API, model *libopenapi.DocumentModel[v3.Document], pack
 		DefaultHost:   defaultHost(model),
 		Methods:       methods,
 	}
+	for _, m := range methods {
+		m.Parent = service
+	}
 	a.Services = append(a.Services, service)
 	a.State.ServiceByID[service.ID] = service
 	return nil

--- a/generator/internal/parser/openapi_test.go
+++ b/generator/internal/parser/openapi_test.go
@@ -874,7 +874,7 @@ func TestOpenAPI_Pagination(t *testing.T) {
 		t.Errorf("missing service (Service) in ServiceByID index")
 		return
 	}
-	checkService(t, *service, api.Service{
+	checkService(t, service, &api.Service{
 		Name: "Service",
 		ID:   "..Service",
 		Methods: []*api.Method{

--- a/generator/internal/parser/parser_test.go
+++ b/generator/internal/parser/parser_test.go
@@ -49,13 +49,18 @@ func checkEnum(t *testing.T, got api.Enum, want api.Enum) {
 	}
 }
 
-func checkService(t *testing.T, got api.Service, want api.Service) {
+func checkService(t *testing.T, got *api.Service, want *api.Service) {
 	t.Helper()
 	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(api.Service{}, "Methods")); diff != "" {
 		t.Errorf("mismatched service attributes (-want, +got):\n%s", diff)
 	}
+	for _, m := range got.Methods {
+		if m.Parent != got {
+			t.Errorf("mismatched method parent want=%v, got=%v", got, m.Parent)
+		}
+	}
 	less := func(a, b *api.Method) bool { return a.Name < b.Name }
-	if diff := cmp.Diff(want.Methods, got.Methods, cmpopts.SortSlices(less)); diff != "" {
+	if diff := cmp.Diff(want.Methods, got.Methods, cmpopts.SortSlices(less), cmpopts.IgnoreFields(api.Method{}, "Parent")); diff != "" {
 		t.Errorf("method mismatch (-want, +got):\n%s", diff)
 	}
 }
@@ -74,7 +79,7 @@ func checkMethod(t *testing.T, service *api.Service, name string, want *api.Meth
 	if !ok {
 		t.Errorf("missing method %s", name)
 	}
-	if diff := cmp.Diff(want, got); diff != "" {
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(api.Method{}, "Parent")); diff != "" {
 		t.Errorf("mismatched data for method %s (-want, +got):\n%s", name, diff)
 	}
 }

--- a/generator/internal/parser/protobuf.go
+++ b/generator/internal/parser/protobuf.go
@@ -284,6 +284,7 @@ func makeAPIForProtobuf(serviceConfig *serviceconfig.Service, req *pluginpb.Code
 			for _, m := range s.Method {
 				mFQN := sFQN + "." + m.GetName()
 				if method := processMethod(state, m, mFQN); method != nil {
+					method.Parent = service
 					service.Methods = append(service.Methods, method)
 				}
 			}
@@ -329,6 +330,7 @@ func makeAPIForProtobuf(serviceConfig *serviceconfig.Service, req *pluginpb.Code
 					continue
 				}
 				if method := processMethod(state, m, mFQN); method != nil {
+					method.Parent = service
 					service.Methods = append(service.Methods, method)
 				}
 			}

--- a/generator/internal/parser/protobuf_test.go
+++ b/generator/internal/parser/protobuf_test.go
@@ -415,7 +415,7 @@ func TestProtobuf_Comments(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find service %s in API State", ".test.Service")
 	}
-	checkService(t, *service, api.Service{
+	checkService(t, service, &api.Service{
 		Name:          "Service",
 		ID:            ".test.Service",
 		Package:       "test",
@@ -669,7 +669,7 @@ func TestProtobuf_Service(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find service %s in API State", ".test.TestService")
 	}
-	checkService(t, *service, api.Service{
+	checkService(t, service, &api.Service{
 		Name:          "TestService",
 		Package:       "test",
 		ID:            ".test.TestService",
@@ -719,7 +719,7 @@ func TestProtobuf_QueryParameters(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find service %s in API State", ".test.TestService")
 	}
-	checkService(t, *service, api.Service{
+	checkService(t, service, &api.Service{
 		Name:          "TestService",
 		Package:       "test",
 		ID:            ".test.TestService",
@@ -844,7 +844,7 @@ func TestProtobuf_LocationMixin(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find service %s in API State", ".google.cloud.location.Locations")
 	}
-	checkService(t, *service, api.Service{
+	checkService(t, service, &api.Service{
 		Documentation: "Manages location-related information with an API service.",
 		DefaultHost:   "cloud.googleapis.com",
 		Name:          "Locations",
@@ -903,7 +903,7 @@ func TestProtobuf_IAMMixin(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find service %s in API State", ".google.iam.v1.IAMPolicy")
 	}
-	checkService(t, *service, api.Service{
+	checkService(t, service, &api.Service{
 		Documentation: "Manages Identity and Access Management (IAM) policies with an API service.",
 		DefaultHost:   "iam-meta-api.googleapis.com",
 		Name:          "IAMPolicy",
@@ -937,7 +937,7 @@ func TestProtobuf_Pagination(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find service %s in API State", ".test.TestService")
 	}
-	checkService(t, *service, api.Service{
+	checkService(t, service, &api.Service{
 		Name:        "TestService",
 		ID:          ".test.TestService",
 		DefaultHost: "test.googleapis.com",
@@ -1096,7 +1096,7 @@ func TestProtobuf_OperationMixin(t *testing.T) {
 	if !ok {
 		t.Fatalf("Cannot find service %s in API State", ".google.longrunning.Operations")
 	}
-	checkService(t, *service, api.Service{
+	checkService(t, service, &api.Service{
 		Documentation: "Manages long-running operations with an API service.",
 		DefaultHost:   "longrunning.googleapis.com",
 		Name:          "Operations",

--- a/generator/internal/sidekick/templatedata.go
+++ b/generator/internal/sidekick/templatedata.go
@@ -181,7 +181,7 @@ func newTemplateData(model *api.API, c language.Codec) *TemplateData {
 func newService(s *api.Service, c language.Codec, state *api.APIState) *Service {
 	return &Service{
 		Methods: mapSlice(s.Methods, func(m *api.Method) *Method {
-			return newMethod(s, m, c, state)
+			return newMethod(m, c, state)
 		}),
 		NameToSnake:         c.ToSnake(s.Name),
 		NameToPascal:        c.ToPascal(s.Name),
@@ -237,7 +237,7 @@ func newMessage(m *api.Message, c language.Codec, state *api.APIState) *Message 
 	}
 }
 
-func newMethod(s *api.Service, m *api.Method, c language.Codec, state *api.APIState) *Method {
+func newMethod(m *api.Method, c language.Codec, state *api.APIState) *Method {
 	return &Method{
 		BodyAccessor:      c.BodyAccessor(m, state),
 		DocLines:          c.FormatDocComments(m.Documentation, state),
@@ -255,9 +255,9 @@ func newMethod(s *api.Service, m *api.Method, c language.Codec, state *api.APISt
 			return newField(s, c, state)
 		}),
 		IsPageable:          m.IsPageable,
-		ServiceNameToPascal: c.ToPascal(s.Name),
-		ServiceNameToCamel:  c.ToCamel(s.Name),
-		ServiceNameToSnake:  c.ToSnake(s.Name),
+		ServiceNameToPascal: c.ToPascal(m.Parent.Name),
+		ServiceNameToCamel:  c.ToCamel(m.Parent.Name),
+		ServiceNameToSnake:  c.ToSnake(m.Parent.Name),
 		InputTypeID:         m.InputTypeID,
 	}
 }


### PR DESCRIPTION
Sometimes we need to find the service that owns a method. Add a
backlink and simplify some code.