### PR TITLE
feat(generator/rust): make clients mockable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,6 +1128,7 @@ dependencies = [
  "gcp-sdk-secretmanager-v1",
  "gcp-sdk-wkt",
  "google-cloud-auth",
+ "mockall",
  "rand",
  "secretmanager-openapi-v1",
  "serde_json",

--- a/generator/internal/language/templates/rust/crate/src/client.rs.mustache
+++ b/generator/internal/language/templates/rust/crate/src/client.rs.mustache
@@ -54,7 +54,7 @@ impl {{NameToPascal}} {
         Ok(Self { inner }) 
     }
 
-    /// Creates a new cient from the provided stub.
+    /// Creates a new client from the provided stub.
     ///
     /// The most common case for calling this function is when mocking the
     /// client.

--- a/generator/internal/language/templates/rust/crate/src/client.rs.mustache
+++ b/generator/internal/language/templates/rust/crate/src/client.rs.mustache
@@ -54,6 +54,15 @@ impl {{NameToPascal}} {
         Ok(Self { inner }) 
     }
 
+    /// Creates a new cient from the provided stub.
+    ///
+    /// The most common case for calling this function is when mocking the
+    /// client.
+    pub fn from_stub<T>(stub: T) -> Self
+    where T: crate::traits::{{NameToPascal}} + 'static {
+        Self { inner: Arc::new(stub) }
+    }
+
     async fn build_inner(conf: crate::ConfigBuilder) -> Result<Arc<dyn crate::traits::dyntraits::{{NameToPascal}}>> {
         if conf.tracing_enabled() {
             return Ok(Arc::new(Self::build_with_tracing(conf).await?));

--- a/generator/testdata/rust/gclient/golden/iam/v1/src/client.rs
+++ b/generator/testdata/rust/gclient/golden/iam/v1/src/client.rs
@@ -69,6 +69,15 @@ impl IAMPolicy {
         Ok(Self { inner }) 
     }
 
+    /// Creates a new cient from the provided stub.
+    ///
+    /// The most common case for calling this function is when mocking the
+    /// client.
+    pub fn from_stub<T>(stub: T) -> Self
+    where T: crate::traits::IAMPolicy + 'static {
+        Self { inner: Arc::new(stub) }
+    }
+
     async fn build_inner(conf: crate::ConfigBuilder) -> Result<Arc<dyn crate::traits::dyntraits::IAMPolicy>> {
         if conf.tracing_enabled() {
             return Ok(Arc::new(Self::build_with_tracing(conf).await?));

--- a/generator/testdata/rust/gclient/golden/iam/v1/src/client.rs
+++ b/generator/testdata/rust/gclient/golden/iam/v1/src/client.rs
@@ -69,7 +69,7 @@ impl IAMPolicy {
         Ok(Self { inner }) 
     }
 
-    /// Creates a new cient from the provided stub.
+    /// Creates a new client from the provided stub.
     ///
     /// The most common case for calling this function is when mocking the
     /// client.

--- a/generator/testdata/rust/gclient/golden/location/src/client.rs
+++ b/generator/testdata/rust/gclient/golden/location/src/client.rs
@@ -49,7 +49,7 @@ impl Locations {
         Ok(Self { inner }) 
     }
 
-    /// Creates a new cient from the provided stub.
+    /// Creates a new client from the provided stub.
     ///
     /// The most common case for calling this function is when mocking the
     /// client.

--- a/generator/testdata/rust/gclient/golden/location/src/client.rs
+++ b/generator/testdata/rust/gclient/golden/location/src/client.rs
@@ -49,6 +49,15 @@ impl Locations {
         Ok(Self { inner }) 
     }
 
+    /// Creates a new cient from the provided stub.
+    ///
+    /// The most common case for calling this function is when mocking the
+    /// client.
+    pub fn from_stub<T>(stub: T) -> Self
+    where T: crate::traits::Locations + 'static {
+        Self { inner: Arc::new(stub) }
+    }
+
     async fn build_inner(conf: crate::ConfigBuilder) -> Result<Arc<dyn crate::traits::dyntraits::Locations>> {
         if conf.tracing_enabled() {
             return Ok(Arc::new(Self::build_with_tracing(conf).await?));

--- a/generator/testdata/rust/gclient/golden/secretmanager/src/client.rs
+++ b/generator/testdata/rust/gclient/golden/secretmanager/src/client.rs
@@ -54,7 +54,7 @@ impl SecretManagerService {
         Ok(Self { inner }) 
     }
 
-    /// Creates a new cient from the provided stub.
+    /// Creates a new client from the provided stub.
     ///
     /// The most common case for calling this function is when mocking the
     /// client.
@@ -257,7 +257,7 @@ impl Locations {
         Ok(Self { inner }) 
     }
 
-    /// Creates a new cient from the provided stub.
+    /// Creates a new client from the provided stub.
     ///
     /// The most common case for calling this function is when mocking the
     /// client.

--- a/generator/testdata/rust/gclient/golden/secretmanager/src/client.rs
+++ b/generator/testdata/rust/gclient/golden/secretmanager/src/client.rs
@@ -54,6 +54,15 @@ impl SecretManagerService {
         Ok(Self { inner }) 
     }
 
+    /// Creates a new cient from the provided stub.
+    ///
+    /// The most common case for calling this function is when mocking the
+    /// client.
+    pub fn from_stub<T>(stub: T) -> Self
+    where T: crate::traits::SecretManagerService + 'static {
+        Self { inner: Arc::new(stub) }
+    }
+
     async fn build_inner(conf: crate::ConfigBuilder) -> Result<Arc<dyn crate::traits::dyntraits::SecretManagerService>> {
         if conf.tracing_enabled() {
             return Ok(Arc::new(Self::build_with_tracing(conf).await?));
@@ -246,6 +255,15 @@ impl Locations {
     pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
         let inner = Self::build_inner(conf).await?;
         Ok(Self { inner }) 
+    }
+
+    /// Creates a new cient from the provided stub.
+    ///
+    /// The most common case for calling this function is when mocking the
+    /// client.
+    pub fn from_stub<T>(stub: T) -> Self
+    where T: crate::traits::Locations + 'static {
+        Self { inner: Arc::new(stub) }
     }
 
     async fn build_inner(conf: crate::ConfigBuilder) -> Result<Arc<dyn crate::traits::dyntraits::Locations>> {

--- a/generator/testdata/rust/openapi/golden/src/client.rs
+++ b/generator/testdata/rust/openapi/golden/src/client.rs
@@ -46,6 +46,15 @@ impl SecretManagerService {
         Ok(Self { inner }) 
     }
 
+    /// Creates a new cient from the provided stub.
+    ///
+    /// The most common case for calling this function is when mocking the
+    /// client.
+    pub fn from_stub<T>(stub: T) -> Self
+    where T: crate::traits::SecretManagerService + 'static {
+        Self { inner: Arc::new(stub) }
+    }
+
     async fn build_inner(conf: crate::ConfigBuilder) -> Result<Arc<dyn crate::traits::dyntraits::SecretManagerService>> {
         if conf.tracing_enabled() {
             return Ok(Arc::new(Self::build_with_tracing(conf).await?));

--- a/generator/testdata/rust/openapi/golden/src/client.rs
+++ b/generator/testdata/rust/openapi/golden/src/client.rs
@@ -46,7 +46,7 @@ impl SecretManagerService {
         Ok(Self { inner }) 
     }
 
-    /// Creates a new cient from the provided stub.
+    /// Creates a new client from the provided stub.
     ///
     /// The most common case for calling this function is when mocking the
     /// client.

--- a/src/generated/cloud/location/src/client.rs
+++ b/src/generated/cloud/location/src/client.rs
@@ -49,6 +49,19 @@ impl Locations {
         Ok(Self { inner })
     }
 
+    /// Creates a new cient from the provided stub.
+    ///
+    /// The most common case for calling this function is when mocking the
+    /// client.
+    pub fn from_stub<T>(stub: T) -> Self
+    where
+        T: crate::traits::Locations + 'static,
+    {
+        Self {
+            inner: Arc::new(stub),
+        }
+    }
+
     async fn build_inner(
         conf: crate::ConfigBuilder,
     ) -> Result<Arc<dyn crate::traits::dyntraits::Locations>> {

--- a/src/generated/cloud/location/src/client.rs
+++ b/src/generated/cloud/location/src/client.rs
@@ -49,7 +49,7 @@ impl Locations {
         Ok(Self { inner })
     }
 
-    /// Creates a new cient from the provided stub.
+    /// Creates a new client from the provided stub.
     ///
     /// The most common case for calling this function is when mocking the
     /// client.

--- a/src/generated/cloud/secretmanager/v1/src/client.rs
+++ b/src/generated/cloud/secretmanager/v1/src/client.rs
@@ -54,7 +54,7 @@ impl SecretManagerService {
         Ok(Self { inner })
     }
 
-    /// Creates a new cient from the provided stub.
+    /// Creates a new client from the provided stub.
     ///
     /// The most common case for calling this function is when mocking the
     /// client.
@@ -268,7 +268,7 @@ impl Locations {
         Ok(Self { inner })
     }
 
-    /// Creates a new cient from the provided stub.
+    /// Creates a new client from the provided stub.
     ///
     /// The most common case for calling this function is when mocking the
     /// client.

--- a/src/generated/cloud/secretmanager/v1/src/client.rs
+++ b/src/generated/cloud/secretmanager/v1/src/client.rs
@@ -54,6 +54,19 @@ impl SecretManagerService {
         Ok(Self { inner })
     }
 
+    /// Creates a new cient from the provided stub.
+    ///
+    /// The most common case for calling this function is when mocking the
+    /// client.
+    pub fn from_stub<T>(stub: T) -> Self
+    where
+        T: crate::traits::SecretManagerService + 'static,
+    {
+        Self {
+            inner: Arc::new(stub),
+        }
+    }
+
     async fn build_inner(
         conf: crate::ConfigBuilder,
     ) -> Result<Arc<dyn crate::traits::dyntraits::SecretManagerService>> {
@@ -253,6 +266,19 @@ impl Locations {
     pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
         let inner = Self::build_inner(conf).await?;
         Ok(Self { inner })
+    }
+
+    /// Creates a new cient from the provided stub.
+    ///
+    /// The most common case for calling this function is when mocking the
+    /// client.
+    pub fn from_stub<T>(stub: T) -> Self
+    where
+        T: crate::traits::Locations + 'static,
+    {
+        Self {
+            inner: Arc::new(stub),
+        }
     }
 
     async fn build_inner(

--- a/src/generated/iam/v1/src/client.rs
+++ b/src/generated/iam/v1/src/client.rs
@@ -69,7 +69,7 @@ impl IAMPolicy {
         Ok(Self { inner })
     }
 
-    /// Creates a new cient from the provided stub.
+    /// Creates a new client from the provided stub.
     ///
     /// The most common case for calling this function is when mocking the
     /// client.

--- a/src/generated/iam/v1/src/client.rs
+++ b/src/generated/iam/v1/src/client.rs
@@ -69,6 +69,19 @@ impl IAMPolicy {
         Ok(Self { inner })
     }
 
+    /// Creates a new cient from the provided stub.
+    ///
+    /// The most common case for calling this function is when mocking the
+    /// client.
+    pub fn from_stub<T>(stub: T) -> Self
+    where
+        T: crate::traits::IAMPolicy + 'static,
+    {
+        Self {
+            inner: Arc::new(stub),
+        }
+    }
+
     async fn build_inner(
         conf: crate::ConfigBuilder,
     ) -> Result<Arc<dyn crate::traits::dyntraits::IAMPolicy>> {

--- a/src/generated/openapi-validation/src/client.rs
+++ b/src/generated/openapi-validation/src/client.rs
@@ -46,6 +46,19 @@ impl SecretManagerService {
         Ok(Self { inner })
     }
 
+    /// Creates a new cient from the provided stub.
+    ///
+    /// The most common case for calling this function is when mocking the
+    /// client.
+    pub fn from_stub<T>(stub: T) -> Self
+    where
+        T: crate::traits::SecretManagerService + 'static,
+    {
+        Self {
+            inner: Arc::new(stub),
+        }
+    }
+
     async fn build_inner(
         conf: crate::ConfigBuilder,
     ) -> Result<Arc<dyn crate::traits::dyntraits::SecretManagerService>> {

--- a/src/generated/openapi-validation/src/client.rs
+++ b/src/generated/openapi-validation/src/client.rs
@@ -46,7 +46,7 @@ impl SecretManagerService {
         Ok(Self { inner })
     }
 
-    /// Creates a new cient from the provided stub.
+    /// Creates a new client from the provided stub.
     ///
     /// The most common case for calling this function is when mocking the
     /// client.

--- a/src/integration-tests/Cargo.toml
+++ b/src/integration-tests/Cargo.toml
@@ -40,5 +40,6 @@ tracing            = "0.1.41"
 tracing-subscriber = "0.3.19"
 
 [dev-dependencies]
+mockall   = "0.13.1"
 test-case = "3.3.1"
 tokio     = { version = "1.42", features = ["full", "macros"] }

--- a/src/integration-tests/tests/mocking.rs
+++ b/src/integration-tests/tests/mocking.rs
@@ -1,0 +1,60 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(test)]
+mod mocking {
+    type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+    mockall::mock! {
+        #[derive(Debug)]
+        SecretManagerService {}
+        impl sm::traits::SecretManagerService for SecretManagerService {
+            async fn create_secret(&self, req: sm::model::CreateSecretRequest, _options: gax::options::RequestOptions) -> sm::Result<sm::model::Secret>;
+        }
+    }
+
+    /// The function under test.
+    async fn helper(
+        client: &sm::client::SecretManagerService,
+        project: &str,
+        region: &str,
+        id: &str,
+    ) -> sm::Result<sm::model::Secret> {
+        client
+            .create_secret()
+            .set_parent(format!("projects/{project}/locations/{region}"))
+            .set_secret_id(id)
+            .send()
+            .await
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_helper() -> Result<()> {
+        let mut mock = MockSecretManagerService::new();
+        mock.expect_create_secret()
+            .withf(|r, _| {
+                r.parent == "projects/my-project/locations/us-central1"
+                    && r.secret_id == "my-secret-id"
+                    && r.secret.is_none()
+            })
+            .return_once(|_, _| Err(gax::error::Error::other("simulated failure")));
+
+        let client = sm::client::SecretManagerService::from_stub(mock);
+
+        let response = helper(&client, "my-project", "us-central1", "my-secret-id").await;
+        assert!(response.is_err());
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Add the necessary constructor and a new integration test.

Fixes #469
