### PR TITLE
feat(generator/rust): top-level enums

### DIFF
--- a/generator/internal/language/templates/rust/crate/src/model.rs.mustache
+++ b/generator/internal/language/templates/rust/crate/src/model.rs.mustache
@@ -25,3 +25,6 @@ limitations under the License.
 {{#Messages}}
 {{> message}}
 {{/Messages}}
+{{#Enums}}
+{{> enum}}
+{{/Enums}}

--- a/generator/internal/language/templates/rust/mod/mod.rs.mustache
+++ b/generator/internal/language/templates/rust/mod/mod.rs.mustache
@@ -25,3 +25,6 @@ limitations under the License.
 {{#Messages}}
 {{> message}}
 {{/Messages}}
+{{#Enums}}
+{{> enum}}
+{{/Enums}}

--- a/generator/internal/sidekick/sidekick_test.go
+++ b/generator/internal/sidekick/sidekick_test.go
@@ -154,7 +154,7 @@ func TestRustModuleFromProtobuf(t *testing.T) {
 	}
 	configs := []TestConfig{
 		{
-			Source:        "google/rpc/error_details.proto",
+			Source:        "google/rpc",
 			ServiceConfig: "google/rpc/rpc_publish.yaml",
 			Name:          "rpc",
 			ExtraOptions: map[string]string{

--- a/generator/internal/sidekick/templatedata.go
+++ b/generator/internal/sidekick/templatedata.go
@@ -36,6 +36,7 @@ type TemplateData struct {
 	DefaultHost       string
 	Services          []*Service
 	Messages          []*Message
+	Enums             []*Enum
 	NameToLower       string
 	NotForPublication bool
 }
@@ -154,6 +155,9 @@ func newTemplateData(model *api.API, c language.Codec) *TemplateData {
 		}),
 		Messages: mapSlice(model.Messages, func(m *api.Message) *Message {
 			return newMessage(m, c, model.State)
+		}),
+		Enums: mapSlice(model.Enums, func(e *api.Enum) *Enum {
+			return newEnum(e, c, model.State)
 		}),
 		NameToLower:       strings.ToLower(model.Name),
 		NotForPublication: c.NotForPublication(),

--- a/generator/testdata/googleapis/google/rpc/code.proto
+++ b/generator/testdata/googleapis/google/rpc/code.proto
@@ -1,0 +1,186 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.rpc;
+
+option go_package = "google.golang.org/genproto/googleapis/rpc/code;code";
+option java_multiple_files = true;
+option java_outer_classname = "CodeProto";
+option java_package = "com.google.rpc";
+option objc_class_prefix = "RPC";
+
+// The canonical error codes for gRPC APIs.
+//
+//
+// Sometimes multiple error codes may apply.  Services should return
+// the most specific error code that applies.  For example, prefer
+// `OUT_OF_RANGE` over `FAILED_PRECONDITION` if both codes apply.
+// Similarly prefer `NOT_FOUND` or `ALREADY_EXISTS` over `FAILED_PRECONDITION`.
+enum Code {
+  // Not an error; returned on success.
+  //
+  // HTTP Mapping: 200 OK
+  OK = 0;
+
+  // The operation was cancelled, typically by the caller.
+  //
+  // HTTP Mapping: 499 Client Closed Request
+  CANCELLED = 1;
+
+  // Unknown error.  For example, this error may be returned when
+  // a `Status` value received from another address space belongs to
+  // an error space that is not known in this address space.  Also
+  // errors raised by APIs that do not return enough error information
+  // may be converted to this error.
+  //
+  // HTTP Mapping: 500 Internal Server Error
+  UNKNOWN = 2;
+
+  // The client specified an invalid argument.  Note that this differs
+  // from `FAILED_PRECONDITION`.  `INVALID_ARGUMENT` indicates arguments
+  // that are problematic regardless of the state of the system
+  // (e.g., a malformed file name).
+  //
+  // HTTP Mapping: 400 Bad Request
+  INVALID_ARGUMENT = 3;
+
+  // The deadline expired before the operation could complete. For operations
+  // that change the state of the system, this error may be returned
+  // even if the operation has completed successfully.  For example, a
+  // successful response from a server could have been delayed long
+  // enough for the deadline to expire.
+  //
+  // HTTP Mapping: 504 Gateway Timeout
+  DEADLINE_EXCEEDED = 4;
+
+  // Some requested entity (e.g., file or directory) was not found.
+  //
+  // Note to server developers: if a request is denied for an entire class
+  // of users, such as gradual feature rollout or undocumented allowlist,
+  // `NOT_FOUND` may be used. If a request is denied for some users within
+  // a class of users, such as user-based access control, `PERMISSION_DENIED`
+  // must be used.
+  //
+  // HTTP Mapping: 404 Not Found
+  NOT_FOUND = 5;
+
+  // The entity that a client attempted to create (e.g., file or directory)
+  // already exists.
+  //
+  // HTTP Mapping: 409 Conflict
+  ALREADY_EXISTS = 6;
+
+  // The caller does not have permission to execute the specified
+  // operation. `PERMISSION_DENIED` must not be used for rejections
+  // caused by exhausting some resource (use `RESOURCE_EXHAUSTED`
+  // instead for those errors). `PERMISSION_DENIED` must not be
+  // used if the caller can not be identified (use `UNAUTHENTICATED`
+  // instead for those errors). This error code does not imply the
+  // request is valid or the requested entity exists or satisfies
+  // other pre-conditions.
+  //
+  // HTTP Mapping: 403 Forbidden
+  PERMISSION_DENIED = 7;
+
+  // The request does not have valid authentication credentials for the
+  // operation.
+  //
+  // HTTP Mapping: 401 Unauthorized
+  UNAUTHENTICATED = 16;
+
+  // Some resource has been exhausted, perhaps a per-user quota, or
+  // perhaps the entire file system is out of space.
+  //
+  // HTTP Mapping: 429 Too Many Requests
+  RESOURCE_EXHAUSTED = 8;
+
+  // The operation was rejected because the system is not in a state
+  // required for the operation's execution.  For example, the directory
+  // to be deleted is non-empty, an rmdir operation is applied to
+  // a non-directory, etc.
+  //
+  // Service implementors can use the following guidelines to decide
+  // between `FAILED_PRECONDITION`, `ABORTED`, and `UNAVAILABLE`:
+  //  (a) Use `UNAVAILABLE` if the client can retry just the failing call.
+  //  (b) Use `ABORTED` if the client should retry at a higher level. For
+  //      example, when a client-specified test-and-set fails, indicating the
+  //      client should restart a read-modify-write sequence.
+  //  (c) Use `FAILED_PRECONDITION` if the client should not retry until
+  //      the system state has been explicitly fixed. For example, if an "rmdir"
+  //      fails because the directory is non-empty, `FAILED_PRECONDITION`
+  //      should be returned since the client should not retry unless
+  //      the files are deleted from the directory.
+  //
+  // HTTP Mapping: 400 Bad Request
+  FAILED_PRECONDITION = 9;
+
+  // The operation was aborted, typically due to a concurrency issue such as
+  // a sequencer check failure or transaction abort.
+  //
+  // See the guidelines above for deciding between `FAILED_PRECONDITION`,
+  // `ABORTED`, and `UNAVAILABLE`.
+  //
+  // HTTP Mapping: 409 Conflict
+  ABORTED = 10;
+
+  // The operation was attempted past the valid range.  E.g., seeking or
+  // reading past end-of-file.
+  //
+  // Unlike `INVALID_ARGUMENT`, this error indicates a problem that may
+  // be fixed if the system state changes. For example, a 32-bit file
+  // system will generate `INVALID_ARGUMENT` if asked to read at an
+  // offset that is not in the range [0,2^32-1], but it will generate
+  // `OUT_OF_RANGE` if asked to read from an offset past the current
+  // file size.
+  //
+  // There is a fair bit of overlap between `FAILED_PRECONDITION` and
+  // `OUT_OF_RANGE`.  We recommend using `OUT_OF_RANGE` (the more specific
+  // error) when it applies so that callers who are iterating through
+  // a space can easily look for an `OUT_OF_RANGE` error to detect when
+  // they are done.
+  //
+  // HTTP Mapping: 400 Bad Request
+  OUT_OF_RANGE = 11;
+
+  // The operation is not implemented or is not supported/enabled in this
+  // service.
+  //
+  // HTTP Mapping: 501 Not Implemented
+  UNIMPLEMENTED = 12;
+
+  // Internal errors.  This means that some invariants expected by the
+  // underlying system have been broken.  This error code is reserved
+  // for serious errors.
+  //
+  // HTTP Mapping: 500 Internal Server Error
+  INTERNAL = 13;
+
+  // The service is currently unavailable.  This is most likely a
+  // transient condition, which can be corrected by retrying with
+  // a backoff. Note that it is not always safe to retry
+  // non-idempotent operations.
+  //
+  // See the guidelines above for deciding between `FAILED_PRECONDITION`,
+  // `ABORTED`, and `UNAVAILABLE`.
+  //
+  // HTTP Mapping: 503 Service Unavailable
+  UNAVAILABLE = 14;
+
+  // Unrecoverable data loss or corruption.
+  //
+  // HTTP Mapping: 500 Internal Server Error
+  DATA_LOSS = 15;
+}

--- a/generator/testdata/rust/gclient/golden/module/rpc/.sidekick.toml
+++ b/generator/testdata/rust/gclient/golden/module/rpc/.sidekick.toml
@@ -15,7 +15,7 @@
 [general]
 language = 'rust'
 specification-format = 'protobuf'
-specification-source = 'google/rpc/error_details.proto'
+specification-source = 'google/rpc'
 service-config = 'google/rpc/rpc_publish.yaml'
 
 [source]

--- a/generator/testdata/rust/gclient/golden/module/rpc/mod.rs
+++ b/generator/testdata/rust/gclient/golden/module/rpc/mod.rs
@@ -451,6 +451,7 @@ pub struct ResourceInfo {
     /// error is
     /// [google.rpc.Code.PERMISSION_DENIED][google.rpc.Code.PERMISSION_DENIED].
     ///
+    /// [google.rpc.Code.PERMISSION_DENIED]: crate::error::rpc::generated::code::PERMISSION_DENIED
     pub resource_name: String,
 
     /// The owner of the resource (optional).
@@ -578,4 +579,189 @@ impl LocalizedMessage {
         self.message = v.into();
         self
     }
+}
+
+/// The canonical error codes for gRPC APIs.
+///
+///
+/// Sometimes multiple error codes may apply.  Services should return
+/// the most specific error code that applies.  For example, prefer
+/// `OUT_OF_RANGE` over `FAILED_PRECONDITION` if both codes apply.
+/// Similarly prefer `NOT_FOUND` or `ALREADY_EXISTS` over `FAILED_PRECONDITION`.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct Code(String);
+
+impl Code {
+    /// Sets the enum value.
+    pub fn set_value<T: Into<String>>(mut self, v: T) -> Self {
+        self.0 = v.into();
+        self
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Useful constants to work with [Code](Code)
+pub mod code {
+
+    /// Not an error; returned on success.
+    ///
+    /// HTTP Mapping: 200 OK
+    pub const OK: &str = "OK";
+
+    /// The operation was cancelled, typically by the caller.
+    ///
+    /// HTTP Mapping: 499 Client Closed Request
+    pub const CANCELLED: &str = "CANCELLED";
+
+    /// Unknown error.  For example, this error may be returned when
+    /// a `Status` value received from another address space belongs to
+    /// an error space that is not known in this address space.  Also
+    /// errors raised by APIs that do not return enough error information
+    /// may be converted to this error.
+    ///
+    /// HTTP Mapping: 500 Internal Server Error
+    pub const UNKNOWN: &str = "UNKNOWN";
+
+    /// The client specified an invalid argument.  Note that this differs
+    /// from `FAILED_PRECONDITION`.  `INVALID_ARGUMENT` indicates arguments
+    /// that are problematic regardless of the state of the system
+    /// (e.g., a malformed file name).
+    ///
+    /// HTTP Mapping: 400 Bad Request
+    pub const INVALID_ARGUMENT: &str = "INVALID_ARGUMENT";
+
+    /// The deadline expired before the operation could complete. For operations
+    /// that change the state of the system, this error may be returned
+    /// even if the operation has completed successfully.  For example, a
+    /// successful response from a server could have been delayed long
+    /// enough for the deadline to expire.
+    ///
+    /// HTTP Mapping: 504 Gateway Timeout
+    pub const DEADLINE_EXCEEDED: &str = "DEADLINE_EXCEEDED";
+
+    /// Some requested entity (e.g., file or directory) was not found.
+    ///
+    /// Note to server developers: if a request is denied for an entire class
+    /// of users, such as gradual feature rollout or undocumented allowlist,
+    /// `NOT_FOUND` may be used. If a request is denied for some users within
+    /// a class of users, such as user-based access control, `PERMISSION_DENIED`
+    /// must be used.
+    ///
+    /// HTTP Mapping: 404 Not Found
+    pub const NOT_FOUND: &str = "NOT_FOUND";
+
+    /// The entity that a client attempted to create (e.g., file or directory)
+    /// already exists.
+    ///
+    /// HTTP Mapping: 409 Conflict
+    pub const ALREADY_EXISTS: &str = "ALREADY_EXISTS";
+
+    /// The caller does not have permission to execute the specified
+    /// operation. `PERMISSION_DENIED` must not be used for rejections
+    /// caused by exhausting some resource (use `RESOURCE_EXHAUSTED`
+    /// instead for those errors). `PERMISSION_DENIED` must not be
+    /// used if the caller can not be identified (use `UNAUTHENTICATED`
+    /// instead for those errors). This error code does not imply the
+    /// request is valid or the requested entity exists or satisfies
+    /// other pre-conditions.
+    ///
+    /// HTTP Mapping: 403 Forbidden
+    pub const PERMISSION_DENIED: &str = "PERMISSION_DENIED";
+
+    /// The request does not have valid authentication credentials for the
+    /// operation.
+    ///
+    /// HTTP Mapping: 401 Unauthorized
+    pub const UNAUTHENTICATED: &str = "UNAUTHENTICATED";
+
+    /// Some resource has been exhausted, perhaps a per-user quota, or
+    /// perhaps the entire file system is out of space.
+    ///
+    /// HTTP Mapping: 429 Too Many Requests
+    pub const RESOURCE_EXHAUSTED: &str = "RESOURCE_EXHAUSTED";
+
+    /// The operation was rejected because the system is not in a state
+    /// required for the operation's execution.  For example, the directory
+    /// to be deleted is non-empty, an rmdir operation is applied to
+    /// a non-directory, etc.
+    ///
+    /// Service implementors can use the following guidelines to decide
+    /// between `FAILED_PRECONDITION`, `ABORTED`, and `UNAVAILABLE`:
+    ///  (a) Use `UNAVAILABLE` if the client can retry just the failing call.
+    ///  (b) Use `ABORTED` if the client should retry at a higher level. For
+    /// ```norust
+    ///  example, when a client-specified test-and-set fails, indicating the
+    ///  client should restart a read-modify-write sequence.
+    /// ```
+    ///  (c) Use `FAILED_PRECONDITION` if the client should not retry until
+    /// ```norust
+    ///  the system state has been explicitly fixed. For example, if an "rmdir"
+    ///  fails because the directory is non-empty, `FAILED_PRECONDITION`
+    ///  should be returned since the client should not retry unless
+    ///  the files are deleted from the directory.
+    /// ```
+    ///
+    /// HTTP Mapping: 400 Bad Request
+    pub const FAILED_PRECONDITION: &str = "FAILED_PRECONDITION";
+
+    /// The operation was aborted, typically due to a concurrency issue such as
+    /// a sequencer check failure or transaction abort.
+    ///
+    /// See the guidelines above for deciding between `FAILED_PRECONDITION`,
+    /// `ABORTED`, and `UNAVAILABLE`.
+    ///
+    /// HTTP Mapping: 409 Conflict
+    pub const ABORTED: &str = "ABORTED";
+
+    /// The operation was attempted past the valid range.  E.g., seeking or
+    /// reading past end-of-file.
+    ///
+    /// Unlike `INVALID_ARGUMENT`, this error indicates a problem that may
+    /// be fixed if the system state changes. For example, a 32-bit file
+    /// system will generate `INVALID_ARGUMENT` if asked to read at an
+    /// offset that is not in the range [0,2^32-1], but it will generate
+    /// `OUT_OF_RANGE` if asked to read from an offset past the current
+    /// file size.
+    ///
+    /// There is a fair bit of overlap between `FAILED_PRECONDITION` and
+    /// `OUT_OF_RANGE`.  We recommend using `OUT_OF_RANGE` (the more specific
+    /// error) when it applies so that callers who are iterating through
+    /// a space can easily look for an `OUT_OF_RANGE` error to detect when
+    /// they are done.
+    ///
+    /// HTTP Mapping: 400 Bad Request
+    pub const OUT_OF_RANGE: &str = "OUT_OF_RANGE";
+
+    /// The operation is not implemented or is not supported/enabled in this
+    /// service.
+    ///
+    /// HTTP Mapping: 501 Not Implemented
+    pub const UNIMPLEMENTED: &str = "UNIMPLEMENTED";
+
+    /// Internal errors.  This means that some invariants expected by the
+    /// underlying system have been broken.  This error code is reserved
+    /// for serious errors.
+    ///
+    /// HTTP Mapping: 500 Internal Server Error
+    pub const INTERNAL: &str = "INTERNAL";
+
+    /// The service is currently unavailable.  This is most likely a
+    /// transient condition, which can be corrected by retrying with
+    /// a backoff. Note that it is not always safe to retry
+    /// non-idempotent operations.
+    ///
+    /// See the guidelines above for deciding between `FAILED_PRECONDITION`,
+    /// `ABORTED`, and `UNAVAILABLE`.
+    ///
+    /// HTTP Mapping: 503 Service Unavailable
+    pub const UNAVAILABLE: &str = "UNAVAILABLE";
+
+    /// Unrecoverable data loss or corruption.
+    ///
+    /// HTTP Mapping: 500 Internal Server Error
+    pub const DATA_LOSS: &str = "DATA_LOSS";
 }

--- a/src/generated/type/src/model.rs
+++ b/src/generated/type/src/model.rs
@@ -1273,3 +1273,159 @@ impl TimeOfDay {
         self
     }
 }
+
+/// A `CalendarPeriod` represents the abstract concept of a time period that has
+/// a canonical start. Grammatically, "the start of the current
+/// `CalendarPeriod`." All calendar times begin at midnight UTC.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct CalendarPeriod(String);
+
+impl CalendarPeriod {
+    /// Sets the enum value.
+    pub fn set_value<T: Into<String>>(mut self, v: T) -> Self {
+        self.0 = v.into();
+        self
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Useful constants to work with [CalendarPeriod](CalendarPeriod)
+pub mod calendar_period {
+
+    /// Undefined period, raises an error.
+    pub const CALENDAR_PERIOD_UNSPECIFIED: &str = "CALENDAR_PERIOD_UNSPECIFIED";
+
+    /// A day.
+    pub const DAY: &str = "DAY";
+
+    /// A week. Weeks begin on Monday, following
+    /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_week_date).
+    pub const WEEK: &str = "WEEK";
+
+    /// A fortnight. The first calendar fortnight of the year begins at the start
+    /// of week 1 according to
+    /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_week_date).
+    pub const FORTNIGHT: &str = "FORTNIGHT";
+
+    /// A month.
+    pub const MONTH: &str = "MONTH";
+
+    /// A quarter. Quarters start on dates 1-Jan, 1-Apr, 1-Jul, and 1-Oct of each
+    /// year.
+    pub const QUARTER: &str = "QUARTER";
+
+    /// A half-year. Half-years start on dates 1-Jan and 1-Jul.
+    pub const HALF: &str = "HALF";
+
+    /// A year.
+    pub const YEAR: &str = "YEAR";
+}
+
+/// Represents a day of the week.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct DayOfWeek(String);
+
+impl DayOfWeek {
+    /// Sets the enum value.
+    pub fn set_value<T: Into<String>>(mut self, v: T) -> Self {
+        self.0 = v.into();
+        self
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Useful constants to work with [DayOfWeek](DayOfWeek)
+pub mod day_of_week {
+
+    /// The day of the week is unspecified.
+    pub const DAY_OF_WEEK_UNSPECIFIED: &str = "DAY_OF_WEEK_UNSPECIFIED";
+
+    /// Monday
+    pub const MONDAY: &str = "MONDAY";
+
+    /// Tuesday
+    pub const TUESDAY: &str = "TUESDAY";
+
+    /// Wednesday
+    pub const WEDNESDAY: &str = "WEDNESDAY";
+
+    /// Thursday
+    pub const THURSDAY: &str = "THURSDAY";
+
+    /// Friday
+    pub const FRIDAY: &str = "FRIDAY";
+
+    /// Saturday
+    pub const SATURDAY: &str = "SATURDAY";
+
+    /// Sunday
+    pub const SUNDAY: &str = "SUNDAY";
+}
+
+/// Represents a month in the Gregorian calendar.
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct Month(String);
+
+impl Month {
+    /// Sets the enum value.
+    pub fn set_value<T: Into<String>>(mut self, v: T) -> Self {
+        self.0 = v.into();
+        self
+    }
+
+    /// Gets the enum value.
+    pub fn value(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Useful constants to work with [Month](Month)
+pub mod month {
+
+    /// The unspecified month.
+    pub const MONTH_UNSPECIFIED: &str = "MONTH_UNSPECIFIED";
+
+    /// The month of January.
+    pub const JANUARY: &str = "JANUARY";
+
+    /// The month of February.
+    pub const FEBRUARY: &str = "FEBRUARY";
+
+    /// The month of March.
+    pub const MARCH: &str = "MARCH";
+
+    /// The month of April.
+    pub const APRIL: &str = "APRIL";
+
+    /// The month of May.
+    pub const MAY: &str = "MAY";
+
+    /// The month of June.
+    pub const JUNE: &str = "JUNE";
+
+    /// The month of July.
+    pub const JULY: &str = "JULY";
+
+    /// The month of August.
+    pub const AUGUST: &str = "AUGUST";
+
+    /// The month of September.
+    pub const SEPTEMBER: &str = "SEPTEMBER";
+
+    /// The month of October.
+    pub const OCTOBER: &str = "OCTOBER";
+
+    /// The month of November.
+    pub const NOVEMBER: &str = "NOVEMBER";
+
+    /// The month of December.
+    pub const DECEMBER: &str = "DECEMBER";
+}


### PR DESCRIPTION
We need to generate top-level enums, that is, those that are not nested
within a message.