### PR TITLE
impl(auth): token provider for user credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,8 +584,10 @@ name = "gcp-sdk-auth"
 version = "0.1.0-rc2"
 dependencies = [
  "async-trait",
+ "axum",
  "http",
  "mockall",
+ "reqwest",
  "serde",
  "serde_json",
  "test-case",

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -26,12 +26,14 @@ categories.workspace = true
 [dependencies]
 async-trait = "0.1.83"
 http        = "1.2.0"
-thiserror   = "2"
+reqwest     = { version = "0.12.9", features = ["json"] }
 serde       = { version = "1.0.214", features = ["derive"] }
 serde_json  = "1.0.133"
+thiserror   = "2"
 time        = "0.3.37"
 
 [dev-dependencies]
+axum      = "0.7.9"
 mockall   = "0.13.1"
 test-case = "3.3.1"
-tokio     = { version = "1.42", features = ["macros", "test-util"] }
+tokio     = { version = "1.42", features = ["macros", "rt-multi-thread", "test-util"] }

--- a/src/auth/src/credentials/user_credential.rs
+++ b/src/auth/src/credentials/user_credential.rs
@@ -14,9 +14,71 @@
 
 use crate::credentials::traits::dynamic::Credential;
 use crate::credentials::Result;
-use crate::errors::CredentialError;
+use crate::errors::{is_retryable, CredentialError};
 use crate::token::{Token, TokenProvider};
-use http::header::{HeaderName, HeaderValue, AUTHORIZATION};
+use http::header::{HeaderName, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
+use reqwest::{Client, Method};
+use std::time::Duration;
+use time::OffsetDateTime;
+
+#[allow(dead_code)] // TODO(#442) - implementation in progress
+struct UserTokenProvider {
+    client_id: String,
+    client_secret: String,
+    refresh_token: String,
+    endpoint: String,
+}
+
+#[async_trait::async_trait]
+impl TokenProvider for UserTokenProvider {
+    async fn get_token(&mut self) -> Result<Token> {
+        let client = Client::new();
+
+        // Make the request
+        let req = Oauth2RefreshRequest {
+            grant_type: RefreshGrantType::RefreshToken,
+            client_id: self.client_id.clone(),
+            client_secret: self.client_secret.clone(),
+            refresh_token: self.refresh_token.clone(),
+        };
+        let header = HeaderValue::try_from("application/json")
+            .map_err(|e| CredentialError::new(false, e.into()))?;
+        let builder = client
+            .request(Method::POST, self.endpoint.as_str())
+            .header(CONTENT_TYPE, header)
+            .json(&req);
+        let resp = builder
+            .send()
+            .await
+            .map_err(|e| CredentialError::new(false, e.into()))?;
+
+        // Process the response
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp
+                .text()
+                .await
+                .map_err(|e| CredentialError::new(false, e.into()))?;
+            return Err(CredentialError::new(
+                is_retryable(status),
+                Box::from(format!("Failed to fetch token. {body}")),
+            ));
+        }
+        let response = resp
+            .json::<Oauth2RefreshResponse>()
+            .await
+            .map_err(|e| CredentialError::new(false, e.into()))?;
+        let token = Token {
+            token: response.access_token,
+            token_type: response.token_type,
+            expires_at: response
+                .expires_in
+                .map(|d| OffsetDateTime::now_utc() + Duration::from_secs(d)),
+            metadata: None,
+        };
+        Ok(token)
+    }
+}
 
 /// Data model for a UserCredential
 #[allow(dead_code)] // TODO(#442) - implementation in progress
@@ -79,6 +141,11 @@ struct Oauth2RefreshResponse {
 mod test {
     use super::*;
     use crate::token::test::MockTokenProvider;
+    use axum::extract::Json;
+    use http::StatusCode;
+    use std::error::Error;
+
+    type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
 
     #[tokio::test]
     async fn get_token_success() {
@@ -234,5 +301,164 @@ mod test {
         assert_eq!(json, expected);
         let roundtrip = serde_json::from_value::<Oauth2RefreshResponse>(json).unwrap();
         assert_eq!(response, roundtrip);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn token_provider_full() -> TestResult {
+        let app = axum::Router::new().route("/token", axum::routing::post(handle_token_full));
+        let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await?;
+        let addr = listener.local_addr()?;
+        let endpoint = format!("http://{}:{}/token", addr.ip(), addr.port());
+        println!("endpoint = {endpoint}");
+
+        let _server = tokio::spawn(async { axum::serve(listener, app).await });
+
+        let tp = UserTokenProvider {
+            client_id: "test-client-id".to_string(),
+            client_secret: "test-client-secret".to_string(),
+            refresh_token: "test-refresh-token".to_string(),
+            endpoint: endpoint,
+        };
+        let mut uc = UserCredential { token_provider: tp };
+        let now = OffsetDateTime::now_utc();
+        let token = uc.get_token().await?;
+        assert_eq!(token.token, "test-access-token");
+        assert_eq!(token.token_type, "test-token-type");
+        assert!(token
+            .expires_at
+            .is_some_and(|d| d >= now + Duration::from_secs(3600)));
+
+        Ok(())
+    }
+
+    async fn handle_token_full(request: Json<Oauth2RefreshRequest>) -> String {
+        assert_eq!(request.client_id, "test-client-id");
+        assert_eq!(request.client_secret, "test-client-secret");
+        assert_eq!(request.refresh_token, "test-refresh-token");
+        assert_eq!(request.grant_type, RefreshGrantType::RefreshToken);
+
+        let response = Oauth2RefreshResponse {
+            access_token: "test-access-token".to_string(),
+            expires_in: Some(3600),
+            refresh_token: Some("test-refresh-token".to_string()),
+            scope: Some("scope1 scope2".to_string()),
+            token_type: "test-token-type".to_string(),
+        };
+        serde_json::to_string(&response).unwrap()
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn token_provider_partial() -> TestResult {
+        let app = axum::Router::new().route("/token", axum::routing::post(handle_token_partial));
+        let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await?;
+        let addr = listener.local_addr()?;
+        let endpoint = format!("http://{}:{}/token", addr.ip(), addr.port());
+        println!("endpoint = {endpoint}");
+
+        let _server = tokio::spawn(async { axum::serve(listener, app).await });
+
+        let tp = UserTokenProvider {
+            client_id: "test-client-id".to_string(),
+            client_secret: "test-client-secret".to_string(),
+            refresh_token: "test-refresh-token".to_string(),
+            endpoint: endpoint,
+        };
+        let mut uc = UserCredential { token_provider: tp };
+        let token = uc.get_token().await?;
+        assert_eq!(token.token, "test-access-token");
+        assert_eq!(token.token_type, "test-token-type");
+        assert_eq!(token.expires_at, None);
+
+        Ok(())
+    }
+
+    async fn handle_token_partial(request: Json<Oauth2RefreshRequest>) -> String {
+        assert_eq!(request.client_id, "test-client-id");
+        assert_eq!(request.client_secret, "test-client-secret");
+        assert_eq!(request.refresh_token, "test-refresh-token");
+        assert_eq!(request.grant_type, RefreshGrantType::RefreshToken);
+
+        let response = Oauth2RefreshResponse {
+            access_token: "test-access-token".to_string(),
+            expires_in: None,
+            refresh_token: None,
+            scope: None,
+            token_type: "test-token-type".to_string(),
+        };
+        serde_json::to_string(&response).unwrap()
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn token_provider_retryable_error() -> TestResult {
+        let app =
+            axum::Router::new().route("/token", axum::routing::post(handle_token_retryable_error));
+        let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await?;
+        let addr = listener.local_addr()?;
+        let endpoint = format!("http://{}:{}/token", addr.ip(), addr.port());
+        println!("endpoint = {endpoint}");
+
+        let _server = tokio::spawn(async { axum::serve(listener, app).await });
+
+        let tp = UserTokenProvider {
+            client_id: "test-client-id".to_string(),
+            client_secret: "test-client-secret".to_string(),
+            refresh_token: "test-refresh-token".to_string(),
+            endpoint: endpoint,
+        };
+        let mut uc = UserCredential { token_provider: tp };
+        let e = uc.get_token().await.err().unwrap();
+        assert!(e.is_retryable());
+        assert!(e.source().unwrap().to_string().contains("try again"));
+
+        Ok(())
+    }
+
+    async fn handle_token_retryable_error(
+        request: Json<Oauth2RefreshRequest>,
+    ) -> (StatusCode, String) {
+        assert_eq!(request.client_id, "test-client-id");
+        assert_eq!(request.client_secret, "test-client-secret");
+        assert_eq!(request.refresh_token, "test-refresh-token");
+        assert_eq!(request.grant_type, RefreshGrantType::RefreshToken);
+
+        (StatusCode::SERVICE_UNAVAILABLE, "try again".to_string())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn token_provider_nonretryable_error() -> TestResult {
+        let app = axum::Router::new().route(
+            "/token",
+            axum::routing::post(handle_token_nonretryable_error),
+        );
+        let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await?;
+        let addr = listener.local_addr()?;
+        let endpoint = format!("http://{}:{}/token", addr.ip(), addr.port());
+        println!("endpoint = {endpoint}");
+
+        let _server = tokio::spawn(async { axum::serve(listener, app).await });
+
+        let tp = UserTokenProvider {
+            client_id: "test-client-id".to_string(),
+            client_secret: "test-client-secret".to_string(),
+            refresh_token: "test-refresh-token".to_string(),
+            endpoint: endpoint,
+        };
+        let mut uc = UserCredential { token_provider: tp };
+        let e = uc.get_token().await.err().unwrap();
+        assert!(!e.is_retryable());
+        assert!(e.source().unwrap().to_string().contains("epic fail"));
+
+        Ok(())
+    }
+
+    async fn handle_token_nonretryable_error(
+        request: Json<Oauth2RefreshRequest>,
+    ) -> (StatusCode, String) {
+        assert_eq!(request.client_id, "test-client-id");
+        assert_eq!(request.client_secret, "test-client-secret");
+        assert_eq!(request.refresh_token, "test-refresh-token");
+        assert_eq!(request.grant_type, RefreshGrantType::RefreshToken);
+
+        (StatusCode::UNAUTHORIZED, "epic fail".to_string())
     }
 }


### PR DESCRIPTION
Part of the work for #442 

Feel free to throw this PR back at me if it is too large.

Add and implement a `UserTokenProvider` for talking with `oauth2.googleapis.com/token`.

### Error handling

I am aware of #389. We should probably start tracking error kinds. I didn't do it in this PR.

### Unit tests

We make a fake server in 4 different unit tests. I really wanted something like:
```
fn MakeHandler(response: OAuth2RefreshResponse) -> axum::handler::Handler;
```

But I couldn't figure it out. So we have 1 handler function per test to test the different response possibilities.

I also did not know how to fake a time in the unit test that checks the expiration time, so I just used a comparison operator.

### Integration tests?

There are none. I did manually use my authorized user credentials and successfully get tokens from `oauth2.googleapis.com/token` though.