### PR TITLE
feat(gax): support `user-agent` option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,7 +615,6 @@ dependencies = [
  "gcp-sdk-wkt",
  "google-cloud-auth",
  "http",
- "lazy_static",
  "pin-project",
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,7 @@ dependencies = [
  "gcp-sdk-wkt",
  "google-cloud-auth",
  "http",
+ "lazy_static",
  "pin-project",
  "reqwest",
  "serde",

--- a/generator/internal/language/templates/rust/crate/src/builders.rs.mustache
+++ b/generator/internal/language/templates/rust/crate/src/builders.rs.mustache
@@ -38,7 +38,7 @@ where R: std::default::Default {
         Self {
             stub,
             request: R::default(),
-            options: gax::options::RequestOptions,
+            options: gax::options::RequestOptions::default(),
         }
     }
 }
@@ -95,6 +95,12 @@ impl {{NameToPascal}} {
         self
     }
     {{/InputType.ExplicitOneOfs}}
+}
+
+impl gax::options::RequestBuilder for {{NameToPascal}} {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
 }
 
 {{/Methods}}

--- a/generator/internal/language/templates/rust/crate/src/transport.rs.mustache
+++ b/generator/internal/language/templates/rust/crate/src/transport.rs.mustache
@@ -57,7 +57,7 @@ impl crate::traits::{{NameToPascal}} for {{NameToPascal}} {
     async fn {{NameToSnake}}(
         &self,
         req: {{InputTypeName}},
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<{{OutputTypeName}}> {
         let builder = self.inner.builder(
             reqwest::Method::{{HTTPMethod}}, format!("{{HTTPPathFmt}}"
@@ -70,7 +70,11 @@ impl crate::traits::{{NameToPascal}} for {{NameToPascal}} {
         {{#QueryParams}}
         let builder = gax::query_parameter::add(builder, "{{JSONName}}", {{{AsQueryParameter}}}).map_err(Error::other)?;
         {{/QueryParams}}
-        self.inner.execute(builder, {{#HasBody}}Some(req{{BodyAccessor}}){{/HasBody}}{{^HasBody}}None::<gax::http_client::NoBody>{{/HasBody}}).await
+        self.inner.execute(
+            builder,
+            {{#HasBody}}Some(req{{BodyAccessor}}){{/HasBody}}{{^HasBody}}None::<gax::http_client::NoBody>{{/HasBody}},
+            &options,
+        ).await
     }
 
     {{/Methods}}

--- a/generator/internal/language/templates/rust/crate/src/transport.rs.mustache
+++ b/generator/internal/language/templates/rust/crate/src/transport.rs.mustache
@@ -73,7 +73,7 @@ impl crate::traits::{{NameToPascal}} for {{NameToPascal}} {
         self.inner.execute(
             builder,
             {{#HasBody}}Some(req{{BodyAccessor}}){{/HasBody}}{{^HasBody}}None::<gax::http_client::NoBody>{{/HasBody}},
-            &options,
+            options,
         ).await
     }
 

--- a/generator/testdata/rust/gclient/golden/iam/v1/src/builders.rs
+++ b/generator/testdata/rust/gclient/golden/iam/v1/src/builders.rs
@@ -31,7 +31,7 @@ where R: std::default::Default {
         Self {
             stub,
             request: R::default(),
-            options: gax::options::RequestOptions,
+            options: gax::options::RequestOptions::default(),
         }
     }
 }
@@ -77,6 +77,12 @@ impl SetIamPolicy {
     }
 }
 
+impl gax::options::RequestBuilder for SetIamPolicy {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a IAMPolicy::get_iam_policy call.
 #[derive(Clone, Debug)]
 pub struct GetIamPolicy(IAMPolicyRequestBuilder<crate::model::GetIamPolicyRequest>);
@@ -112,6 +118,12 @@ impl GetIamPolicy {
     }
 }
 
+impl gax::options::RequestBuilder for GetIamPolicy {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a IAMPolicy::test_iam_permissions call.
 #[derive(Clone, Debug)]
 pub struct TestIamPermissions(IAMPolicyRequestBuilder<crate::model::TestIamPermissionsRequest>);
@@ -144,6 +156,12 @@ impl TestIamPermissions {
     pub fn set_permissions<T: Into<Vec<String>>>(mut self, v: T) -> Self {
         self.0.request.permissions = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for TestIamPermissions {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 

--- a/generator/testdata/rust/gclient/golden/iam/v1/src/transport.rs
+++ b/generator/testdata/rust/gclient/golden/iam/v1/src/transport.rs
@@ -71,7 +71,7 @@ impl crate::traits::IAMPolicy for IAMPolicy {
     async fn set_iam_policy(
         &self,
         req: crate::model::SetIamPolicyRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/{}:setIamPolicy"
@@ -79,7 +79,11 @@ impl crate::traits::IAMPolicy for IAMPolicy {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(
+            builder,
+            Some(req),
+            &options,
+        ).await
     }
 
     /// Gets the access control policy for a resource.
@@ -88,7 +92,7 @@ impl crate::traits::IAMPolicy for IAMPolicy {
     async fn get_iam_policy(
         &self,
         req: crate::model::GetIamPolicyRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/{}:getIamPolicy"
@@ -96,7 +100,11 @@ impl crate::traits::IAMPolicy for IAMPolicy {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(
+            builder,
+            Some(req),
+            &options,
+        ).await
     }
 
     /// Returns permissions that a caller has on the specified resource.
@@ -109,7 +117,7 @@ impl crate::traits::IAMPolicy for IAMPolicy {
     async fn test_iam_permissions(
         &self,
         req: crate::model::TestIamPermissionsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::TestIamPermissionsResponse> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/{}:testIamPermissions"
@@ -117,7 +125,11 @@ impl crate::traits::IAMPolicy for IAMPolicy {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(
+            builder,
+            Some(req),
+            &options,
+        ).await
     }
 
 }

--- a/generator/testdata/rust/gclient/golden/iam/v1/src/transport.rs
+++ b/generator/testdata/rust/gclient/golden/iam/v1/src/transport.rs
@@ -82,7 +82,7 @@ impl crate::traits::IAMPolicy for IAMPolicy {
         self.inner.execute(
             builder,
             Some(req),
-            &options,
+            options,
         ).await
     }
 
@@ -103,7 +103,7 @@ impl crate::traits::IAMPolicy for IAMPolicy {
         self.inner.execute(
             builder,
             Some(req),
-            &options,
+            options,
         ).await
     }
 
@@ -128,7 +128,7 @@ impl crate::traits::IAMPolicy for IAMPolicy {
         self.inner.execute(
             builder,
             Some(req),
-            &options,
+            options,
         ).await
     }
 

--- a/generator/testdata/rust/gclient/golden/location/src/builders.rs
+++ b/generator/testdata/rust/gclient/golden/location/src/builders.rs
@@ -31,7 +31,7 @@ where R: std::default::Default {
         Self {
             stub,
             request: R::default(),
-            options: gax::options::RequestOptions,
+            options: gax::options::RequestOptions::default(),
         }
     }
 }
@@ -95,6 +95,12 @@ impl ListLocations {
     }
 }
 
+impl gax::options::RequestBuilder for ListLocations {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a Locations::get_location call.
 #[derive(Clone, Debug)]
 pub struct GetLocation(LocationsRequestBuilder<crate::model::GetLocationRequest>);
@@ -121,6 +127,12 @@ impl GetLocation {
     pub fn set_name<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.name = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for GetLocation {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 

--- a/generator/testdata/rust/gclient/golden/location/src/transport.rs
+++ b/generator/testdata/rust/gclient/golden/location/src/transport.rs
@@ -62,7 +62,7 @@ impl crate::traits::Locations for Locations {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -81,7 +81,7 @@ impl crate::traits::Locations for Locations {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 

--- a/generator/testdata/rust/gclient/golden/location/src/transport.rs
+++ b/generator/testdata/rust/gclient/golden/location/src/transport.rs
@@ -48,7 +48,7 @@ impl crate::traits::Locations for Locations {
     async fn list_locations(
         &self,
         req: crate::model::ListLocationsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListLocationsResponse> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/{}"
@@ -59,14 +59,18 @@ impl crate::traits::Locations for Locations {
         let builder = gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
         let builder = gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
         let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token).map_err(Error::other)?;
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Gets information about a location.
     async fn get_location(
         &self,
         req: crate::model::GetLocationRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Location> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/{}"
@@ -74,7 +78,11 @@ impl crate::traits::Locations for Locations {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
 }

--- a/generator/testdata/rust/gclient/golden/secretmanager/src/builders.rs
+++ b/generator/testdata/rust/gclient/golden/secretmanager/src/builders.rs
@@ -31,7 +31,7 @@ where R: std::default::Default {
         Self {
             stub,
             request: R::default(),
-            options: gax::options::RequestOptions,
+            options: gax::options::RequestOptions::default(),
         }
     }
 }
@@ -95,6 +95,12 @@ impl ListSecrets {
     }
 }
 
+impl gax::options::RequestBuilder for ListSecrets {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::create_secret call.
 #[derive(Clone, Debug)]
 pub struct CreateSecret(SecretManagerServiceRequestBuilder<crate::model::CreateSecretRequest>);
@@ -136,6 +142,12 @@ impl CreateSecret {
     }
 }
 
+impl gax::options::RequestBuilder for CreateSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::add_secret_version call.
 #[derive(Clone, Debug)]
 pub struct AddSecretVersion(SecretManagerServiceRequestBuilder<crate::model::AddSecretVersionRequest>);
@@ -171,6 +183,12 @@ impl AddSecretVersion {
     }
 }
 
+impl gax::options::RequestBuilder for AddSecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::get_secret call.
 #[derive(Clone, Debug)]
 pub struct GetSecret(SecretManagerServiceRequestBuilder<crate::model::GetSecretRequest>);
@@ -197,6 +215,12 @@ impl GetSecret {
     pub fn set_name<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.name = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for GetSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -235,6 +259,12 @@ impl UpdateSecret {
     }
 }
 
+impl gax::options::RequestBuilder for UpdateSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::delete_secret call.
 #[derive(Clone, Debug)]
 pub struct DeleteSecret(SecretManagerServiceRequestBuilder<crate::model::DeleteSecretRequest>);
@@ -267,6 +297,12 @@ impl DeleteSecret {
     pub fn set_etag<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.etag = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for DeleteSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -329,6 +365,12 @@ impl ListSecretVersions {
     }
 }
 
+impl gax::options::RequestBuilder for ListSecretVersions {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::get_secret_version call.
 #[derive(Clone, Debug)]
 pub struct GetSecretVersion(SecretManagerServiceRequestBuilder<crate::model::GetSecretVersionRequest>);
@@ -358,6 +400,12 @@ impl GetSecretVersion {
     }
 }
 
+impl gax::options::RequestBuilder for GetSecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::access_secret_version call.
 #[derive(Clone, Debug)]
 pub struct AccessSecretVersion(SecretManagerServiceRequestBuilder<crate::model::AccessSecretVersionRequest>);
@@ -384,6 +432,12 @@ impl AccessSecretVersion {
     pub fn set_name<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.name = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for AccessSecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -422,6 +476,12 @@ impl DisableSecretVersion {
     }
 }
 
+impl gax::options::RequestBuilder for DisableSecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::enable_secret_version call.
 #[derive(Clone, Debug)]
 pub struct EnableSecretVersion(SecretManagerServiceRequestBuilder<crate::model::EnableSecretVersionRequest>);
@@ -457,6 +517,12 @@ impl EnableSecretVersion {
     }
 }
 
+impl gax::options::RequestBuilder for EnableSecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::destroy_secret_version call.
 #[derive(Clone, Debug)]
 pub struct DestroySecretVersion(SecretManagerServiceRequestBuilder<crate::model::DestroySecretVersionRequest>);
@@ -489,6 +555,12 @@ impl DestroySecretVersion {
     pub fn set_etag<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.etag = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for DestroySecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -533,6 +605,12 @@ impl SetIamPolicy {
     }
 }
 
+impl gax::options::RequestBuilder for SetIamPolicy {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::get_iam_policy call.
 #[derive(Clone, Debug)]
 pub struct GetIamPolicy(SecretManagerServiceRequestBuilder<iam::model::GetIamPolicyRequest>);
@@ -565,6 +643,12 @@ impl GetIamPolicy {
     pub fn set_options<T: Into<Option<iam::model::GetPolicyOptions>>>(mut self, v: T) -> Self {
         self.0.request.options = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for GetIamPolicy {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -603,6 +687,12 @@ impl TestIamPermissions {
     }
 }
 
+impl gax::options::RequestBuilder for TestIamPermissions {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 
 /// Common implementation for [crate::client::Locations] request builders.
 #[derive(Clone, Debug)]
@@ -618,7 +708,7 @@ where R: std::default::Default {
         Self {
             stub,
             request: R::default(),
-            options: gax::options::RequestOptions,
+            options: gax::options::RequestOptions::default(),
         }
     }
 }
@@ -682,6 +772,12 @@ impl ListLocations {
     }
 }
 
+impl gax::options::RequestBuilder for ListLocations {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a Locations::get_location call.
 #[derive(Clone, Debug)]
 pub struct GetLocation(LocationsRequestBuilder<location::model::GetLocationRequest>);
@@ -708,6 +804,12 @@ impl GetLocation {
     pub fn set_name<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.name = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for GetLocation {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 

--- a/generator/testdata/rust/gclient/golden/secretmanager/src/transport.rs
+++ b/generator/testdata/rust/gclient/golden/secretmanager/src/transport.rs
@@ -69,7 +69,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -93,7 +93,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req.secret),
-            &options,
+            options,
         ).await
     }
 
@@ -117,7 +117,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req),
-            &options,
+            options,
         ).await
     }
 
@@ -138,7 +138,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -161,7 +161,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req.secret),
-            &options,
+            options,
         ).await
     }
 
@@ -183,7 +183,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -208,7 +208,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -233,7 +233,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -258,7 +258,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -285,7 +285,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req),
-            &options,
+            options,
         ).await
     }
 
@@ -312,7 +312,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req),
-            &options,
+            options,
         ).await
     }
 
@@ -340,7 +340,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req),
-            &options,
+            options,
         ).await
     }
 
@@ -368,7 +368,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req),
-            &options,
+            options,
         ).await
     }
 
@@ -389,7 +389,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -414,7 +414,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req),
-            &options,
+            options,
         ).await
     }
 
@@ -460,7 +460,7 @@ impl crate::traits::Locations for Locations {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -479,7 +479,7 @@ impl crate::traits::Locations for Locations {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 

--- a/generator/testdata/rust/gclient/golden/secretmanager/src/transport.rs
+++ b/generator/testdata/rust/gclient/golden/secretmanager/src/transport.rs
@@ -55,7 +55,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn list_secrets(
         &self,
         req: crate::model::ListSecretsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretsResponse> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/{}/secrets"
@@ -66,7 +66,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder = gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
         let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token).map_err(Error::other)?;
         let builder = gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Creates a new [Secret][google.cloud.secretmanager.v1.Secret] containing no
@@ -77,7 +81,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn create_secret(
         &self,
         req: crate::model::CreateSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/{}/secrets"
@@ -86,7 +90,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = gax::query_parameter::add(builder, "secretId", &req.secret_id).map_err(Error::other)?;
-        self.inner.execute(builder, Some(req.secret)).await
+        self.inner.execute(
+            builder,
+            Some(req.secret),
+            &options,
+        ).await
     }
 
     /// Creates a new [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
@@ -98,7 +106,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn add_secret_version(
         &self,
         req: crate::model::AddSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/{}:addVersion"
@@ -106,7 +114,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(
+            builder,
+            Some(req),
+            &options,
+        ).await
     }
 
     /// Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].
@@ -115,7 +127,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn get_secret(
         &self,
         req: crate::model::GetSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/{}"
@@ -123,7 +135,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Updates metadata of an existing
@@ -133,7 +149,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn update_secret(
         &self,
         req: crate::model::UpdateSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let builder = self.inner.builder(
             reqwest::Method::PATCH, format!("/v1/{}"
@@ -142,7 +158,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = gax::query_parameter::add(builder, "updateMask", &serde_json::to_value(&req.update_mask).map_err(Error::serde)?).map_err(Error::other)?;
-        self.inner.execute(builder, Some(req.secret)).await
+        self.inner.execute(
+            builder,
+            Some(req.secret),
+            &options,
+        ).await
     }
 
     /// Deletes a [Secret][google.cloud.secretmanager.v1.Secret].
@@ -151,7 +171,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn delete_secret(
         &self,
         req: crate::model::DeleteSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<wkt::Empty> {
         let builder = self.inner.builder(
             reqwest::Method::DELETE, format!("/v1/{}"
@@ -160,7 +180,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = gax::query_parameter::add(builder, "etag", &req.etag).map_err(Error::other)?;
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Lists [SecretVersions][google.cloud.secretmanager.v1.SecretVersion]. This
@@ -170,7 +194,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn list_secret_versions(
         &self,
         req: crate::model::ListSecretVersionsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretVersionsResponse> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/{}/versions"
@@ -181,7 +205,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder = gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
         let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token).map_err(Error::other)?;
         let builder = gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Gets metadata for a
@@ -194,7 +222,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn get_secret_version(
         &self,
         req: crate::model::GetSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/{}"
@@ -202,7 +230,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Accesses a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -215,7 +247,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn access_secret_version(
         &self,
         req: crate::model::AccessSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::AccessSecretVersionResponse> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/{}:access"
@@ -223,7 +255,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Disables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -238,7 +274,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn disable_secret_version(
         &self,
         req: crate::model::DisableSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/{}:disable"
@@ -246,7 +282,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(
+            builder,
+            Some(req),
+            &options,
+        ).await
     }
 
     /// Enables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -261,7 +301,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn enable_secret_version(
         &self,
         req: crate::model::EnableSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/{}:enable"
@@ -269,7 +309,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(
+            builder,
+            Some(req),
+            &options,
+        ).await
     }
 
     /// Destroys a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -285,7 +329,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn destroy_secret_version(
         &self,
         req: crate::model::DestroySecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/{}:destroy"
@@ -293,7 +337,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(
+            builder,
+            Some(req),
+            &options,
+        ).await
     }
 
     /// Sets the access control policy on the specified secret. Replaces any
@@ -309,7 +357,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn set_iam_policy(
         &self,
         req: iam::model::SetIamPolicyRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<iam::model::Policy> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/{}:setIamPolicy"
@@ -317,7 +365,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(
+            builder,
+            Some(req),
+            &options,
+        ).await
     }
 
     /// Gets the access control policy for a secret.
@@ -325,7 +377,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn get_iam_policy(
         &self,
         req: iam::model::GetIamPolicyRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<iam::model::Policy> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/{}:getIamPolicy"
@@ -334,7 +386,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = gax::query_parameter::add(builder, "options", &serde_json::to_value(&req.options).map_err(Error::serde)?).map_err(Error::other)?;
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Returns permissions that a caller has for the specified secret.
@@ -347,7 +403,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn test_iam_permissions(
         &self,
         req: iam::model::TestIamPermissionsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<iam::model::TestIamPermissionsResponse> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/{}:testIamPermissions"
@@ -355,7 +411,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(
+            builder,
+            Some(req),
+            &options,
+        ).await
     }
 
 }
@@ -386,7 +446,7 @@ impl crate::traits::Locations for Locations {
     async fn list_locations(
         &self,
         req: location::model::ListLocationsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<location::model::ListLocationsResponse> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/{}/locations"
@@ -397,14 +457,18 @@ impl crate::traits::Locations for Locations {
         let builder = gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
         let builder = gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
         let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token).map_err(Error::other)?;
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Gets information about a location.
     async fn get_location(
         &self,
         req: location::model::GetLocationRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<location::model::Location> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/{}"
@@ -412,7 +476,11 @@ impl crate::traits::Locations for Locations {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
 }

--- a/generator/testdata/rust/openapi/golden/src/builders.rs
+++ b/generator/testdata/rust/openapi/golden/src/builders.rs
@@ -31,7 +31,7 @@ where R: std::default::Default {
         Self {
             stub,
             request: R::default(),
-            options: gax::options::RequestOptions,
+            options: gax::options::RequestOptions::default(),
         }
     }
 }
@@ -95,6 +95,12 @@ impl ListLocations {
     }
 }
 
+impl gax::options::RequestBuilder for ListLocations {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::get_location call.
 #[derive(Clone, Debug)]
 pub struct GetLocation(SecretManagerServiceRequestBuilder<crate::model::GetLocationRequest>);
@@ -127,6 +133,12 @@ impl GetLocation {
     pub fn set_location<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.location = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for GetLocation {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -189,6 +201,12 @@ impl ListSecrets {
     }
 }
 
+impl gax::options::RequestBuilder for ListSecrets {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::create_secret call.
 #[derive(Clone, Debug)]
 pub struct CreateSecret(SecretManagerServiceRequestBuilder<crate::model::CreateSecretRequest>);
@@ -227,6 +245,12 @@ impl CreateSecret {
     pub fn set_secret_id<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.secret_id = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for CreateSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -295,6 +319,12 @@ impl ListSecretsByProjectAndLocation {
     }
 }
 
+impl gax::options::RequestBuilder for ListSecretsByProjectAndLocation {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::create_secret_by_project_and_location call.
 #[derive(Clone, Debug)]
 pub struct CreateSecretByProjectAndLocation(SecretManagerServiceRequestBuilder<crate::model::CreateSecretByProjectAndLocationRequest>);
@@ -339,6 +369,12 @@ impl CreateSecretByProjectAndLocation {
     pub fn set_secret_id<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.secret_id = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for CreateSecretByProjectAndLocation {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -389,6 +425,12 @@ impl AddSecretVersion {
     }
 }
 
+impl gax::options::RequestBuilder for AddSecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::add_secret_version_by_project_and_location_and_secret call.
 #[derive(Clone, Debug)]
 pub struct AddSecretVersionByProjectAndLocationAndSecret(SecretManagerServiceRequestBuilder<crate::model::AddSecretVersionRequest>);
@@ -436,6 +478,12 @@ impl AddSecretVersionByProjectAndLocationAndSecret {
     }
 }
 
+impl gax::options::RequestBuilder for AddSecretVersionByProjectAndLocationAndSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::get_secret call.
 #[derive(Clone, Debug)]
 pub struct GetSecret(SecretManagerServiceRequestBuilder<crate::model::GetSecretRequest>);
@@ -468,6 +516,12 @@ impl GetSecret {
     pub fn set_secret<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.secret = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for GetSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -509,6 +563,12 @@ impl DeleteSecret {
     pub fn set_etag<T: Into<Option<String>>>(mut self, v: T) -> Self {
         self.0.request.etag = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for DeleteSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -559,6 +619,12 @@ impl UpdateSecret {
     }
 }
 
+impl gax::options::RequestBuilder for UpdateSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::get_secret_by_project_and_location_and_secret call.
 #[derive(Clone, Debug)]
 pub struct GetSecretByProjectAndLocationAndSecret(SecretManagerServiceRequestBuilder<crate::model::GetSecretByProjectAndLocationAndSecretRequest>);
@@ -597,6 +663,12 @@ impl GetSecretByProjectAndLocationAndSecret {
     pub fn set_secret<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.secret = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for GetSecretByProjectAndLocationAndSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -644,6 +716,12 @@ impl DeleteSecretByProjectAndLocationAndSecret {
     pub fn set_etag<T: Into<Option<String>>>(mut self, v: T) -> Self {
         self.0.request.etag = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for DeleteSecretByProjectAndLocationAndSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -697,6 +775,12 @@ impl UpdateSecretByProjectAndLocationAndSecret {
     pub fn set_update_mask<T: Into<wkt::FieldMask>>(mut self, v: T) -> Self {
         self.0.request.update_mask = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for UpdateSecretByProjectAndLocationAndSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -762,6 +846,12 @@ impl ListSecretVersions {
     pub fn set_filter<T: Into<Option<String>>>(mut self, v: T) -> Self {
         self.0.request.filter = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for ListSecretVersions {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -836,6 +926,12 @@ impl ListSecretVersionsByProjectAndLocationAndSecret {
     }
 }
 
+impl gax::options::RequestBuilder for ListSecretVersionsByProjectAndLocationAndSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::get_secret_version call.
 #[derive(Clone, Debug)]
 pub struct GetSecretVersion(SecretManagerServiceRequestBuilder<crate::model::GetSecretVersionRequest>);
@@ -874,6 +970,12 @@ impl GetSecretVersion {
     pub fn set_version<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.version = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for GetSecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -924,6 +1026,12 @@ impl GetSecretVersionByProjectAndLocationAndSecretAndVersion {
     }
 }
 
+impl gax::options::RequestBuilder for GetSecretVersionByProjectAndLocationAndSecretAndVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::access_secret_version call.
 #[derive(Clone, Debug)]
 pub struct AccessSecretVersion(SecretManagerServiceRequestBuilder<crate::model::AccessSecretVersionRequest>);
@@ -962,6 +1070,12 @@ impl AccessSecretVersion {
     pub fn set_version<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.version = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for AccessSecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -1009,6 +1123,12 @@ impl AccessSecretVersionByProjectAndLocationAndSecretAndVersion {
     pub fn set_version<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.version = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for AccessSecretVersionByProjectAndLocationAndSecretAndVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -1065,6 +1185,12 @@ impl DisableSecretVersion {
     }
 }
 
+impl gax::options::RequestBuilder for DisableSecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::disable_secret_version_by_project_and_location_and_secret_and_version call.
 #[derive(Clone, Debug)]
 pub struct DisableSecretVersionByProjectAndLocationAndSecretAndVersion(SecretManagerServiceRequestBuilder<crate::model::DisableSecretVersionRequest>);
@@ -1115,6 +1241,12 @@ impl DisableSecretVersionByProjectAndLocationAndSecretAndVersion {
     pub fn set_location<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.location = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for DisableSecretVersionByProjectAndLocationAndSecretAndVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -1171,6 +1303,12 @@ impl EnableSecretVersion {
     }
 }
 
+impl gax::options::RequestBuilder for EnableSecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::enable_secret_version_by_project_and_location_and_secret_and_version call.
 #[derive(Clone, Debug)]
 pub struct EnableSecretVersionByProjectAndLocationAndSecretAndVersion(SecretManagerServiceRequestBuilder<crate::model::EnableSecretVersionRequest>);
@@ -1221,6 +1359,12 @@ impl EnableSecretVersionByProjectAndLocationAndSecretAndVersion {
     pub fn set_location<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.location = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for EnableSecretVersionByProjectAndLocationAndSecretAndVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -1277,6 +1421,12 @@ impl DestroySecretVersion {
     }
 }
 
+impl gax::options::RequestBuilder for DestroySecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::destroy_secret_version_by_project_and_location_and_secret_and_version call.
 #[derive(Clone, Debug)]
 pub struct DestroySecretVersionByProjectAndLocationAndSecretAndVersion(SecretManagerServiceRequestBuilder<crate::model::DestroySecretVersionRequest>);
@@ -1327,6 +1477,12 @@ impl DestroySecretVersionByProjectAndLocationAndSecretAndVersion {
     pub fn set_location<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.location = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for DestroySecretVersionByProjectAndLocationAndSecretAndVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -1383,6 +1539,12 @@ impl SetIamPolicy {
     }
 }
 
+impl gax::options::RequestBuilder for SetIamPolicy {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::set_iam_policy_by_project_and_location_and_secret call.
 #[derive(Clone, Debug)]
 pub struct SetIamPolicyByProjectAndLocationAndSecret(SecretManagerServiceRequestBuilder<crate::model::SetIamPolicyRequest>);
@@ -1436,6 +1598,12 @@ impl SetIamPolicyByProjectAndLocationAndSecret {
     }
 }
 
+impl gax::options::RequestBuilder for SetIamPolicyByProjectAndLocationAndSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::get_iam_policy call.
 #[derive(Clone, Debug)]
 pub struct GetIamPolicy(SecretManagerServiceRequestBuilder<crate::model::GetIamPolicyRequest>);
@@ -1474,6 +1642,12 @@ impl GetIamPolicy {
     pub fn set_options_requested_policy_version<T: Into<Option<i32>>>(mut self, v: T) -> Self {
         self.0.request.options_requested_policy_version = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for GetIamPolicy {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -1524,6 +1698,12 @@ impl GetIamPolicyByProjectAndLocationAndSecret {
     }
 }
 
+impl gax::options::RequestBuilder for GetIamPolicyByProjectAndLocationAndSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::test_iam_permissions call.
 #[derive(Clone, Debug)]
 pub struct TestIamPermissions(SecretManagerServiceRequestBuilder<crate::model::TestIamPermissionsRequest>);
@@ -1571,6 +1751,12 @@ impl TestIamPermissions {
     }
 }
 
+impl gax::options::RequestBuilder for TestIamPermissions {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::test_iam_permissions_by_project_and_location_and_secret call.
 #[derive(Clone, Debug)]
 pub struct TestIamPermissionsByProjectAndLocationAndSecret(SecretManagerServiceRequestBuilder<crate::model::TestIamPermissionsRequest>);
@@ -1615,6 +1801,12 @@ impl TestIamPermissionsByProjectAndLocationAndSecret {
     pub fn set_location<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.location = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for TestIamPermissionsByProjectAndLocationAndSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 

--- a/generator/testdata/rust/openapi/golden/src/transport.rs
+++ b/generator/testdata/rust/openapi/golden/src/transport.rs
@@ -45,7 +45,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn list_locations(
         &self,
         req: crate::model::ListLocationsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListLocationsResponse> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/locations"
@@ -56,14 +56,18 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder = gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
         let builder = gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
         let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token).map_err(Error::other)?;
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Gets information about a location.
     async fn get_location(
         &self,
         req: crate::model::GetLocationRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Location> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/locations/{}"
@@ -72,14 +76,18 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Lists Secrets.
     async fn list_secrets(
         &self,
         req: crate::model::ListSecretsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretsResponse> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/secrets"
@@ -90,14 +98,18 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder = gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
         let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token).map_err(Error::other)?;
         let builder = gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Creates a new Secret containing no SecretVersions.
     async fn create_secret(
         &self,
         req: crate::model::CreateSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/secrets"
@@ -106,14 +118,18 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = gax::query_parameter::add(builder, "secretId", &req.secret_id).map_err(Error::other)?;
-        self.inner.execute(builder, Some(req.request_body)).await
+        self.inner.execute(
+            builder,
+            Some(req.request_body),
+            &options,
+        ).await
     }
 
     /// Lists Secrets.
     async fn list_secrets_by_project_and_location(
         &self,
         req: crate::model::ListSecretsByProjectAndLocationRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretsResponse> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/locations/{}/secrets"
@@ -125,14 +141,18 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder = gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
         let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token).map_err(Error::other)?;
         let builder = gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Creates a new Secret containing no SecretVersions.
     async fn create_secret_by_project_and_location(
         &self,
         req: crate::model::CreateSecretByProjectAndLocationRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/locations/{}/secrets"
@@ -142,7 +162,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = gax::query_parameter::add(builder, "secretId", &req.secret_id).map_err(Error::other)?;
-        self.inner.execute(builder, Some(req.request_body)).await
+        self.inner.execute(
+            builder,
+            Some(req.request_body),
+            &options,
+        ).await
     }
 
     /// Creates a new SecretVersion containing secret data and attaches
@@ -150,7 +174,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn add_secret_version(
         &self,
         req: crate::model::AddSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/secrets/{}:addVersion"
@@ -159,7 +183,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(
+            builder,
+            Some(req),
+            &options,
+        ).await
     }
 
     /// Creates a new SecretVersion containing secret data and attaches
@@ -167,7 +195,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn add_secret_version_by_project_and_location_and_secret(
         &self,
         req: crate::model::AddSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/locations/{}/secrets/{}:addVersion"
@@ -177,14 +205,18 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(
+            builder,
+            Some(req),
+            &options,
+        ).await
     }
 
     /// Gets metadata for a given Secret.
     async fn get_secret(
         &self,
         req: crate::model::GetSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/secrets/{}"
@@ -193,14 +225,18 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Deletes a Secret.
     async fn delete_secret(
         &self,
         req: crate::model::DeleteSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Empty> {
         let builder = self.inner.builder(
             reqwest::Method::DELETE, format!("/v1/projects/{}/secrets/{}"
@@ -210,14 +246,18 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = gax::query_parameter::add(builder, "etag", &req.etag).map_err(Error::other)?;
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Updates metadata of an existing Secret.
     async fn update_secret(
         &self,
         req: crate::model::UpdateSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let builder = self.inner.builder(
             reqwest::Method::PATCH, format!("/v1/projects/{}/secrets/{}"
@@ -227,14 +267,18 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = gax::query_parameter::add(builder, "updateMask", &serde_json::to_value(&req.update_mask).map_err(Error::serde)?).map_err(Error::other)?;
-        self.inner.execute(builder, Some(req.request_body)).await
+        self.inner.execute(
+            builder,
+            Some(req.request_body),
+            &options,
+        ).await
     }
 
     /// Gets metadata for a given Secret.
     async fn get_secret_by_project_and_location_and_secret(
         &self,
         req: crate::model::GetSecretByProjectAndLocationAndSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/locations/{}/secrets/{}"
@@ -244,14 +288,18 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Deletes a Secret.
     async fn delete_secret_by_project_and_location_and_secret(
         &self,
         req: crate::model::DeleteSecretByProjectAndLocationAndSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Empty> {
         let builder = self.inner.builder(
             reqwest::Method::DELETE, format!("/v1/projects/{}/locations/{}/secrets/{}"
@@ -262,14 +310,18 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = gax::query_parameter::add(builder, "etag", &req.etag).map_err(Error::other)?;
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Updates metadata of an existing Secret.
     async fn update_secret_by_project_and_location_and_secret(
         &self,
         req: crate::model::UpdateSecretByProjectAndLocationAndSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let builder = self.inner.builder(
             reqwest::Method::PATCH, format!("/v1/projects/{}/locations/{}/secrets/{}"
@@ -280,7 +332,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = gax::query_parameter::add(builder, "updateMask", &serde_json::to_value(&req.update_mask).map_err(Error::serde)?).map_err(Error::other)?;
-        self.inner.execute(builder, Some(req.request_body)).await
+        self.inner.execute(
+            builder,
+            Some(req.request_body),
+            &options,
+        ).await
     }
 
     /// Lists SecretVersions. This call does not return secret
@@ -288,7 +344,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn list_secret_versions(
         &self,
         req: crate::model::ListSecretVersionsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretVersionsResponse> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/secrets/{}/versions"
@@ -300,7 +356,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder = gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
         let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token).map_err(Error::other)?;
         let builder = gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Lists SecretVersions. This call does not return secret
@@ -308,7 +368,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn list_secret_versions_by_project_and_location_and_secret(
         &self,
         req: crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretVersionsResponse> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/locations/{}/secrets/{}/versions"
@@ -321,7 +381,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder = gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
         let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token).map_err(Error::other)?;
         let builder = gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Gets metadata for a SecretVersion.
@@ -331,7 +395,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn get_secret_version(
         &self,
         req: crate::model::GetSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/secrets/{}/versions/{}"
@@ -341,7 +405,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Gets metadata for a SecretVersion.
@@ -351,7 +419,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn get_secret_version_by_project_and_location_and_secret_and_version(
         &self,
         req: crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/locations/{}/secrets/{}/versions/{}"
@@ -362,7 +430,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Accesses a SecretVersion. This call returns the secret data.
@@ -372,7 +444,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn access_secret_version(
         &self,
         req: crate::model::AccessSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::AccessSecretVersionResponse> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/secrets/{}/versions/{}:access"
@@ -382,7 +454,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Accesses a SecretVersion. This call returns the secret data.
@@ -392,7 +468,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn access_secret_version_by_project_and_location_and_secret_and_version(
         &self,
         req: crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::AccessSecretVersionResponse> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/locations/{}/secrets/{}/versions/{}:access"
@@ -403,7 +479,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Disables a SecretVersion.
@@ -413,7 +493,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn disable_secret_version(
         &self,
         req: crate::model::DisableSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/secrets/{}/versions/{}:disable"
@@ -423,7 +503,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(
+            builder,
+            Some(req),
+            &options,
+        ).await
     }
 
     /// Disables a SecretVersion.
@@ -433,7 +517,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn disable_secret_version_by_project_and_location_and_secret_and_version(
         &self,
         req: crate::model::DisableSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/locations/{}/secrets/{}/versions/{}:disable"
@@ -444,7 +528,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(
+            builder,
+            Some(req),
+            &options,
+        ).await
     }
 
     /// Enables a SecretVersion.
@@ -454,7 +542,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn enable_secret_version(
         &self,
         req: crate::model::EnableSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/secrets/{}/versions/{}:enable"
@@ -464,7 +552,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(
+            builder,
+            Some(req),
+            &options,
+        ).await
     }
 
     /// Enables a SecretVersion.
@@ -474,7 +566,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn enable_secret_version_by_project_and_location_and_secret_and_version(
         &self,
         req: crate::model::EnableSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/locations/{}/secrets/{}/versions/{}:enable"
@@ -485,7 +577,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(
+            builder,
+            Some(req),
+            &options,
+        ).await
     }
 
     /// Destroys a SecretVersion.
@@ -496,7 +592,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn destroy_secret_version(
         &self,
         req: crate::model::DestroySecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/secrets/{}/versions/{}:destroy"
@@ -506,7 +602,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(
+            builder,
+            Some(req),
+            &options,
+        ).await
     }
 
     /// Destroys a SecretVersion.
@@ -517,7 +617,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn destroy_secret_version_by_project_and_location_and_secret_and_version(
         &self,
         req: crate::model::DestroySecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/locations/{}/secrets/{}/versions/{}:destroy"
@@ -528,7 +628,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(
+            builder,
+            Some(req),
+            &options,
+        ).await
     }
 
     /// Sets the access control policy on the specified secret. Replaces any
@@ -539,7 +643,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn set_iam_policy(
         &self,
         req: crate::model::SetIamPolicyRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/secrets/{}:setIamPolicy"
@@ -548,7 +652,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(
+            builder,
+            Some(req),
+            &options,
+        ).await
     }
 
     /// Sets the access control policy on the specified secret. Replaces any
@@ -559,7 +667,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn set_iam_policy_by_project_and_location_and_secret(
         &self,
         req: crate::model::SetIamPolicyRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/locations/{}/secrets/{}:setIamPolicy"
@@ -569,7 +677,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(
+            builder,
+            Some(req),
+            &options,
+        ).await
     }
 
     /// Gets the access control policy for a secret.
@@ -577,7 +689,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn get_iam_policy(
         &self,
         req: crate::model::GetIamPolicyRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/secrets/{}:getIamPolicy"
@@ -587,7 +699,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = gax::query_parameter::add(builder, "options.requestedPolicyVersion", &req.options_requested_policy_version).map_err(Error::other)?;
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Gets the access control policy for a secret.
@@ -595,7 +711,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn get_iam_policy_by_project_and_location_and_secret(
         &self,
         req: crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/locations/{}/secrets/{}:getIamPolicy"
@@ -606,7 +722,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = gax::query_parameter::add(builder, "options.requestedPolicyVersion", &req.options_requested_policy_version).map_err(Error::other)?;
-        self.inner.execute(builder, None::<gax::http_client::NoBody>).await
+        self.inner.execute(
+            builder,
+            None::<gax::http_client::NoBody>,
+            &options,
+        ).await
     }
 
     /// Returns permissions that a caller has for the specified secret.
@@ -619,7 +739,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn test_iam_permissions(
         &self,
         req: crate::model::TestIamPermissionsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::TestIamPermissionsResponse> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/secrets/{}:testIamPermissions"
@@ -628,7 +748,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(
+            builder,
+            Some(req),
+            &options,
+        ).await
     }
 
     /// Returns permissions that a caller has for the specified secret.
@@ -641,7 +765,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn test_iam_permissions_by_project_and_location_and_secret(
         &self,
         req: crate::model::TestIamPermissionsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::TestIamPermissionsResponse> {
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/locations/{}/secrets/{}:testIamPermissions"
@@ -651,7 +775,11 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(
+            builder,
+            Some(req),
+            &options,
+        ).await
     }
 
 }

--- a/generator/testdata/rust/openapi/golden/src/transport.rs
+++ b/generator/testdata/rust/openapi/golden/src/transport.rs
@@ -59,7 +59,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -79,7 +79,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -101,7 +101,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -121,7 +121,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req.request_body),
-            &options,
+            options,
         ).await
     }
 
@@ -144,7 +144,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -165,7 +165,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req.request_body),
-            &options,
+            options,
         ).await
     }
 
@@ -186,7 +186,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req),
-            &options,
+            options,
         ).await
     }
 
@@ -208,7 +208,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req),
-            &options,
+            options,
         ).await
     }
 
@@ -228,7 +228,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -249,7 +249,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -270,7 +270,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req.request_body),
-            &options,
+            options,
         ).await
     }
 
@@ -291,7 +291,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -313,7 +313,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -335,7 +335,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req.request_body),
-            &options,
+            options,
         ).await
     }
 
@@ -359,7 +359,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -384,7 +384,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -408,7 +408,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -433,7 +433,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -457,7 +457,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -482,7 +482,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -506,7 +506,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req),
-            &options,
+            options,
         ).await
     }
 
@@ -531,7 +531,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req),
-            &options,
+            options,
         ).await
     }
 
@@ -555,7 +555,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req),
-            &options,
+            options,
         ).await
     }
 
@@ -580,7 +580,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req),
-            &options,
+            options,
         ).await
     }
 
@@ -605,7 +605,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req),
-            &options,
+            options,
         ).await
     }
 
@@ -631,7 +631,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req),
-            &options,
+            options,
         ).await
     }
 
@@ -655,7 +655,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req),
-            &options,
+            options,
         ).await
     }
 
@@ -680,7 +680,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req),
-            &options,
+            options,
         ).await
     }
 
@@ -702,7 +702,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -725,7 +725,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
-            &options,
+            options,
         ).await
     }
 
@@ -751,7 +751,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req),
-            &options,
+            options,
         ).await
     }
 
@@ -778,7 +778,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         self.inner.execute(
             builder,
             Some(req),
-            &options,
+            options,
         ).await
     }
 

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -28,6 +28,7 @@ categories.workspace = true
 bytes       = "1.8.0"
 futures     = { version = "0.3.31", optional = true }
 http        = "1.1.0"
+lazy_static = { version = "1.5.0", optional = true }
 pin-project = { version = "1.1.7", optional = true }
 reqwest     = { version = "0.12.9", optional = true }
 serde       = "1.0.214"
@@ -51,5 +52,5 @@ tokio     = { version = "1.42", features = ["macros"] }
 built = "0.7"
 
 [features]
-unstable-sdk-client = ["dep:auth", "dep:reqwest"]
+unstable-sdk-client = ["dep:auth", "dep:lazy_static", "dep:reqwest"]
 unstable-stream     = ["dep:futures", "dep:pin-project"]

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -28,7 +28,6 @@ categories.workspace = true
 bytes       = "1.8.0"
 futures     = { version = "0.3.31", optional = true }
 http        = "1.1.0"
-lazy_static = { version = "1.5.0", optional = true }
 pin-project = { version = "1.1.7", optional = true }
 reqwest     = { version = "0.12.9", optional = true }
 serde       = "1.0.214"
@@ -52,5 +51,5 @@ tokio     = { version = "1.42", features = ["macros"] }
 built = "0.7"
 
 [features]
-unstable-sdk-client = ["dep:auth", "dep:lazy_static", "dep:reqwest"]
+unstable-sdk-client = ["dep:auth", "dep:reqwest"]
 unstable-stream     = ["dep:futures", "dep:pin-project"]

--- a/src/gax/src/http_client/mod.rs
+++ b/src/gax/src/http_client/mod.rs
@@ -14,8 +14,8 @@
 
 use crate::error::Error;
 use crate::error::HttpError;
+use crate::Result;
 use auth::Credential;
-type Result<T> = std::result::Result<T, crate::error::Error>;
 
 #[derive(Clone)]
 pub struct ReqwestClient {
@@ -51,8 +51,15 @@ impl ReqwestClient {
         &self,
         mut builder: reqwest::RequestBuilder,
         body: Option<I>,
+        options: &crate::options::RequestOptions,
     ) -> Result<O> {
         builder = builder.bearer_auth(Self::fetch_token(&self.cred).await?);
+        if let Some(user_agent) = options.user_agent_prefix() {
+            builder = builder.header(
+                reqwest::header::USER_AGENT,
+                reqwest::header::HeaderValue::from_str(user_agent).map_err(Error::other)?,
+            );
+        }
         if let Some(body) = body {
             builder = builder.json(&body);
         }

--- a/src/gax/src/http_client/mod.rs
+++ b/src/gax/src/http_client/mod.rs
@@ -51,7 +51,7 @@ impl ReqwestClient {
         &self,
         mut builder: reqwest::RequestBuilder,
         body: Option<I>,
-        options: &crate::options::RequestOptions,
+        options: crate::options::RequestOptions,
     ) -> Result<O> {
         builder = builder.bearer_auth(Self::fetch_token(&self.cred).await?);
         if let Some(user_agent) = options.user_agent_prefix() {

--- a/src/gax/src/lib.rs
+++ b/src/gax/src/lib.rs
@@ -25,6 +25,11 @@
 //! change both if needed.
 //! </div>
 
+/// An alias of [std::result::Result] where the error is always [crate::error::Error].
+///
+/// This is the result type used by all functions wrapping RPCs.
+type Result<T> = std::result::Result<T, crate::error::Error>;
+
 /// Defines traits and helpers to serialize query parameters.
 ///
 /// Query parameters in the Google APIs can be types other than strings and

--- a/src/gax/src/options/mod.rs
+++ b/src/gax/src/options/mod.rs
@@ -22,4 +22,36 @@
 ///
 /// All other code uses this type indirectly, via the per-request builders.
 #[derive(Clone, Debug, Default)]
-pub struct RequestOptions;
+pub struct RequestOptions {
+    user_agent: Option<String>,
+}
+
+impl RequestOptions {
+    /// Prepends this prefix to the user agent header value.
+    pub fn set_user_agent<T: Into<String>>(&mut self, v: T) {
+        self.user_agent = Some(v.into());
+    }
+
+    /// Gets the current user-agent prefix
+    pub fn user_agent_prefix(&self) -> &Option<String> {
+        &self.user_agent
+    }
+}
+
+pub trait RequestBuilder {
+    fn request_options(&mut self) -> &mut RequestOptions;
+}
+
+pub trait RequestOptionsBuilder {
+    fn with_user_agent<T: Into<String>>(self, v: T) -> Self;
+}
+
+impl<T> RequestOptionsBuilder for T
+where
+    T: RequestBuilder,
+{
+    fn with_user_agent<V: Into<String>>(mut self, v: V) -> Self {
+        self.request_options().set_user_agent(v);
+        self
+    }
+}

--- a/src/gax/src/options/mod.rs
+++ b/src/gax/src/options/mod.rs
@@ -39,7 +39,7 @@ impl RequestOptions {
 }
 
 /// Implementations of this trait provide setters to configure request options.
-/// 
+///
 /// The Google Cloud Client Libraries for Rust provide a builder for each RPC.
 /// These builders can be used to set the request parameters, e.g., the name of
 /// the resource targeted by the RPC, as well as any options affecting the
@@ -49,9 +49,9 @@ pub trait RequestOptionsBuilder {
     fn with_user_agent<T: Into<String>>(self, v: T) -> Self;
 }
 
-/// Simplify implementation of the `RequestOptionsBuilder` trait in generated
+/// Simplify implementation of the [RequestOptionsBuilder] trait in generated
 /// code.
-/// 
+///
 /// This is an implementation detail, most applications have little need to
 /// worry about or use this trait.
 pub trait RequestBuilder {

--- a/src/gax/src/options/mod.rs
+++ b/src/gax/src/options/mod.rs
@@ -38,14 +38,28 @@ impl RequestOptions {
     }
 }
 
+/// Implementations of this trait provide setters to configure request options.
+/// 
+/// The Google Cloud Client Libraries for Rust provide a builder for each RPC.
+/// These builders can be used to set the request parameters, e.g., the name of
+/// the resource targeted by the RPC, as well as any options affecting the
+/// request, such as additional headers or timeouts.
+pub trait RequestOptionsBuilder {
+    /// Set the user agent header.
+    fn with_user_agent<T: Into<String>>(self, v: T) -> Self;
+}
+
+/// Simplify implementation of the `RequestOptionsBuilder` trait in generated
+/// code.
+/// 
+/// This is an implementation detail, most applications have little need to
+/// worry about or use this trait.
 pub trait RequestBuilder {
     fn request_options(&mut self) -> &mut RequestOptions;
 }
 
-pub trait RequestOptionsBuilder {
-    fn with_user_agent<T: Into<String>>(self, v: T) -> Self;
-}
-
+/// Implements the [RequestOptionsBuilder] trait for any [RequestBuilder]
+/// implementation.
 impl<T> RequestOptionsBuilder for T
 where
     T: RequestBuilder,

--- a/src/gax/tests/echo_server.rs
+++ b/src/gax/tests/echo_server.rs
@@ -1,0 +1,96 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Defines helpers functions to run ReqwestClient integration tests.
+//!
+//! Setting up integration tests is a bit complicated. So we refactor that code
+//! to some helper functions.
+
+use axum::{
+    extract::Query,
+    http::{HeaderMap, StatusCode},
+};
+use serde_json::json;
+use std::collections::HashMap;
+use tokio::task::JoinHandle;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+pub async fn start() -> Result<(String, JoinHandle<()>)> {
+    let app = axum::Router::new().route("/echo", axum::routing::get(echo));
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await?;
+    let addr = listener.local_addr()?;
+    let server = tokio::spawn(async {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    Ok((format!("http://{}:{}", addr.ip(), addr.port()), server))
+}
+
+#[allow(dead_code)]
+pub fn get_query_value(response: &serde_json::Value, name: &str) -> Option<String> {
+    response
+        .as_object()
+        .map(|o| o.get("query"))
+        .flatten()
+        .map(|h| h.get(name))
+        .flatten()
+        .map(|v| v.as_str())
+        .flatten()
+        .map(str::to_string)
+}
+
+async fn echo(
+    Query(query): Query<HashMap<String, String>>,
+    headers: HeaderMap,
+) -> (http::StatusCode, String) {
+    let response = echo_impl(query, headers).await;
+    match response {
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
+        Ok(s) => (StatusCode::OK, s),
+    }
+}
+
+async fn echo_impl(query: HashMap<String, String>, headers: HeaderMap) -> Result<String> {
+    let query = serde_json::Value::Object(
+        query
+            .into_iter()
+            .map(|(k, v)| (k, serde_json::Value::String(v)))
+            .collect(),
+    );
+    let headers = headers_to_json(headers)?;
+    let object = json!({
+        "headers": headers,
+        "query": query,
+    });
+    let body = serde_json::to_string(&object)?;
+    Ok(body)
+}
+
+fn headers_to_json(headers: HeaderMap) -> Result<serde_json::Value> {
+    let to_dyn = |e| -> Box<dyn std::error::Error + 'static> { Box::new(e) };
+    let headers = headers
+        .into_iter()
+        .map(|(k, v)| {
+            (
+                k.map(|h| h.to_string()).unwrap_or("__status__".to_string()),
+                v.to_str().map(|s| serde_json::Value::String(s.to_string())),
+            )
+        })
+        .map(|(k, v)| v.map(|s| (k, s)))
+        .map(|r| r.map_err(to_dyn))
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(serde_json::Value::Object(headers.into_iter().collect()))
+}

--- a/src/gax/tests/paginator.rs
+++ b/src/gax/tests/paginator.rs
@@ -103,7 +103,7 @@ impl Client {
             .execute(
                 builder,
                 None::<NoBody>,
-                &gcp_sdk_gax::options::RequestOptions::default(),
+                gcp_sdk_gax::options::RequestOptions::default(),
             )
             .await
     }

--- a/src/gax/tests/paginator.rs
+++ b/src/gax/tests/paginator.rs
@@ -99,7 +99,13 @@ impl Client {
         if !req.page_token.is_empty() {
             builder = builder.query(&[("pageToken", req.page_token)]);
         }
-        self.inner.execute(builder, None::<NoBody>).await
+        self.inner
+            .execute(
+                builder,
+                None::<NoBody>,
+                &gcp_sdk_gax::options::RequestOptions::default(),
+            )
+            .await
     }
 
     pub async fn list(

--- a/src/gax/tests/user_agent.rs
+++ b/src/gax/tests/user_agent.rs
@@ -31,7 +31,7 @@ async fn test_user_agent() -> Result<()> {
     let builder = client.builder(reqwest::Method::GET, "/echo".into());
     let body = json!({});
     let response: serde_json::Value = client
-        .execute(builder, Some(body), &RequestOptions::default())
+        .execute(builder, Some(body), RequestOptions::default())
         .await?;
     let got = get_header_value(&response, "user-agent");
     assert_eq!(got, None);
@@ -53,7 +53,7 @@ async fn test_user_agent_with_prefix() -> Result<()> {
         o.set_user_agent(prefix);
         o
     };
-    let response: serde_json::Value = client.execute(builder, Some(body), &options).await?;
+    let response: serde_json::Value = client.execute(builder, Some(body), options).await?;
     let got = get_header_value(&response, "user-agent");
     assert_eq!(got.as_deref(), Some(prefix));
     Ok(())

--- a/src/gax/tests/user_agent.rs
+++ b/src/gax/tests/user_agent.rs
@@ -1,0 +1,72 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use gax::http_client::*;
+use gax::options::*;
+use gcp_sdk_gax as gax;
+use serde_json::json;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+mod echo_server;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_user_agent() -> Result<()> {
+    let (endpoint, _server) = echo_server::start().await?;
+
+    let config = ClientConfig::default().set_credential(auth::Credential::test_credentials());
+    let client = ReqwestClient::new(config, &endpoint).await?;
+
+    let builder = client.builder(reqwest::Method::GET, "/echo".into());
+    let body = json!({});
+    let response: serde_json::Value = client
+        .execute(builder, Some(body), &RequestOptions::default())
+        .await?;
+    let got = get_header_value(&response, "user-agent");
+    assert_eq!(got, None);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_user_agent_with_prefix() -> Result<()> {
+    let (endpoint, _server) = echo_server::start().await?;
+
+    let config = ClientConfig::default().set_credential(auth::Credential::test_credentials());
+    let client = ReqwestClient::new(config, &endpoint).await?;
+
+    let builder = client.builder(reqwest::Method::GET, "/echo".into());
+    let body = json!({});
+    let prefix = "test-prefix/1.2.3";
+    let options = {
+        let mut o = RequestOptions::default();
+        o.set_user_agent(prefix);
+        o
+    };
+    let response: serde_json::Value = client.execute(builder, Some(body), &options).await?;
+    let got = get_header_value(&response, "user-agent");
+    assert_eq!(got.as_deref(), Some(prefix));
+    Ok(())
+}
+
+fn get_header_value(response: &serde_json::Value, name: &str) -> Option<String> {
+    response
+        .as_object()
+        .map(|o| o.get("headers"))
+        .flatten()
+        .map(|h| h.get(name))
+        .flatten()
+        .map(|v| v.as_str())
+        .flatten()
+        .map(str::to_string)
+}

--- a/src/generated/cloud/location/src/builders.rs
+++ b/src/generated/cloud/location/src/builders.rs
@@ -33,7 +33,7 @@ where
         Self {
             stub,
             request: R::default(),
-            options: gax::options::RequestOptions,
+            options: gax::options::RequestOptions::default(),
         }
     }
 }
@@ -100,6 +100,12 @@ impl ListLocations {
     }
 }
 
+impl gax::options::RequestBuilder for ListLocations {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a Locations::get_location call.
 #[derive(Clone, Debug)]
 pub struct GetLocation(LocationsRequestBuilder<crate::model::GetLocationRequest>);
@@ -127,5 +133,11 @@ impl GetLocation {
     pub fn set_name<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.name = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for GetLocation {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }

--- a/src/generated/cloud/location/src/transport.rs
+++ b/src/generated/cloud/location/src/transport.rs
@@ -65,7 +65,7 @@ impl crate::traits::Locations for Locations {
         let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token)
             .map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -84,7 +84,7 @@ impl crate::traits::Locations for Locations {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 }

--- a/src/generated/cloud/location/src/transport.rs
+++ b/src/generated/cloud/location/src/transport.rs
@@ -48,7 +48,7 @@ impl crate::traits::Locations for Locations {
     async fn list_locations(
         &self,
         req: crate::model::ListLocationsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListLocationsResponse> {
         let builder = self
             .inner
@@ -65,7 +65,7 @@ impl crate::traits::Locations for Locations {
         let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token)
             .map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -73,7 +73,7 @@ impl crate::traits::Locations for Locations {
     async fn get_location(
         &self,
         req: crate::model::GetLocationRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Location> {
         let builder = self
             .inner
@@ -84,7 +84,7 @@ impl crate::traits::Locations for Locations {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 }

--- a/src/generated/cloud/secretmanager/v1/src/builders.rs
+++ b/src/generated/cloud/secretmanager/v1/src/builders.rs
@@ -33,7 +33,7 @@ where
         Self {
             stub,
             request: R::default(),
-            options: gax::options::RequestOptions,
+            options: gax::options::RequestOptions::default(),
         }
     }
 }
@@ -100,6 +100,12 @@ impl ListSecrets {
     }
 }
 
+impl gax::options::RequestBuilder for ListSecrets {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::create_secret call.
 #[derive(Clone, Debug)]
 pub struct CreateSecret(SecretManagerServiceRequestBuilder<crate::model::CreateSecretRequest>);
@@ -142,6 +148,12 @@ impl CreateSecret {
     }
 }
 
+impl gax::options::RequestBuilder for CreateSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::add_secret_version call.
 #[derive(Clone, Debug)]
 pub struct AddSecretVersion(
@@ -180,6 +192,12 @@ impl AddSecretVersion {
     }
 }
 
+impl gax::options::RequestBuilder for AddSecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::get_secret call.
 #[derive(Clone, Debug)]
 pub struct GetSecret(SecretManagerServiceRequestBuilder<crate::model::GetSecretRequest>);
@@ -204,6 +222,12 @@ impl GetSecret {
     pub fn set_name<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.name = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for GetSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -243,6 +267,12 @@ impl UpdateSecret {
     }
 }
 
+impl gax::options::RequestBuilder for UpdateSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::delete_secret call.
 #[derive(Clone, Debug)]
 pub struct DeleteSecret(SecretManagerServiceRequestBuilder<crate::model::DeleteSecretRequest>);
@@ -276,6 +306,12 @@ impl DeleteSecret {
     pub fn set_etag<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.etag = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for DeleteSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -344,6 +380,12 @@ impl ListSecretVersions {
     }
 }
 
+impl gax::options::RequestBuilder for ListSecretVersions {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::get_secret_version call.
 #[derive(Clone, Debug)]
 pub struct GetSecretVersion(
@@ -376,6 +418,12 @@ impl GetSecretVersion {
     }
 }
 
+impl gax::options::RequestBuilder for GetSecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::access_secret_version call.
 #[derive(Clone, Debug)]
 pub struct AccessSecretVersion(
@@ -405,6 +453,12 @@ impl AccessSecretVersion {
     pub fn set_name<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.name = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for AccessSecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -449,6 +503,12 @@ impl DisableSecretVersion {
     }
 }
 
+impl gax::options::RequestBuilder for DisableSecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::enable_secret_version call.
 #[derive(Clone, Debug)]
 pub struct EnableSecretVersion(
@@ -484,6 +544,12 @@ impl EnableSecretVersion {
     pub fn set_etag<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.etag = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for EnableSecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -525,6 +591,12 @@ impl DestroySecretVersion {
     pub fn set_etag<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.etag = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for DestroySecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -570,6 +642,12 @@ impl SetIamPolicy {
     }
 }
 
+impl gax::options::RequestBuilder for SetIamPolicy {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::get_iam_policy call.
 #[derive(Clone, Debug)]
 pub struct GetIamPolicy(SecretManagerServiceRequestBuilder<iam_v1::model::GetIamPolicyRequest>);
@@ -603,6 +681,12 @@ impl GetIamPolicy {
     pub fn set_options<T: Into<Option<iam_v1::model::GetPolicyOptions>>>(mut self, v: T) -> Self {
         self.0.request.options = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for GetIamPolicy {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -644,6 +728,12 @@ impl TestIamPermissions {
     }
 }
 
+impl gax::options::RequestBuilder for TestIamPermissions {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// Common implementation for [crate::client::Locations] request builders.
 #[derive(Clone, Debug)]
 pub struct LocationsRequestBuilder<R: std::default::Default> {
@@ -660,7 +750,7 @@ where
         Self {
             stub,
             request: R::default(),
-            options: gax::options::RequestOptions,
+            options: gax::options::RequestOptions::default(),
         }
     }
 }
@@ -727,6 +817,12 @@ impl ListLocations {
     }
 }
 
+impl gax::options::RequestBuilder for ListLocations {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a Locations::get_location call.
 #[derive(Clone, Debug)]
 pub struct GetLocation(LocationsRequestBuilder<location::model::GetLocationRequest>);
@@ -754,5 +850,11 @@ impl GetLocation {
     pub fn set_name<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.name = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for GetLocation {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }

--- a/src/generated/cloud/secretmanager/v1/src/transport.rs
+++ b/src/generated/cloud/secretmanager/v1/src/transport.rs
@@ -72,7 +72,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder =
             gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -96,9 +96,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             );
         let builder =
             gax::query_parameter::add(builder, "secretId", &req.secret_id).map_err(Error::other)?;
-        self.inner
-            .execute(builder, Some(req.secret), &options)
-            .await
+        self.inner.execute(builder, Some(req.secret), options).await
     }
 
     /// Creates a new [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
@@ -123,7 +121,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), &options).await
+        self.inner.execute(builder, Some(req), options).await
     }
 
     /// Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].
@@ -143,7 +141,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -178,9 +176,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             &serde_json::to_value(&req.update_mask).map_err(Error::serde)?,
         )
         .map_err(Error::other)?;
-        self.inner
-            .execute(builder, Some(req.secret), &options)
-            .await
+        self.inner.execute(builder, Some(req.secret), options).await
     }
 
     /// Deletes a [Secret][google.cloud.secretmanager.v1.Secret].
@@ -202,7 +198,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder =
             gax::query_parameter::add(builder, "etag", &req.etag).map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -230,7 +226,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder =
             gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -255,7 +251,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -280,7 +276,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -306,7 +302,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), &options).await
+        self.inner.execute(builder, Some(req), options).await
     }
 
     /// Enables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -331,7 +327,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), &options).await
+        self.inner.execute(builder, Some(req), options).await
     }
 
     /// Destroys a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -357,7 +353,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), &options).await
+        self.inner.execute(builder, Some(req), options).await
     }
 
     /// Sets the access control policy on the specified secret. Replaces any
@@ -386,7 +382,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), &options).await
+        self.inner.execute(builder, Some(req), options).await
     }
 
     /// Gets the access control policy for a secret.
@@ -414,7 +410,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         )
         .map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -441,7 +437,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), &options).await
+        self.inner.execute(builder, Some(req), options).await
     }
 }
 
@@ -488,7 +484,7 @@ impl crate::traits::Locations for Locations {
         let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token)
             .map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -507,7 +503,7 @@ impl crate::traits::Locations for Locations {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 }

--- a/src/generated/cloud/secretmanager/v1/src/transport.rs
+++ b/src/generated/cloud/secretmanager/v1/src/transport.rs
@@ -55,7 +55,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn list_secrets(
         &self,
         req: crate::model::ListSecretsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretsResponse> {
         let builder = self
             .inner
@@ -72,7 +72,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder =
             gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -84,7 +84,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn create_secret(
         &self,
         req: crate::model::CreateSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let builder = self
             .inner
@@ -96,7 +96,9 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             );
         let builder =
             gax::query_parameter::add(builder, "secretId", &req.secret_id).map_err(Error::other)?;
-        self.inner.execute(builder, Some(req.secret)).await
+        self.inner
+            .execute(builder, Some(req.secret), &options)
+            .await
     }
 
     /// Creates a new [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
@@ -108,7 +110,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn add_secret_version(
         &self,
         req: crate::model::AddSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self
             .inner
@@ -121,7 +123,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(builder, Some(req), &options).await
     }
 
     /// Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].
@@ -130,7 +132,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn get_secret(
         &self,
         req: crate::model::GetSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let builder = self
             .inner
@@ -141,7 +143,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -152,7 +154,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn update_secret(
         &self,
         req: crate::model::UpdateSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let builder = self
             .inner
@@ -176,7 +178,9 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             &serde_json::to_value(&req.update_mask).map_err(Error::serde)?,
         )
         .map_err(Error::other)?;
-        self.inner.execute(builder, Some(req.secret)).await
+        self.inner
+            .execute(builder, Some(req.secret), &options)
+            .await
     }
 
     /// Deletes a [Secret][google.cloud.secretmanager.v1.Secret].
@@ -185,7 +189,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn delete_secret(
         &self,
         req: crate::model::DeleteSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<wkt::Empty> {
         let builder = self
             .inner
@@ -198,7 +202,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder =
             gax::query_parameter::add(builder, "etag", &req.etag).map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -209,7 +213,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn list_secret_versions(
         &self,
         req: crate::model::ListSecretVersionsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretVersionsResponse> {
         let builder = self
             .inner
@@ -226,7 +230,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder =
             gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -240,7 +244,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn get_secret_version(
         &self,
         req: crate::model::GetSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self
             .inner
@@ -251,7 +255,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -265,7 +269,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn access_secret_version(
         &self,
         req: crate::model::AccessSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::AccessSecretVersionResponse> {
         let builder = self
             .inner
@@ -276,7 +280,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -292,7 +296,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn disable_secret_version(
         &self,
         req: crate::model::DisableSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self
             .inner
@@ -302,7 +306,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(builder, Some(req), &options).await
     }
 
     /// Enables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -317,7 +321,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn enable_secret_version(
         &self,
         req: crate::model::EnableSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self
             .inner
@@ -327,7 +331,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(builder, Some(req), &options).await
     }
 
     /// Destroys a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -343,7 +347,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn destroy_secret_version(
         &self,
         req: crate::model::DestroySecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self
             .inner
@@ -353,7 +357,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(builder, Some(req), &options).await
     }
 
     /// Sets the access control policy on the specified secret. Replaces any
@@ -369,7 +373,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn set_iam_policy(
         &self,
         req: iam_v1::model::SetIamPolicyRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<iam_v1::model::Policy> {
         let builder = self
             .inner
@@ -382,7 +386,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(builder, Some(req), &options).await
     }
 
     /// Gets the access control policy for a secret.
@@ -390,7 +394,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn get_iam_policy(
         &self,
         req: iam_v1::model::GetIamPolicyRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<iam_v1::model::Policy> {
         let builder = self
             .inner
@@ -410,7 +414,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         )
         .map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -424,7 +428,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn test_iam_permissions(
         &self,
         req: iam_v1::model::TestIamPermissionsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<iam_v1::model::TestIamPermissionsResponse> {
         let builder = self
             .inner
@@ -437,7 +441,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(builder, Some(req), &options).await
     }
 }
 
@@ -467,7 +471,7 @@ impl crate::traits::Locations for Locations {
     async fn list_locations(
         &self,
         req: location::model::ListLocationsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<location::model::ListLocationsResponse> {
         let builder = self
             .inner
@@ -484,7 +488,7 @@ impl crate::traits::Locations for Locations {
         let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token)
             .map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -492,7 +496,7 @@ impl crate::traits::Locations for Locations {
     async fn get_location(
         &self,
         req: location::model::GetLocationRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<location::model::Location> {
         let builder = self
             .inner
@@ -503,7 +507,7 @@ impl crate::traits::Locations for Locations {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 }

--- a/src/generated/iam/v1/src/builders.rs
+++ b/src/generated/iam/v1/src/builders.rs
@@ -33,7 +33,7 @@ where
         Self {
             stub,
             request: R::default(),
-            options: gax::options::RequestOptions,
+            options: gax::options::RequestOptions::default(),
         }
     }
 }
@@ -80,6 +80,12 @@ impl SetIamPolicy {
     }
 }
 
+impl gax::options::RequestBuilder for SetIamPolicy {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a IAMPolicy::get_iam_policy call.
 #[derive(Clone, Debug)]
 pub struct GetIamPolicy(IAMPolicyRequestBuilder<crate::model::GetIamPolicyRequest>);
@@ -116,6 +122,12 @@ impl GetIamPolicy {
     }
 }
 
+impl gax::options::RequestBuilder for GetIamPolicy {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a IAMPolicy::test_iam_permissions call.
 #[derive(Clone, Debug)]
 pub struct TestIamPermissions(IAMPolicyRequestBuilder<crate::model::TestIamPermissionsRequest>);
@@ -149,5 +161,11 @@ impl TestIamPermissions {
     pub fn set_permissions<T: Into<Vec<String>>>(mut self, v: T) -> Self {
         self.0.request.permissions = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for TestIamPermissions {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }

--- a/src/generated/iam/v1/src/transport.rs
+++ b/src/generated/iam/v1/src/transport.rs
@@ -72,7 +72,7 @@ impl crate::traits::IAMPolicy for IAMPolicy {
     async fn set_iam_policy(
         &self,
         req: crate::model::SetIamPolicyRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
         let builder = self
             .inner
@@ -85,7 +85,7 @@ impl crate::traits::IAMPolicy for IAMPolicy {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(builder, Some(req), &options).await
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
@@ -93,7 +93,7 @@ impl crate::traits::IAMPolicy for IAMPolicy {
     async fn get_iam_policy(
         &self,
         req: crate::model::GetIamPolicyRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
         let builder = self
             .inner
@@ -106,7 +106,7 @@ impl crate::traits::IAMPolicy for IAMPolicy {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(builder, Some(req), &options).await
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -119,7 +119,7 @@ impl crate::traits::IAMPolicy for IAMPolicy {
     async fn test_iam_permissions(
         &self,
         req: crate::model::TestIamPermissionsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::TestIamPermissionsResponse> {
         let builder = self
             .inner
@@ -132,6 +132,6 @@ impl crate::traits::IAMPolicy for IAMPolicy {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(builder, Some(req), &options).await
     }
 }

--- a/src/generated/iam/v1/src/transport.rs
+++ b/src/generated/iam/v1/src/transport.rs
@@ -85,7 +85,7 @@ impl crate::traits::IAMPolicy for IAMPolicy {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), &options).await
+        self.inner.execute(builder, Some(req), options).await
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
@@ -106,7 +106,7 @@ impl crate::traits::IAMPolicy for IAMPolicy {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), &options).await
+        self.inner.execute(builder, Some(req), options).await
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -132,6 +132,6 @@ impl crate::traits::IAMPolicy for IAMPolicy {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), &options).await
+        self.inner.execute(builder, Some(req), options).await
     }
 }

--- a/src/generated/openapi-validation/src/builders.rs
+++ b/src/generated/openapi-validation/src/builders.rs
@@ -33,7 +33,7 @@ where
         Self {
             stub,
             request: R::default(),
-            options: gax::options::RequestOptions,
+            options: gax::options::RequestOptions::default(),
         }
     }
 }
@@ -100,6 +100,12 @@ impl ListLocations {
     }
 }
 
+impl gax::options::RequestBuilder for ListLocations {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::get_location call.
 #[derive(Clone, Debug)]
 pub struct GetLocation(SecretManagerServiceRequestBuilder<crate::model::GetLocationRequest>);
@@ -133,6 +139,12 @@ impl GetLocation {
     pub fn set_location<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.location = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for GetLocation {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -198,6 +210,12 @@ impl ListSecrets {
     }
 }
 
+impl gax::options::RequestBuilder for ListSecrets {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::create_secret call.
 #[derive(Clone, Debug)]
 pub struct CreateSecret(SecretManagerServiceRequestBuilder<crate::model::CreateSecretRequest>);
@@ -237,6 +255,12 @@ impl CreateSecret {
     pub fn set_secret_id<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.secret_id = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for CreateSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -313,6 +337,12 @@ impl ListSecretsByProjectAndLocation {
     }
 }
 
+impl gax::options::RequestBuilder for ListSecretsByProjectAndLocation {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::create_secret_by_project_and_location call.
 #[derive(Clone, Debug)]
 pub struct CreateSecretByProjectAndLocation(
@@ -366,6 +396,12 @@ impl CreateSecretByProjectAndLocation {
     }
 }
 
+impl gax::options::RequestBuilder for CreateSecretByProjectAndLocation {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::add_secret_version call.
 #[derive(Clone, Debug)]
 pub struct AddSecretVersion(
@@ -413,6 +449,12 @@ impl AddSecretVersion {
     pub fn set_location<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.location = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for AddSecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -466,6 +508,12 @@ impl AddSecretVersionByProjectAndLocationAndSecret {
     }
 }
 
+impl gax::options::RequestBuilder for AddSecretVersionByProjectAndLocationAndSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::get_secret call.
 #[derive(Clone, Debug)]
 pub struct GetSecret(SecretManagerServiceRequestBuilder<crate::model::GetSecretRequest>);
@@ -496,6 +544,12 @@ impl GetSecret {
     pub fn set_secret<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.secret = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for GetSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -538,6 +592,12 @@ impl DeleteSecret {
     pub fn set_etag<T: Into<Option<String>>>(mut self, v: T) -> Self {
         self.0.request.etag = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for DeleteSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -589,6 +649,12 @@ impl UpdateSecret {
     }
 }
 
+impl gax::options::RequestBuilder for UpdateSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::get_secret_by_project_and_location_and_secret call.
 #[derive(Clone, Debug)]
 pub struct GetSecretByProjectAndLocationAndSecret(
@@ -633,6 +699,12 @@ impl GetSecretByProjectAndLocationAndSecret {
     pub fn set_secret<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.secret = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for GetSecretByProjectAndLocationAndSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -688,6 +760,12 @@ impl DeleteSecretByProjectAndLocationAndSecret {
     pub fn set_etag<T: Into<Option<String>>>(mut self, v: T) -> Self {
         self.0.request.etag = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for DeleteSecretByProjectAndLocationAndSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -749,6 +827,12 @@ impl UpdateSecretByProjectAndLocationAndSecret {
     pub fn set_update_mask<T: Into<wkt::FieldMask>>(mut self, v: T) -> Self {
         self.0.request.update_mask = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for UpdateSecretByProjectAndLocationAndSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -820,6 +904,12 @@ impl ListSecretVersions {
     pub fn set_filter<T: Into<Option<String>>>(mut self, v: T) -> Self {
         self.0.request.filter = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for ListSecretVersions {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -907,6 +997,12 @@ impl ListSecretVersionsByProjectAndLocationAndSecret {
     }
 }
 
+impl gax::options::RequestBuilder for ListSecretVersionsByProjectAndLocationAndSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::get_secret_version call.
 #[derive(Clone, Debug)]
 pub struct GetSecretVersion(
@@ -948,6 +1044,12 @@ impl GetSecretVersion {
     pub fn set_version<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.version = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for GetSecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -1011,6 +1113,12 @@ impl GetSecretVersionByProjectAndLocationAndSecretAndVersion {
     }
 }
 
+impl gax::options::RequestBuilder for GetSecretVersionByProjectAndLocationAndSecretAndVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::access_secret_version call.
 #[derive(Clone, Debug)]
 pub struct AccessSecretVersion(
@@ -1052,6 +1160,12 @@ impl AccessSecretVersion {
     pub fn set_version<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.version = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for AccessSecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -1115,6 +1229,12 @@ impl AccessSecretVersionByProjectAndLocationAndSecretAndVersion {
     }
 }
 
+impl gax::options::RequestBuilder for AccessSecretVersionByProjectAndLocationAndSecretAndVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::disable_secret_version call.
 #[derive(Clone, Debug)]
 pub struct DisableSecretVersion(
@@ -1171,6 +1291,12 @@ impl DisableSecretVersion {
     pub fn set_location<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.location = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for DisableSecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -1236,6 +1362,12 @@ impl DisableSecretVersionByProjectAndLocationAndSecretAndVersion {
     }
 }
 
+impl gax::options::RequestBuilder for DisableSecretVersionByProjectAndLocationAndSecretAndVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::enable_secret_version call.
 #[derive(Clone, Debug)]
 pub struct EnableSecretVersion(
@@ -1289,6 +1421,12 @@ impl EnableSecretVersion {
     pub fn set_location<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.location = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for EnableSecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -1351,6 +1489,12 @@ impl EnableSecretVersionByProjectAndLocationAndSecretAndVersion {
     }
 }
 
+impl gax::options::RequestBuilder for EnableSecretVersionByProjectAndLocationAndSecretAndVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::destroy_secret_version call.
 #[derive(Clone, Debug)]
 pub struct DestroySecretVersion(
@@ -1407,6 +1551,12 @@ impl DestroySecretVersion {
     pub fn set_location<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.location = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for DestroySecretVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -1472,6 +1622,12 @@ impl DestroySecretVersionByProjectAndLocationAndSecretAndVersion {
     }
 }
 
+impl gax::options::RequestBuilder for DestroySecretVersionByProjectAndLocationAndSecretAndVersion {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::set_iam_policy call.
 #[derive(Clone, Debug)]
 pub struct SetIamPolicy(SecretManagerServiceRequestBuilder<crate::model::SetIamPolicyRequest>);
@@ -1523,6 +1679,12 @@ impl SetIamPolicy {
     pub fn set_location<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.location = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for SetIamPolicy {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -1582,6 +1744,12 @@ impl SetIamPolicyByProjectAndLocationAndSecret {
     }
 }
 
+impl gax::options::RequestBuilder for SetIamPolicyByProjectAndLocationAndSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::get_iam_policy call.
 #[derive(Clone, Debug)]
 pub struct GetIamPolicy(SecretManagerServiceRequestBuilder<crate::model::GetIamPolicyRequest>);
@@ -1621,6 +1789,12 @@ impl GetIamPolicy {
     pub fn set_options_requested_policy_version<T: Into<Option<i32>>>(mut self, v: T) -> Self {
         self.0.request.options_requested_policy_version = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for GetIamPolicy {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }
 
@@ -1679,6 +1853,12 @@ impl GetIamPolicyByProjectAndLocationAndSecret {
     }
 }
 
+impl gax::options::RequestBuilder for GetIamPolicyByProjectAndLocationAndSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::test_iam_permissions call.
 #[derive(Clone, Debug)]
 pub struct TestIamPermissions(
@@ -1729,6 +1909,12 @@ impl TestIamPermissions {
     }
 }
 
+impl gax::options::RequestBuilder for TestIamPermissions {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
+    }
+}
+
 /// The request builder for a SecretManagerService::test_iam_permissions_by_project_and_location_and_secret call.
 #[derive(Clone, Debug)]
 pub struct TestIamPermissionsByProjectAndLocationAndSecret(
@@ -1776,5 +1962,11 @@ impl TestIamPermissionsByProjectAndLocationAndSecret {
     pub fn set_location<T: Into<String>>(mut self, v: T) -> Self {
         self.0.request.location = v.into();
         self
+    }
+}
+
+impl gax::options::RequestBuilder for TestIamPermissionsByProjectAndLocationAndSecret {
+    fn request_options(&mut self) -> &mut gax::options::RequestOptions {
+        &mut self.0.options
     }
 }

--- a/src/generated/openapi-validation/src/transport.rs
+++ b/src/generated/openapi-validation/src/transport.rs
@@ -45,7 +45,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn list_locations(
         &self,
         req: crate::model::ListLocationsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListLocationsResponse> {
         let builder = self
             .inner
@@ -65,7 +65,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token)
             .map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -73,7 +73,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn get_location(
         &self,
         req: crate::model::GetLocationRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Location> {
         let builder = self
             .inner
@@ -87,7 +87,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -95,7 +95,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn list_secrets(
         &self,
         req: crate::model::ListSecretsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretsResponse> {
         let builder = self
             .inner
@@ -115,7 +115,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder =
             gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -123,7 +123,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn create_secret(
         &self,
         req: crate::model::CreateSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let builder = self
             .inner
@@ -138,14 +138,16 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             );
         let builder =
             gax::query_parameter::add(builder, "secretId", &req.secret_id).map_err(Error::other)?;
-        self.inner.execute(builder, Some(req.request_body)).await
+        self.inner
+            .execute(builder, Some(req.request_body), &options)
+            .await
     }
 
     /// Lists Secrets.
     async fn list_secrets_by_project_and_location(
         &self,
         req: crate::model::ListSecretsByProjectAndLocationRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretsResponse> {
         let builder = self
             .inner
@@ -168,7 +170,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder =
             gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -176,7 +178,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn create_secret_by_project_and_location(
         &self,
         req: crate::model::CreateSecretByProjectAndLocationRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let builder = self
             .inner
@@ -194,7 +196,9 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             );
         let builder =
             gax::query_parameter::add(builder, "secretId", &req.secret_id).map_err(Error::other)?;
-        self.inner.execute(builder, Some(req.request_body)).await
+        self.inner
+            .execute(builder, Some(req.request_body), &options)
+            .await
     }
 
     /// Creates a new SecretVersion containing secret data and attaches
@@ -202,7 +206,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn add_secret_version(
         &self,
         req: crate::model::AddSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self
             .inner
@@ -218,7 +222,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(builder, Some(req), &options).await
     }
 
     /// Creates a new SecretVersion containing secret data and attaches
@@ -226,7 +230,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn add_secret_version_by_project_and_location_and_secret(
         &self,
         req: crate::model::AddSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self
             .inner
@@ -242,14 +246,14 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(builder, Some(req), &options).await
     }
 
     /// Gets metadata for a given Secret.
     async fn get_secret(
         &self,
         req: crate::model::GetSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let builder = self
             .inner
@@ -263,7 +267,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -271,7 +275,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn delete_secret(
         &self,
         req: crate::model::DeleteSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Empty> {
         let builder = self
             .inner
@@ -287,7 +291,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder =
             gax::query_parameter::add(builder, "etag", &req.etag).map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -295,7 +299,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn update_secret(
         &self,
         req: crate::model::UpdateSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let builder = self
             .inner
@@ -314,14 +318,16 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             &serde_json::to_value(&req.update_mask).map_err(Error::serde)?,
         )
         .map_err(Error::other)?;
-        self.inner.execute(builder, Some(req.request_body)).await
+        self.inner
+            .execute(builder, Some(req.request_body), &options)
+            .await
     }
 
     /// Gets metadata for a given Secret.
     async fn get_secret_by_project_and_location_and_secret(
         &self,
         req: crate::model::GetSecretByProjectAndLocationAndSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let builder = self
             .inner
@@ -338,7 +344,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -346,7 +352,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn delete_secret_by_project_and_location_and_secret(
         &self,
         req: crate::model::DeleteSecretByProjectAndLocationAndSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Empty> {
         let builder = self
             .inner
@@ -365,7 +371,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder =
             gax::query_parameter::add(builder, "etag", &req.etag).map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -373,7 +379,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn update_secret_by_project_and_location_and_secret(
         &self,
         req: crate::model::UpdateSecretByProjectAndLocationAndSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let builder = self
             .inner
@@ -395,7 +401,9 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             &serde_json::to_value(&req.update_mask).map_err(Error::serde)?,
         )
         .map_err(Error::other)?;
-        self.inner.execute(builder, Some(req.request_body)).await
+        self.inner
+            .execute(builder, Some(req.request_body), &options)
+            .await
     }
 
     /// Lists SecretVersions. This call does not return secret
@@ -403,7 +411,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn list_secret_versions(
         &self,
         req: crate::model::ListSecretVersionsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretVersionsResponse> {
         let builder = self
             .inner
@@ -426,7 +434,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder =
             gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -435,7 +443,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn list_secret_versions_by_project_and_location_and_secret(
         &self,
         req: crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretVersionsResponse> {
         let builder = self
             .inner
@@ -458,7 +466,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder =
             gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -469,7 +477,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn get_secret_version(
         &self,
         req: crate::model::GetSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self
             .inner
@@ -486,7 +494,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -497,7 +505,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn get_secret_version_by_project_and_location_and_secret_and_version(
         &self,
         req: crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self
             .inner
@@ -514,7 +522,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -525,7 +533,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn access_secret_version(
         &self,
         req: crate::model::AccessSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::AccessSecretVersionResponse> {
         let builder = self
             .inner
@@ -542,7 +550,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -553,7 +561,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn access_secret_version_by_project_and_location_and_secret_and_version(
         &self,
         req: crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::AccessSecretVersionResponse> {
         let builder = self
             .inner
@@ -570,7 +578,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -581,7 +589,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn disable_secret_version(
         &self,
         req: crate::model::DisableSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self
             .inner
@@ -597,7 +605,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(builder, Some(req), &options).await
     }
 
     /// Disables a SecretVersion.
@@ -607,7 +615,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn disable_secret_version_by_project_and_location_and_secret_and_version(
         &self,
         req: crate::model::DisableSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self
             .inner
@@ -623,7 +631,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(builder, Some(req), &options).await
     }
 
     /// Enables a SecretVersion.
@@ -633,7 +641,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn enable_secret_version(
         &self,
         req: crate::model::EnableSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self
             .inner
@@ -649,7 +657,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(builder, Some(req), &options).await
     }
 
     /// Enables a SecretVersion.
@@ -659,7 +667,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn enable_secret_version_by_project_and_location_and_secret_and_version(
         &self,
         req: crate::model::EnableSecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self
             .inner
@@ -675,7 +683,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(builder, Some(req), &options).await
     }
 
     /// Destroys a SecretVersion.
@@ -686,7 +694,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn destroy_secret_version(
         &self,
         req: crate::model::DestroySecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self
             .inner
@@ -702,7 +710,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(builder, Some(req), &options).await
     }
 
     /// Destroys a SecretVersion.
@@ -713,7 +721,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn destroy_secret_version_by_project_and_location_and_secret_and_version(
         &self,
         req: crate::model::DestroySecretVersionRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let builder = self
             .inner
@@ -729,7 +737,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(builder, Some(req), &options).await
     }
 
     /// Sets the access control policy on the specified secret. Replaces any
@@ -740,7 +748,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn set_iam_policy(
         &self,
         req: crate::model::SetIamPolicyRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
         let builder = self
             .inner
@@ -756,7 +764,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(builder, Some(req), &options).await
     }
 
     /// Sets the access control policy on the specified secret. Replaces any
@@ -767,7 +775,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn set_iam_policy_by_project_and_location_and_secret(
         &self,
         req: crate::model::SetIamPolicyRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
         let builder = self
             .inner
@@ -783,7 +791,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(builder, Some(req), &options).await
     }
 
     /// Gets the access control policy for a secret.
@@ -791,7 +799,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn get_iam_policy(
         &self,
         req: crate::model::GetIamPolicyRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
         let builder = self
             .inner
@@ -814,7 +822,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         )
         .map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -823,7 +831,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn get_iam_policy_by_project_and_location_and_secret(
         &self,
         req: crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
         let builder = self
             .inner
@@ -846,7 +854,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         )
         .map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>)
+            .execute(builder, None::<gax::http_client::NoBody>, &options)
             .await
     }
 
@@ -860,7 +868,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn test_iam_permissions(
         &self,
         req: crate::model::TestIamPermissionsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::TestIamPermissionsResponse> {
         let builder = self
             .inner
@@ -876,7 +884,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(builder, Some(req), &options).await
     }
 
     /// Returns permissions that a caller has for the specified secret.
@@ -889,7 +897,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
     async fn test_iam_permissions_by_project_and_location_and_secret(
         &self,
         req: crate::model::TestIamPermissionsRequest,
-        _options: gax::options::RequestOptions,
+        options: gax::options::RequestOptions,
     ) -> Result<crate::model::TestIamPermissionsResponse> {
         let builder = self
             .inner
@@ -905,6 +913,6 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req)).await
+        self.inner.execute(builder, Some(req), &options).await
     }
 }

--- a/src/generated/openapi-validation/src/transport.rs
+++ b/src/generated/openapi-validation/src/transport.rs
@@ -65,7 +65,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token)
             .map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -87,7 +87,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -115,7 +115,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder =
             gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -139,7 +139,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder =
             gax::query_parameter::add(builder, "secretId", &req.secret_id).map_err(Error::other)?;
         self.inner
-            .execute(builder, Some(req.request_body), &options)
+            .execute(builder, Some(req.request_body), options)
             .await
     }
 
@@ -170,7 +170,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder =
             gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -197,7 +197,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder =
             gax::query_parameter::add(builder, "secretId", &req.secret_id).map_err(Error::other)?;
         self.inner
-            .execute(builder, Some(req.request_body), &options)
+            .execute(builder, Some(req.request_body), options)
             .await
     }
 
@@ -222,7 +222,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), &options).await
+        self.inner.execute(builder, Some(req), options).await
     }
 
     /// Creates a new SecretVersion containing secret data and attaches
@@ -246,7 +246,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), &options).await
+        self.inner.execute(builder, Some(req), options).await
     }
 
     /// Gets metadata for a given Secret.
@@ -267,7 +267,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -291,7 +291,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder =
             gax::query_parameter::add(builder, "etag", &req.etag).map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -319,7 +319,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         )
         .map_err(Error::other)?;
         self.inner
-            .execute(builder, Some(req.request_body), &options)
+            .execute(builder, Some(req.request_body), options)
             .await
     }
 
@@ -344,7 +344,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -371,7 +371,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder =
             gax::query_parameter::add(builder, "etag", &req.etag).map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -402,7 +402,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         )
         .map_err(Error::other)?;
         self.inner
-            .execute(builder, Some(req.request_body), &options)
+            .execute(builder, Some(req.request_body), options)
             .await
     }
 
@@ -434,7 +434,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder =
             gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -466,7 +466,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder =
             gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -494,7 +494,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -522,7 +522,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -550,7 +550,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -578,7 +578,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -605,7 +605,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), &options).await
+        self.inner.execute(builder, Some(req), options).await
     }
 
     /// Disables a SecretVersion.
@@ -631,7 +631,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), &options).await
+        self.inner.execute(builder, Some(req), options).await
     }
 
     /// Enables a SecretVersion.
@@ -657,7 +657,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), &options).await
+        self.inner.execute(builder, Some(req), options).await
     }
 
     /// Enables a SecretVersion.
@@ -683,7 +683,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), &options).await
+        self.inner.execute(builder, Some(req), options).await
     }
 
     /// Destroys a SecretVersion.
@@ -710,7 +710,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), &options).await
+        self.inner.execute(builder, Some(req), options).await
     }
 
     /// Destroys a SecretVersion.
@@ -737,7 +737,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), &options).await
+        self.inner.execute(builder, Some(req), options).await
     }
 
     /// Sets the access control policy on the specified secret. Replaces any
@@ -764,7 +764,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), &options).await
+        self.inner.execute(builder, Some(req), options).await
     }
 
     /// Sets the access control policy on the specified secret. Replaces any
@@ -791,7 +791,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), &options).await
+        self.inner.execute(builder, Some(req), options).await
     }
 
     /// Gets the access control policy for a secret.
@@ -822,7 +822,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         )
         .map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -854,7 +854,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         )
         .map_err(Error::other)?;
         self.inner
-            .execute(builder, None::<gax::http_client::NoBody>, &options)
+            .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
     }
 
@@ -884,7 +884,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), &options).await
+        self.inner.execute(builder, Some(req), options).await
     }
 
     /// Returns permissions that a caller has for the specified secret.
@@ -913,6 +913,6 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), &options).await
+        self.inner.execute(builder, Some(req), options).await
     }
 }

--- a/src/integration-tests/src/secret_manager/protobuf.rs
+++ b/src/integration-tests/src/secret_manager/protobuf.rs
@@ -52,8 +52,10 @@ pub async fn run(tracing: bool) -> Result<()> {
     cleanup_stale_secrets(&client, &project_id, &secret_id).await?;
 
     println!("\nTesting create_secret()");
+    use gax::options::RequestOptionsBuilder;
     let create = client
         .create_secret()
+        .with_user_agent("test/1.2.3")
         .set_parent(format!("projects/{project_id}"))
         .set_secret_id(&secret_id)
         .set_secret(


### PR DESCRIPTION
This introduces an end-to-end option from the generated code all the
way down to the `ReqwestClient::execute()` method. The option is not
particularly important (though it is used by some customers), but it is
easy to understand.

Fixes #436