### PR TITLE
feat(generator/rust): `update` cmd preserves comments

### DIFF
--- a/generator/internal/sidekick/update_test.go
+++ b/generator/internal/sidekick/update_test.go
@@ -80,6 +80,9 @@ func TestUpdateRootConfig(t *testing.T) {
 		},
 		Codec: map[string]string{},
 	}
+	if err := writeSidekickToml(".", rootConfig); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := updateRootConfig(rootConfig); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The `update` command updates the top-level `.sidekick.toml` file. This file is
hand-crafted, and contains comments and other annotation. We need to preserve
those or the updates get tedious.