### PR TITLE
impl(auth): oauth2 token req/resp types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,8 @@ dependencies = [
  "async-trait",
  "http",
  "mockall",
+ "serde",
+ "serde_json",
  "test-case",
  "thiserror",
  "time",

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -25,8 +25,10 @@ categories.workspace = true
 
 [dependencies]
 async-trait = "0.1.83"
-thiserror   = "2"
 http        = "1.2.0"
+thiserror   = "2"
+serde       = { version = "1.0.214", features = ["derive"] }
+serde_json  = "1.0.133"
 time        = "0.3.37"
 
 [dev-dependencies]


### PR DESCRIPTION
Part of the work for #442

Add OAuth2 request/response types and test their serialization/deserialization. (Re: https://github.com/googleapis/google-cloud-rust/pull/489/files#r1893394717)