### PR TITLE
feat(generator): skip unsupported methods

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -118,7 +118,12 @@ type Method struct {
 	// IsPageable is true if the method conforms to standard defined by
 	// [AIP-4233](https://google.aip.dev/client-libraries/4233).
 	IsPageable bool
-	Parent     *Service
+	// The service that contains this method.
+	Parent *Service
+	// The streaming attributes of the method. Bidi streaming methods have both
+	// set to true.
+	ClientSideStreaming bool
+	ServerSideStreaming bool
 }
 
 // Normalized request path information.

--- a/generator/internal/parser/protobuf.go
+++ b/generator/internal/parser/protobuf.go
@@ -448,8 +448,8 @@ func processMethod(state *api.APIState, m *descriptorpb.MethodDescriptorProto, m
 		Name:                m.GetName(),
 		InputTypeID:         m.GetInputType(),
 		OutputTypeID:        m.GetOutputType(),
-		ClientSideStreaming: m.ClientStreaming != nil && *m.ClientStreaming,
-		ServerSideStreaming: m.ServerStreaming != nil && *m.ServerStreaming,
+		ClientSideStreaming: m.GetClientStreaming(),
+		ServerSideStreaming: m.GetServerStreaming(),
 	}
 	state.MethodByID[mFQN] = method
 	return method

--- a/generator/internal/parser/protobuf.go
+++ b/generator/internal/parser/protobuf.go
@@ -191,6 +191,8 @@ const (
 	fileDescriptorMessageType = 4
 	fileDescriptorEnumType    = 5
 	fileDescriptorService     = 6
+	fileDescriptorExtension   = 7
+	fileDescriptorOptions     = 8
 
 	// From https://pkg.go.dev/google.golang.org/protobuf/types/descriptorpb#ServiceDescriptorProto
 	serviceDescriptorProtoMethod = 2
@@ -311,8 +313,11 @@ func makeAPIForProtobuf(serviceConfig *serviceconfig.Service, req *pluginpb.Code
 			case fileDescriptorService:
 				sFQN := fFQN + "." + f.GetService()[p[1]].GetName()
 				addServiceDocumentation(state, p[2:], loc.GetLeadingComments(), sFQN)
+			case fileDescriptorExtension, fileDescriptorOptions:
+				// We ignore this type of documentation because it produces no
+				// output in the generated code.
 			default:
-				slog.Warn("file dropped documentation", "loc", p, "docs", loc.GetLeadingComments())
+				slog.Warn("dropped unknown documentation type", "loc", p, "docs", loc.GetLeadingComments())
 			}
 		}
 		result.Services = append(result.Services, fileServices...)
@@ -438,11 +443,13 @@ func processMethod(state *api.APIState, m *descriptorpb.MethodDescriptorProto, m
 		return nil
 	}
 	method := &api.Method{
-		ID:           mFQN,
-		PathInfo:     pathInfo,
-		Name:         m.GetName(),
-		InputTypeID:  m.GetInputType(),
-		OutputTypeID: m.GetOutputType(),
+		ID:                  mFQN,
+		PathInfo:            pathInfo,
+		Name:                m.GetName(),
+		InputTypeID:         m.GetInputType(),
+		OutputTypeID:        m.GetOutputType(),
+		ClientSideStreaming: m.ClientStreaming != nil && *m.ClientStreaming,
+		ServerSideStreaming: m.ServerStreaming != nil && *m.ServerStreaming,
 	}
 	state.MethodByID[mFQN] = method
 	return method

--- a/generator/internal/parser/protobuf_annotations.go
+++ b/generator/internal/parser/protobuf_annotations.go
@@ -51,7 +51,14 @@ func processRule(httpRule *annotations.HttpRule, state *api.APIState, mID string
 		verb = "PATCH"
 		rawPath = httpRule.GetPatch()
 	default:
-		return nil, fmt.Errorf("unsupported http method: %q", httpRule.GetPattern())
+		// Most often this happens with streaming RPCs. We will handle any
+		/// errors later in the code generation, maybe by ignoring the RPC.
+		return &api.PathInfo{
+			Verb:            "POST",
+			PathTemplate:    []api.PathSegment{},
+			QueryParameters: map[string]bool{},
+			BodyFieldPath:   "*",
+		}, nil
 	}
 	pathTemplate := parseRawPath(rawPath)
 	queryParameters, err := queryParameters(mID, pathTemplate, httpRule.GetBody(), state)

--- a/generator/internal/parser/protobuf_test.go
+++ b/generator/internal/parser/protobuf_test.go
@@ -709,6 +709,53 @@ func TestProtobuf_Service(t *testing.T) {
 					BodyFieldPath:   "foo",
 				},
 			},
+			{
+				Name:          "UploadFoos",
+				ID:            ".test.TestService.UploadFoos",
+				Documentation: "A client-side streaming RPC.",
+				InputTypeID:   ".test.CreateFooRequest",
+				OutputTypeID:  ".test.Foo",
+				PathInfo: &api.PathInfo{
+					Verb:            "POST",
+					PathTemplate:    []api.PathSegment{},
+					QueryParameters: map[string]bool{},
+					BodyFieldPath:   "*",
+				},
+				ClientSideStreaming: true,
+			},
+			{
+				Name:          "DownloadFoos",
+				ID:            ".test.TestService.DownloadFoos",
+				Documentation: "A server-side streaming RPC.",
+				InputTypeID:   ".test.GetFooRequest",
+				OutputTypeID:  ".test.Foo",
+				PathInfo: &api.PathInfo{
+					Verb: "GET",
+					PathTemplate: []api.PathSegment{
+						api.NewLiteralPathSegment("v1"),
+						api.NewFieldPathPathSegment("name"),
+						api.NewVerbPathSegment("Download"),
+					},
+					QueryParameters: map[string]bool{},
+					BodyFieldPath:   "",
+				},
+				ServerSideStreaming: true,
+			},
+			{
+				Name:          "ChatLike",
+				ID:            ".test.TestService.ChatLike",
+				Documentation: "A bidi streaming RPC.",
+				InputTypeID:   ".test.Foo",
+				OutputTypeID:  ".test.Foo",
+				PathInfo: &api.PathInfo{
+					Verb:            "POST",
+					PathTemplate:    []api.PathSegment{},
+					QueryParameters: map[string]bool{},
+					BodyFieldPath:   "*",
+				},
+				ClientSideStreaming: true,
+				ServerSideStreaming: true,
+			},
 		},
 	})
 }

--- a/generator/internal/parser/testdata/test_service.proto
+++ b/generator/internal/parser/testdata/test_service.proto
@@ -42,6 +42,19 @@ service TestService {
     };
     option (google.api.method_signature) = "parent,foo_id,foo";
   }
+
+  // A client-side streaming RPC.
+  rpc UploadFoos(stream CreateFooRequest) returns (Foo) {}
+
+  // A server-side streaming RPC.
+  rpc DownloadFoos(GetFooRequest) returns (stream Foo) {
+    option (google.api.http) = {
+      get: "/v1/{name=projects/*/foos/*}:Download"
+    };
+  }
+
+  // A bidi streaming RPC.
+  rpc ChatLike(stream Foo) returns (stream Foo) {}
 }
 
 // The resource message.


### PR DESCRIPTION
We will cannot support streaming methods, or methods that lack HTTP
annotations. Skip them until we have the support for them.

