### PR TITLE
fix(gax): more request parameter types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,6 +607,7 @@ name = "gcp-sdk-gax"
 version = "0.1.0-rc2"
 dependencies = [
  "axum",
+ "base64",
  "built",
  "bytes",
  "futures",

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -25,6 +25,7 @@ keywords.workspace   = true
 categories.workspace = true
 
 [dependencies]
+base64      = "0.22.1"
 bytes       = "1.8.0"
 futures     = { version = "0.3.31", optional = true }
 http        = "1.1.0"

--- a/src/gax/src/lib.rs
+++ b/src/gax/src/lib.rs
@@ -30,22 +30,6 @@
 /// This is the result type used by all functions wrapping RPCs.
 type Result<T> = std::result::Result<T, crate::error::Error>;
 
-/// Defines traits and helpers to serialize query parameters.
-///
-/// Query parameters in the Google APIs can be types other than strings and
-/// integers. We need a helper to efficiently serialize parameters of different
-/// types. We also want the generator to be relatively simple.
-///
-/// The Rust SDK generator produces query parameters as optional fields in the
-/// request object. The generator code can be simplified if all the query
-/// parameters can be treated uniformly, without any conditionally generated
-/// code to handle different types.
-///
-/// This module defines some traits and helpers to simplify the code generator.
-///
-/// The types are not intended for application developers to use. They are
-/// public because we will generate many crates (roughly one per service), and
-/// most of these crates will use these helpers.
 #[cfg(feature = "unstable-sdk-client")]
 #[doc(hidden)]
 pub mod query_parameter;

--- a/src/gax/src/query_parameter.rs
+++ b/src/gax/src/query_parameter.rs
@@ -12,6 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Defines traits and helpers to serialize query parameters.
+//!
+//! Query parameters in the Google APIs can be types other than strings and
+//! integers. We need a helper to efficiently serialize parameters of different
+//! types. We also want the generator to be relatively simple.
+//!
+//! The Rust SDK generator produces query parameters as optional fields in the
+//! request object. The generator code can be simplified if all the query
+//! parameters can be treated uniformly, without any conditionally generated
+//! code to handle different types.
+//!
+//! This module defines some traits and helpers to simplify the code generator.
+//!
+//! The types are not intended for application developers to use. They are
+//! public because we will generate many crates (roughly one per service), and
+//! most of these crates will use these helpers.
+
 type Result<T> = std::result::Result<T, crate::request_parameter::Error>;
 
 /// Adds a query parameter to a builder.
@@ -118,6 +135,9 @@ mod tests {
         let builder = QueryParameter::add(&None::<u64>, builder, "test")?;
         let builder = QueryParameter::add(&None::<f32>, builder, "test")?;
         let builder = QueryParameter::add(&None::<f64>, builder, "test")?;
+        let builder = QueryParameter::add(&None::<String>, builder, "test")?;
+        let builder = QueryParameter::add(&None::<bool>, builder, "test")?;
+        let builder = QueryParameter::add(&None::<bytes::Bytes>, builder, "test")?;
         let r = builder.build()?;
         assert_eq!(None, r.url().query());
 
@@ -135,12 +155,31 @@ mod tests {
         let builder = QueryParameter::add(&Some(42_u64), builder, "u64")?;
         let builder = QueryParameter::add(&Some(42_f32), builder, "f32")?;
         let builder = QueryParameter::add(&Some(42_f64), builder, "f64")?;
+        let builder = QueryParameter::add(&Some("42".to_string()), builder, "string")?;
+        let builder = QueryParameter::add(&Some(true), builder, "bool")?;
+        let builder = QueryParameter::add(
+            &Some(bytes::Bytes::from(
+                "the quick brown fox jumps over the laze dog",
+            )),
+            builder,
+            "bytes",
+        )?;
         let r = builder.build()?;
         assert_eq!(
             Some(
-                ["i32=42", "i64=42", "u32=42", "u64=42", "f32=42", "f64=42",]
-                    .join("&")
-                    .as_str()
+                [
+                    "i32=42",
+                    "i64=42",
+                    "u32=42",
+                    "u64=42",
+                    "f32=42",
+                    "f64=42",
+                    "string=42",
+                    "bool=true",
+                    "bytes=dGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXplIGRvZw",
+                ]
+                .join("&")
+                .as_str()
             ),
             r.url().query()
         );

--- a/src/gax/src/request_parameter.rs
+++ b/src/gax/src/request_parameter.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use base64::Engine;
+
 type Result = std::result::Result<String, Error>;
 
 pub(crate) trait RequestParameter {
@@ -63,6 +65,18 @@ impl RequestParameter for f64 {
 impl RequestParameter for String {
     fn format(&self) -> Result {
         Ok(self.clone())
+    }
+}
+impl RequestParameter for bool {
+    fn format(&self) -> Result {
+        Ok(format!("{self}"))
+    }
+}
+
+impl RequestParameter for bytes::Bytes {
+    fn format(&self) -> Result {
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        Ok(URL_SAFE_NO_PAD.encode(self.iter()))
     }
 }
 

--- a/src/gax/tests/query_parameters.rs
+++ b/src/gax/tests/query_parameters.rs
@@ -23,6 +23,7 @@ pub struct FakeRequest {
     pub parent: String,
     // Most query parameter fields are optional.
     pub count: Option<i32>,
+    pub boolean: Option<bool>,
     pub filter_expression: Option<String>,
     pub get_mask: Option<wkt::FieldMask>,
     pub ttl: Option<wkt::Duration>,
@@ -55,6 +56,7 @@ fn with_query_parameters(request: &FakeRequest) -> Result<reqwest::RequestBuilde
     let client = reqwest::Client::builder().build()?;
     let builder = client.get("https://test.googleapis.com/v1/unused");
     let builder = gcp_sdk_gax::query_parameter::add(builder, "count", &request.count)?;
+    let builder = gcp_sdk_gax::query_parameter::add(builder, "boolean", &request.boolean)?;
     let builder =
         gcp_sdk_gax::query_parameter::add(builder, "filterExpression", &request.filter_expression)?;
     let builder = gcp_sdk_gax::query_parameter::add(builder, "getMask", &request.get_mask)?;


### PR DESCRIPTION
We also need to support `bool` and `bytes` path and query parameter
types. Both are used in `gapic-showcase`, hopefully because real
services use them.