### PR TITLE
feat(generator): do not link skipped methods

### DIFF
--- a/generator/internal/language/codec.go
+++ b/generator/internal/language/codec.go
@@ -125,6 +125,9 @@ type Codec interface {
 	// intended only for testing the generator or the SDK, or the service may
 	// not be GA.
 	NotForPublication() bool
+	// Return true if the method should be generated. Some codecs may
+	// (temporarily) not support some methods.
+	GenerateMethod(m *api.Method) bool
 }
 
 // This represents an input template and its corresponding output file.

--- a/generator/internal/language/golang.go
+++ b/generator/internal/language/golang.go
@@ -387,6 +387,14 @@ func (c *GoCodec) NotForPublication() bool {
 	return c.DoNotPublish
 }
 
+func (c *GoCodec) GenerateMethod(m *api.Method) bool {
+	// Ignore methods without HTTP annotations, we cannot generate working
+	// RPCs for them.
+	// TODO(#499) - switch to explicitly excluding such functions. Easier to
+	//     find them and fix them that way.
+	return !m.ClientSideStreaming && !m.ServerSideStreaming && m.PathInfo != nil && len(m.PathInfo.PathTemplate) != 0
+}
+
 // The list of Golang keywords and reserved words can be found at:
 //
 // https://go.dev/ref/spec#Keywords

--- a/generator/internal/language/rust.go
+++ b/generator/internal/language/rust.go
@@ -919,6 +919,11 @@ func (c *RustCodec) tryEnumValueRustdocLink(id string, state *api.APIState) stri
 }
 
 func (c *RustCodec) methodRustdocLink(m *api.Method, state *api.APIState) string {
+	// Sometimes we remove methods from a service. In that case we cannot
+	// reference the method.
+	if !c.GenerateMethod(m) {
+		return ""
+	}
 	idx := strings.LastIndex(m.ID, ".")
 	if idx == -1 {
 		return ""
@@ -1097,6 +1102,14 @@ func (c *RustCodec) Imports() []string {
 
 func (c *RustCodec) NotForPublication() bool {
 	return c.DoNotPublish
+}
+
+func (c *RustCodec) GenerateMethod(m *api.Method) bool {
+	// Ignore methods without HTTP annotations, we cannot generate working
+	// RPCs for them.
+	// TODO(#499) - switch to explicitly excluding such functions. Easier to
+	//     find them and fix them that way.
+	return !m.ClientSideStreaming && !m.ServerSideStreaming && m.PathInfo != nil && len(m.PathInfo.PathTemplate) != 0
 }
 
 // The list of Rust keywords and reserved words can be found at:

--- a/generator/internal/language/rust_test.go
+++ b/generator/internal/language/rust_test.go
@@ -1070,6 +1070,7 @@ func TestRust_FormatDocCommentsCrossLinks(t *testing.T) {
 [ExternalService][google.iam.v1.Iampolicy]
 [ENUM_VALUE][test.v1.SomeMessage.SomeEnum.ENUM_VALUE]
 [SomeService.CreateFoo][test.v1.SomeService.CreateFoo]
+[SomeService.CreateBar][test.v1.SomeService.CreateBar]
 `
 	want := []string{
 		"///",
@@ -1082,6 +1083,7 @@ func TestRust_FormatDocCommentsCrossLinks(t *testing.T) {
 		"/// [ExternalService][google.iam.v1.Iampolicy]",
 		"/// [ENUM_VALUE][test.v1.SomeMessage.SomeEnum.ENUM_VALUE]",
 		"/// [SomeService.CreateFoo][test.v1.SomeService.CreateFoo]",
+		"/// [SomeService.CreateBar][test.v1.SomeService.CreateBar]",
 		"///",
 		"///",
 		"/// [google.iam.v1.Iampolicy]: iam_v1::traits::Iampolicy",
@@ -1092,6 +1094,8 @@ func TestRust_FormatDocCommentsCrossLinks(t *testing.T) {
 		"/// [test.v1.SomeMessage.SomeEnum.ENUM_VALUE]: crate::model::some_message::some_enum::ENUM_VALUE",
 		"/// [test.v1.SomeMessage.field]: crate::model::SomeMessage::field",
 		"/// [test.v1.SomeService]: crate::traits::SomeService",
+		// Skipped because the method is skipped
+		// "/// [test.v1.SomeService.CreateBar]: crate::traits::SomeService::create_bar",
 		"/// [test.v1.SomeService.CreateFoo]: crate::traits::SomeService::create_foo",
 	}
 
@@ -1148,7 +1152,16 @@ func makeApiForRustFormatDocCommentsCrossLinks() *api.API {
 		Name: "SomeService",
 		ID:   ".test.v1.SomeService",
 		Methods: []*api.Method{
-			{Name: "CreateFoo", ID: ".test.v1.SomeService.CreateFoo"},
+			{
+				Name: "CreateFoo", ID: ".test.v1.SomeService.CreateFoo",
+				PathInfo: &api.PathInfo{
+					Verb: "GET",
+					PathTemplate: []api.PathSegment{
+						api.NewLiteralPathSegment("/v1/foo"),
+					},
+				},
+			},
+			{Name: "CreateBar", ID: ".test.v1.SomeService.CreateBar"},
 		},
 	}
 	a := newTestAPI(

--- a/generator/internal/sidekick/templatedata.go
+++ b/generator/internal/sidekick/templatedata.go
@@ -183,16 +183,9 @@ func newTemplateData(model *api.API, c language.Codec) *TemplateData {
 }
 
 func newService(s *api.Service, c language.Codec, state *api.APIState) *Service {
-	// Ignore streaming RPCs.
+	// Some codecs skip some methods.
 	methods := filterSlice(s.Methods, func(m *api.Method) bool {
-		return !m.ClientSideStreaming && !m.ServerSideStreaming
-	})
-	// Ignore methods without HTTP annotations, we cannot generate working
-	// RPCs for them.
-	// TODO(#499) - switch to explicitly excluding such functions. Easier to
-	//     find them and fix them that way.
-	methods = filterSlice(methods, func(m *api.Method) bool {
-		return m.PathInfo != nil && len(m.PathInfo.PathTemplate) != 0
+		return c.GenerateMethod(m)
 	})
 	return &Service{
 		Methods: mapSlice(methods, func(m *api.Method) *Method {


### PR DESCRIPTION
Refactor the code to decide what methods are skipped to the codec. Then
avoid linking those methods in the `rustdoc` documentation.