### PR TITLE
feat(gax): per-attempt timeouts

### DIFF
--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -35,6 +35,7 @@ serde       = "1.0.214"
 serde_json  = "1.0.133"
 serde_with  = { version = "3.11.0", default-features = false, features = ["base64", "macros"] }
 thiserror   = "2.0.3"
+tokio       = { version = "1.42", features = ["time"] }
 auth        = { version = "0.1.0", path = "../../auth", package = "google-cloud-auth", optional = true }
 rpc         = { version = "0.1.0-rc2", path = "../generated/rpc", package = "gcp-sdk-rpc" }
 wkt         = { version = "0.1.0-rc2", path = "../wkt", package = "gcp-sdk-wkt" }
@@ -46,7 +47,7 @@ gax       = { path = ".", package = "gcp-sdk-gax", features = ["unstable-sdk-cli
 axum      = "0.7.9"
 serde     = { version = "1.0.214", features = ["serde_derive"] }
 test-case = "3.3.1"
-tokio     = { version = "1.42", features = ["macros"] }
+tokio     = { version = "1.42", features = ["macros", "test-util"] }
 
 [build-dependencies]
 built = "0.7"

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -35,7 +35,6 @@ serde       = "1.0.214"
 serde_json  = "1.0.133"
 serde_with  = { version = "3.11.0", default-features = false, features = ["base64", "macros"] }
 thiserror   = "2.0.3"
-tokio       = { version = "1.42", features = ["time"] }
 auth        = { version = "0.1.0", path = "../../auth", package = "google-cloud-auth", optional = true }
 rpc         = { version = "0.1.0-rc2", path = "../generated/rpc", package = "gcp-sdk-rpc" }
 wkt         = { version = "0.1.0-rc2", path = "../wkt", package = "gcp-sdk-wkt" }

--- a/src/gax/src/options/mod.rs
+++ b/src/gax/src/options/mod.rs
@@ -24,6 +24,7 @@
 #[derive(Clone, Debug, Default)]
 pub struct RequestOptions {
     user_agent: Option<String>,
+    attempt_timeout: Option<std::time::Duration>,
 }
 
 impl RequestOptions {
@@ -36,6 +37,19 @@ impl RequestOptions {
     pub fn user_agent_prefix(&self) -> &Option<String> {
         &self.user_agent
     }
+
+    /// Sets the per-attempt timeout.
+    ///
+    /// When using a retry loop, this affects the timeout for each attempt. The
+    /// overall timeout for a request is set by the retry policy.
+    pub fn set_attempt_timeout<T: Into<std::time::Duration>>(&mut self, v: T) {
+        self.attempt_timeout = Some(v.into());
+    }
+
+    /// Gets the current per-attempt timeout.
+    pub fn attempt_timeout(&self) -> &Option<std::time::Duration> {
+        &self.attempt_timeout
+    }
 }
 
 /// Implementations of this trait provide setters to configure request options.
@@ -46,7 +60,13 @@ impl RequestOptions {
 /// request, such as additional headers or timeouts.
 pub trait RequestOptionsBuilder {
     /// Set the user agent header.
-    fn with_user_agent<T: Into<String>>(self, v: T) -> Self;
+    fn with_user_agent<V: Into<String>>(self, v: V) -> Self;
+
+    /// Sets the per-attempt timeout.
+    ///
+    /// When using a retry loop, this affects the timeout for each attempt. The
+    /// overall timeout for a request is set by the retry policy.
+    fn with_attempt_timeout<V: Into<std::time::Duration>>(self, v: V) -> Self;
 }
 
 /// Simplify implementation of the [RequestOptionsBuilder] trait in generated
@@ -66,6 +86,11 @@ where
 {
     fn with_user_agent<V: Into<String>>(mut self, v: V) -> Self {
         self.request_options().set_user_agent(v);
+        self
+    }
+
+    fn with_attempt_timeout<V: Into<std::time::Duration>>(mut self, v: V) -> Self {
+        self.request_options().set_attempt_timeout(v);
         self
     }
 }

--- a/src/gax/tests/timeout.rs
+++ b/src/gax/tests/timeout.rs
@@ -1,0 +1,158 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use gax::http_client::*;
+use gax::options::*;
+use gcp_sdk_gax as gax;
+use serde_json::json;
+use std::time::Duration;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+mod echo_server;
+
+#[tokio::test(start_paused = true)]
+async fn test_no_timeout() -> Result<()> {
+    let (endpoint, server) = echo_server::start().await?;
+    let config = ClientConfig::default().set_credential(auth::Credential::test_credentials());
+    let client = ReqwestClient::new(config, &endpoint).await?;
+
+    let delay = Duration::from_millis(200);
+    let mut interval = tokio::time::interval(Duration::from_millis(10));
+    let builder = client
+        .builder(reqwest::Method::GET, "/echo".into())
+        .query(&[("delay_ms", format!("{}", delay.as_millis()))]);
+    let response = client.execute::<serde_json::Value, serde_json::Value>(
+        builder,
+        Some(json!({})),
+        RequestOptions::default(),
+    );
+
+    tokio::pin!(server);
+    tokio::pin!(response);
+    loop {
+        tokio::select! {
+            _ = &mut server => { },
+            r = &mut response => {
+                let response = r?;
+                assert_eq!(
+                    get_query_value(&response, "delay_ms"),
+                    Some("200".to_string())
+                );
+                break;
+            },
+            _ = interval.tick() => { },
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::test(start_paused = true)]
+async fn test_timeout_does_not_expire() -> Result<()> {
+    let (endpoint, server) = echo_server::start().await?;
+    let config = ClientConfig::default().set_credential(auth::Credential::test_credentials());
+    let client = ReqwestClient::new(config, &endpoint).await?;
+
+    let delay = Duration::from_millis(200);
+    let timeout = Duration::from_millis(2000);
+    let mut interval = tokio::time::interval(Duration::from_millis(10));
+    let builder = client
+        .builder(reqwest::Method::GET, "/echo".into())
+        .query(&[("delay_ms", format!("{}", delay.as_millis()))]);
+    let response = client.execute::<serde_json::Value, serde_json::Value>(
+        builder,
+        Some(json!({})),
+        test_options(&timeout),
+    );
+
+    tokio::pin!(server);
+    tokio::pin!(response);
+    loop {
+        tokio::select! {
+            _ = &mut server => {  },
+            r = &mut response => {
+                let response = r?;
+                assert_eq!(
+                    get_query_value(&response, "delay_ms"),
+                    Some("200".to_string())
+                );
+                break;
+            },
+            _ = interval.tick() => { },
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::test(start_paused = true)]
+async fn test_timeout_expires() -> Result<()> {
+    let (endpoint, server) = echo_server::start().await?;
+    let config = ClientConfig::default().set_credential(auth::Credential::test_credentials());
+    let client = ReqwestClient::new(config, &endpoint).await?;
+
+    let delay = Duration::from_millis(200);
+    let timeout = Duration::from_millis(150);
+    let mut interval = tokio::time::interval(Duration::from_millis(10));
+    let builder = client
+        .builder(reqwest::Method::GET, "/echo".into())
+        .query(&[("delay_ms", format!("{}", delay.as_millis()))]);
+    let response = client.execute::<serde_json::Value, serde_json::Value>(
+        builder,
+        Some(json!({})),
+        test_options(&timeout),
+    );
+
+    tokio::pin!(server);
+    tokio::pin!(response);
+    loop {
+        tokio::select! {
+            _ = &mut server => {  },
+            r = &mut response => {
+                use gax::error::ErrorKind;
+                assert!(
+                    r.is_err(),
+                    "expected an error when timeout={}, got={:?}",
+                    timeout.as_millis(),
+                    r
+                );
+                let err = r.err().unwrap();
+                assert_eq!(err.kind(), ErrorKind::Io);
+                break;
+            },
+            _ = interval.tick() => { },
+        }
+    }
+
+    Ok(())
+}
+
+fn test_options(timeout: &std::time::Duration) -> RequestOptions {
+    let mut options = RequestOptions::default();
+    options.set_attempt_timeout(timeout.clone());
+    options
+}
+
+fn get_query_value(response: &serde_json::Value, name: &str) -> Option<String> {
+    response
+        .as_object()
+        .map(|o| o.get("query"))
+        .flatten()
+        .map(|h| h.get(name))
+        .flatten()
+        .map(|v| v.as_str())
+        .flatten()
+        .map(str::to_string)
+}


### PR DESCRIPTION
Support setting per-attempt timeouts on the request builders, and use
these timeouts when sending the RPC.

Fixes #435 