### PR TITLE
cleanup(gax): simplify `Status::try_from()`

### DIFF
--- a/src/gax/src/error/http_error.rs
+++ b/src/gax/src/error/http_error.rs
@@ -62,7 +62,7 @@ impl std::fmt::Display for HttpError {
             self.status_code, self.headers
         )?;
         if let Some(payload) = self.payload() {
-            if let Ok(status) = TryInto::<crate::error::rpc::Status>::try_into(payload.clone()) {
+            if let Ok(status) = TryInto::<crate::error::rpc::Status>::try_into(payload) {
                 return write!(f, ", payload:\n{:?}", status);
             }
             write!(f, ", payload:\n{:?}", payload)?;

--- a/src/gax/src/error/mod.rs
+++ b/src/gax/src/error/mod.rs
@@ -37,7 +37,7 @@ pub use http_error::*;
 /// use error::rpc::Status;
 /// fn handle_error(e: Error) {
 ///     if let Some(e) = e.as_inner::<HttpError>() {
-///         let status : Status = e.clone().try_into().unwrap();
+///         let status = Status::try_from(e).unwrap();
 ///         println!("{status:?}")
 ///     }
 /// }

--- a/src/gax/tests/errors.rs
+++ b/src/gax/tests/errors.rs
@@ -114,7 +114,7 @@ fn http_error_to_status() -> Result<(), Box<dyn std::error::Error>> {
         Some(json.to_string().into()),
     );
 
-    let status: Status = http_err.try_into()?;
+    let status = Status::try_from(&http_err)?;
     assert_eq!(status.code, 9);
     assert_eq!(status.message, "msg");
     assert_eq!(status.details.len(), 1);
@@ -130,7 +130,7 @@ fn http_error_to_status() -> Result<(), Box<dyn std::error::Error>> {
         Some(html.into()),
     );
 
-    let status: Result<Status, Error> = http_err.try_into();
+    let status = Status::try_from(&http_err);
     assert!(status.is_err());
 
     Ok(())

--- a/src/gax/tests/http_client_errors.rs
+++ b/src/gax/tests/http_client_errors.rs
@@ -42,7 +42,7 @@ async fn test_error_with_status() -> Result<()> {
                 axum::http::StatusCode::BAD_REQUEST.as_u16()
             );
             assert!(!inner.headers().is_empty(), "missing headers in {inner}");
-            let got = gax::error::rpc::Status::try_from(inner.clone()).map_err(|e| Box::new(e))?;
+            let got = gax::error::rpc::Status::try_from(inner).map_err(|e| Box::new(e))?;
             let want = echo_server::make_status()?;
             assert_eq!(got, want);
         }


### PR DESCRIPTION
The implementation of `Status::try_from()` works better with references: we will use a reference to deserialize the bytes, and we often have a reference to `HttpError` as the result of `err.as_inner()`.

Motivated by #437 where I will need to examine the status more often than not.
