### PR TITLE
feat(generator/rust): require path parameters

### DIFF
--- a/generator/internal/language/codec.go
+++ b/generator/internal/language/codec.go
@@ -156,20 +156,22 @@ func PathParams(m *api.Method, state *api.APIState) []*api.Field {
 		slog.Error("unable to lookup request type", "id", m.InputTypeID)
 		return nil
 	}
-	pathNames := map[string]bool{}
+	pathNames := []string{}
 	for _, arg := range m.PathInfo.PathTemplate {
 		if arg.FieldPath != nil {
 			components := strings.Split(*arg.FieldPath, ".")
-			pathNames[components[0]] = true
+			pathNames = append(pathNames, components[0])
 		}
 	}
 
 	var params []*api.Field
-	for _, field := range msg.Fields {
-		if !pathNames[field.Name] {
-			continue
+	for _, name := range pathNames {
+		for _, field := range msg.Fields {
+			if field.Name == name {
+				params = append(params, field)
+				break
+			}
 		}
-		params = append(params, field)
 	}
 	return params
 }

--- a/generator/internal/language/codec.go
+++ b/generator/internal/language/codec.go
@@ -14,7 +14,12 @@
 
 package language
 
-import "github.com/googleapis/google-cloud-rust/generator/internal/api"
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/googleapis/google-cloud-rust/generator/internal/api"
+)
 
 // Codec is an adapter used to transform values into language idiomatic
 // representations. This is used to manipulate the data the is fed into
@@ -77,10 +82,6 @@ type Codec interface {
 	// should be used in conjunction with HTTPPathFmt. An example return value
 	// might be `, req.PathParam()`
 	HTTPPathArgs(h *api.PathInfo, state *api.APIState) []string
-	// QueryParams returns key-value pairs of name to accessor for query params.
-	// An example return value might be
-	// `&Pair{Key: "secretId", Value: "req.SecretId()"}`
-	QueryParams(m *api.Method, state *api.APIState) []*api.Field
 	// ToSnake converts a symbol name to `snake_case`, applying any mangling
 	// required by the language, e.g., to avoid clashes with reserved words.
 	ToSnake(string) string
@@ -148,3 +149,44 @@ type GeneratedFile struct {
 // and the `.mustache` extension, such as `rust/crate/src/lib.rs.mustach` and
 // tuen return the full contents of the template (or an error).
 type TemplateProvider func(templateName string) (string, error)
+
+func PathParams(m *api.Method, state *api.APIState) []*api.Field {
+	msg, ok := state.MessageByID[m.InputTypeID]
+	if !ok {
+		slog.Error("unable to lookup request type", "id", m.InputTypeID)
+		return nil
+	}
+	pathNames := map[string]bool{}
+	for _, arg := range m.PathInfo.PathTemplate {
+		if arg.FieldPath != nil {
+			components := strings.Split(*arg.FieldPath, ".")
+			pathNames[components[0]] = true
+		}
+	}
+
+	var params []*api.Field
+	for _, field := range msg.Fields {
+		if !pathNames[field.Name] {
+			continue
+		}
+		params = append(params, field)
+	}
+	return params
+}
+
+func QueryParams(m *api.Method, state *api.APIState) []*api.Field {
+	msg, ok := state.MessageByID[m.InputTypeID]
+	if !ok {
+		slog.Error("unable to lookup request type", "id", m.InputTypeID)
+		return nil
+	}
+
+	var queryParams []*api.Field
+	for _, field := range msg.Fields {
+		if !m.PathInfo.QueryParameters[field.Name] {
+			continue
+		}
+		queryParams = append(queryParams, field)
+	}
+	return queryParams
+}

--- a/generator/internal/language/codec_test.go
+++ b/generator/internal/language/codec_test.go
@@ -1,0 +1,188 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package language
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/googleapis/google-cloud-rust/generator/internal/api"
+)
+
+func TestQueryParams(t *testing.T) {
+	options := &api.Message{
+		Name:   "Options",
+		ID:     "..Options",
+		Fields: []*api.Field{},
+	}
+	optionsField := &api.Field{
+		Name:     "options_field",
+		JSONName: "optionsField",
+		Typez:    api.MESSAGE_TYPE,
+		TypezID:  options.ID,
+	}
+	anotherField := &api.Field{
+		Name:     "another_field",
+		JSONName: "anotherField",
+		Typez:    api.STRING_TYPE,
+		TypezID:  options.ID,
+	}
+	request := &api.Message{
+		Name: "TestRequest",
+		ID:   "..TestRequest",
+		Fields: []*api.Field{
+			optionsField, anotherField,
+			{
+				Name: "unused",
+			},
+		},
+	}
+	method := &api.Method{
+		Name:         "Test",
+		ID:           "..TestService.Test",
+		InputTypeID:  request.ID,
+		OutputTypeID: ".google.protobuf.Empty",
+		PathInfo: &api.PathInfo{
+			Verb: "GET",
+			QueryParameters: map[string]bool{
+				"options_field": true,
+				"another_field": true,
+			},
+		},
+	}
+	test := newTestAPI(
+		[]*api.Message{options, request},
+		[]*api.Enum{},
+		[]*api.Service{
+			{
+				Name:    "TestService",
+				ID:      "..TestService",
+				Methods: []*api.Method{method},
+			},
+		})
+
+	got := QueryParams(method, test.State)
+	want := []*api.Field{optionsField, anotherField}
+	less := func(a, b *api.Field) bool { return a.Name < b.Name }
+	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("mismatched query parameters (-want, +got):\n%s", diff)
+	}
+}
+
+func TestPathParams(t *testing.T) {
+	secret := &api.Message{
+		Name: "Secret",
+		ID:   "..Secret",
+		Fields: []*api.Field{
+			{
+				Name:     "name",
+				JSONName: "name",
+				Typez:    api.STRING_TYPE,
+			},
+		},
+	}
+	updateRequest := &api.Message{
+		Name: "UpdateRequest",
+		ID:   "..UpdateRequest",
+		Fields: []*api.Field{
+			{
+				Name:     "secret",
+				JSONName: "secret",
+				Typez:    api.MESSAGE_TYPE,
+				TypezID:  "..Secret",
+			},
+			{
+				Name:     "field_mask",
+				JSONName: "fieldMask",
+				Typez:    api.MESSAGE_TYPE,
+				TypezID:  ".google.protobuf.FieldMask",
+				Optional: true,
+			},
+		},
+	}
+	updateMethod := &api.Method{
+		Name:         "UpdateSecret",
+		ID:           "..TestService.Test",
+		InputTypeID:  updateRequest.ID,
+		OutputTypeID: ".google.protobuf.Empty",
+		PathInfo: &api.PathInfo{
+			Verb: "PATCH",
+			PathTemplate: []api.PathSegment{
+				api.NewLiteralPathSegment("v1"),
+				api.NewFieldPathPathSegment("secret.name"),
+			},
+			QueryParameters: map[string]bool{
+				"field_mask": true,
+			},
+		},
+	}
+	createRequest := &api.Message{
+		Name: "CreateRequest",
+		ID:   "..CreateRequest",
+		Fields: []*api.Field{
+			{
+				Name:     "parent",
+				JSONName: "parent",
+				Typez:    api.STRING_TYPE,
+			},
+			{
+				Name:     "secret_id",
+				JSONName: "secret_id",
+				Typez:    api.STRING_TYPE,
+			},
+		},
+	}
+	createMethod := &api.Method{
+		Name:         "CreateSecret",
+		ID:           "..TestService.CreateSecret",
+		InputTypeID:  createRequest.ID,
+		OutputTypeID: ".google.protobuf.Empty",
+		PathInfo: &api.PathInfo{
+			Verb: "POST",
+			PathTemplate: []api.PathSegment{
+				api.NewLiteralPathSegment("v1"),
+				api.NewFieldPathPathSegment("parent"),
+				api.NewLiteralPathSegment("secrets"),
+				api.NewFieldPathPathSegment("secret_id"),
+			},
+			QueryParameters: map[string]bool{},
+		},
+	}
+	test := newTestAPI(
+		[]*api.Message{secret, updateRequest, createRequest},
+		[]*api.Enum{},
+		[]*api.Service{
+			{
+				Name:    "TestService",
+				ID:      "..TestService",
+				Methods: []*api.Method{updateMethod, createMethod},
+			},
+		})
+
+	less := func(a, b *api.Field) bool { return a.Name < b.Name }
+
+	got := PathParams(createMethod, test.State)
+	want := createRequest.Fields
+	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("mismatched query parameters (-want, +got):\n%s", diff)
+	}
+
+	got = PathParams(updateMethod, test.State)
+	want = []*api.Field{updateRequest.Fields[0]}
+	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("mismatched query parameters (-want, +got):\n%s", diff)
+	}
+}

--- a/generator/internal/language/golang.go
+++ b/generator/internal/language/golang.go
@@ -261,23 +261,6 @@ func (c *GoCodec) HTTPPathArgs(h *api.PathInfo, state *api.APIState) []string {
 	return args
 }
 
-func (c *GoCodec) QueryParams(m *api.Method, state *api.APIState) []*api.Field {
-	msg, ok := state.MessageByID[m.InputTypeID]
-	if !ok {
-		slog.Error("unable to lookup type", "id", m.InputTypeID)
-		return nil
-	}
-
-	var queryParams []*api.Field
-	for _, field := range msg.Fields {
-		if !m.PathInfo.QueryParameters[field.JSONName] {
-			continue
-		}
-		queryParams = append(queryParams, field)
-	}
-	return queryParams
-}
-
 func (c *GoCodec) ToSnake(symbol string) string {
 	return goEscapeKeyword(c.ToSnakeNoMangling(symbol))
 }

--- a/generator/internal/language/rust.go
+++ b/generator/internal/language/rust.go
@@ -710,23 +710,6 @@ func (c *RustCodec) HTTPPathArgs(h *api.PathInfo, state *api.APIState) []string 
 	return args
 }
 
-func (c *RustCodec) QueryParams(m *api.Method, state *api.APIState) []*api.Field {
-	msg, ok := state.MessageByID[m.InputTypeID]
-	if !ok {
-		slog.Error("unable to lookup request type", "id", m.InputTypeID)
-		return nil
-	}
-
-	var queryParams []*api.Field
-	for _, field := range msg.Fields {
-		if !m.PathInfo.QueryParameters[field.Name] {
-			continue
-		}
-		queryParams = append(queryParams, field)
-	}
-	return queryParams
-}
-
 // Convert a name to `snake_case`. The Rust naming conventions use this style
 // for modules, fields, and functions.
 //

--- a/generator/internal/language/rust_test.go
+++ b/generator/internal/language/rust_test.go
@@ -767,68 +767,6 @@ func TestRust_FieldType(t *testing.T) {
 	}
 }
 
-func TestRust_QueryParams(t *testing.T) {
-	options := &api.Message{
-		Name:   "Options",
-		ID:     "..Options",
-		Fields: []*api.Field{},
-	}
-	optionsField := &api.Field{
-		Name:     "options_field",
-		JSONName: "optionsField",
-		Typez:    api.MESSAGE_TYPE,
-		TypezID:  options.ID,
-	}
-	anotherField := &api.Field{
-		Name:     "another_field",
-		JSONName: "anotherField",
-		Typez:    api.STRING_TYPE,
-		TypezID:  options.ID,
-	}
-	request := &api.Message{
-		Name: "TestRequest",
-		ID:   "..TestRequest",
-		Fields: []*api.Field{
-			optionsField, anotherField,
-			{
-				Name: "unused",
-			},
-		},
-	}
-	method := &api.Method{
-		Name:         "Test",
-		ID:           "..TestService.Test",
-		InputTypeID:  request.ID,
-		OutputTypeID: ".google.protobuf.Empty",
-		PathInfo: &api.PathInfo{
-			Verb: "GET",
-			QueryParameters: map[string]bool{
-				"options_field": true,
-				"another_field": true,
-			},
-		},
-	}
-	test := newTestAPI(
-		[]*api.Message{options, request},
-		[]*api.Enum{},
-		[]*api.Service{
-			{
-				Name:    "TestService",
-				ID:      "..TestService",
-				Methods: []*api.Method{method},
-			},
-		})
-	c := createRustCodec()
-	c.LoadWellKnownTypes(test.State)
-
-	got := c.QueryParams(method, test.State)
-	want := []*api.Field{optionsField, anotherField}
-	less := func(a, b *api.Field) bool { return a.Name < b.Name }
-	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {
-		t.Errorf("mismatched query parameters (-want, +got):\n%s", diff)
-	}
-}
-
 func TestRust_AsQueryParameter(t *testing.T) {
 	options := &api.Message{
 		Name:   "Options",

--- a/generator/internal/language/templates/rust/crate/src/client.rs.mustache
+++ b/generator/internal/language/templates/rust/crate/src/client.rs.mustache
@@ -82,20 +82,12 @@ impl {{NameToPascal}} {
     {{#DocLines}}
     {{{.}}}
     {{/DocLines}}
-    pub fn {{NameToSnake}}<
-        {{#PathParams}}
-        Into{{{NameToPascal}}},
-        {{/PathParams}}
-    >(
+    pub fn {{NameToSnake}}(
         &self,
         {{#PathParams}}
-        {{{NameToSnake}}}: Into{{{NameToPascal}}},
+        {{{NameToSnake}}}: impl Into<{{{PrimitiveFieldType}}}>,
         {{/PathParams}}
     ) -> crate::builders::{{NameToPascal}}
-    where
-        {{#PathParams}}
-        Into{{NameToPascal}}: Into<{{{PrimitiveFieldType}}}>,
-        {{/PathParams}}
     {
         crate::builders::{{NameToPascal}}::new(self.inner.clone())
         {{#PathParams}}

--- a/generator/internal/language/templates/rust/crate/src/client.rs.mustache
+++ b/generator/internal/language/templates/rust/crate/src/client.rs.mustache
@@ -82,8 +82,25 @@ impl {{NameToPascal}} {
     {{#DocLines}}
     {{{.}}}
     {{/DocLines}}
-    pub fn {{NameToSnake}}(&self) -> crate::builders::{{NameToPascal}} {
+    pub fn {{NameToSnake}}<
+        {{#PathParams}}
+        Into{{{NameToPascal}}},
+        {{/PathParams}}
+    >(
+        &self,
+        {{#PathParams}}
+        {{{NameToSnake}}}: Into{{{NameToPascal}}},
+        {{/PathParams}}
+    ) -> crate::builders::{{NameToPascal}}
+    where
+        {{#PathParams}}
+        Into{{NameToPascal}}: Into<{{{PrimitiveFieldType}}}>,
+        {{/PathParams}}
+    {
         crate::builders::{{NameToPascal}}::new(self.inner.clone())
+        {{#PathParams}}
+            .set_{{NameToSnakeNoMangling}} ( {{NameToSnake}}.into() )
+        {{/PathParams}}
     }
 
     {{/Methods}}

--- a/generator/internal/sidekick/templatedata.go
+++ b/generator/internal/sidekick/templatedata.go
@@ -81,6 +81,7 @@ type Method struct {
 	HTTPMethodToLower   string
 	HTTPPathFmt         string
 	HTTPPathArgs        []string
+	PathParams          []*Field
 	QueryParams         []*Field
 	HasBody             bool
 	BodyAccessor        string
@@ -262,7 +263,10 @@ func newMethod(m *api.Method, c language.Codec, state *api.APIState) *Method {
 		NameToPascal:      c.ToPascal(m.Name),
 		NameToSnake:       strcase.ToSnake(m.Name),
 		OutputTypeName:    c.MethodInOutTypeName(m.OutputTypeID, state),
-		QueryParams: mapSlice(c.QueryParams(m, state), func(s *api.Field) *Field {
+		PathParams: mapSlice(language.PathParams(m, state), func(s *api.Field) *Field {
+			return newField(s, c, state)
+		}),
+		QueryParams: mapSlice(language.QueryParams(m, state), func(s *api.Field) *Field {
 			return newField(s, c, state)
 		}),
 		IsPageable:          m.IsPageable,

--- a/generator/testdata/rust/gclient/golden/iam/v1/src/client.rs
+++ b/generator/testdata/rust/gclient/golden/iam/v1/src/client.rs
@@ -97,15 +97,33 @@ impl IAMPolicy {
     /// existing policy.
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.
-    pub fn set_iam_policy(&self) -> crate::builders::SetIamPolicy {
+    pub fn set_iam_policy<
+        IntoResource,
+    >(
+        &self,
+        resource: IntoResource,
+    ) -> crate::builders::SetIamPolicy
+    where
+        IntoResource: Into<String>,
+    {
         crate::builders::SetIamPolicy::new(self.inner.clone())
+            .set_resource ( resource.into() )
     }
 
     /// Gets the access control policy for a resource.
     /// Returns an empty policy if the resource exists and does not have a policy
     /// set.
-    pub fn get_iam_policy(&self) -> crate::builders::GetIamPolicy {
+    pub fn get_iam_policy<
+        IntoResource,
+    >(
+        &self,
+        resource: IntoResource,
+    ) -> crate::builders::GetIamPolicy
+    where
+        IntoResource: Into<String>,
+    {
         crate::builders::GetIamPolicy::new(self.inner.clone())
+            .set_resource ( resource.into() )
     }
 
     /// Returns permissions that a caller has on the specified resource.
@@ -115,8 +133,17 @@ impl IAMPolicy {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
-    pub fn test_iam_permissions(&self) -> crate::builders::TestIamPermissions {
+    pub fn test_iam_permissions<
+        IntoResource,
+    >(
+        &self,
+        resource: IntoResource,
+    ) -> crate::builders::TestIamPermissions
+    where
+        IntoResource: Into<String>,
+    {
         crate::builders::TestIamPermissions::new(self.inner.clone())
+            .set_resource ( resource.into() )
     }
 
 }

--- a/generator/testdata/rust/gclient/golden/iam/v1/src/client.rs
+++ b/generator/testdata/rust/gclient/golden/iam/v1/src/client.rs
@@ -97,14 +97,10 @@ impl IAMPolicy {
     /// existing policy.
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.
-    pub fn set_iam_policy<
-        IntoResource,
-    >(
+    pub fn set_iam_policy(
         &self,
-        resource: IntoResource,
+        resource: impl Into<String>,
     ) -> crate::builders::SetIamPolicy
-    where
-        IntoResource: Into<String>,
     {
         crate::builders::SetIamPolicy::new(self.inner.clone())
             .set_resource ( resource.into() )
@@ -113,14 +109,10 @@ impl IAMPolicy {
     /// Gets the access control policy for a resource.
     /// Returns an empty policy if the resource exists and does not have a policy
     /// set.
-    pub fn get_iam_policy<
-        IntoResource,
-    >(
+    pub fn get_iam_policy(
         &self,
-        resource: IntoResource,
+        resource: impl Into<String>,
     ) -> crate::builders::GetIamPolicy
-    where
-        IntoResource: Into<String>,
     {
         crate::builders::GetIamPolicy::new(self.inner.clone())
             .set_resource ( resource.into() )
@@ -133,14 +125,10 @@ impl IAMPolicy {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
-    pub fn test_iam_permissions<
-        IntoResource,
-    >(
+    pub fn test_iam_permissions(
         &self,
-        resource: IntoResource,
+        resource: impl Into<String>,
     ) -> crate::builders::TestIamPermissions
-    where
-        IntoResource: Into<String>,
     {
         crate::builders::TestIamPermissions::new(self.inner.clone())
             .set_resource ( resource.into() )

--- a/generator/testdata/rust/gclient/golden/location/src/client.rs
+++ b/generator/testdata/rust/gclient/golden/location/src/client.rs
@@ -74,13 +74,31 @@ impl Locations {
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(&self) -> crate::builders::ListLocations {
+    pub fn list_locations<
+        IntoName,
+    >(
+        &self,
+        name: IntoName,
+    ) -> crate::builders::ListLocations
+    where
+        IntoName: Into<String>,
+    {
         crate::builders::ListLocations::new(self.inner.clone())
+            .set_name ( name.into() )
     }
 
     /// Gets information about a location.
-    pub fn get_location(&self) -> crate::builders::GetLocation {
+    pub fn get_location<
+        IntoName,
+    >(
+        &self,
+        name: IntoName,
+    ) -> crate::builders::GetLocation
+    where
+        IntoName: Into<String>,
+    {
         crate::builders::GetLocation::new(self.inner.clone())
+            .set_name ( name.into() )
     }
 
 }

--- a/generator/testdata/rust/gclient/golden/location/src/client.rs
+++ b/generator/testdata/rust/gclient/golden/location/src/client.rs
@@ -74,28 +74,20 @@ impl Locations {
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations<
-        IntoName,
-    >(
+    pub fn list_locations(
         &self,
-        name: IntoName,
+        name: impl Into<String>,
     ) -> crate::builders::ListLocations
-    where
-        IntoName: Into<String>,
     {
         crate::builders::ListLocations::new(self.inner.clone())
             .set_name ( name.into() )
     }
 
     /// Gets information about a location.
-    pub fn get_location<
-        IntoName,
-    >(
+    pub fn get_location(
         &self,
-        name: IntoName,
+        name: impl Into<String>,
     ) -> crate::builders::GetLocation
-    where
-        IntoName: Into<String>,
     {
         crate::builders::GetLocation::new(self.inner.clone())
             .set_name ( name.into() )

--- a/generator/testdata/rust/gclient/golden/secretmanager/src/client.rs
+++ b/generator/testdata/rust/gclient/golden/secretmanager/src/client.rs
@@ -81,14 +81,10 @@ impl SecretManagerService {
     /// Lists [Secrets][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-    pub fn list_secrets<
-        IntoParent,
-    >(
+    pub fn list_secrets(
         &self,
-        parent: IntoParent,
+        parent: impl Into<String>,
     ) -> crate::builders::ListSecrets
-    where
-        IntoParent: Into<String>,
     {
         crate::builders::ListSecrets::new(self.inner.clone())
             .set_parent ( parent.into() )
@@ -99,14 +95,10 @@ impl SecretManagerService {
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn create_secret<
-        IntoParent,
-    >(
+    pub fn create_secret(
         &self,
-        parent: IntoParent,
+        parent: impl Into<String>,
     ) -> crate::builders::CreateSecret
-    where
-        IntoParent: Into<String>,
     {
         crate::builders::CreateSecret::new(self.inner.clone())
             .set_parent ( parent.into() )
@@ -118,14 +110,10 @@ impl SecretManagerService {
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn add_secret_version<
-        IntoParent,
-    >(
+    pub fn add_secret_version(
         &self,
-        parent: IntoParent,
+        parent: impl Into<String>,
     ) -> crate::builders::AddSecretVersion
-    where
-        IntoParent: Into<String>,
     {
         crate::builders::AddSecretVersion::new(self.inner.clone())
             .set_parent ( parent.into() )
@@ -134,14 +122,10 @@ impl SecretManagerService {
     /// Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-    pub fn get_secret<
-        IntoName,
-    >(
+    pub fn get_secret(
         &self,
-        name: IntoName,
+        name: impl Into<String>,
     ) -> crate::builders::GetSecret
-    where
-        IntoName: Into<String>,
     {
         crate::builders::GetSecret::new(self.inner.clone())
             .set_name ( name.into() )
@@ -151,14 +135,10 @@ impl SecretManagerService {
     /// [Secret][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-    pub fn update_secret<
-        IntoSecret,
-    >(
+    pub fn update_secret(
         &self,
-        secret: IntoSecret,
+        secret: impl Into<crate::model::Secret>,
     ) -> crate::builders::UpdateSecret
-    where
-        IntoSecret: Into<crate::model::Secret>,
     {
         crate::builders::UpdateSecret::new(self.inner.clone())
             .set_secret ( secret.into() )
@@ -167,14 +147,10 @@ impl SecretManagerService {
     /// Deletes a [Secret][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-    pub fn delete_secret<
-        IntoName,
-    >(
+    pub fn delete_secret(
         &self,
-        name: IntoName,
+        name: impl Into<String>,
     ) -> crate::builders::DeleteSecret
-    where
-        IntoName: Into<String>,
     {
         crate::builders::DeleteSecret::new(self.inner.clone())
             .set_name ( name.into() )
@@ -184,14 +160,10 @@ impl SecretManagerService {
     /// call does not return secret data.
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn list_secret_versions<
-        IntoParent,
-    >(
+    pub fn list_secret_versions(
         &self,
-        parent: IntoParent,
+        parent: impl Into<String>,
     ) -> crate::builders::ListSecretVersions
-    where
-        IntoParent: Into<String>,
     {
         crate::builders::ListSecretVersions::new(self.inner.clone())
             .set_parent ( parent.into() )
@@ -204,14 +176,10 @@ impl SecretManagerService {
     /// created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn get_secret_version<
-        IntoName,
-    >(
+    pub fn get_secret_version(
         &self,
-        name: IntoName,
+        name: impl Into<String>,
     ) -> crate::builders::GetSecretVersion
-    where
-        IntoName: Into<String>,
     {
         crate::builders::GetSecretVersion::new(self.inner.clone())
             .set_name ( name.into() )
@@ -224,14 +192,10 @@ impl SecretManagerService {
     /// created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn access_secret_version<
-        IntoName,
-    >(
+    pub fn access_secret_version(
         &self,
-        name: IntoName,
+        name: impl Into<String>,
     ) -> crate::builders::AccessSecretVersion
-    where
-        IntoName: Into<String>,
     {
         crate::builders::AccessSecretVersion::new(self.inner.clone())
             .set_name ( name.into() )
@@ -246,14 +210,10 @@ impl SecretManagerService {
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
     /// [google.cloud.secretmanager.v1.SecretVersion.State.DISABLED]: crate::model::secret_version::state::DISABLED
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
-    pub fn disable_secret_version<
-        IntoName,
-    >(
+    pub fn disable_secret_version(
         &self,
-        name: IntoName,
+        name: impl Into<String>,
     ) -> crate::builders::DisableSecretVersion
-    where
-        IntoName: Into<String>,
     {
         crate::builders::DisableSecretVersion::new(self.inner.clone())
             .set_name ( name.into() )
@@ -268,14 +228,10 @@ impl SecretManagerService {
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
     /// [google.cloud.secretmanager.v1.SecretVersion.State.ENABLED]: crate::model::secret_version::state::ENABLED
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
-    pub fn enable_secret_version<
-        IntoName,
-    >(
+    pub fn enable_secret_version(
         &self,
-        name: IntoName,
+        name: impl Into<String>,
     ) -> crate::builders::EnableSecretVersion
-    where
-        IntoName: Into<String>,
     {
         crate::builders::EnableSecretVersion::new(self.inner.clone())
             .set_name ( name.into() )
@@ -291,14 +247,10 @@ impl SecretManagerService {
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
     /// [google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED]: crate::model::secret_version::state::DESTROYED
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
-    pub fn destroy_secret_version<
-        IntoName,
-    >(
+    pub fn destroy_secret_version(
         &self,
-        name: IntoName,
+        name: impl Into<String>,
     ) -> crate::builders::DestroySecretVersion
-    where
-        IntoName: Into<String>,
     {
         crate::builders::DestroySecretVersion::new(self.inner.clone())
             .set_name ( name.into() )
@@ -314,14 +266,10 @@ impl SecretManagerService {
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn set_iam_policy<
-        IntoResource,
-    >(
+    pub fn set_iam_policy(
         &self,
-        resource: IntoResource,
+        resource: impl Into<String>,
     ) -> crate::builders::SetIamPolicy
-    where
-        IntoResource: Into<String>,
     {
         crate::builders::SetIamPolicy::new(self.inner.clone())
             .set_resource ( resource.into() )
@@ -329,14 +277,10 @@ impl SecretManagerService {
 
     /// Gets the access control policy for a secret.
     /// Returns empty policy if the secret exists and does not have a policy set.
-    pub fn get_iam_policy<
-        IntoResource,
-    >(
+    pub fn get_iam_policy(
         &self,
-        resource: IntoResource,
+        resource: impl Into<String>,
     ) -> crate::builders::GetIamPolicy
-    where
-        IntoResource: Into<String>,
     {
         crate::builders::GetIamPolicy::new(self.inner.clone())
             .set_resource ( resource.into() )
@@ -349,14 +293,10 @@ impl SecretManagerService {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
-    pub fn test_iam_permissions<
-        IntoResource,
-    >(
+    pub fn test_iam_permissions(
         &self,
-        resource: IntoResource,
+        resource: impl Into<String>,
     ) -> crate::builders::TestIamPermissions
-    where
-        IntoResource: Into<String>,
     {
         crate::builders::TestIamPermissions::new(self.inner.clone())
             .set_resource ( resource.into() )
@@ -417,28 +357,20 @@ impl Locations {
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations<
-        IntoName,
-    >(
+    pub fn list_locations(
         &self,
-        name: IntoName,
+        name: impl Into<String>,
     ) -> crate::builders::ListLocations
-    where
-        IntoName: Into<String>,
     {
         crate::builders::ListLocations::new(self.inner.clone())
             .set_name ( name.into() )
     }
 
     /// Gets information about a location.
-    pub fn get_location<
-        IntoName,
-    >(
+    pub fn get_location(
         &self,
-        name: IntoName,
+        name: impl Into<String>,
     ) -> crate::builders::GetLocation
-    where
-        IntoName: Into<String>,
     {
         crate::builders::GetLocation::new(self.inner.clone())
             .set_name ( name.into() )

--- a/generator/testdata/rust/gclient/golden/secretmanager/src/client.rs
+++ b/generator/testdata/rust/gclient/golden/secretmanager/src/client.rs
@@ -81,8 +81,17 @@ impl SecretManagerService {
     /// Lists [Secrets][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-    pub fn list_secrets(&self) -> crate::builders::ListSecrets {
+    pub fn list_secrets<
+        IntoParent,
+    >(
+        &self,
+        parent: IntoParent,
+    ) -> crate::builders::ListSecrets
+    where
+        IntoParent: Into<String>,
+    {
         crate::builders::ListSecrets::new(self.inner.clone())
+            .set_parent ( parent.into() )
     }
 
     /// Creates a new [Secret][google.cloud.secretmanager.v1.Secret] containing no
@@ -90,8 +99,17 @@ impl SecretManagerService {
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn create_secret(&self) -> crate::builders::CreateSecret {
+    pub fn create_secret<
+        IntoParent,
+    >(
+        &self,
+        parent: IntoParent,
+    ) -> crate::builders::CreateSecret
+    where
+        IntoParent: Into<String>,
+    {
         crate::builders::CreateSecret::new(self.inner.clone())
+            .set_parent ( parent.into() )
     }
 
     /// Creates a new [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
@@ -100,38 +118,83 @@ impl SecretManagerService {
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn add_secret_version(&self) -> crate::builders::AddSecretVersion {
+    pub fn add_secret_version<
+        IntoParent,
+    >(
+        &self,
+        parent: IntoParent,
+    ) -> crate::builders::AddSecretVersion
+    where
+        IntoParent: Into<String>,
+    {
         crate::builders::AddSecretVersion::new(self.inner.clone())
+            .set_parent ( parent.into() )
     }
 
     /// Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-    pub fn get_secret(&self) -> crate::builders::GetSecret {
+    pub fn get_secret<
+        IntoName,
+    >(
+        &self,
+        name: IntoName,
+    ) -> crate::builders::GetSecret
+    where
+        IntoName: Into<String>,
+    {
         crate::builders::GetSecret::new(self.inner.clone())
+            .set_name ( name.into() )
     }
 
     /// Updates metadata of an existing
     /// [Secret][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-    pub fn update_secret(&self) -> crate::builders::UpdateSecret {
+    pub fn update_secret<
+        IntoSecret,
+    >(
+        &self,
+        secret: IntoSecret,
+    ) -> crate::builders::UpdateSecret
+    where
+        IntoSecret: Into<crate::model::Secret>,
+    {
         crate::builders::UpdateSecret::new(self.inner.clone())
+            .set_secret ( secret.into() )
     }
 
     /// Deletes a [Secret][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-    pub fn delete_secret(&self) -> crate::builders::DeleteSecret {
+    pub fn delete_secret<
+        IntoName,
+    >(
+        &self,
+        name: IntoName,
+    ) -> crate::builders::DeleteSecret
+    where
+        IntoName: Into<String>,
+    {
         crate::builders::DeleteSecret::new(self.inner.clone())
+            .set_name ( name.into() )
     }
 
     /// Lists [SecretVersions][google.cloud.secretmanager.v1.SecretVersion]. This
     /// call does not return secret data.
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn list_secret_versions(&self) -> crate::builders::ListSecretVersions {
+    pub fn list_secret_versions<
+        IntoParent,
+    >(
+        &self,
+        parent: IntoParent,
+    ) -> crate::builders::ListSecretVersions
+    where
+        IntoParent: Into<String>,
+    {
         crate::builders::ListSecretVersions::new(self.inner.clone())
+            .set_parent ( parent.into() )
     }
 
     /// Gets metadata for a
@@ -141,8 +204,17 @@ impl SecretManagerService {
     /// created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn get_secret_version(&self) -> crate::builders::GetSecretVersion {
+    pub fn get_secret_version<
+        IntoName,
+    >(
+        &self,
+        name: IntoName,
+    ) -> crate::builders::GetSecretVersion
+    where
+        IntoName: Into<String>,
+    {
         crate::builders::GetSecretVersion::new(self.inner.clone())
+            .set_name ( name.into() )
     }
 
     /// Accesses a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -152,8 +224,17 @@ impl SecretManagerService {
     /// created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn access_secret_version(&self) -> crate::builders::AccessSecretVersion {
+    pub fn access_secret_version<
+        IntoName,
+    >(
+        &self,
+        name: IntoName,
+    ) -> crate::builders::AccessSecretVersion
+    where
+        IntoName: Into<String>,
+    {
         crate::builders::AccessSecretVersion::new(self.inner.clone())
+            .set_name ( name.into() )
     }
 
     /// Disables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -165,8 +246,17 @@ impl SecretManagerService {
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
     /// [google.cloud.secretmanager.v1.SecretVersion.State.DISABLED]: crate::model::secret_version::state::DISABLED
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
-    pub fn disable_secret_version(&self) -> crate::builders::DisableSecretVersion {
+    pub fn disable_secret_version<
+        IntoName,
+    >(
+        &self,
+        name: IntoName,
+    ) -> crate::builders::DisableSecretVersion
+    where
+        IntoName: Into<String>,
+    {
         crate::builders::DisableSecretVersion::new(self.inner.clone())
+            .set_name ( name.into() )
     }
 
     /// Enables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -178,8 +268,17 @@ impl SecretManagerService {
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
     /// [google.cloud.secretmanager.v1.SecretVersion.State.ENABLED]: crate::model::secret_version::state::ENABLED
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
-    pub fn enable_secret_version(&self) -> crate::builders::EnableSecretVersion {
+    pub fn enable_secret_version<
+        IntoName,
+    >(
+        &self,
+        name: IntoName,
+    ) -> crate::builders::EnableSecretVersion
+    where
+        IntoName: Into<String>,
+    {
         crate::builders::EnableSecretVersion::new(self.inner.clone())
+            .set_name ( name.into() )
     }
 
     /// Destroys a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -192,8 +291,17 @@ impl SecretManagerService {
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
     /// [google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED]: crate::model::secret_version::state::DESTROYED
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
-    pub fn destroy_secret_version(&self) -> crate::builders::DestroySecretVersion {
+    pub fn destroy_secret_version<
+        IntoName,
+    >(
+        &self,
+        name: IntoName,
+    ) -> crate::builders::DestroySecretVersion
+    where
+        IntoName: Into<String>,
+    {
         crate::builders::DestroySecretVersion::new(self.inner.clone())
+            .set_name ( name.into() )
     }
 
     /// Sets the access control policy on the specified secret. Replaces any
@@ -206,14 +314,32 @@ impl SecretManagerService {
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn set_iam_policy(&self) -> crate::builders::SetIamPolicy {
+    pub fn set_iam_policy<
+        IntoResource,
+    >(
+        &self,
+        resource: IntoResource,
+    ) -> crate::builders::SetIamPolicy
+    where
+        IntoResource: Into<String>,
+    {
         crate::builders::SetIamPolicy::new(self.inner.clone())
+            .set_resource ( resource.into() )
     }
 
     /// Gets the access control policy for a secret.
     /// Returns empty policy if the secret exists and does not have a policy set.
-    pub fn get_iam_policy(&self) -> crate::builders::GetIamPolicy {
+    pub fn get_iam_policy<
+        IntoResource,
+    >(
+        &self,
+        resource: IntoResource,
+    ) -> crate::builders::GetIamPolicy
+    where
+        IntoResource: Into<String>,
+    {
         crate::builders::GetIamPolicy::new(self.inner.clone())
+            .set_resource ( resource.into() )
     }
 
     /// Returns permissions that a caller has for the specified secret.
@@ -223,8 +349,17 @@ impl SecretManagerService {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
-    pub fn test_iam_permissions(&self) -> crate::builders::TestIamPermissions {
+    pub fn test_iam_permissions<
+        IntoResource,
+    >(
+        &self,
+        resource: IntoResource,
+    ) -> crate::builders::TestIamPermissions
+    where
+        IntoResource: Into<String>,
+    {
         crate::builders::TestIamPermissions::new(self.inner.clone())
+            .set_resource ( resource.into() )
     }
 
 }
@@ -282,13 +417,31 @@ impl Locations {
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(&self) -> crate::builders::ListLocations {
+    pub fn list_locations<
+        IntoName,
+    >(
+        &self,
+        name: IntoName,
+    ) -> crate::builders::ListLocations
+    where
+        IntoName: Into<String>,
+    {
         crate::builders::ListLocations::new(self.inner.clone())
+            .set_name ( name.into() )
     }
 
     /// Gets information about a location.
-    pub fn get_location(&self) -> crate::builders::GetLocation {
+    pub fn get_location<
+        IntoName,
+    >(
+        &self,
+        name: IntoName,
+    ) -> crate::builders::GetLocation
+    where
+        IntoName: Into<String>,
+    {
         crate::builders::GetLocation::new(self.inner.clone())
+            .set_name ( name.into() )
     }
 
 }

--- a/generator/testdata/rust/openapi/golden/src/client.rs
+++ b/generator/testdata/rust/openapi/golden/src/client.rs
@@ -71,151 +71,519 @@ impl SecretManagerService {
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(&self) -> crate::builders::ListLocations {
+    pub fn list_locations<
+        IntoProject,
+    >(
+        &self,
+        project: IntoProject,
+    ) -> crate::builders::ListLocations
+    where
+        IntoProject: Into<String>,
+    {
         crate::builders::ListLocations::new(self.inner.clone())
+            .set_project ( project.into() )
     }
 
     /// Gets information about a location.
-    pub fn get_location(&self) -> crate::builders::GetLocation {
+    pub fn get_location<
+        IntoProject,
+        IntoLocation,
+    >(
+        &self,
+        project: IntoProject,
+        location: IntoLocation,
+    ) -> crate::builders::GetLocation
+    where
+        IntoProject: Into<String>,
+        IntoLocation: Into<String>,
+    {
         crate::builders::GetLocation::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_location ( location.into() )
     }
 
     /// Lists Secrets.
-    pub fn list_secrets(&self) -> crate::builders::ListSecrets {
+    pub fn list_secrets<
+        IntoProject,
+    >(
+        &self,
+        project: IntoProject,
+    ) -> crate::builders::ListSecrets
+    where
+        IntoProject: Into<String>,
+    {
         crate::builders::ListSecrets::new(self.inner.clone())
+            .set_project ( project.into() )
     }
 
     /// Creates a new Secret containing no SecretVersions.
-    pub fn create_secret(&self) -> crate::builders::CreateSecret {
+    pub fn create_secret<
+        IntoProject,
+    >(
+        &self,
+        project: IntoProject,
+    ) -> crate::builders::CreateSecret
+    where
+        IntoProject: Into<String>,
+    {
         crate::builders::CreateSecret::new(self.inner.clone())
+            .set_project ( project.into() )
     }
 
     /// Lists Secrets.
-    pub fn list_secrets_by_project_and_location(&self) -> crate::builders::ListSecretsByProjectAndLocation {
+    pub fn list_secrets_by_project_and_location<
+        IntoProject,
+        IntoLocation,
+    >(
+        &self,
+        project: IntoProject,
+        location: IntoLocation,
+    ) -> crate::builders::ListSecretsByProjectAndLocation
+    where
+        IntoProject: Into<String>,
+        IntoLocation: Into<String>,
+    {
         crate::builders::ListSecretsByProjectAndLocation::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_location ( location.into() )
     }
 
     /// Creates a new Secret containing no SecretVersions.
-    pub fn create_secret_by_project_and_location(&self) -> crate::builders::CreateSecretByProjectAndLocation {
+    pub fn create_secret_by_project_and_location<
+        IntoProject,
+        IntoLocation,
+    >(
+        &self,
+        project: IntoProject,
+        location: IntoLocation,
+    ) -> crate::builders::CreateSecretByProjectAndLocation
+    where
+        IntoProject: Into<String>,
+        IntoLocation: Into<String>,
+    {
         crate::builders::CreateSecretByProjectAndLocation::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_location ( location.into() )
     }
 
     /// Creates a new SecretVersion containing secret data and attaches
     /// it to an existing Secret.
-    pub fn add_secret_version(&self) -> crate::builders::AddSecretVersion {
+    pub fn add_secret_version<
+        IntoProject,
+        IntoSecret,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+    ) -> crate::builders::AddSecretVersion
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::AddSecretVersion::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_secret ( secret.into() )
     }
 
     /// Creates a new SecretVersion containing secret data and attaches
     /// it to an existing Secret.
-    pub fn add_secret_version_by_project_and_location_and_secret(&self) -> crate::builders::AddSecretVersionByProjectAndLocationAndSecret {
+    pub fn add_secret_version_by_project_and_location_and_secret<
+        IntoProject,
+        IntoSecret,
+        IntoLocation,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+        location: IntoLocation,
+    ) -> crate::builders::AddSecretVersionByProjectAndLocationAndSecret
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoLocation: Into<String>,
+    {
         crate::builders::AddSecretVersionByProjectAndLocationAndSecret::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_secret ( secret.into() )
+            .set_location ( location.into() )
     }
 
     /// Gets metadata for a given Secret.
-    pub fn get_secret(&self) -> crate::builders::GetSecret {
+    pub fn get_secret<
+        IntoProject,
+        IntoSecret,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+    ) -> crate::builders::GetSecret
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::GetSecret::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_secret ( secret.into() )
     }
 
     /// Deletes a Secret.
-    pub fn delete_secret(&self) -> crate::builders::DeleteSecret {
+    pub fn delete_secret<
+        IntoProject,
+        IntoSecret,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+    ) -> crate::builders::DeleteSecret
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::DeleteSecret::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_secret ( secret.into() )
     }
 
     /// Updates metadata of an existing Secret.
-    pub fn update_secret(&self) -> crate::builders::UpdateSecret {
+    pub fn update_secret<
+        IntoProject,
+        IntoSecret,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+    ) -> crate::builders::UpdateSecret
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::UpdateSecret::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_secret ( secret.into() )
     }
 
     /// Gets metadata for a given Secret.
-    pub fn get_secret_by_project_and_location_and_secret(&self) -> crate::builders::GetSecretByProjectAndLocationAndSecret {
+    pub fn get_secret_by_project_and_location_and_secret<
+        IntoProject,
+        IntoLocation,
+        IntoSecret,
+    >(
+        &self,
+        project: IntoProject,
+        location: IntoLocation,
+        secret: IntoSecret,
+    ) -> crate::builders::GetSecretByProjectAndLocationAndSecret
+    where
+        IntoProject: Into<String>,
+        IntoLocation: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::GetSecretByProjectAndLocationAndSecret::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_location ( location.into() )
+            .set_secret ( secret.into() )
     }
 
     /// Deletes a Secret.
-    pub fn delete_secret_by_project_and_location_and_secret(&self) -> crate::builders::DeleteSecretByProjectAndLocationAndSecret {
+    pub fn delete_secret_by_project_and_location_and_secret<
+        IntoProject,
+        IntoLocation,
+        IntoSecret,
+    >(
+        &self,
+        project: IntoProject,
+        location: IntoLocation,
+        secret: IntoSecret,
+    ) -> crate::builders::DeleteSecretByProjectAndLocationAndSecret
+    where
+        IntoProject: Into<String>,
+        IntoLocation: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::DeleteSecretByProjectAndLocationAndSecret::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_location ( location.into() )
+            .set_secret ( secret.into() )
     }
 
     /// Updates metadata of an existing Secret.
-    pub fn update_secret_by_project_and_location_and_secret(&self) -> crate::builders::UpdateSecretByProjectAndLocationAndSecret {
+    pub fn update_secret_by_project_and_location_and_secret<
+        IntoProject,
+        IntoLocation,
+        IntoSecret,
+    >(
+        &self,
+        project: IntoProject,
+        location: IntoLocation,
+        secret: IntoSecret,
+    ) -> crate::builders::UpdateSecretByProjectAndLocationAndSecret
+    where
+        IntoProject: Into<String>,
+        IntoLocation: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::UpdateSecretByProjectAndLocationAndSecret::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_location ( location.into() )
+            .set_secret ( secret.into() )
     }
 
     /// Lists SecretVersions. This call does not return secret
     /// data.
-    pub fn list_secret_versions(&self) -> crate::builders::ListSecretVersions {
+    pub fn list_secret_versions<
+        IntoProject,
+        IntoSecret,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+    ) -> crate::builders::ListSecretVersions
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::ListSecretVersions::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_secret ( secret.into() )
     }
 
     /// Lists SecretVersions. This call does not return secret
     /// data.
-    pub fn list_secret_versions_by_project_and_location_and_secret(&self) -> crate::builders::ListSecretVersionsByProjectAndLocationAndSecret {
+    pub fn list_secret_versions_by_project_and_location_and_secret<
+        IntoProject,
+        IntoLocation,
+        IntoSecret,
+    >(
+        &self,
+        project: IntoProject,
+        location: IntoLocation,
+        secret: IntoSecret,
+    ) -> crate::builders::ListSecretVersionsByProjectAndLocationAndSecret
+    where
+        IntoProject: Into<String>,
+        IntoLocation: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::ListSecretVersionsByProjectAndLocationAndSecret::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_location ( location.into() )
+            .set_secret ( secret.into() )
     }
 
     /// Gets metadata for a SecretVersion.
     ///
     /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
     /// created SecretVersion.
-    pub fn get_secret_version(&self) -> crate::builders::GetSecretVersion {
+    pub fn get_secret_version<
+        IntoProject,
+        IntoSecret,
+        IntoVersion,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+        version: IntoVersion,
+    ) -> crate::builders::GetSecretVersion
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoVersion: Into<String>,
+    {
         crate::builders::GetSecretVersion::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_secret ( secret.into() )
+            .set_version ( version.into() )
     }
 
     /// Gets metadata for a SecretVersion.
     ///
     /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
     /// created SecretVersion.
-    pub fn get_secret_version_by_project_and_location_and_secret_and_version(&self) -> crate::builders::GetSecretVersionByProjectAndLocationAndSecretAndVersion {
+    pub fn get_secret_version_by_project_and_location_and_secret_and_version<
+        IntoProject,
+        IntoLocation,
+        IntoSecret,
+        IntoVersion,
+    >(
+        &self,
+        project: IntoProject,
+        location: IntoLocation,
+        secret: IntoSecret,
+        version: IntoVersion,
+    ) -> crate::builders::GetSecretVersionByProjectAndLocationAndSecretAndVersion
+    where
+        IntoProject: Into<String>,
+        IntoLocation: Into<String>,
+        IntoSecret: Into<String>,
+        IntoVersion: Into<String>,
+    {
         crate::builders::GetSecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_location ( location.into() )
+            .set_secret ( secret.into() )
+            .set_version ( version.into() )
     }
 
     /// Accesses a SecretVersion. This call returns the secret data.
     ///
     /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
     /// created SecretVersion.
-    pub fn access_secret_version(&self) -> crate::builders::AccessSecretVersion {
+    pub fn access_secret_version<
+        IntoProject,
+        IntoSecret,
+        IntoVersion,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+        version: IntoVersion,
+    ) -> crate::builders::AccessSecretVersion
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoVersion: Into<String>,
+    {
         crate::builders::AccessSecretVersion::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_secret ( secret.into() )
+            .set_version ( version.into() )
     }
 
     /// Accesses a SecretVersion. This call returns the secret data.
     ///
     /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
     /// created SecretVersion.
-    pub fn access_secret_version_by_project_and_location_and_secret_and_version(&self) -> crate::builders::AccessSecretVersionByProjectAndLocationAndSecretAndVersion {
+    pub fn access_secret_version_by_project_and_location_and_secret_and_version<
+        IntoProject,
+        IntoLocation,
+        IntoSecret,
+        IntoVersion,
+    >(
+        &self,
+        project: IntoProject,
+        location: IntoLocation,
+        secret: IntoSecret,
+        version: IntoVersion,
+    ) -> crate::builders::AccessSecretVersionByProjectAndLocationAndSecretAndVersion
+    where
+        IntoProject: Into<String>,
+        IntoLocation: Into<String>,
+        IntoSecret: Into<String>,
+        IntoVersion: Into<String>,
+    {
         crate::builders::AccessSecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_location ( location.into() )
+            .set_secret ( secret.into() )
+            .set_version ( version.into() )
     }
 
     /// Disables a SecretVersion.
     ///
     /// Sets the state of the SecretVersion to
     /// DISABLED.
-    pub fn disable_secret_version(&self) -> crate::builders::DisableSecretVersion {
+    pub fn disable_secret_version<
+        IntoProject,
+        IntoSecret,
+        IntoVersion,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+        version: IntoVersion,
+    ) -> crate::builders::DisableSecretVersion
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoVersion: Into<String>,
+    {
         crate::builders::DisableSecretVersion::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_secret ( secret.into() )
+            .set_version ( version.into() )
     }
 
     /// Disables a SecretVersion.
     ///
     /// Sets the state of the SecretVersion to
     /// DISABLED.
-    pub fn disable_secret_version_by_project_and_location_and_secret_and_version(&self) -> crate::builders::DisableSecretVersionByProjectAndLocationAndSecretAndVersion {
+    pub fn disable_secret_version_by_project_and_location_and_secret_and_version<
+        IntoProject,
+        IntoSecret,
+        IntoVersion,
+        IntoLocation,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+        version: IntoVersion,
+        location: IntoLocation,
+    ) -> crate::builders::DisableSecretVersionByProjectAndLocationAndSecretAndVersion
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoVersion: Into<String>,
+        IntoLocation: Into<String>,
+    {
         crate::builders::DisableSecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_secret ( secret.into() )
+            .set_version ( version.into() )
+            .set_location ( location.into() )
     }
 
     /// Enables a SecretVersion.
     ///
     /// Sets the state of the SecretVersion to
     /// ENABLED.
-    pub fn enable_secret_version(&self) -> crate::builders::EnableSecretVersion {
+    pub fn enable_secret_version<
+        IntoProject,
+        IntoSecret,
+        IntoVersion,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+        version: IntoVersion,
+    ) -> crate::builders::EnableSecretVersion
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoVersion: Into<String>,
+    {
         crate::builders::EnableSecretVersion::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_secret ( secret.into() )
+            .set_version ( version.into() )
     }
 
     /// Enables a SecretVersion.
     ///
     /// Sets the state of the SecretVersion to
     /// ENABLED.
-    pub fn enable_secret_version_by_project_and_location_and_secret_and_version(&self) -> crate::builders::EnableSecretVersionByProjectAndLocationAndSecretAndVersion {
+    pub fn enable_secret_version_by_project_and_location_and_secret_and_version<
+        IntoProject,
+        IntoSecret,
+        IntoVersion,
+        IntoLocation,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+        version: IntoVersion,
+        location: IntoLocation,
+    ) -> crate::builders::EnableSecretVersionByProjectAndLocationAndSecretAndVersion
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoVersion: Into<String>,
+        IntoLocation: Into<String>,
+    {
         crate::builders::EnableSecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_secret ( secret.into() )
+            .set_version ( version.into() )
+            .set_location ( location.into() )
     }
 
     /// Destroys a SecretVersion.
@@ -223,8 +591,25 @@ impl SecretManagerService {
     /// Sets the state of the SecretVersion to
     /// DESTROYED and irrevocably destroys the
     /// secret data.
-    pub fn destroy_secret_version(&self) -> crate::builders::DestroySecretVersion {
+    pub fn destroy_secret_version<
+        IntoProject,
+        IntoSecret,
+        IntoVersion,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+        version: IntoVersion,
+    ) -> crate::builders::DestroySecretVersion
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoVersion: Into<String>,
+    {
         crate::builders::DestroySecretVersion::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_secret ( secret.into() )
+            .set_version ( version.into() )
     }
 
     /// Destroys a SecretVersion.
@@ -232,8 +617,29 @@ impl SecretManagerService {
     /// Sets the state of the SecretVersion to
     /// DESTROYED and irrevocably destroys the
     /// secret data.
-    pub fn destroy_secret_version_by_project_and_location_and_secret_and_version(&self) -> crate::builders::DestroySecretVersionByProjectAndLocationAndSecretAndVersion {
+    pub fn destroy_secret_version_by_project_and_location_and_secret_and_version<
+        IntoProject,
+        IntoSecret,
+        IntoVersion,
+        IntoLocation,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+        version: IntoVersion,
+        location: IntoLocation,
+    ) -> crate::builders::DestroySecretVersionByProjectAndLocationAndSecretAndVersion
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoVersion: Into<String>,
+        IntoLocation: Into<String>,
+    {
         crate::builders::DestroySecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_secret ( secret.into() )
+            .set_version ( version.into() )
+            .set_location ( location.into() )
     }
 
     /// Sets the access control policy on the specified secret. Replaces any
@@ -241,8 +647,21 @@ impl SecretManagerService {
     ///
     /// Permissions on SecretVersions are enforced according
     /// to the policy set on the associated Secret.
-    pub fn set_iam_policy(&self) -> crate::builders::SetIamPolicy {
+    pub fn set_iam_policy<
+        IntoProject,
+        IntoSecret,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+    ) -> crate::builders::SetIamPolicy
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::SetIamPolicy::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_secret ( secret.into() )
     }
 
     /// Sets the access control policy on the specified secret. Replaces any
@@ -250,20 +669,67 @@ impl SecretManagerService {
     ///
     /// Permissions on SecretVersions are enforced according
     /// to the policy set on the associated Secret.
-    pub fn set_iam_policy_by_project_and_location_and_secret(&self) -> crate::builders::SetIamPolicyByProjectAndLocationAndSecret {
+    pub fn set_iam_policy_by_project_and_location_and_secret<
+        IntoProject,
+        IntoSecret,
+        IntoLocation,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+        location: IntoLocation,
+    ) -> crate::builders::SetIamPolicyByProjectAndLocationAndSecret
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoLocation: Into<String>,
+    {
         crate::builders::SetIamPolicyByProjectAndLocationAndSecret::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_secret ( secret.into() )
+            .set_location ( location.into() )
     }
 
     /// Gets the access control policy for a secret.
     /// Returns empty policy if the secret exists and does not have a policy set.
-    pub fn get_iam_policy(&self) -> crate::builders::GetIamPolicy {
+    pub fn get_iam_policy<
+        IntoProject,
+        IntoSecret,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+    ) -> crate::builders::GetIamPolicy
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::GetIamPolicy::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_secret ( secret.into() )
     }
 
     /// Gets the access control policy for a secret.
     /// Returns empty policy if the secret exists and does not have a policy set.
-    pub fn get_iam_policy_by_project_and_location_and_secret(&self) -> crate::builders::GetIamPolicyByProjectAndLocationAndSecret {
+    pub fn get_iam_policy_by_project_and_location_and_secret<
+        IntoProject,
+        IntoLocation,
+        IntoSecret,
+    >(
+        &self,
+        project: IntoProject,
+        location: IntoLocation,
+        secret: IntoSecret,
+    ) -> crate::builders::GetIamPolicyByProjectAndLocationAndSecret
+    where
+        IntoProject: Into<String>,
+        IntoLocation: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::GetIamPolicyByProjectAndLocationAndSecret::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_location ( location.into() )
+            .set_secret ( secret.into() )
     }
 
     /// Returns permissions that a caller has for the specified secret.
@@ -273,8 +739,21 @@ impl SecretManagerService {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
-    pub fn test_iam_permissions(&self) -> crate::builders::TestIamPermissions {
+    pub fn test_iam_permissions<
+        IntoProject,
+        IntoSecret,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+    ) -> crate::builders::TestIamPermissions
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::TestIamPermissions::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_secret ( secret.into() )
     }
 
     /// Returns permissions that a caller has for the specified secret.
@@ -284,8 +763,25 @@ impl SecretManagerService {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
-    pub fn test_iam_permissions_by_project_and_location_and_secret(&self) -> crate::builders::TestIamPermissionsByProjectAndLocationAndSecret {
+    pub fn test_iam_permissions_by_project_and_location_and_secret<
+        IntoProject,
+        IntoSecret,
+        IntoLocation,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+        location: IntoLocation,
+    ) -> crate::builders::TestIamPermissionsByProjectAndLocationAndSecret
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoLocation: Into<String>,
+    {
         crate::builders::TestIamPermissionsByProjectAndLocationAndSecret::new(self.inner.clone())
+            .set_project ( project.into() )
+            .set_secret ( secret.into() )
+            .set_location ( location.into() )
     }
 
 }

--- a/generator/testdata/rust/openapi/golden/src/client.rs
+++ b/generator/testdata/rust/openapi/golden/src/client.rs
@@ -189,23 +189,23 @@ impl SecretManagerService {
     /// it to an existing Secret.
     pub fn add_secret_version_by_project_and_location_and_secret<
         IntoProject,
-        IntoSecret,
         IntoLocation,
+        IntoSecret,
     >(
         &self,
         project: IntoProject,
-        secret: IntoSecret,
         location: IntoLocation,
+        secret: IntoSecret,
     ) -> crate::builders::AddSecretVersionByProjectAndLocationAndSecret
     where
         IntoProject: Into<String>,
-        IntoSecret: Into<String>,
         IntoLocation: Into<String>,
+        IntoSecret: Into<String>,
     {
         crate::builders::AddSecretVersionByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project ( project.into() )
-            .set_secret ( secret.into() )
             .set_location ( location.into() )
+            .set_secret ( secret.into() )
     }
 
     /// Gets metadata for a given Secret.
@@ -509,27 +509,27 @@ impl SecretManagerService {
     /// DISABLED.
     pub fn disable_secret_version_by_project_and_location_and_secret_and_version<
         IntoProject,
+        IntoLocation,
         IntoSecret,
         IntoVersion,
-        IntoLocation,
     >(
         &self,
         project: IntoProject,
+        location: IntoLocation,
         secret: IntoSecret,
         version: IntoVersion,
-        location: IntoLocation,
     ) -> crate::builders::DisableSecretVersionByProjectAndLocationAndSecretAndVersion
     where
         IntoProject: Into<String>,
+        IntoLocation: Into<String>,
         IntoSecret: Into<String>,
         IntoVersion: Into<String>,
-        IntoLocation: Into<String>,
     {
         crate::builders::DisableSecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
             .set_project ( project.into() )
+            .set_location ( location.into() )
             .set_secret ( secret.into() )
             .set_version ( version.into() )
-            .set_location ( location.into() )
     }
 
     /// Enables a SecretVersion.
@@ -563,27 +563,27 @@ impl SecretManagerService {
     /// ENABLED.
     pub fn enable_secret_version_by_project_and_location_and_secret_and_version<
         IntoProject,
+        IntoLocation,
         IntoSecret,
         IntoVersion,
-        IntoLocation,
     >(
         &self,
         project: IntoProject,
+        location: IntoLocation,
         secret: IntoSecret,
         version: IntoVersion,
-        location: IntoLocation,
     ) -> crate::builders::EnableSecretVersionByProjectAndLocationAndSecretAndVersion
     where
         IntoProject: Into<String>,
+        IntoLocation: Into<String>,
         IntoSecret: Into<String>,
         IntoVersion: Into<String>,
-        IntoLocation: Into<String>,
     {
         crate::builders::EnableSecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
             .set_project ( project.into() )
+            .set_location ( location.into() )
             .set_secret ( secret.into() )
             .set_version ( version.into() )
-            .set_location ( location.into() )
     }
 
     /// Destroys a SecretVersion.
@@ -619,27 +619,27 @@ impl SecretManagerService {
     /// secret data.
     pub fn destroy_secret_version_by_project_and_location_and_secret_and_version<
         IntoProject,
+        IntoLocation,
         IntoSecret,
         IntoVersion,
-        IntoLocation,
     >(
         &self,
         project: IntoProject,
+        location: IntoLocation,
         secret: IntoSecret,
         version: IntoVersion,
-        location: IntoLocation,
     ) -> crate::builders::DestroySecretVersionByProjectAndLocationAndSecretAndVersion
     where
         IntoProject: Into<String>,
+        IntoLocation: Into<String>,
         IntoSecret: Into<String>,
         IntoVersion: Into<String>,
-        IntoLocation: Into<String>,
     {
         crate::builders::DestroySecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
             .set_project ( project.into() )
+            .set_location ( location.into() )
             .set_secret ( secret.into() )
             .set_version ( version.into() )
-            .set_location ( location.into() )
     }
 
     /// Sets the access control policy on the specified secret. Replaces any
@@ -671,23 +671,23 @@ impl SecretManagerService {
     /// to the policy set on the associated Secret.
     pub fn set_iam_policy_by_project_and_location_and_secret<
         IntoProject,
-        IntoSecret,
         IntoLocation,
+        IntoSecret,
     >(
         &self,
         project: IntoProject,
-        secret: IntoSecret,
         location: IntoLocation,
+        secret: IntoSecret,
     ) -> crate::builders::SetIamPolicyByProjectAndLocationAndSecret
     where
         IntoProject: Into<String>,
-        IntoSecret: Into<String>,
         IntoLocation: Into<String>,
+        IntoSecret: Into<String>,
     {
         crate::builders::SetIamPolicyByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project ( project.into() )
-            .set_secret ( secret.into() )
             .set_location ( location.into() )
+            .set_secret ( secret.into() )
     }
 
     /// Gets the access control policy for a secret.
@@ -765,23 +765,23 @@ impl SecretManagerService {
     /// may "fail open" without warning.
     pub fn test_iam_permissions_by_project_and_location_and_secret<
         IntoProject,
-        IntoSecret,
         IntoLocation,
+        IntoSecret,
     >(
         &self,
         project: IntoProject,
-        secret: IntoSecret,
         location: IntoLocation,
+        secret: IntoSecret,
     ) -> crate::builders::TestIamPermissionsByProjectAndLocationAndSecret
     where
         IntoProject: Into<String>,
-        IntoSecret: Into<String>,
         IntoLocation: Into<String>,
+        IntoSecret: Into<String>,
     {
         crate::builders::TestIamPermissionsByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project ( project.into() )
-            .set_secret ( secret.into() )
             .set_location ( location.into() )
+            .set_secret ( secret.into() )
     }
 
 }

--- a/generator/testdata/rust/openapi/golden/src/client.rs
+++ b/generator/testdata/rust/openapi/golden/src/client.rs
@@ -71,31 +71,21 @@ impl SecretManagerService {
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations<
-        IntoProject,
-    >(
+    pub fn list_locations(
         &self,
-        project: IntoProject,
+        project: impl Into<String>,
     ) -> crate::builders::ListLocations
-    where
-        IntoProject: Into<String>,
     {
         crate::builders::ListLocations::new(self.inner.clone())
             .set_project ( project.into() )
     }
 
     /// Gets information about a location.
-    pub fn get_location<
-        IntoProject,
-        IntoLocation,
-    >(
+    pub fn get_location(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
+        project: impl Into<String>,
+        location: impl Into<String>,
     ) -> crate::builders::GetLocation
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
     {
         crate::builders::GetLocation::new(self.inner.clone())
             .set_project ( project.into() )
@@ -103,45 +93,31 @@ impl SecretManagerService {
     }
 
     /// Lists Secrets.
-    pub fn list_secrets<
-        IntoProject,
-    >(
+    pub fn list_secrets(
         &self,
-        project: IntoProject,
+        project: impl Into<String>,
     ) -> crate::builders::ListSecrets
-    where
-        IntoProject: Into<String>,
     {
         crate::builders::ListSecrets::new(self.inner.clone())
             .set_project ( project.into() )
     }
 
     /// Creates a new Secret containing no SecretVersions.
-    pub fn create_secret<
-        IntoProject,
-    >(
+    pub fn create_secret(
         &self,
-        project: IntoProject,
+        project: impl Into<String>,
     ) -> crate::builders::CreateSecret
-    where
-        IntoProject: Into<String>,
     {
         crate::builders::CreateSecret::new(self.inner.clone())
             .set_project ( project.into() )
     }
 
     /// Lists Secrets.
-    pub fn list_secrets_by_project_and_location<
-        IntoProject,
-        IntoLocation,
-    >(
+    pub fn list_secrets_by_project_and_location(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
+        project: impl Into<String>,
+        location: impl Into<String>,
     ) -> crate::builders::ListSecretsByProjectAndLocation
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
     {
         crate::builders::ListSecretsByProjectAndLocation::new(self.inner.clone())
             .set_project ( project.into() )
@@ -149,17 +125,11 @@ impl SecretManagerService {
     }
 
     /// Creates a new Secret containing no SecretVersions.
-    pub fn create_secret_by_project_and_location<
-        IntoProject,
-        IntoLocation,
-    >(
+    pub fn create_secret_by_project_and_location(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
+        project: impl Into<String>,
+        location: impl Into<String>,
     ) -> crate::builders::CreateSecretByProjectAndLocation
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
     {
         crate::builders::CreateSecretByProjectAndLocation::new(self.inner.clone())
             .set_project ( project.into() )
@@ -168,17 +138,11 @@ impl SecretManagerService {
 
     /// Creates a new SecretVersion containing secret data and attaches
     /// it to an existing Secret.
-    pub fn add_secret_version<
-        IntoProject,
-        IntoSecret,
-    >(
+    pub fn add_secret_version(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
+        project: impl Into<String>,
+        secret: impl Into<String>,
     ) -> crate::builders::AddSecretVersion
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
     {
         crate::builders::AddSecretVersion::new(self.inner.clone())
             .set_project ( project.into() )
@@ -187,20 +151,12 @@ impl SecretManagerService {
 
     /// Creates a new SecretVersion containing secret data and attaches
     /// it to an existing Secret.
-    pub fn add_secret_version_by_project_and_location_and_secret<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-    >(
+    pub fn add_secret_version_by_project_and_location_and_secret(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
     ) -> crate::builders::AddSecretVersionByProjectAndLocationAndSecret
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
     {
         crate::builders::AddSecretVersionByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project ( project.into() )
@@ -209,17 +165,11 @@ impl SecretManagerService {
     }
 
     /// Gets metadata for a given Secret.
-    pub fn get_secret<
-        IntoProject,
-        IntoSecret,
-    >(
+    pub fn get_secret(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
+        project: impl Into<String>,
+        secret: impl Into<String>,
     ) -> crate::builders::GetSecret
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
     {
         crate::builders::GetSecret::new(self.inner.clone())
             .set_project ( project.into() )
@@ -227,17 +177,11 @@ impl SecretManagerService {
     }
 
     /// Deletes a Secret.
-    pub fn delete_secret<
-        IntoProject,
-        IntoSecret,
-    >(
+    pub fn delete_secret(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
+        project: impl Into<String>,
+        secret: impl Into<String>,
     ) -> crate::builders::DeleteSecret
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
     {
         crate::builders::DeleteSecret::new(self.inner.clone())
             .set_project ( project.into() )
@@ -245,17 +189,11 @@ impl SecretManagerService {
     }
 
     /// Updates metadata of an existing Secret.
-    pub fn update_secret<
-        IntoProject,
-        IntoSecret,
-    >(
+    pub fn update_secret(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
+        project: impl Into<String>,
+        secret: impl Into<String>,
     ) -> crate::builders::UpdateSecret
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
     {
         crate::builders::UpdateSecret::new(self.inner.clone())
             .set_project ( project.into() )
@@ -263,20 +201,12 @@ impl SecretManagerService {
     }
 
     /// Gets metadata for a given Secret.
-    pub fn get_secret_by_project_and_location_and_secret<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-    >(
+    pub fn get_secret_by_project_and_location_and_secret(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
     ) -> crate::builders::GetSecretByProjectAndLocationAndSecret
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
     {
         crate::builders::GetSecretByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project ( project.into() )
@@ -285,20 +215,12 @@ impl SecretManagerService {
     }
 
     /// Deletes a Secret.
-    pub fn delete_secret_by_project_and_location_and_secret<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-    >(
+    pub fn delete_secret_by_project_and_location_and_secret(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
     ) -> crate::builders::DeleteSecretByProjectAndLocationAndSecret
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
     {
         crate::builders::DeleteSecretByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project ( project.into() )
@@ -307,20 +229,12 @@ impl SecretManagerService {
     }
 
     /// Updates metadata of an existing Secret.
-    pub fn update_secret_by_project_and_location_and_secret<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-    >(
+    pub fn update_secret_by_project_and_location_and_secret(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
     ) -> crate::builders::UpdateSecretByProjectAndLocationAndSecret
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
     {
         crate::builders::UpdateSecretByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project ( project.into() )
@@ -330,17 +244,11 @@ impl SecretManagerService {
 
     /// Lists SecretVersions. This call does not return secret
     /// data.
-    pub fn list_secret_versions<
-        IntoProject,
-        IntoSecret,
-    >(
+    pub fn list_secret_versions(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
+        project: impl Into<String>,
+        secret: impl Into<String>,
     ) -> crate::builders::ListSecretVersions
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
     {
         crate::builders::ListSecretVersions::new(self.inner.clone())
             .set_project ( project.into() )
@@ -349,20 +257,12 @@ impl SecretManagerService {
 
     /// Lists SecretVersions. This call does not return secret
     /// data.
-    pub fn list_secret_versions_by_project_and_location_and_secret<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-    >(
+    pub fn list_secret_versions_by_project_and_location_and_secret(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
     ) -> crate::builders::ListSecretVersionsByProjectAndLocationAndSecret
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
     {
         crate::builders::ListSecretVersionsByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project ( project.into() )
@@ -374,20 +274,12 @@ impl SecretManagerService {
     ///
     /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
     /// created SecretVersion.
-    pub fn get_secret_version<
-        IntoProject,
-        IntoSecret,
-        IntoVersion,
-    >(
+    pub fn get_secret_version(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
-        version: IntoVersion,
+        project: impl Into<String>,
+        secret: impl Into<String>,
+        version: impl Into<String>,
     ) -> crate::builders::GetSecretVersion
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
-        IntoVersion: Into<String>,
     {
         crate::builders::GetSecretVersion::new(self.inner.clone())
             .set_project ( project.into() )
@@ -399,23 +291,13 @@ impl SecretManagerService {
     ///
     /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
     /// created SecretVersion.
-    pub fn get_secret_version_by_project_and_location_and_secret_and_version<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-        IntoVersion,
-    >(
+    pub fn get_secret_version_by_project_and_location_and_secret_and_version(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
-        version: IntoVersion,
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
+        version: impl Into<String>,
     ) -> crate::builders::GetSecretVersionByProjectAndLocationAndSecretAndVersion
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
-        IntoVersion: Into<String>,
     {
         crate::builders::GetSecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
             .set_project ( project.into() )
@@ -428,20 +310,12 @@ impl SecretManagerService {
     ///
     /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
     /// created SecretVersion.
-    pub fn access_secret_version<
-        IntoProject,
-        IntoSecret,
-        IntoVersion,
-    >(
+    pub fn access_secret_version(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
-        version: IntoVersion,
+        project: impl Into<String>,
+        secret: impl Into<String>,
+        version: impl Into<String>,
     ) -> crate::builders::AccessSecretVersion
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
-        IntoVersion: Into<String>,
     {
         crate::builders::AccessSecretVersion::new(self.inner.clone())
             .set_project ( project.into() )
@@ -453,23 +327,13 @@ impl SecretManagerService {
     ///
     /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
     /// created SecretVersion.
-    pub fn access_secret_version_by_project_and_location_and_secret_and_version<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-        IntoVersion,
-    >(
+    pub fn access_secret_version_by_project_and_location_and_secret_and_version(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
-        version: IntoVersion,
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
+        version: impl Into<String>,
     ) -> crate::builders::AccessSecretVersionByProjectAndLocationAndSecretAndVersion
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
-        IntoVersion: Into<String>,
     {
         crate::builders::AccessSecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
             .set_project ( project.into() )
@@ -482,20 +346,12 @@ impl SecretManagerService {
     ///
     /// Sets the state of the SecretVersion to
     /// DISABLED.
-    pub fn disable_secret_version<
-        IntoProject,
-        IntoSecret,
-        IntoVersion,
-    >(
+    pub fn disable_secret_version(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
-        version: IntoVersion,
+        project: impl Into<String>,
+        secret: impl Into<String>,
+        version: impl Into<String>,
     ) -> crate::builders::DisableSecretVersion
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
-        IntoVersion: Into<String>,
     {
         crate::builders::DisableSecretVersion::new(self.inner.clone())
             .set_project ( project.into() )
@@ -507,23 +363,13 @@ impl SecretManagerService {
     ///
     /// Sets the state of the SecretVersion to
     /// DISABLED.
-    pub fn disable_secret_version_by_project_and_location_and_secret_and_version<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-        IntoVersion,
-    >(
+    pub fn disable_secret_version_by_project_and_location_and_secret_and_version(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
-        version: IntoVersion,
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
+        version: impl Into<String>,
     ) -> crate::builders::DisableSecretVersionByProjectAndLocationAndSecretAndVersion
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
-        IntoVersion: Into<String>,
     {
         crate::builders::DisableSecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
             .set_project ( project.into() )
@@ -536,20 +382,12 @@ impl SecretManagerService {
     ///
     /// Sets the state of the SecretVersion to
     /// ENABLED.
-    pub fn enable_secret_version<
-        IntoProject,
-        IntoSecret,
-        IntoVersion,
-    >(
+    pub fn enable_secret_version(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
-        version: IntoVersion,
+        project: impl Into<String>,
+        secret: impl Into<String>,
+        version: impl Into<String>,
     ) -> crate::builders::EnableSecretVersion
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
-        IntoVersion: Into<String>,
     {
         crate::builders::EnableSecretVersion::new(self.inner.clone())
             .set_project ( project.into() )
@@ -561,23 +399,13 @@ impl SecretManagerService {
     ///
     /// Sets the state of the SecretVersion to
     /// ENABLED.
-    pub fn enable_secret_version_by_project_and_location_and_secret_and_version<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-        IntoVersion,
-    >(
+    pub fn enable_secret_version_by_project_and_location_and_secret_and_version(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
-        version: IntoVersion,
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
+        version: impl Into<String>,
     ) -> crate::builders::EnableSecretVersionByProjectAndLocationAndSecretAndVersion
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
-        IntoVersion: Into<String>,
     {
         crate::builders::EnableSecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
             .set_project ( project.into() )
@@ -591,20 +419,12 @@ impl SecretManagerService {
     /// Sets the state of the SecretVersion to
     /// DESTROYED and irrevocably destroys the
     /// secret data.
-    pub fn destroy_secret_version<
-        IntoProject,
-        IntoSecret,
-        IntoVersion,
-    >(
+    pub fn destroy_secret_version(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
-        version: IntoVersion,
+        project: impl Into<String>,
+        secret: impl Into<String>,
+        version: impl Into<String>,
     ) -> crate::builders::DestroySecretVersion
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
-        IntoVersion: Into<String>,
     {
         crate::builders::DestroySecretVersion::new(self.inner.clone())
             .set_project ( project.into() )
@@ -617,23 +437,13 @@ impl SecretManagerService {
     /// Sets the state of the SecretVersion to
     /// DESTROYED and irrevocably destroys the
     /// secret data.
-    pub fn destroy_secret_version_by_project_and_location_and_secret_and_version<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-        IntoVersion,
-    >(
+    pub fn destroy_secret_version_by_project_and_location_and_secret_and_version(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
-        version: IntoVersion,
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
+        version: impl Into<String>,
     ) -> crate::builders::DestroySecretVersionByProjectAndLocationAndSecretAndVersion
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
-        IntoVersion: Into<String>,
     {
         crate::builders::DestroySecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
             .set_project ( project.into() )
@@ -647,17 +457,11 @@ impl SecretManagerService {
     ///
     /// Permissions on SecretVersions are enforced according
     /// to the policy set on the associated Secret.
-    pub fn set_iam_policy<
-        IntoProject,
-        IntoSecret,
-    >(
+    pub fn set_iam_policy(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
+        project: impl Into<String>,
+        secret: impl Into<String>,
     ) -> crate::builders::SetIamPolicy
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
     {
         crate::builders::SetIamPolicy::new(self.inner.clone())
             .set_project ( project.into() )
@@ -669,20 +473,12 @@ impl SecretManagerService {
     ///
     /// Permissions on SecretVersions are enforced according
     /// to the policy set on the associated Secret.
-    pub fn set_iam_policy_by_project_and_location_and_secret<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-    >(
+    pub fn set_iam_policy_by_project_and_location_and_secret(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
     ) -> crate::builders::SetIamPolicyByProjectAndLocationAndSecret
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
     {
         crate::builders::SetIamPolicyByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project ( project.into() )
@@ -692,17 +488,11 @@ impl SecretManagerService {
 
     /// Gets the access control policy for a secret.
     /// Returns empty policy if the secret exists and does not have a policy set.
-    pub fn get_iam_policy<
-        IntoProject,
-        IntoSecret,
-    >(
+    pub fn get_iam_policy(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
+        project: impl Into<String>,
+        secret: impl Into<String>,
     ) -> crate::builders::GetIamPolicy
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
     {
         crate::builders::GetIamPolicy::new(self.inner.clone())
             .set_project ( project.into() )
@@ -711,20 +501,12 @@ impl SecretManagerService {
 
     /// Gets the access control policy for a secret.
     /// Returns empty policy if the secret exists and does not have a policy set.
-    pub fn get_iam_policy_by_project_and_location_and_secret<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-    >(
+    pub fn get_iam_policy_by_project_and_location_and_secret(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
     ) -> crate::builders::GetIamPolicyByProjectAndLocationAndSecret
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
     {
         crate::builders::GetIamPolicyByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project ( project.into() )
@@ -739,17 +521,11 @@ impl SecretManagerService {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
-    pub fn test_iam_permissions<
-        IntoProject,
-        IntoSecret,
-    >(
+    pub fn test_iam_permissions(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
+        project: impl Into<String>,
+        secret: impl Into<String>,
     ) -> crate::builders::TestIamPermissions
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
     {
         crate::builders::TestIamPermissions::new(self.inner.clone())
             .set_project ( project.into() )
@@ -763,20 +539,12 @@ impl SecretManagerService {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
-    pub fn test_iam_permissions_by_project_and_location_and_secret<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-    >(
+    pub fn test_iam_permissions_by_project_and_location_and_secret(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
     ) -> crate::builders::TestIamPermissionsByProjectAndLocationAndSecret
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
     {
         crate::builders::TestIamPermissionsByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project ( project.into() )

--- a/src/generated/cloud/location/src/client.rs
+++ b/src/generated/cloud/location/src/client.rs
@@ -84,12 +84,18 @@ impl Locations {
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(&self) -> crate::builders::ListLocations {
-        crate::builders::ListLocations::new(self.inner.clone())
+    pub fn list_locations<IntoName>(&self, name: IntoName) -> crate::builders::ListLocations
+    where
+        IntoName: Into<String>,
+    {
+        crate::builders::ListLocations::new(self.inner.clone()).set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(&self) -> crate::builders::GetLocation {
-        crate::builders::GetLocation::new(self.inner.clone())
+    pub fn get_location<IntoName>(&self, name: IntoName) -> crate::builders::GetLocation
+    where
+        IntoName: Into<String>,
+    {
+        crate::builders::GetLocation::new(self.inner.clone()).set_name(name.into())
     }
 }

--- a/src/generated/cloud/location/src/client.rs
+++ b/src/generated/cloud/location/src/client.rs
@@ -84,18 +84,12 @@ impl Locations {
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations<IntoName>(&self, name: IntoName) -> crate::builders::ListLocations
-    where
-        IntoName: Into<String>,
-    {
+    pub fn list_locations(&self, name: impl Into<String>) -> crate::builders::ListLocations {
         crate::builders::ListLocations::new(self.inner.clone()).set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location<IntoName>(&self, name: IntoName) -> crate::builders::GetLocation
-    where
-        IntoName: Into<String>,
-    {
+    pub fn get_location(&self, name: impl Into<String>) -> crate::builders::GetLocation {
         crate::builders::GetLocation::new(self.inner.clone()).set_name(name.into())
     }
 }

--- a/src/generated/cloud/secretmanager/v1/src/client.rs
+++ b/src/generated/cloud/secretmanager/v1/src/client.rs
@@ -93,8 +93,11 @@ impl SecretManagerService {
     /// Lists [Secrets][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-    pub fn list_secrets(&self) -> crate::builders::ListSecrets {
-        crate::builders::ListSecrets::new(self.inner.clone())
+    pub fn list_secrets<IntoParent>(&self, parent: IntoParent) -> crate::builders::ListSecrets
+    where
+        IntoParent: Into<String>,
+    {
+        crate::builders::ListSecrets::new(self.inner.clone()).set_parent(parent.into())
     }
 
     /// Creates a new [Secret][google.cloud.secretmanager.v1.Secret] containing no
@@ -102,8 +105,11 @@ impl SecretManagerService {
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn create_secret(&self) -> crate::builders::CreateSecret {
-        crate::builders::CreateSecret::new(self.inner.clone())
+    pub fn create_secret<IntoParent>(&self, parent: IntoParent) -> crate::builders::CreateSecret
+    where
+        IntoParent: Into<String>,
+    {
+        crate::builders::CreateSecret::new(self.inner.clone()).set_parent(parent.into())
     }
 
     /// Creates a new [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
@@ -112,38 +118,59 @@ impl SecretManagerService {
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn add_secret_version(&self) -> crate::builders::AddSecretVersion {
-        crate::builders::AddSecretVersion::new(self.inner.clone())
+    pub fn add_secret_version<IntoParent>(
+        &self,
+        parent: IntoParent,
+    ) -> crate::builders::AddSecretVersion
+    where
+        IntoParent: Into<String>,
+    {
+        crate::builders::AddSecretVersion::new(self.inner.clone()).set_parent(parent.into())
     }
 
     /// Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-    pub fn get_secret(&self) -> crate::builders::GetSecret {
-        crate::builders::GetSecret::new(self.inner.clone())
+    pub fn get_secret<IntoName>(&self, name: IntoName) -> crate::builders::GetSecret
+    where
+        IntoName: Into<String>,
+    {
+        crate::builders::GetSecret::new(self.inner.clone()).set_name(name.into())
     }
 
     /// Updates metadata of an existing
     /// [Secret][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-    pub fn update_secret(&self) -> crate::builders::UpdateSecret {
-        crate::builders::UpdateSecret::new(self.inner.clone())
+    pub fn update_secret<IntoSecret>(&self, secret: IntoSecret) -> crate::builders::UpdateSecret
+    where
+        IntoSecret: Into<crate::model::Secret>,
+    {
+        crate::builders::UpdateSecret::new(self.inner.clone()).set_secret(secret.into())
     }
 
     /// Deletes a [Secret][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-    pub fn delete_secret(&self) -> crate::builders::DeleteSecret {
-        crate::builders::DeleteSecret::new(self.inner.clone())
+    pub fn delete_secret<IntoName>(&self, name: IntoName) -> crate::builders::DeleteSecret
+    where
+        IntoName: Into<String>,
+    {
+        crate::builders::DeleteSecret::new(self.inner.clone()).set_name(name.into())
     }
 
     /// Lists [SecretVersions][google.cloud.secretmanager.v1.SecretVersion]. This
     /// call does not return secret data.
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn list_secret_versions(&self) -> crate::builders::ListSecretVersions {
-        crate::builders::ListSecretVersions::new(self.inner.clone())
+    pub fn list_secret_versions<IntoParent>(
+        &self,
+        parent: IntoParent,
+    ) -> crate::builders::ListSecretVersions
+    where
+        IntoParent: Into<String>,
+    {
+        crate::builders::ListSecretVersions::new(self.inner.clone()).set_parent(parent.into())
     }
 
     /// Gets metadata for a
@@ -153,8 +180,11 @@ impl SecretManagerService {
     /// created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn get_secret_version(&self) -> crate::builders::GetSecretVersion {
-        crate::builders::GetSecretVersion::new(self.inner.clone())
+    pub fn get_secret_version<IntoName>(&self, name: IntoName) -> crate::builders::GetSecretVersion
+    where
+        IntoName: Into<String>,
+    {
+        crate::builders::GetSecretVersion::new(self.inner.clone()).set_name(name.into())
     }
 
     /// Accesses a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -164,8 +194,14 @@ impl SecretManagerService {
     /// created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn access_secret_version(&self) -> crate::builders::AccessSecretVersion {
-        crate::builders::AccessSecretVersion::new(self.inner.clone())
+    pub fn access_secret_version<IntoName>(
+        &self,
+        name: IntoName,
+    ) -> crate::builders::AccessSecretVersion
+    where
+        IntoName: Into<String>,
+    {
+        crate::builders::AccessSecretVersion::new(self.inner.clone()).set_name(name.into())
     }
 
     /// Disables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -177,8 +213,14 @@ impl SecretManagerService {
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
     /// [google.cloud.secretmanager.v1.SecretVersion.State.DISABLED]: crate::model::secret_version::state::DISABLED
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
-    pub fn disable_secret_version(&self) -> crate::builders::DisableSecretVersion {
-        crate::builders::DisableSecretVersion::new(self.inner.clone())
+    pub fn disable_secret_version<IntoName>(
+        &self,
+        name: IntoName,
+    ) -> crate::builders::DisableSecretVersion
+    where
+        IntoName: Into<String>,
+    {
+        crate::builders::DisableSecretVersion::new(self.inner.clone()).set_name(name.into())
     }
 
     /// Enables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -190,8 +232,14 @@ impl SecretManagerService {
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
     /// [google.cloud.secretmanager.v1.SecretVersion.State.ENABLED]: crate::model::secret_version::state::ENABLED
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
-    pub fn enable_secret_version(&self) -> crate::builders::EnableSecretVersion {
-        crate::builders::EnableSecretVersion::new(self.inner.clone())
+    pub fn enable_secret_version<IntoName>(
+        &self,
+        name: IntoName,
+    ) -> crate::builders::EnableSecretVersion
+    where
+        IntoName: Into<String>,
+    {
+        crate::builders::EnableSecretVersion::new(self.inner.clone()).set_name(name.into())
     }
 
     /// Destroys a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -204,8 +252,14 @@ impl SecretManagerService {
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
     /// [google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED]: crate::model::secret_version::state::DESTROYED
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
-    pub fn destroy_secret_version(&self) -> crate::builders::DestroySecretVersion {
-        crate::builders::DestroySecretVersion::new(self.inner.clone())
+    pub fn destroy_secret_version<IntoName>(
+        &self,
+        name: IntoName,
+    ) -> crate::builders::DestroySecretVersion
+    where
+        IntoName: Into<String>,
+    {
+        crate::builders::DestroySecretVersion::new(self.inner.clone()).set_name(name.into())
     }
 
     /// Sets the access control policy on the specified secret. Replaces any
@@ -218,14 +272,26 @@ impl SecretManagerService {
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn set_iam_policy(&self) -> crate::builders::SetIamPolicy {
-        crate::builders::SetIamPolicy::new(self.inner.clone())
+    pub fn set_iam_policy<IntoResource>(
+        &self,
+        resource: IntoResource,
+    ) -> crate::builders::SetIamPolicy
+    where
+        IntoResource: Into<String>,
+    {
+        crate::builders::SetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
     }
 
     /// Gets the access control policy for a secret.
     /// Returns empty policy if the secret exists and does not have a policy set.
-    pub fn get_iam_policy(&self) -> crate::builders::GetIamPolicy {
-        crate::builders::GetIamPolicy::new(self.inner.clone())
+    pub fn get_iam_policy<IntoResource>(
+        &self,
+        resource: IntoResource,
+    ) -> crate::builders::GetIamPolicy
+    where
+        IntoResource: Into<String>,
+    {
+        crate::builders::GetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has for the specified secret.
@@ -235,8 +301,14 @@ impl SecretManagerService {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
-    pub fn test_iam_permissions(&self) -> crate::builders::TestIamPermissions {
-        crate::builders::TestIamPermissions::new(self.inner.clone())
+    pub fn test_iam_permissions<IntoResource>(
+        &self,
+        resource: IntoResource,
+    ) -> crate::builders::TestIamPermissions
+    where
+        IntoResource: Into<String>,
+    {
+        crate::builders::TestIamPermissions::new(self.inner.clone()).set_resource(resource.into())
     }
 }
 
@@ -303,12 +375,18 @@ impl Locations {
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(&self) -> crate::builders::ListLocations {
-        crate::builders::ListLocations::new(self.inner.clone())
+    pub fn list_locations<IntoName>(&self, name: IntoName) -> crate::builders::ListLocations
+    where
+        IntoName: Into<String>,
+    {
+        crate::builders::ListLocations::new(self.inner.clone()).set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(&self) -> crate::builders::GetLocation {
-        crate::builders::GetLocation::new(self.inner.clone())
+    pub fn get_location<IntoName>(&self, name: IntoName) -> crate::builders::GetLocation
+    where
+        IntoName: Into<String>,
+    {
+        crate::builders::GetLocation::new(self.inner.clone()).set_name(name.into())
     }
 }

--- a/src/generated/cloud/secretmanager/v1/src/client.rs
+++ b/src/generated/cloud/secretmanager/v1/src/client.rs
@@ -93,10 +93,7 @@ impl SecretManagerService {
     /// Lists [Secrets][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-    pub fn list_secrets<IntoParent>(&self, parent: IntoParent) -> crate::builders::ListSecrets
-    where
-        IntoParent: Into<String>,
-    {
+    pub fn list_secrets(&self, parent: impl Into<String>) -> crate::builders::ListSecrets {
         crate::builders::ListSecrets::new(self.inner.clone()).set_parent(parent.into())
     }
 
@@ -105,10 +102,7 @@ impl SecretManagerService {
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn create_secret<IntoParent>(&self, parent: IntoParent) -> crate::builders::CreateSecret
-    where
-        IntoParent: Into<String>,
-    {
+    pub fn create_secret(&self, parent: impl Into<String>) -> crate::builders::CreateSecret {
         crate::builders::CreateSecret::new(self.inner.clone()).set_parent(parent.into())
     }
 
@@ -118,23 +112,17 @@ impl SecretManagerService {
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn add_secret_version<IntoParent>(
+    pub fn add_secret_version(
         &self,
-        parent: IntoParent,
-    ) -> crate::builders::AddSecretVersion
-    where
-        IntoParent: Into<String>,
-    {
+        parent: impl Into<String>,
+    ) -> crate::builders::AddSecretVersion {
         crate::builders::AddSecretVersion::new(self.inner.clone()).set_parent(parent.into())
     }
 
     /// Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-    pub fn get_secret<IntoName>(&self, name: IntoName) -> crate::builders::GetSecret
-    where
-        IntoName: Into<String>,
-    {
+    pub fn get_secret(&self, name: impl Into<String>) -> crate::builders::GetSecret {
         crate::builders::GetSecret::new(self.inner.clone()).set_name(name.into())
     }
 
@@ -142,20 +130,17 @@ impl SecretManagerService {
     /// [Secret][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-    pub fn update_secret<IntoSecret>(&self, secret: IntoSecret) -> crate::builders::UpdateSecret
-    where
-        IntoSecret: Into<crate::model::Secret>,
-    {
+    pub fn update_secret(
+        &self,
+        secret: impl Into<crate::model::Secret>,
+    ) -> crate::builders::UpdateSecret {
         crate::builders::UpdateSecret::new(self.inner.clone()).set_secret(secret.into())
     }
 
     /// Deletes a [Secret][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-    pub fn delete_secret<IntoName>(&self, name: IntoName) -> crate::builders::DeleteSecret
-    where
-        IntoName: Into<String>,
-    {
+    pub fn delete_secret(&self, name: impl Into<String>) -> crate::builders::DeleteSecret {
         crate::builders::DeleteSecret::new(self.inner.clone()).set_name(name.into())
     }
 
@@ -163,13 +148,10 @@ impl SecretManagerService {
     /// call does not return secret data.
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn list_secret_versions<IntoParent>(
+    pub fn list_secret_versions(
         &self,
-        parent: IntoParent,
-    ) -> crate::builders::ListSecretVersions
-    where
-        IntoParent: Into<String>,
-    {
+        parent: impl Into<String>,
+    ) -> crate::builders::ListSecretVersions {
         crate::builders::ListSecretVersions::new(self.inner.clone()).set_parent(parent.into())
     }
 
@@ -180,10 +162,7 @@ impl SecretManagerService {
     /// created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn get_secret_version<IntoName>(&self, name: IntoName) -> crate::builders::GetSecretVersion
-    where
-        IntoName: Into<String>,
-    {
+    pub fn get_secret_version(&self, name: impl Into<String>) -> crate::builders::GetSecretVersion {
         crate::builders::GetSecretVersion::new(self.inner.clone()).set_name(name.into())
     }
 
@@ -194,13 +173,10 @@ impl SecretManagerService {
     /// created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn access_secret_version<IntoName>(
+    pub fn access_secret_version(
         &self,
-        name: IntoName,
-    ) -> crate::builders::AccessSecretVersion
-    where
-        IntoName: Into<String>,
-    {
+        name: impl Into<String>,
+    ) -> crate::builders::AccessSecretVersion {
         crate::builders::AccessSecretVersion::new(self.inner.clone()).set_name(name.into())
     }
 
@@ -213,13 +189,10 @@ impl SecretManagerService {
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
     /// [google.cloud.secretmanager.v1.SecretVersion.State.DISABLED]: crate::model::secret_version::state::DISABLED
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
-    pub fn disable_secret_version<IntoName>(
+    pub fn disable_secret_version(
         &self,
-        name: IntoName,
-    ) -> crate::builders::DisableSecretVersion
-    where
-        IntoName: Into<String>,
-    {
+        name: impl Into<String>,
+    ) -> crate::builders::DisableSecretVersion {
         crate::builders::DisableSecretVersion::new(self.inner.clone()).set_name(name.into())
     }
 
@@ -232,13 +205,10 @@ impl SecretManagerService {
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
     /// [google.cloud.secretmanager.v1.SecretVersion.State.ENABLED]: crate::model::secret_version::state::ENABLED
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
-    pub fn enable_secret_version<IntoName>(
+    pub fn enable_secret_version(
         &self,
-        name: IntoName,
-    ) -> crate::builders::EnableSecretVersion
-    where
-        IntoName: Into<String>,
-    {
+        name: impl Into<String>,
+    ) -> crate::builders::EnableSecretVersion {
         crate::builders::EnableSecretVersion::new(self.inner.clone()).set_name(name.into())
     }
 
@@ -252,13 +222,10 @@ impl SecretManagerService {
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
     /// [google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED]: crate::model::secret_version::state::DESTROYED
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
-    pub fn destroy_secret_version<IntoName>(
+    pub fn destroy_secret_version(
         &self,
-        name: IntoName,
-    ) -> crate::builders::DestroySecretVersion
-    where
-        IntoName: Into<String>,
-    {
+        name: impl Into<String>,
+    ) -> crate::builders::DestroySecretVersion {
         crate::builders::DestroySecretVersion::new(self.inner.clone()).set_name(name.into())
     }
 
@@ -272,25 +239,13 @@ impl SecretManagerService {
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn set_iam_policy<IntoResource>(
-        &self,
-        resource: IntoResource,
-    ) -> crate::builders::SetIamPolicy
-    where
-        IntoResource: Into<String>,
-    {
+    pub fn set_iam_policy(&self, resource: impl Into<String>) -> crate::builders::SetIamPolicy {
         crate::builders::SetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
     }
 
     /// Gets the access control policy for a secret.
     /// Returns empty policy if the secret exists and does not have a policy set.
-    pub fn get_iam_policy<IntoResource>(
-        &self,
-        resource: IntoResource,
-    ) -> crate::builders::GetIamPolicy
-    where
-        IntoResource: Into<String>,
-    {
+    pub fn get_iam_policy(&self, resource: impl Into<String>) -> crate::builders::GetIamPolicy {
         crate::builders::GetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
     }
 
@@ -301,13 +256,10 @@ impl SecretManagerService {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
-    pub fn test_iam_permissions<IntoResource>(
+    pub fn test_iam_permissions(
         &self,
-        resource: IntoResource,
-    ) -> crate::builders::TestIamPermissions
-    where
-        IntoResource: Into<String>,
-    {
+        resource: impl Into<String>,
+    ) -> crate::builders::TestIamPermissions {
         crate::builders::TestIamPermissions::new(self.inner.clone()).set_resource(resource.into())
     }
 }
@@ -375,18 +327,12 @@ impl Locations {
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations<IntoName>(&self, name: IntoName) -> crate::builders::ListLocations
-    where
-        IntoName: Into<String>,
-    {
+    pub fn list_locations(&self, name: impl Into<String>) -> crate::builders::ListLocations {
         crate::builders::ListLocations::new(self.inner.clone()).set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location<IntoName>(&self, name: IntoName) -> crate::builders::GetLocation
-    where
-        IntoName: Into<String>,
-    {
+    pub fn get_location(&self, name: impl Into<String>) -> crate::builders::GetLocation {
         crate::builders::GetLocation::new(self.inner.clone()).set_name(name.into())
     }
 }

--- a/src/generated/iam/v1/src/client.rs
+++ b/src/generated/iam/v1/src/client.rs
@@ -108,25 +108,13 @@ impl IAMPolicy {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy<IntoResource>(
-        &self,
-        resource: IntoResource,
-    ) -> crate::builders::SetIamPolicy
-    where
-        IntoResource: Into<String>,
-    {
+    pub fn set_iam_policy(&self, resource: impl Into<String>) -> crate::builders::SetIamPolicy {
         crate::builders::SetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy<IntoResource>(
-        &self,
-        resource: IntoResource,
-    ) -> crate::builders::GetIamPolicy
-    where
-        IntoResource: Into<String>,
-    {
+    pub fn get_iam_policy(&self, resource: impl Into<String>) -> crate::builders::GetIamPolicy {
         crate::builders::GetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
     }
 
@@ -137,13 +125,10 @@ impl IAMPolicy {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions<IntoResource>(
+    pub fn test_iam_permissions(
         &self,
-        resource: IntoResource,
-    ) -> crate::builders::TestIamPermissions
-    where
-        IntoResource: Into<String>,
-    {
+        resource: impl Into<String>,
+    ) -> crate::builders::TestIamPermissions {
         crate::builders::TestIamPermissions::new(self.inner.clone()).set_resource(resource.into())
     }
 }

--- a/src/generated/iam/v1/src/client.rs
+++ b/src/generated/iam/v1/src/client.rs
@@ -108,14 +108,26 @@ impl IAMPolicy {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(&self) -> crate::builders::SetIamPolicy {
-        crate::builders::SetIamPolicy::new(self.inner.clone())
+    pub fn set_iam_policy<IntoResource>(
+        &self,
+        resource: IntoResource,
+    ) -> crate::builders::SetIamPolicy
+    where
+        IntoResource: Into<String>,
+    {
+        crate::builders::SetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(&self) -> crate::builders::GetIamPolicy {
-        crate::builders::GetIamPolicy::new(self.inner.clone())
+    pub fn get_iam_policy<IntoResource>(
+        &self,
+        resource: IntoResource,
+    ) -> crate::builders::GetIamPolicy
+    where
+        IntoResource: Into<String>,
+    {
+        crate::builders::GetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -125,7 +137,13 @@ impl IAMPolicy {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(&self) -> crate::builders::TestIamPermissions {
-        crate::builders::TestIamPermissions::new(self.inner.clone())
+    pub fn test_iam_permissions<IntoResource>(
+        &self,
+        resource: IntoResource,
+    ) -> crate::builders::TestIamPermissions
+    where
+        IntoResource: Into<String>,
+    {
+        crate::builders::TestIamPermissions::new(self.inner.clone()).set_resource(resource.into())
     }
 }

--- a/src/generated/longrunning/src/client.rs
+++ b/src/generated/longrunning/src/client.rs
@@ -91,20 +91,14 @@ impl Operations {
 
     /// Lists operations that match the specified filter in the request. If the
     /// server doesn't support this method, it returns `UNIMPLEMENTED`.
-    pub fn list_operations<IntoName>(&self, name: IntoName) -> crate::builders::ListOperations
-    where
-        IntoName: Into<String>,
-    {
+    pub fn list_operations(&self, name: impl Into<String>) -> crate::builders::ListOperations {
         crate::builders::ListOperations::new(self.inner.clone()).set_name(name.into())
     }
 
     /// Gets the latest state of a long-running operation.  Clients can use this
     /// method to poll the operation result at intervals as recommended by the API
     /// service.
-    pub fn get_operation<IntoName>(&self, name: IntoName) -> crate::builders::GetOperation
-    where
-        IntoName: Into<String>,
-    {
+    pub fn get_operation(&self, name: impl Into<String>) -> crate::builders::GetOperation {
         crate::builders::GetOperation::new(self.inner.clone()).set_name(name.into())
     }
 
@@ -112,10 +106,7 @@ impl Operations {
     /// no longer interested in the operation result. It does not cancel the
     /// operation. If the server doesn't support this method, it returns
     /// `google.rpc.Code.UNIMPLEMENTED`.
-    pub fn delete_operation<IntoName>(&self, name: IntoName) -> crate::builders::DeleteOperation
-    where
-        IntoName: Into<String>,
-    {
+    pub fn delete_operation(&self, name: impl Into<String>) -> crate::builders::DeleteOperation {
         crate::builders::DeleteOperation::new(self.inner.clone()).set_name(name.into())
     }
 
@@ -134,10 +125,7 @@ impl Operations {
     /// [google.longrunning.Operation.error]: crate::model::Operation::result
     /// [google.longrunning.Operations.GetOperation]: crate::traits::Operations::get_operation
     /// [google.rpc.Status.code]: rpc::model::Status::code
-    pub fn cancel_operation<IntoName>(&self, name: IntoName) -> crate::builders::CancelOperation
-    where
-        IntoName: Into<String>,
-    {
+    pub fn cancel_operation(&self, name: impl Into<String>) -> crate::builders::CancelOperation {
         crate::builders::CancelOperation::new(self.inner.clone()).set_name(name.into())
     }
 }

--- a/src/generated/longrunning/src/client.rs
+++ b/src/generated/longrunning/src/client.rs
@@ -91,23 +91,32 @@ impl Operations {
 
     /// Lists operations that match the specified filter in the request. If the
     /// server doesn't support this method, it returns `UNIMPLEMENTED`.
-    pub fn list_operations(&self) -> crate::builders::ListOperations {
-        crate::builders::ListOperations::new(self.inner.clone())
+    pub fn list_operations<IntoName>(&self, name: IntoName) -> crate::builders::ListOperations
+    where
+        IntoName: Into<String>,
+    {
+        crate::builders::ListOperations::new(self.inner.clone()).set_name(name.into())
     }
 
     /// Gets the latest state of a long-running operation.  Clients can use this
     /// method to poll the operation result at intervals as recommended by the API
     /// service.
-    pub fn get_operation(&self) -> crate::builders::GetOperation {
-        crate::builders::GetOperation::new(self.inner.clone())
+    pub fn get_operation<IntoName>(&self, name: IntoName) -> crate::builders::GetOperation
+    where
+        IntoName: Into<String>,
+    {
+        crate::builders::GetOperation::new(self.inner.clone()).set_name(name.into())
     }
 
     /// Deletes a long-running operation. This method indicates that the client is
     /// no longer interested in the operation result. It does not cancel the
     /// operation. If the server doesn't support this method, it returns
     /// `google.rpc.Code.UNIMPLEMENTED`.
-    pub fn delete_operation(&self) -> crate::builders::DeleteOperation {
-        crate::builders::DeleteOperation::new(self.inner.clone())
+    pub fn delete_operation<IntoName>(&self, name: IntoName) -> crate::builders::DeleteOperation
+    where
+        IntoName: Into<String>,
+    {
+        crate::builders::DeleteOperation::new(self.inner.clone()).set_name(name.into())
     }
 
     /// Starts asynchronous cancellation on a long-running operation.  The server
@@ -125,7 +134,10 @@ impl Operations {
     /// [google.longrunning.Operation.error]: crate::model::Operation::result
     /// [google.longrunning.Operations.GetOperation]: crate::traits::Operations::get_operation
     /// [google.rpc.Status.code]: rpc::model::Status::code
-    pub fn cancel_operation(&self) -> crate::builders::CancelOperation {
-        crate::builders::CancelOperation::new(self.inner.clone())
+    pub fn cancel_operation<IntoName>(&self, name: IntoName) -> crate::builders::CancelOperation
+    where
+        IntoName: Into<String>,
+    {
+        crate::builders::CancelOperation::new(self.inner.clone()).set_name(name.into())
     }
 }

--- a/src/generated/openapi-validation/src/client.rs
+++ b/src/generated/openapi-validation/src/client.rs
@@ -83,72 +83,48 @@ impl SecretManagerService {
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations<IntoProject>(
-        &self,
-        project: IntoProject,
-    ) -> crate::builders::ListLocations
-    where
-        IntoProject: Into<String>,
-    {
+    pub fn list_locations(&self, project: impl Into<String>) -> crate::builders::ListLocations {
         crate::builders::ListLocations::new(self.inner.clone()).set_project(project.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location<IntoProject, IntoLocation>(
+    pub fn get_location(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-    ) -> crate::builders::GetLocation
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-    {
+        project: impl Into<String>,
+        location: impl Into<String>,
+    ) -> crate::builders::GetLocation {
         crate::builders::GetLocation::new(self.inner.clone())
             .set_project(project.into())
             .set_location(location.into())
     }
 
     /// Lists Secrets.
-    pub fn list_secrets<IntoProject>(&self, project: IntoProject) -> crate::builders::ListSecrets
-    where
-        IntoProject: Into<String>,
-    {
+    pub fn list_secrets(&self, project: impl Into<String>) -> crate::builders::ListSecrets {
         crate::builders::ListSecrets::new(self.inner.clone()).set_project(project.into())
     }
 
     /// Creates a new Secret containing no SecretVersions.
-    pub fn create_secret<IntoProject>(&self, project: IntoProject) -> crate::builders::CreateSecret
-    where
-        IntoProject: Into<String>,
-    {
+    pub fn create_secret(&self, project: impl Into<String>) -> crate::builders::CreateSecret {
         crate::builders::CreateSecret::new(self.inner.clone()).set_project(project.into())
     }
 
     /// Lists Secrets.
-    pub fn list_secrets_by_project_and_location<IntoProject, IntoLocation>(
+    pub fn list_secrets_by_project_and_location(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-    ) -> crate::builders::ListSecretsByProjectAndLocation
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-    {
+        project: impl Into<String>,
+        location: impl Into<String>,
+    ) -> crate::builders::ListSecretsByProjectAndLocation {
         crate::builders::ListSecretsByProjectAndLocation::new(self.inner.clone())
             .set_project(project.into())
             .set_location(location.into())
     }
 
     /// Creates a new Secret containing no SecretVersions.
-    pub fn create_secret_by_project_and_location<IntoProject, IntoLocation>(
+    pub fn create_secret_by_project_and_location(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-    ) -> crate::builders::CreateSecretByProjectAndLocation
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-    {
+        project: impl Into<String>,
+        location: impl Into<String>,
+    ) -> crate::builders::CreateSecretByProjectAndLocation {
         crate::builders::CreateSecretByProjectAndLocation::new(self.inner.clone())
             .set_project(project.into())
             .set_location(location.into())
@@ -156,15 +132,11 @@ impl SecretManagerService {
 
     /// Creates a new SecretVersion containing secret data and attaches
     /// it to an existing Secret.
-    pub fn add_secret_version<IntoProject, IntoSecret>(
+    pub fn add_secret_version(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
-    ) -> crate::builders::AddSecretVersion
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
-    {
+        project: impl Into<String>,
+        secret: impl Into<String>,
+    ) -> crate::builders::AddSecretVersion {
         crate::builders::AddSecretVersion::new(self.inner.clone())
             .set_project(project.into())
             .set_secret(secret.into())
@@ -172,21 +144,12 @@ impl SecretManagerService {
 
     /// Creates a new SecretVersion containing secret data and attaches
     /// it to an existing Secret.
-    pub fn add_secret_version_by_project_and_location_and_secret<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-    >(
+    pub fn add_secret_version_by_project_and_location_and_secret(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
-    ) -> crate::builders::AddSecretVersionByProjectAndLocationAndSecret
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
-    {
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
+    ) -> crate::builders::AddSecretVersionByProjectAndLocationAndSecret {
         crate::builders::AddSecretVersionByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project(project.into())
             .set_location(location.into())
@@ -194,62 +157,45 @@ impl SecretManagerService {
     }
 
     /// Gets metadata for a given Secret.
-    pub fn get_secret<IntoProject, IntoSecret>(
+    pub fn get_secret(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
-    ) -> crate::builders::GetSecret
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
-    {
+        project: impl Into<String>,
+        secret: impl Into<String>,
+    ) -> crate::builders::GetSecret {
         crate::builders::GetSecret::new(self.inner.clone())
             .set_project(project.into())
             .set_secret(secret.into())
     }
 
     /// Deletes a Secret.
-    pub fn delete_secret<IntoProject, IntoSecret>(
+    pub fn delete_secret(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
-    ) -> crate::builders::DeleteSecret
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
-    {
+        project: impl Into<String>,
+        secret: impl Into<String>,
+    ) -> crate::builders::DeleteSecret {
         crate::builders::DeleteSecret::new(self.inner.clone())
             .set_project(project.into())
             .set_secret(secret.into())
     }
 
     /// Updates metadata of an existing Secret.
-    pub fn update_secret<IntoProject, IntoSecret>(
+    pub fn update_secret(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
-    ) -> crate::builders::UpdateSecret
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
-    {
+        project: impl Into<String>,
+        secret: impl Into<String>,
+    ) -> crate::builders::UpdateSecret {
         crate::builders::UpdateSecret::new(self.inner.clone())
             .set_project(project.into())
             .set_secret(secret.into())
     }
 
     /// Gets metadata for a given Secret.
-    pub fn get_secret_by_project_and_location_and_secret<IntoProject, IntoLocation, IntoSecret>(
+    pub fn get_secret_by_project_and_location_and_secret(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
-    ) -> crate::builders::GetSecretByProjectAndLocationAndSecret
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
-    {
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
+    ) -> crate::builders::GetSecretByProjectAndLocationAndSecret {
         crate::builders::GetSecretByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project(project.into())
             .set_location(location.into())
@@ -257,17 +203,12 @@ impl SecretManagerService {
     }
 
     /// Deletes a Secret.
-    pub fn delete_secret_by_project_and_location_and_secret<IntoProject, IntoLocation, IntoSecret>(
+    pub fn delete_secret_by_project_and_location_and_secret(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
-    ) -> crate::builders::DeleteSecretByProjectAndLocationAndSecret
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
-    {
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
+    ) -> crate::builders::DeleteSecretByProjectAndLocationAndSecret {
         crate::builders::DeleteSecretByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project(project.into())
             .set_location(location.into())
@@ -275,17 +216,12 @@ impl SecretManagerService {
     }
 
     /// Updates metadata of an existing Secret.
-    pub fn update_secret_by_project_and_location_and_secret<IntoProject, IntoLocation, IntoSecret>(
+    pub fn update_secret_by_project_and_location_and_secret(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
-    ) -> crate::builders::UpdateSecretByProjectAndLocationAndSecret
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
-    {
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
+    ) -> crate::builders::UpdateSecretByProjectAndLocationAndSecret {
         crate::builders::UpdateSecretByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project(project.into())
             .set_location(location.into())
@@ -294,15 +230,11 @@ impl SecretManagerService {
 
     /// Lists SecretVersions. This call does not return secret
     /// data.
-    pub fn list_secret_versions<IntoProject, IntoSecret>(
+    pub fn list_secret_versions(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
-    ) -> crate::builders::ListSecretVersions
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
-    {
+        project: impl Into<String>,
+        secret: impl Into<String>,
+    ) -> crate::builders::ListSecretVersions {
         crate::builders::ListSecretVersions::new(self.inner.clone())
             .set_project(project.into())
             .set_secret(secret.into())
@@ -310,21 +242,12 @@ impl SecretManagerService {
 
     /// Lists SecretVersions. This call does not return secret
     /// data.
-    pub fn list_secret_versions_by_project_and_location_and_secret<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-    >(
+    pub fn list_secret_versions_by_project_and_location_and_secret(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
-    ) -> crate::builders::ListSecretVersionsByProjectAndLocationAndSecret
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
-    {
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
+    ) -> crate::builders::ListSecretVersionsByProjectAndLocationAndSecret {
         crate::builders::ListSecretVersionsByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project(project.into())
             .set_location(location.into())
@@ -335,17 +258,12 @@ impl SecretManagerService {
     ///
     /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
     /// created SecretVersion.
-    pub fn get_secret_version<IntoProject, IntoSecret, IntoVersion>(
+    pub fn get_secret_version(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
-        version: IntoVersion,
-    ) -> crate::builders::GetSecretVersion
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
-        IntoVersion: Into<String>,
-    {
+        project: impl Into<String>,
+        secret: impl Into<String>,
+        version: impl Into<String>,
+    ) -> crate::builders::GetSecretVersion {
         crate::builders::GetSecretVersion::new(self.inner.clone())
             .set_project(project.into())
             .set_secret(secret.into())
@@ -356,24 +274,13 @@ impl SecretManagerService {
     ///
     /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
     /// created SecretVersion.
-    pub fn get_secret_version_by_project_and_location_and_secret_and_version<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-        IntoVersion,
-    >(
+    pub fn get_secret_version_by_project_and_location_and_secret_and_version(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
-        version: IntoVersion,
-    ) -> crate::builders::GetSecretVersionByProjectAndLocationAndSecretAndVersion
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
-        IntoVersion: Into<String>,
-    {
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
+        version: impl Into<String>,
+    ) -> crate::builders::GetSecretVersionByProjectAndLocationAndSecretAndVersion {
         crate::builders::GetSecretVersionByProjectAndLocationAndSecretAndVersion::new(
             self.inner.clone(),
         )
@@ -387,17 +294,12 @@ impl SecretManagerService {
     ///
     /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
     /// created SecretVersion.
-    pub fn access_secret_version<IntoProject, IntoSecret, IntoVersion>(
+    pub fn access_secret_version(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
-        version: IntoVersion,
-    ) -> crate::builders::AccessSecretVersion
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
-        IntoVersion: Into<String>,
-    {
+        project: impl Into<String>,
+        secret: impl Into<String>,
+        version: impl Into<String>,
+    ) -> crate::builders::AccessSecretVersion {
         crate::builders::AccessSecretVersion::new(self.inner.clone())
             .set_project(project.into())
             .set_secret(secret.into())
@@ -408,24 +310,13 @@ impl SecretManagerService {
     ///
     /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
     /// created SecretVersion.
-    pub fn access_secret_version_by_project_and_location_and_secret_and_version<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-        IntoVersion,
-    >(
+    pub fn access_secret_version_by_project_and_location_and_secret_and_version(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
-        version: IntoVersion,
-    ) -> crate::builders::AccessSecretVersionByProjectAndLocationAndSecretAndVersion
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
-        IntoVersion: Into<String>,
-    {
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
+        version: impl Into<String>,
+    ) -> crate::builders::AccessSecretVersionByProjectAndLocationAndSecretAndVersion {
         crate::builders::AccessSecretVersionByProjectAndLocationAndSecretAndVersion::new(
             self.inner.clone(),
         )
@@ -439,17 +330,12 @@ impl SecretManagerService {
     ///
     /// Sets the state of the SecretVersion to
     /// DISABLED.
-    pub fn disable_secret_version<IntoProject, IntoSecret, IntoVersion>(
+    pub fn disable_secret_version(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
-        version: IntoVersion,
-    ) -> crate::builders::DisableSecretVersion
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
-        IntoVersion: Into<String>,
-    {
+        project: impl Into<String>,
+        secret: impl Into<String>,
+        version: impl Into<String>,
+    ) -> crate::builders::DisableSecretVersion {
         crate::builders::DisableSecretVersion::new(self.inner.clone())
             .set_project(project.into())
             .set_secret(secret.into())
@@ -460,24 +346,13 @@ impl SecretManagerService {
     ///
     /// Sets the state of the SecretVersion to
     /// DISABLED.
-    pub fn disable_secret_version_by_project_and_location_and_secret_and_version<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-        IntoVersion,
-    >(
+    pub fn disable_secret_version_by_project_and_location_and_secret_and_version(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
-        version: IntoVersion,
-    ) -> crate::builders::DisableSecretVersionByProjectAndLocationAndSecretAndVersion
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
-        IntoVersion: Into<String>,
-    {
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
+        version: impl Into<String>,
+    ) -> crate::builders::DisableSecretVersionByProjectAndLocationAndSecretAndVersion {
         crate::builders::DisableSecretVersionByProjectAndLocationAndSecretAndVersion::new(
             self.inner.clone(),
         )
@@ -491,17 +366,12 @@ impl SecretManagerService {
     ///
     /// Sets the state of the SecretVersion to
     /// ENABLED.
-    pub fn enable_secret_version<IntoProject, IntoSecret, IntoVersion>(
+    pub fn enable_secret_version(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
-        version: IntoVersion,
-    ) -> crate::builders::EnableSecretVersion
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
-        IntoVersion: Into<String>,
-    {
+        project: impl Into<String>,
+        secret: impl Into<String>,
+        version: impl Into<String>,
+    ) -> crate::builders::EnableSecretVersion {
         crate::builders::EnableSecretVersion::new(self.inner.clone())
             .set_project(project.into())
             .set_secret(secret.into())
@@ -512,24 +382,13 @@ impl SecretManagerService {
     ///
     /// Sets the state of the SecretVersion to
     /// ENABLED.
-    pub fn enable_secret_version_by_project_and_location_and_secret_and_version<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-        IntoVersion,
-    >(
+    pub fn enable_secret_version_by_project_and_location_and_secret_and_version(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
-        version: IntoVersion,
-    ) -> crate::builders::EnableSecretVersionByProjectAndLocationAndSecretAndVersion
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
-        IntoVersion: Into<String>,
-    {
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
+        version: impl Into<String>,
+    ) -> crate::builders::EnableSecretVersionByProjectAndLocationAndSecretAndVersion {
         crate::builders::EnableSecretVersionByProjectAndLocationAndSecretAndVersion::new(
             self.inner.clone(),
         )
@@ -544,17 +403,12 @@ impl SecretManagerService {
     /// Sets the state of the SecretVersion to
     /// DESTROYED and irrevocably destroys the
     /// secret data.
-    pub fn destroy_secret_version<IntoProject, IntoSecret, IntoVersion>(
+    pub fn destroy_secret_version(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
-        version: IntoVersion,
-    ) -> crate::builders::DestroySecretVersion
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
-        IntoVersion: Into<String>,
-    {
+        project: impl Into<String>,
+        secret: impl Into<String>,
+        version: impl Into<String>,
+    ) -> crate::builders::DestroySecretVersion {
         crate::builders::DestroySecretVersion::new(self.inner.clone())
             .set_project(project.into())
             .set_secret(secret.into())
@@ -566,24 +420,13 @@ impl SecretManagerService {
     /// Sets the state of the SecretVersion to
     /// DESTROYED and irrevocably destroys the
     /// secret data.
-    pub fn destroy_secret_version_by_project_and_location_and_secret_and_version<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-        IntoVersion,
-    >(
+    pub fn destroy_secret_version_by_project_and_location_and_secret_and_version(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
-        version: IntoVersion,
-    ) -> crate::builders::DestroySecretVersionByProjectAndLocationAndSecretAndVersion
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
-        IntoVersion: Into<String>,
-    {
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
+        version: impl Into<String>,
+    ) -> crate::builders::DestroySecretVersionByProjectAndLocationAndSecretAndVersion {
         crate::builders::DestroySecretVersionByProjectAndLocationAndSecretAndVersion::new(
             self.inner.clone(),
         )
@@ -598,15 +441,11 @@ impl SecretManagerService {
     ///
     /// Permissions on SecretVersions are enforced according
     /// to the policy set on the associated Secret.
-    pub fn set_iam_policy<IntoProject, IntoSecret>(
+    pub fn set_iam_policy(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
-    ) -> crate::builders::SetIamPolicy
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
-    {
+        project: impl Into<String>,
+        secret: impl Into<String>,
+    ) -> crate::builders::SetIamPolicy {
         crate::builders::SetIamPolicy::new(self.inner.clone())
             .set_project(project.into())
             .set_secret(secret.into())
@@ -617,21 +456,12 @@ impl SecretManagerService {
     ///
     /// Permissions on SecretVersions are enforced according
     /// to the policy set on the associated Secret.
-    pub fn set_iam_policy_by_project_and_location_and_secret<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-    >(
+    pub fn set_iam_policy_by_project_and_location_and_secret(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
-    ) -> crate::builders::SetIamPolicyByProjectAndLocationAndSecret
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
-    {
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
+    ) -> crate::builders::SetIamPolicyByProjectAndLocationAndSecret {
         crate::builders::SetIamPolicyByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project(project.into())
             .set_location(location.into())
@@ -640,15 +470,11 @@ impl SecretManagerService {
 
     /// Gets the access control policy for a secret.
     /// Returns empty policy if the secret exists and does not have a policy set.
-    pub fn get_iam_policy<IntoProject, IntoSecret>(
+    pub fn get_iam_policy(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
-    ) -> crate::builders::GetIamPolicy
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
-    {
+        project: impl Into<String>,
+        secret: impl Into<String>,
+    ) -> crate::builders::GetIamPolicy {
         crate::builders::GetIamPolicy::new(self.inner.clone())
             .set_project(project.into())
             .set_secret(secret.into())
@@ -656,21 +482,12 @@ impl SecretManagerService {
 
     /// Gets the access control policy for a secret.
     /// Returns empty policy if the secret exists and does not have a policy set.
-    pub fn get_iam_policy_by_project_and_location_and_secret<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-    >(
+    pub fn get_iam_policy_by_project_and_location_and_secret(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
-    ) -> crate::builders::GetIamPolicyByProjectAndLocationAndSecret
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
-    {
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
+    ) -> crate::builders::GetIamPolicyByProjectAndLocationAndSecret {
         crate::builders::GetIamPolicyByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project(project.into())
             .set_location(location.into())
@@ -684,15 +501,11 @@ impl SecretManagerService {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
-    pub fn test_iam_permissions<IntoProject, IntoSecret>(
+    pub fn test_iam_permissions(
         &self,
-        project: IntoProject,
-        secret: IntoSecret,
-    ) -> crate::builders::TestIamPermissions
-    where
-        IntoProject: Into<String>,
-        IntoSecret: Into<String>,
-    {
+        project: impl Into<String>,
+        secret: impl Into<String>,
+    ) -> crate::builders::TestIamPermissions {
         crate::builders::TestIamPermissions::new(self.inner.clone())
             .set_project(project.into())
             .set_secret(secret.into())
@@ -705,21 +518,12 @@ impl SecretManagerService {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
-    pub fn test_iam_permissions_by_project_and_location_and_secret<
-        IntoProject,
-        IntoLocation,
-        IntoSecret,
-    >(
+    pub fn test_iam_permissions_by_project_and_location_and_secret(
         &self,
-        project: IntoProject,
-        location: IntoLocation,
-        secret: IntoSecret,
-    ) -> crate::builders::TestIamPermissionsByProjectAndLocationAndSecret
-    where
-        IntoProject: Into<String>,
-        IntoLocation: Into<String>,
-        IntoSecret: Into<String>,
-    {
+        project: impl Into<String>,
+        location: impl Into<String>,
+        secret: impl Into<String>,
+    ) -> crate::builders::TestIamPermissionsByProjectAndLocationAndSecret {
         crate::builders::TestIamPermissionsByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project(project.into())
             .set_location(location.into())

--- a/src/generated/openapi-validation/src/client.rs
+++ b/src/generated/openapi-validation/src/client.rs
@@ -83,181 +83,460 @@ impl SecretManagerService {
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(&self) -> crate::builders::ListLocations {
-        crate::builders::ListLocations::new(self.inner.clone())
+    pub fn list_locations<IntoProject>(
+        &self,
+        project: IntoProject,
+    ) -> crate::builders::ListLocations
+    where
+        IntoProject: Into<String>,
+    {
+        crate::builders::ListLocations::new(self.inner.clone()).set_project(project.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(&self) -> crate::builders::GetLocation {
+    pub fn get_location<IntoProject, IntoLocation>(
+        &self,
+        project: IntoProject,
+        location: IntoLocation,
+    ) -> crate::builders::GetLocation
+    where
+        IntoProject: Into<String>,
+        IntoLocation: Into<String>,
+    {
         crate::builders::GetLocation::new(self.inner.clone())
+            .set_project(project.into())
+            .set_location(location.into())
     }
 
     /// Lists Secrets.
-    pub fn list_secrets(&self) -> crate::builders::ListSecrets {
-        crate::builders::ListSecrets::new(self.inner.clone())
+    pub fn list_secrets<IntoProject>(&self, project: IntoProject) -> crate::builders::ListSecrets
+    where
+        IntoProject: Into<String>,
+    {
+        crate::builders::ListSecrets::new(self.inner.clone()).set_project(project.into())
     }
 
     /// Creates a new Secret containing no SecretVersions.
-    pub fn create_secret(&self) -> crate::builders::CreateSecret {
-        crate::builders::CreateSecret::new(self.inner.clone())
+    pub fn create_secret<IntoProject>(&self, project: IntoProject) -> crate::builders::CreateSecret
+    where
+        IntoProject: Into<String>,
+    {
+        crate::builders::CreateSecret::new(self.inner.clone()).set_project(project.into())
     }
 
     /// Lists Secrets.
-    pub fn list_secrets_by_project_and_location(
+    pub fn list_secrets_by_project_and_location<IntoProject, IntoLocation>(
         &self,
-    ) -> crate::builders::ListSecretsByProjectAndLocation {
+        project: IntoProject,
+        location: IntoLocation,
+    ) -> crate::builders::ListSecretsByProjectAndLocation
+    where
+        IntoProject: Into<String>,
+        IntoLocation: Into<String>,
+    {
         crate::builders::ListSecretsByProjectAndLocation::new(self.inner.clone())
+            .set_project(project.into())
+            .set_location(location.into())
     }
 
     /// Creates a new Secret containing no SecretVersions.
-    pub fn create_secret_by_project_and_location(
+    pub fn create_secret_by_project_and_location<IntoProject, IntoLocation>(
         &self,
-    ) -> crate::builders::CreateSecretByProjectAndLocation {
+        project: IntoProject,
+        location: IntoLocation,
+    ) -> crate::builders::CreateSecretByProjectAndLocation
+    where
+        IntoProject: Into<String>,
+        IntoLocation: Into<String>,
+    {
         crate::builders::CreateSecretByProjectAndLocation::new(self.inner.clone())
+            .set_project(project.into())
+            .set_location(location.into())
     }
 
     /// Creates a new SecretVersion containing secret data and attaches
     /// it to an existing Secret.
-    pub fn add_secret_version(&self) -> crate::builders::AddSecretVersion {
+    pub fn add_secret_version<IntoProject, IntoSecret>(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+    ) -> crate::builders::AddSecretVersion
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::AddSecretVersion::new(self.inner.clone())
+            .set_project(project.into())
+            .set_secret(secret.into())
     }
 
     /// Creates a new SecretVersion containing secret data and attaches
     /// it to an existing Secret.
-    pub fn add_secret_version_by_project_and_location_and_secret(
+    pub fn add_secret_version_by_project_and_location_and_secret<
+        IntoProject,
+        IntoSecret,
+        IntoLocation,
+    >(
         &self,
-    ) -> crate::builders::AddSecretVersionByProjectAndLocationAndSecret {
+        project: IntoProject,
+        secret: IntoSecret,
+        location: IntoLocation,
+    ) -> crate::builders::AddSecretVersionByProjectAndLocationAndSecret
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoLocation: Into<String>,
+    {
         crate::builders::AddSecretVersionByProjectAndLocationAndSecret::new(self.inner.clone())
+            .set_project(project.into())
+            .set_secret(secret.into())
+            .set_location(location.into())
     }
 
     /// Gets metadata for a given Secret.
-    pub fn get_secret(&self) -> crate::builders::GetSecret {
+    pub fn get_secret<IntoProject, IntoSecret>(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+    ) -> crate::builders::GetSecret
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::GetSecret::new(self.inner.clone())
+            .set_project(project.into())
+            .set_secret(secret.into())
     }
 
     /// Deletes a Secret.
-    pub fn delete_secret(&self) -> crate::builders::DeleteSecret {
+    pub fn delete_secret<IntoProject, IntoSecret>(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+    ) -> crate::builders::DeleteSecret
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::DeleteSecret::new(self.inner.clone())
+            .set_project(project.into())
+            .set_secret(secret.into())
     }
 
     /// Updates metadata of an existing Secret.
-    pub fn update_secret(&self) -> crate::builders::UpdateSecret {
+    pub fn update_secret<IntoProject, IntoSecret>(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+    ) -> crate::builders::UpdateSecret
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::UpdateSecret::new(self.inner.clone())
+            .set_project(project.into())
+            .set_secret(secret.into())
     }
 
     /// Gets metadata for a given Secret.
-    pub fn get_secret_by_project_and_location_and_secret(
+    pub fn get_secret_by_project_and_location_and_secret<IntoProject, IntoLocation, IntoSecret>(
         &self,
-    ) -> crate::builders::GetSecretByProjectAndLocationAndSecret {
+        project: IntoProject,
+        location: IntoLocation,
+        secret: IntoSecret,
+    ) -> crate::builders::GetSecretByProjectAndLocationAndSecret
+    where
+        IntoProject: Into<String>,
+        IntoLocation: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::GetSecretByProjectAndLocationAndSecret::new(self.inner.clone())
+            .set_project(project.into())
+            .set_location(location.into())
+            .set_secret(secret.into())
     }
 
     /// Deletes a Secret.
-    pub fn delete_secret_by_project_and_location_and_secret(
+    pub fn delete_secret_by_project_and_location_and_secret<IntoProject, IntoLocation, IntoSecret>(
         &self,
-    ) -> crate::builders::DeleteSecretByProjectAndLocationAndSecret {
+        project: IntoProject,
+        location: IntoLocation,
+        secret: IntoSecret,
+    ) -> crate::builders::DeleteSecretByProjectAndLocationAndSecret
+    where
+        IntoProject: Into<String>,
+        IntoLocation: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::DeleteSecretByProjectAndLocationAndSecret::new(self.inner.clone())
+            .set_project(project.into())
+            .set_location(location.into())
+            .set_secret(secret.into())
     }
 
     /// Updates metadata of an existing Secret.
-    pub fn update_secret_by_project_and_location_and_secret(
+    pub fn update_secret_by_project_and_location_and_secret<IntoProject, IntoLocation, IntoSecret>(
         &self,
-    ) -> crate::builders::UpdateSecretByProjectAndLocationAndSecret {
+        project: IntoProject,
+        location: IntoLocation,
+        secret: IntoSecret,
+    ) -> crate::builders::UpdateSecretByProjectAndLocationAndSecret
+    where
+        IntoProject: Into<String>,
+        IntoLocation: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::UpdateSecretByProjectAndLocationAndSecret::new(self.inner.clone())
+            .set_project(project.into())
+            .set_location(location.into())
+            .set_secret(secret.into())
     }
 
     /// Lists SecretVersions. This call does not return secret
     /// data.
-    pub fn list_secret_versions(&self) -> crate::builders::ListSecretVersions {
+    pub fn list_secret_versions<IntoProject, IntoSecret>(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+    ) -> crate::builders::ListSecretVersions
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::ListSecretVersions::new(self.inner.clone())
+            .set_project(project.into())
+            .set_secret(secret.into())
     }
 
     /// Lists SecretVersions. This call does not return secret
     /// data.
-    pub fn list_secret_versions_by_project_and_location_and_secret(
+    pub fn list_secret_versions_by_project_and_location_and_secret<
+        IntoProject,
+        IntoLocation,
+        IntoSecret,
+    >(
         &self,
-    ) -> crate::builders::ListSecretVersionsByProjectAndLocationAndSecret {
+        project: IntoProject,
+        location: IntoLocation,
+        secret: IntoSecret,
+    ) -> crate::builders::ListSecretVersionsByProjectAndLocationAndSecret
+    where
+        IntoProject: Into<String>,
+        IntoLocation: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::ListSecretVersionsByProjectAndLocationAndSecret::new(self.inner.clone())
+            .set_project(project.into())
+            .set_location(location.into())
+            .set_secret(secret.into())
     }
 
     /// Gets metadata for a SecretVersion.
     ///
     /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
     /// created SecretVersion.
-    pub fn get_secret_version(&self) -> crate::builders::GetSecretVersion {
-        crate::builders::GetSecretVersion::new(self.inner.clone())
-    }
-
-    /// Gets metadata for a SecretVersion.
-    ///
-    /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
-    /// created SecretVersion.
-    pub fn get_secret_version_by_project_and_location_and_secret_and_version(
+    pub fn get_secret_version<IntoProject, IntoSecret, IntoVersion>(
         &self,
-    ) -> crate::builders::GetSecretVersionByProjectAndLocationAndSecretAndVersion {
+        project: IntoProject,
+        secret: IntoSecret,
+        version: IntoVersion,
+    ) -> crate::builders::GetSecretVersion
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoVersion: Into<String>,
+    {
+        crate::builders::GetSecretVersion::new(self.inner.clone())
+            .set_project(project.into())
+            .set_secret(secret.into())
+            .set_version(version.into())
+    }
+
+    /// Gets metadata for a SecretVersion.
+    ///
+    /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
+    /// created SecretVersion.
+    pub fn get_secret_version_by_project_and_location_and_secret_and_version<
+        IntoProject,
+        IntoLocation,
+        IntoSecret,
+        IntoVersion,
+    >(
+        &self,
+        project: IntoProject,
+        location: IntoLocation,
+        secret: IntoSecret,
+        version: IntoVersion,
+    ) -> crate::builders::GetSecretVersionByProjectAndLocationAndSecretAndVersion
+    where
+        IntoProject: Into<String>,
+        IntoLocation: Into<String>,
+        IntoSecret: Into<String>,
+        IntoVersion: Into<String>,
+    {
         crate::builders::GetSecretVersionByProjectAndLocationAndSecretAndVersion::new(
             self.inner.clone(),
         )
+        .set_project(project.into())
+        .set_location(location.into())
+        .set_secret(secret.into())
+        .set_version(version.into())
     }
 
     /// Accesses a SecretVersion. This call returns the secret data.
     ///
     /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
     /// created SecretVersion.
-    pub fn access_secret_version(&self) -> crate::builders::AccessSecretVersion {
-        crate::builders::AccessSecretVersion::new(self.inner.clone())
-    }
-
-    /// Accesses a SecretVersion. This call returns the secret data.
-    ///
-    /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
-    /// created SecretVersion.
-    pub fn access_secret_version_by_project_and_location_and_secret_and_version(
+    pub fn access_secret_version<IntoProject, IntoSecret, IntoVersion>(
         &self,
-    ) -> crate::builders::AccessSecretVersionByProjectAndLocationAndSecretAndVersion {
+        project: IntoProject,
+        secret: IntoSecret,
+        version: IntoVersion,
+    ) -> crate::builders::AccessSecretVersion
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoVersion: Into<String>,
+    {
+        crate::builders::AccessSecretVersion::new(self.inner.clone())
+            .set_project(project.into())
+            .set_secret(secret.into())
+            .set_version(version.into())
+    }
+
+    /// Accesses a SecretVersion. This call returns the secret data.
+    ///
+    /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
+    /// created SecretVersion.
+    pub fn access_secret_version_by_project_and_location_and_secret_and_version<
+        IntoProject,
+        IntoLocation,
+        IntoSecret,
+        IntoVersion,
+    >(
+        &self,
+        project: IntoProject,
+        location: IntoLocation,
+        secret: IntoSecret,
+        version: IntoVersion,
+    ) -> crate::builders::AccessSecretVersionByProjectAndLocationAndSecretAndVersion
+    where
+        IntoProject: Into<String>,
+        IntoLocation: Into<String>,
+        IntoSecret: Into<String>,
+        IntoVersion: Into<String>,
+    {
         crate::builders::AccessSecretVersionByProjectAndLocationAndSecretAndVersion::new(
             self.inner.clone(),
         )
+        .set_project(project.into())
+        .set_location(location.into())
+        .set_secret(secret.into())
+        .set_version(version.into())
     }
 
     /// Disables a SecretVersion.
     ///
     /// Sets the state of the SecretVersion to
     /// DISABLED.
-    pub fn disable_secret_version(&self) -> crate::builders::DisableSecretVersion {
-        crate::builders::DisableSecretVersion::new(self.inner.clone())
-    }
-
-    /// Disables a SecretVersion.
-    ///
-    /// Sets the state of the SecretVersion to
-    /// DISABLED.
-    pub fn disable_secret_version_by_project_and_location_and_secret_and_version(
+    pub fn disable_secret_version<IntoProject, IntoSecret, IntoVersion>(
         &self,
-    ) -> crate::builders::DisableSecretVersionByProjectAndLocationAndSecretAndVersion {
+        project: IntoProject,
+        secret: IntoSecret,
+        version: IntoVersion,
+    ) -> crate::builders::DisableSecretVersion
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoVersion: Into<String>,
+    {
+        crate::builders::DisableSecretVersion::new(self.inner.clone())
+            .set_project(project.into())
+            .set_secret(secret.into())
+            .set_version(version.into())
+    }
+
+    /// Disables a SecretVersion.
+    ///
+    /// Sets the state of the SecretVersion to
+    /// DISABLED.
+    pub fn disable_secret_version_by_project_and_location_and_secret_and_version<
+        IntoProject,
+        IntoSecret,
+        IntoVersion,
+        IntoLocation,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+        version: IntoVersion,
+        location: IntoLocation,
+    ) -> crate::builders::DisableSecretVersionByProjectAndLocationAndSecretAndVersion
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoVersion: Into<String>,
+        IntoLocation: Into<String>,
+    {
         crate::builders::DisableSecretVersionByProjectAndLocationAndSecretAndVersion::new(
             self.inner.clone(),
         )
+        .set_project(project.into())
+        .set_secret(secret.into())
+        .set_version(version.into())
+        .set_location(location.into())
     }
 
     /// Enables a SecretVersion.
     ///
     /// Sets the state of the SecretVersion to
     /// ENABLED.
-    pub fn enable_secret_version(&self) -> crate::builders::EnableSecretVersion {
-        crate::builders::EnableSecretVersion::new(self.inner.clone())
-    }
-
-    /// Enables a SecretVersion.
-    ///
-    /// Sets the state of the SecretVersion to
-    /// ENABLED.
-    pub fn enable_secret_version_by_project_and_location_and_secret_and_version(
+    pub fn enable_secret_version<IntoProject, IntoSecret, IntoVersion>(
         &self,
-    ) -> crate::builders::EnableSecretVersionByProjectAndLocationAndSecretAndVersion {
+        project: IntoProject,
+        secret: IntoSecret,
+        version: IntoVersion,
+    ) -> crate::builders::EnableSecretVersion
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoVersion: Into<String>,
+    {
+        crate::builders::EnableSecretVersion::new(self.inner.clone())
+            .set_project(project.into())
+            .set_secret(secret.into())
+            .set_version(version.into())
+    }
+
+    /// Enables a SecretVersion.
+    ///
+    /// Sets the state of the SecretVersion to
+    /// ENABLED.
+    pub fn enable_secret_version_by_project_and_location_and_secret_and_version<
+        IntoProject,
+        IntoSecret,
+        IntoVersion,
+        IntoLocation,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+        version: IntoVersion,
+        location: IntoLocation,
+    ) -> crate::builders::EnableSecretVersionByProjectAndLocationAndSecretAndVersion
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoVersion: Into<String>,
+        IntoLocation: Into<String>,
+    {
         crate::builders::EnableSecretVersionByProjectAndLocationAndSecretAndVersion::new(
             self.inner.clone(),
         )
+        .set_project(project.into())
+        .set_secret(secret.into())
+        .set_version(version.into())
+        .set_location(location.into())
     }
 
     /// Destroys a SecretVersion.
@@ -265,21 +544,53 @@ impl SecretManagerService {
     /// Sets the state of the SecretVersion to
     /// DESTROYED and irrevocably destroys the
     /// secret data.
-    pub fn destroy_secret_version(&self) -> crate::builders::DestroySecretVersion {
-        crate::builders::DestroySecretVersion::new(self.inner.clone())
-    }
-
-    /// Destroys a SecretVersion.
-    ///
-    /// Sets the state of the SecretVersion to
-    /// DESTROYED and irrevocably destroys the
-    /// secret data.
-    pub fn destroy_secret_version_by_project_and_location_and_secret_and_version(
+    pub fn destroy_secret_version<IntoProject, IntoSecret, IntoVersion>(
         &self,
-    ) -> crate::builders::DestroySecretVersionByProjectAndLocationAndSecretAndVersion {
+        project: IntoProject,
+        secret: IntoSecret,
+        version: IntoVersion,
+    ) -> crate::builders::DestroySecretVersion
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoVersion: Into<String>,
+    {
+        crate::builders::DestroySecretVersion::new(self.inner.clone())
+            .set_project(project.into())
+            .set_secret(secret.into())
+            .set_version(version.into())
+    }
+
+    /// Destroys a SecretVersion.
+    ///
+    /// Sets the state of the SecretVersion to
+    /// DESTROYED and irrevocably destroys the
+    /// secret data.
+    pub fn destroy_secret_version_by_project_and_location_and_secret_and_version<
+        IntoProject,
+        IntoSecret,
+        IntoVersion,
+        IntoLocation,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+        version: IntoVersion,
+        location: IntoLocation,
+    ) -> crate::builders::DestroySecretVersionByProjectAndLocationAndSecretAndVersion
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoVersion: Into<String>,
+        IntoLocation: Into<String>,
+    {
         crate::builders::DestroySecretVersionByProjectAndLocationAndSecretAndVersion::new(
             self.inner.clone(),
         )
+        .set_project(project.into())
+        .set_secret(secret.into())
+        .set_version(version.into())
+        .set_location(location.into())
     }
 
     /// Sets the access control policy on the specified secret. Replaces any
@@ -287,8 +598,18 @@ impl SecretManagerService {
     ///
     /// Permissions on SecretVersions are enforced according
     /// to the policy set on the associated Secret.
-    pub fn set_iam_policy(&self) -> crate::builders::SetIamPolicy {
+    pub fn set_iam_policy<IntoProject, IntoSecret>(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+    ) -> crate::builders::SetIamPolicy
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::SetIamPolicy::new(self.inner.clone())
+            .set_project(project.into())
+            .set_secret(secret.into())
     }
 
     /// Sets the access control policy on the specified secret. Replaces any
@@ -296,24 +617,64 @@ impl SecretManagerService {
     ///
     /// Permissions on SecretVersions are enforced according
     /// to the policy set on the associated Secret.
-    pub fn set_iam_policy_by_project_and_location_and_secret(
+    pub fn set_iam_policy_by_project_and_location_and_secret<
+        IntoProject,
+        IntoSecret,
+        IntoLocation,
+    >(
         &self,
-    ) -> crate::builders::SetIamPolicyByProjectAndLocationAndSecret {
+        project: IntoProject,
+        secret: IntoSecret,
+        location: IntoLocation,
+    ) -> crate::builders::SetIamPolicyByProjectAndLocationAndSecret
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoLocation: Into<String>,
+    {
         crate::builders::SetIamPolicyByProjectAndLocationAndSecret::new(self.inner.clone())
+            .set_project(project.into())
+            .set_secret(secret.into())
+            .set_location(location.into())
     }
 
     /// Gets the access control policy for a secret.
     /// Returns empty policy if the secret exists and does not have a policy set.
-    pub fn get_iam_policy(&self) -> crate::builders::GetIamPolicy {
+    pub fn get_iam_policy<IntoProject, IntoSecret>(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+    ) -> crate::builders::GetIamPolicy
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::GetIamPolicy::new(self.inner.clone())
+            .set_project(project.into())
+            .set_secret(secret.into())
     }
 
     /// Gets the access control policy for a secret.
     /// Returns empty policy if the secret exists and does not have a policy set.
-    pub fn get_iam_policy_by_project_and_location_and_secret(
+    pub fn get_iam_policy_by_project_and_location_and_secret<
+        IntoProject,
+        IntoLocation,
+        IntoSecret,
+    >(
         &self,
-    ) -> crate::builders::GetIamPolicyByProjectAndLocationAndSecret {
+        project: IntoProject,
+        location: IntoLocation,
+        secret: IntoSecret,
+    ) -> crate::builders::GetIamPolicyByProjectAndLocationAndSecret
+    where
+        IntoProject: Into<String>,
+        IntoLocation: Into<String>,
+        IntoSecret: Into<String>,
+    {
         crate::builders::GetIamPolicyByProjectAndLocationAndSecret::new(self.inner.clone())
+            .set_project(project.into())
+            .set_location(location.into())
+            .set_secret(secret.into())
     }
 
     /// Returns permissions that a caller has for the specified secret.
@@ -323,20 +684,45 @@ impl SecretManagerService {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
-    pub fn test_iam_permissions(&self) -> crate::builders::TestIamPermissions {
-        crate::builders::TestIamPermissions::new(self.inner.clone())
-    }
-
-    /// Returns permissions that a caller has for the specified secret.
-    /// If the secret does not exist, this call returns an empty set of
-    /// permissions, not a NOT_FOUND error.
-    ///
-    /// Note: This operation is designed to be used for building permission-aware
-    /// UIs and command-line tools, not for authorization checking. This operation
-    /// may "fail open" without warning.
-    pub fn test_iam_permissions_by_project_and_location_and_secret(
+    pub fn test_iam_permissions<IntoProject, IntoSecret>(
         &self,
-    ) -> crate::builders::TestIamPermissionsByProjectAndLocationAndSecret {
+        project: IntoProject,
+        secret: IntoSecret,
+    ) -> crate::builders::TestIamPermissions
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+    {
+        crate::builders::TestIamPermissions::new(self.inner.clone())
+            .set_project(project.into())
+            .set_secret(secret.into())
+    }
+
+    /// Returns permissions that a caller has for the specified secret.
+    /// If the secret does not exist, this call returns an empty set of
+    /// permissions, not a NOT_FOUND error.
+    ///
+    /// Note: This operation is designed to be used for building permission-aware
+    /// UIs and command-line tools, not for authorization checking. This operation
+    /// may "fail open" without warning.
+    pub fn test_iam_permissions_by_project_and_location_and_secret<
+        IntoProject,
+        IntoSecret,
+        IntoLocation,
+    >(
+        &self,
+        project: IntoProject,
+        secret: IntoSecret,
+        location: IntoLocation,
+    ) -> crate::builders::TestIamPermissionsByProjectAndLocationAndSecret
+    where
+        IntoProject: Into<String>,
+        IntoSecret: Into<String>,
+        IntoLocation: Into<String>,
+    {
         crate::builders::TestIamPermissionsByProjectAndLocationAndSecret::new(self.inner.clone())
+            .set_project(project.into())
+            .set_secret(secret.into())
+            .set_location(location.into())
     }
 }

--- a/src/generated/openapi-validation/src/client.rs
+++ b/src/generated/openapi-validation/src/client.rs
@@ -174,23 +174,23 @@ impl SecretManagerService {
     /// it to an existing Secret.
     pub fn add_secret_version_by_project_and_location_and_secret<
         IntoProject,
-        IntoSecret,
         IntoLocation,
+        IntoSecret,
     >(
         &self,
         project: IntoProject,
-        secret: IntoSecret,
         location: IntoLocation,
+        secret: IntoSecret,
     ) -> crate::builders::AddSecretVersionByProjectAndLocationAndSecret
     where
         IntoProject: Into<String>,
-        IntoSecret: Into<String>,
         IntoLocation: Into<String>,
+        IntoSecret: Into<String>,
     {
         crate::builders::AddSecretVersionByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project(project.into())
-            .set_secret(secret.into())
             .set_location(location.into())
+            .set_secret(secret.into())
     }
 
     /// Gets metadata for a given Secret.
@@ -462,29 +462,29 @@ impl SecretManagerService {
     /// DISABLED.
     pub fn disable_secret_version_by_project_and_location_and_secret_and_version<
         IntoProject,
+        IntoLocation,
         IntoSecret,
         IntoVersion,
-        IntoLocation,
     >(
         &self,
         project: IntoProject,
+        location: IntoLocation,
         secret: IntoSecret,
         version: IntoVersion,
-        location: IntoLocation,
     ) -> crate::builders::DisableSecretVersionByProjectAndLocationAndSecretAndVersion
     where
         IntoProject: Into<String>,
+        IntoLocation: Into<String>,
         IntoSecret: Into<String>,
         IntoVersion: Into<String>,
-        IntoLocation: Into<String>,
     {
         crate::builders::DisableSecretVersionByProjectAndLocationAndSecretAndVersion::new(
             self.inner.clone(),
         )
         .set_project(project.into())
+        .set_location(location.into())
         .set_secret(secret.into())
         .set_version(version.into())
-        .set_location(location.into())
     }
 
     /// Enables a SecretVersion.
@@ -514,29 +514,29 @@ impl SecretManagerService {
     /// ENABLED.
     pub fn enable_secret_version_by_project_and_location_and_secret_and_version<
         IntoProject,
+        IntoLocation,
         IntoSecret,
         IntoVersion,
-        IntoLocation,
     >(
         &self,
         project: IntoProject,
+        location: IntoLocation,
         secret: IntoSecret,
         version: IntoVersion,
-        location: IntoLocation,
     ) -> crate::builders::EnableSecretVersionByProjectAndLocationAndSecretAndVersion
     where
         IntoProject: Into<String>,
+        IntoLocation: Into<String>,
         IntoSecret: Into<String>,
         IntoVersion: Into<String>,
-        IntoLocation: Into<String>,
     {
         crate::builders::EnableSecretVersionByProjectAndLocationAndSecretAndVersion::new(
             self.inner.clone(),
         )
         .set_project(project.into())
+        .set_location(location.into())
         .set_secret(secret.into())
         .set_version(version.into())
-        .set_location(location.into())
     }
 
     /// Destroys a SecretVersion.
@@ -568,29 +568,29 @@ impl SecretManagerService {
     /// secret data.
     pub fn destroy_secret_version_by_project_and_location_and_secret_and_version<
         IntoProject,
+        IntoLocation,
         IntoSecret,
         IntoVersion,
-        IntoLocation,
     >(
         &self,
         project: IntoProject,
+        location: IntoLocation,
         secret: IntoSecret,
         version: IntoVersion,
-        location: IntoLocation,
     ) -> crate::builders::DestroySecretVersionByProjectAndLocationAndSecretAndVersion
     where
         IntoProject: Into<String>,
+        IntoLocation: Into<String>,
         IntoSecret: Into<String>,
         IntoVersion: Into<String>,
-        IntoLocation: Into<String>,
     {
         crate::builders::DestroySecretVersionByProjectAndLocationAndSecretAndVersion::new(
             self.inner.clone(),
         )
         .set_project(project.into())
+        .set_location(location.into())
         .set_secret(secret.into())
         .set_version(version.into())
-        .set_location(location.into())
     }
 
     /// Sets the access control policy on the specified secret. Replaces any
@@ -619,23 +619,23 @@ impl SecretManagerService {
     /// to the policy set on the associated Secret.
     pub fn set_iam_policy_by_project_and_location_and_secret<
         IntoProject,
-        IntoSecret,
         IntoLocation,
+        IntoSecret,
     >(
         &self,
         project: IntoProject,
-        secret: IntoSecret,
         location: IntoLocation,
+        secret: IntoSecret,
     ) -> crate::builders::SetIamPolicyByProjectAndLocationAndSecret
     where
         IntoProject: Into<String>,
-        IntoSecret: Into<String>,
         IntoLocation: Into<String>,
+        IntoSecret: Into<String>,
     {
         crate::builders::SetIamPolicyByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project(project.into())
-            .set_secret(secret.into())
             .set_location(location.into())
+            .set_secret(secret.into())
     }
 
     /// Gets the access control policy for a secret.
@@ -707,22 +707,22 @@ impl SecretManagerService {
     /// may "fail open" without warning.
     pub fn test_iam_permissions_by_project_and_location_and_secret<
         IntoProject,
-        IntoSecret,
         IntoLocation,
+        IntoSecret,
     >(
         &self,
         project: IntoProject,
-        secret: IntoSecret,
         location: IntoLocation,
+        secret: IntoSecret,
     ) -> crate::builders::TestIamPermissionsByProjectAndLocationAndSecret
     where
         IntoProject: Into<String>,
-        IntoSecret: Into<String>,
         IntoLocation: Into<String>,
+        IntoSecret: Into<String>,
     {
         crate::builders::TestIamPermissionsByProjectAndLocationAndSecret::new(self.inner.clone())
             .set_project(project.into())
-            .set_secret(secret.into())
             .set_location(location.into())
+            .set_secret(secret.into())
     }
 }

--- a/src/integration-tests/src/secret_manager/openapi.rs
+++ b/src/integration-tests/src/secret_manager/openapi.rs
@@ -39,8 +39,7 @@ pub async fn run(tracing: bool) -> Result<()> {
 
     println!("\nTesting create_secret()");
     let create = client
-        .create_secret()
-        .set_project(&project_id)
+        .create_secret(&project_id)
         .set_secret_id(&secret_id)
         .set_request_body(
             smo::model::Secret::default()
@@ -63,12 +62,7 @@ pub async fn run(tracing: bool) -> Result<()> {
     assert!(project_name.is_some());
 
     println!("\nTesting get_secret()");
-    let get = client
-        .get_secret()
-        .set_project(&project_id)
-        .set_secret(&secret_id)
-        .send()
-        .await?;
+    let get = client.get_secret(&project_id, &secret_id).send().await?;
     println!("GET = {get:?}");
     assert_eq!(get, create);
     assert!(get.name.is_some());
@@ -79,9 +73,7 @@ pub async fn run(tracing: bool) -> Result<()> {
     let mut new_labels = get.labels.clone();
     new_labels.insert("updated".to_string(), "true".to_string());
     let update = client
-        .update_secret()
-        .set_project(&project_id)
-        .set_secret(&secret_id)
+        .update_secret(&project_id, &secret_id)
         .set_update_mask(
             wkt::FieldMask::default().set_paths(["labels"].map(str::to_string).to_vec()),
         )
@@ -103,23 +95,14 @@ pub async fn run(tracing: bool) -> Result<()> {
     run_locations(&client, &project_id).await?;
 
     println!("\nTesting delete_secret()");
-    let response = client
-        .delete_secret()
-        .set_project(&project_id)
-        .set_secret(&secret_id)
-        .send()
-        .await?;
+    let response = client.delete_secret(&project_id, &secret_id).send().await?;
     println!("DELETE = {response:?}");
     Ok(())
 }
 
 async fn run_locations(client: &smo::client::SecretManagerService, project_id: &str) -> Result<()> {
     println!("\nTesting list_locations()");
-    let locations = client
-        .list_locations()
-        .set_project(project_id)
-        .send()
-        .await?;
+    let locations = client.list_locations(project_id).send().await?;
     println!("LOCATIONS = {locations:?}");
 
     assert!(
@@ -134,9 +117,7 @@ async fn run_locations(client: &smo::client::SecretManagerService, project_id: &
 
     println!("\nTesting get_location()");
     let get = client
-        .get_location()
-        .set_project(project_id)
-        .set_location(first.location_id.clone().unwrap())
+        .get_location(project_id, first.location_id.clone().unwrap())
         .send()
         .await?;
     println!("GET = {get:?}");
@@ -154,19 +135,12 @@ async fn run_iam(
     let service_account = crate::service_account_for_iam_tests()?;
 
     println!("\nTesting get_iam_policy()");
-    let policy = client
-        .get_iam_policy()
-        .set_project(project_id)
-        .set_secret(secret_id)
-        .send()
-        .await?;
+    let policy = client.get_iam_policy(project_id, secret_id).send().await?;
     println!("POLICY = {policy:?}");
 
     println!("\nTesting test_iam_permissions()");
     let response = client
-        .test_iam_permissions()
-        .set_project(project_id)
-        .set_secret(secret_id)
+        .test_iam_permissions(project_id, secret_id)
         .set_permissions(
             ["secretmanager.versions.access"]
                 .map(str::to_string)
@@ -198,9 +172,7 @@ async fn run_iam(
         );
     }
     let response = client
-        .set_iam_policy()
-        .set_project(project_id)
-        .set_secret(secret_id)
+        .set_iam_policy(project_id, secret_id)
         .set_update_mask(
             wkt::FieldMask::default().set_paths(["bindings"].map(str::to_string).to_vec()),
         )
@@ -221,9 +193,7 @@ async fn run_secret_versions(
     let data = "The quick brown fox jumps over the lazy dog".as_bytes();
     let checksum = crc32c::crc32c(data);
     let create = client
-        .add_secret_version()
-        .set_project(project_id)
-        .set_secret(secret_id)
+        .add_secret_version(project_id, secret_id)
         .set_payload(
             smo::model::SecretPayload::default()
                 .set_data(bytes::Bytes::from(data))
@@ -249,10 +219,7 @@ async fn run_secret_versions(
 
     println!("\nTesting get_secret_version()");
     let get = client
-        .get_secret_version()
-        .set_project(project_id)
-        .set_secret(secret_id)
-        .set_version(version_id)
+        .get_secret_version(project_id, secret_id, version_id)
         .send()
         .await?;
     println!("GET_SECRET_VERSION = {get:?}");
@@ -270,10 +237,7 @@ async fn run_secret_versions(
 
     println!("\nTesting access_secret_version()");
     let access_secret_version = client
-        .access_secret_version()
-        .set_project(project_id)
-        .set_secret(secret_id)
-        .set_version(version_id)
+        .access_secret_version(project_id, secret_id, version_id)
         .send()
         .await?;
     println!("ACCESS_SECRET_VERSION = {access_secret_version:?}");
@@ -284,30 +248,21 @@ async fn run_secret_versions(
 
     println!("\nTesting disable_secret_version()");
     let disable = client
-        .disable_secret_version()
-        .set_project(project_id)
-        .set_secret(secret_id)
-        .set_version(version_id)
+        .disable_secret_version(project_id, secret_id, version_id)
         .send()
         .await?;
     println!("DISABLE_SECRET_VERSION = {disable:?}");
 
     println!("\nTesting enable_secret_version()");
     let enable = client
-        .enable_secret_version()
-        .set_project(project_id)
-        .set_secret(secret_id)
-        .set_version(version_id)
+        .enable_secret_version(project_id, secret_id, version_id)
         .send()
         .await?;
     println!("ENABLE_SECRET_VERSION = {enable:?}");
 
     println!("\nTesting destroy_secret_version()");
     let delete = client
-        .destroy_secret_version()
-        .set_project(project_id)
-        .set_secret(secret_id)
-        .set_version(version_id)
+        .destroy_secret_version(project_id, secret_id, version_id)
         .send()
         .await?;
     println!("RESPONSE = {delete:?}");
@@ -324,9 +279,7 @@ async fn get_all_secret_version_names(
     let mut page_token = None::<String>;
     loop {
         let response = client
-            .list_secret_versions()
-            .set_project(project_id)
-            .set_secret(secret_id)
+            .list_secret_versions(project_id, secret_id)
             .set_page_token(page_token)
             .send()
             .await?;
@@ -348,7 +301,7 @@ async fn get_all_secret_names(
     project_id: &str,
 ) -> Result<Vec<String>> {
     let mut names = Vec::new();
-    let mut stream = client.list_secrets().set_project(project_id).stream().await;
+    let mut stream = client.list_secrets(project_id).stream().await;
     while let Some(response) = stream.next().await {
         response?
             .secrets

--- a/src/integration-tests/src/secret_manager/openapi_locational.rs
+++ b/src/integration-tests/src/secret_manager/openapi_locational.rs
@@ -38,9 +38,7 @@ pub async fn run(tracing: bool) -> Result<()> {
 
     println!("\nTesting create_secret_by_project_and_location({project_id}, {location_id})");
     let create = client
-        .create_secret_by_project_and_location()
-        .set_project(&project_id)
-        .set_location(&location_id)
+        .create_secret_by_project_and_location(&project_id, &location_id)
         .set_secret_id(&secret_id)
         .set_request_body(smo::model::Secret::default().set_labels(
             [("integration-test", "true")].map(|(k, v)| (k.to_string(), v.to_string())),
@@ -51,10 +49,7 @@ pub async fn run(tracing: bool) -> Result<()> {
 
     println!("\nTesting get_secret_by_project_and_location_and_secret()");
     let get = client
-        .get_secret_by_project_and_location_and_secret()
-        .set_project(&project_id)
-        .set_location(&location_id)
-        .set_secret(&secret_id)
+        .get_secret_by_project_and_location_and_secret(&project_id, &location_id, &secret_id)
         .send()
         .await?;
     println!("GET = {get:?}");
@@ -65,10 +60,7 @@ pub async fn run(tracing: bool) -> Result<()> {
     let mut new_labels = get.labels.clone();
     new_labels.insert("updated".to_string(), "true".to_string());
     let update = client
-        .update_secret_by_project_and_location_and_secret()
-        .set_project(&project_id)
-        .set_location(&location_id)
-        .set_secret(&secret_id)
+        .update_secret_by_project_and_location_and_secret(&project_id, &location_id, &secret_id)
         .set_update_mask(
             wkt::FieldMask::default().set_paths(["labels"].map(str::to_string).to_vec()),
         )
@@ -92,10 +84,7 @@ pub async fn run(tracing: bool) -> Result<()> {
 
     println!("\nTesting delete_secret_by_project_and_location_and_secret()");
     let response = client
-        .delete_secret_by_project_and_location_and_secret()
-        .set_project(&project_id)
-        .set_location(&location_id)
-        .set_secret(&secret_id)
+        .delete_secret_by_project_and_location_and_secret(&project_id, &location_id, &secret_id)
         .send()
         .await?;
     println!("DELETE = {response:?}");
@@ -113,20 +102,14 @@ async fn run_iam(
 
     println!("\nTesting get_iam_policy_by_project_and_location_and_secret()");
     let policy = client
-        .get_iam_policy_by_project_and_location_and_secret()
-        .set_project(project_id)
-        .set_location(location_id)
-        .set_secret(secret_id)
+        .get_iam_policy_by_project_and_location_and_secret(project_id, location_id, secret_id)
         .send()
         .await?;
     println!("POLICY = {policy:?}");
 
     println!("\nTesting test_iam_permissions_by_project_and_location_and_secret()");
     let response = client
-        .test_iam_permissions_by_project_and_location_and_secret()
-        .set_project(project_id)
-        .set_location(location_id)
-        .set_secret(secret_id)
+        .test_iam_permissions_by_project_and_location_and_secret(project_id, location_id, secret_id)
         .set_permissions(
             ["secretmanager.versions.access"]
                 .map(str::to_string)
@@ -158,10 +141,7 @@ async fn run_iam(
         );
     }
     let response = client
-        .set_iam_policy_by_project_and_location_and_secret()
-        .set_project(project_id)
-        .set_location(location_id)
-        .set_secret(secret_id)
+        .set_iam_policy_by_project_and_location_and_secret(project_id, location_id, secret_id)
         .set_update_mask(
             wkt::FieldMask::default().set_paths(["bindings"].map(str::to_string).to_vec()),
         )
@@ -183,10 +163,7 @@ async fn run_secret_versions(
     let data = "The quick brown fox jumps over the lazy dog".as_bytes();
     let checksum = crc32c::crc32c(data);
     let create = client
-        .add_secret_version_by_project_and_location_and_secret()
-        .set_project(project_id)
-        .set_location(location_id)
-        .set_secret(secret_id)
+        .add_secret_version_by_project_and_location_and_secret(project_id, location_id, secret_id)
         .set_payload(
             smo::model::SecretPayload::default()
                 .set_data(bytes::Bytes::from(data))
@@ -212,11 +189,12 @@ async fn run_secret_versions(
 
     println!("\nTesting get_secret_version_by_project_and_location_and_secret_and_version()");
     let get = client
-        .get_secret_version_by_project_and_location_and_secret_and_version()
-        .set_project(project_id)
-        .set_location(location_id)
-        .set_secret(secret_id)
-        .set_version(version_id)
+        .get_secret_version_by_project_and_location_and_secret_and_version(
+            project_id,
+            location_id,
+            secret_id,
+            version_id,
+        )
         .send()
         .await?;
     println!("GET_SECRET_VERSION = {get:?}");
@@ -235,11 +213,12 @@ async fn run_secret_versions(
 
     println!("\nTesting access_secret_version_by_project_and_location_and_secret_and_version()");
     let access_secret_version = client
-        .access_secret_version_by_project_and_location_and_secret_and_version()
-        .set_project(project_id)
-        .set_location(location_id)
-        .set_secret(secret_id)
-        .set_version(version_id)
+        .access_secret_version_by_project_and_location_and_secret_and_version(
+            project_id,
+            location_id,
+            secret_id,
+            version_id,
+        )
         .send()
         .await?;
     println!("ACCESS_SECRET_VERSION = {access_secret_version:?}");
@@ -250,33 +229,36 @@ async fn run_secret_versions(
 
     println!("\nTesting disable_secret_version_by_project_and_location_and_secret_and_version()");
     let disable = client
-        .disable_secret_version_by_project_and_location_and_secret_and_version()
-        .set_project(project_id)
-        .set_location(location_id)
-        .set_secret(secret_id)
-        .set_version(version_id)
+        .disable_secret_version_by_project_and_location_and_secret_and_version(
+            project_id,
+            location_id,
+            secret_id,
+            version_id,
+        )
         .send()
         .await?;
     println!("DISABLE_SECRET_VERSION = {disable:?}");
 
     println!("\nTesting enable_secret_version_by_project_and_location_and_secret_and_version()");
     let enable = client
-        .enable_secret_version_by_project_and_location_and_secret_and_version()
-        .set_project(project_id)
-        .set_location(location_id)
-        .set_secret(secret_id)
-        .set_version(version_id)
+        .enable_secret_version_by_project_and_location_and_secret_and_version(
+            project_id,
+            location_id,
+            secret_id,
+            version_id,
+        )
         .send()
         .await?;
     println!("ENABLE_SECRET_VERSION = {enable:?}");
 
     println!("\nTesting destroy_secret_version_by_project_and_location_and_secret_and_version()");
     let delete = client
-        .destroy_secret_version_by_project_and_location_and_secret_and_version()
-        .set_project(project_id)
-        .set_location(location_id)
-        .set_secret(secret_id)
-        .set_version(version_id)
+        .destroy_secret_version_by_project_and_location_and_secret_and_version(
+            project_id,
+            location_id,
+            secret_id,
+            version_id,
+        )
         .send()
         .await?;
     println!("RESPONSE = {delete:?}");
@@ -294,10 +276,11 @@ async fn get_all_secret_version_names(
     let mut page_token = None::<String>;
     loop {
         let response = client
-            .list_secret_versions_by_project_and_location_and_secret()
-            .set_project(project_id)
-            .set_location(location_id)
-            .set_secret(secret_id)
+            .list_secret_versions_by_project_and_location_and_secret(
+                project_id,
+                location_id,
+                secret_id,
+            )
             .set_page_token(page_token)
             .send()
             .await?;
@@ -323,9 +306,7 @@ async fn get_all_secret_names(
     let mut page_token = None::<String>;
     loop {
         let response = client
-            .list_secrets_by_project_and_location()
-            .set_project(project_id)
-            .set_location(location_id)
+            .list_secrets_by_project_and_location(project_id, location_id)
             .set_page_token(page_token)
             .send()
             .await?;
@@ -358,9 +339,7 @@ async fn cleanup_stale_secrets(
     let mut page_token = None::<String>;
     loop {
         let response = client
-            .list_secrets_by_project_and_location()
-            .set_project(project_id)
-            .set_location(location_id)
+            .list_secrets_by_project_and_location(project_id, location_id)
             .set_page_token(page_token.clone())
             .send()
             .await?;
@@ -389,10 +368,7 @@ async fn cleanup_stale_secrets(
         .iter()
         .map(|v| {
             client
-                .delete_secret_by_project_and_location_and_secret()
-                .set_project(project_id)
-                .set_location(location_id)
-                .set_secret(v)
+                .delete_secret_by_project_and_location_and_secret(project_id, location_id, v)
                 .send()
         })
         .collect::<Vec<_>>();

--- a/src/integration-tests/src/secret_manager/protobuf.rs
+++ b/src/integration-tests/src/secret_manager/protobuf.rs
@@ -54,9 +54,8 @@ pub async fn run(tracing: bool) -> Result<()> {
     println!("\nTesting create_secret()");
     use gax::options::RequestOptionsBuilder;
     let create = client
-        .create_secret()
+        .create_secret(format!("projects/{project_id}"))
         .with_user_agent("test/1.2.3")
-        .set_parent(format!("projects/{project_id}"))
         .set_secret_id(&secret_id)
         .set_secret(
             sm::model::Secret::default()
@@ -79,7 +78,7 @@ pub async fn run(tracing: bool) -> Result<()> {
     assert!(project_name.is_some());
 
     println!("\nTesting get_secret()");
-    let get = client.get_secret().set_name(&create.name).send().await?;
+    let get = client.get_secret(&create.name).send().await?;
     println!("GET = {get:?}");
     assert_eq!(get, create);
 
@@ -87,14 +86,13 @@ pub async fn run(tracing: bool) -> Result<()> {
     let mut new_labels = get.labels.clone();
     new_labels.insert("updated".to_string(), "true".to_string());
     let update = client
-        .update_secret()
-        .set_update_mask(
-            wkt::FieldMask::default().set_paths(["labels"].map(str::to_string).to_vec()),
-        )
-        .set_secret(
+        .update_secret(
             sm::model::Secret::default()
                 .set_name(&get.name)
                 .set_labels(new_labels),
+        )
+        .set_update_mask(
+            wkt::FieldMask::default().set_paths(["labels"].map(str::to_string).to_vec()),
         )
         .send()
         .await?;
@@ -113,7 +111,7 @@ pub async fn run(tracing: bool) -> Result<()> {
     run_locations(&location_client, &project_id).await?;
 
     println!("\nTesting delete_secret()");
-    let delete = client.delete_secret().set_name(get.name).send().await?;
+    let delete = client.delete_secret(get.name).send().await?;
     println!("DELETE = {delete:?}");
 
     Ok(())
@@ -122,8 +120,7 @@ pub async fn run(tracing: bool) -> Result<()> {
 async fn run_locations(client: &sm::client::Locations, project_id: &str) -> Result<()> {
     println!("\nTesting list_locations()");
     let locations = client
-        .list_locations()
-        .set_name(format!("projects/{project_id}"))
+        .list_locations(format!("projects/{project_id}"))
         .send()
         .await?;
     println!("LOCATIONS = {locations:?}");
@@ -140,8 +137,7 @@ async fn run_locations(client: &sm::client::Locations, project_id: &str) -> Resu
 
     println!("\nTesting get_location()");
     let get = client
-        .get_location()
-        .set_name(format!(
+        .get_location(format!(
             "projects/{project_id}/locations/{}",
             first.location_id
         ))
@@ -158,17 +154,12 @@ async fn run_iam(client: &sm::client::SecretManagerService, secret_name: &str) -
     let service_account = crate::service_account_for_iam_tests()?;
 
     println!("\nTesting get_iam_policy()");
-    let policy = client
-        .get_iam_policy()
-        .set_resource(secret_name)
-        .send()
-        .await?;
+    let policy = client.get_iam_policy(secret_name).send().await?;
     println!("POLICY = {policy:?}");
 
     println!("\nTesting test_iam_permissions()");
     let response = client
-        .test_iam_permissions()
-        .set_resource(secret_name)
+        .test_iam_permissions(secret_name)
         .set_permissions(
             ["secretmanager.versions.access"]
                 .map(str::to_string)
@@ -200,8 +191,7 @@ async fn run_iam(client: &sm::client::SecretManagerService, secret_name: &str) -
         );
     }
     let response = client
-        .set_iam_policy()
-        .set_resource(secret_name)
+        .set_iam_policy(secret_name)
         .set_update_mask(
             wkt::FieldMask::default().set_paths(["bindings"].map(str::to_string).to_vec()),
         )
@@ -221,8 +211,7 @@ async fn run_secret_versions(
     let data = "The quick brown fox jumps over the lazy dog".as_bytes();
     let checksum = crc32c::crc32c(data);
     let create_secret_version = client
-        .add_secret_version()
-        .set_parent(secret_name)
+        .add_secret_version(secret_name)
         .set_payload(
             sm::model::SecretPayload::default()
                 .set_data(bytes::Bytes::from(data))
@@ -234,8 +223,7 @@ async fn run_secret_versions(
 
     println!("\nTesting get_secret_version()");
     let get_secret_version = client
-        .get_secret_version()
-        .set_name(&create_secret_version.name)
+        .get_secret_version(&create_secret_version.name)
         .send()
         .await?;
     println!("GET_SECRET_VERSION = {create_secret_version:?}");
@@ -253,8 +241,7 @@ async fn run_secret_versions(
 
     println!("\nTesting access_secret_version()");
     let access_secret_version = client
-        .access_secret_version()
-        .set_name(&create_secret_version.name)
+        .access_secret_version(&create_secret_version.name)
         .send()
         .await?;
     println!("ACCESS_SECRET_VERSION = {access_secret_version:?}");
@@ -265,24 +252,21 @@ async fn run_secret_versions(
 
     println!("\nTesting disable_secret_version()");
     let disable = client
-        .disable_secret_version()
-        .set_name(&create_secret_version.name)
+        .disable_secret_version(&create_secret_version.name)
         .send()
         .await?;
     println!("DISABLE_SECRET_VERSION = {disable:?}");
 
     println!("\nTesting disable_secret_version()");
     let enable = client
-        .enable_secret_version()
-        .set_name(&create_secret_version.name)
+        .enable_secret_version(&create_secret_version.name)
         .send()
         .await?;
     println!("ENABLE_SECRET_VERSION = {enable:?}");
 
     println!("\nTesting destroy_secret_version()");
     let delete = client
-        .destroy_secret_version()
-        .set_name(&get_secret_version.name)
+        .destroy_secret_version(&get_secret_version.name)
         .send()
         .await?;
     println!("RESPONSE = {delete:?}");
@@ -298,8 +282,7 @@ async fn get_all_secret_version_names(
     let mut page_token = String::new();
     loop {
         let response = client
-            .list_secret_versions()
-            .set_parent(secret_name)
+            .list_secret_versions(secret_name)
             .set_page_token(&page_token)
             .send()
             .await?;
@@ -321,8 +304,7 @@ async fn get_all_secret_names(
 ) -> Result<Vec<String>> {
     let mut names = Vec::new();
     let mut stream = client
-        .list_secrets()
-        .set_parent(format!("projects/{project_id}"))
+        .list_secrets(format!("projects/{project_id}"))
         .stream()
         .await
         .items();
@@ -346,39 +328,32 @@ async fn cleanup_stale_secrets(
     let stale_deadline = wkt::Timestamp::clamp(stale_deadline.as_secs() as i64, 0);
 
     let mut stale_secrets = Vec::new();
-    let mut list_request =
-        sm::model::ListSecretsRequest::default().set_parent(format!("projects/{project_id}"));
-    loop {
-        let response = client
-            .list_secrets()
-            .with_request(list_request.clone())
-            .send()
-            .await?;
-        for secret in response.secrets {
-            if secret
-                .name
-                .ends_with(format!("/secrets/{secret_id}").as_str())
-            {
-                return Err(Error::other(
-                    "randomly generated secret id already exists {secret_id}",
-                ));
-            }
+    let mut stream = client
+        .list_secrets(format!("projects/{project_id}"))
+        .stream()
+        .await
+        .items();
+    while let Some(secret) = stream.next().await {
+        let secret = secret?;
+        if secret
+            .name
+            .ends_with(format!("/secrets/{secret_id}").as_str())
+        {
+            return Err(Error::other(
+                "randomly generated secret id already exists {secret_id}",
+            ));
+        }
 
-            if let Some("true") = secret.labels.get("integration-test").map(String::as_str) {
-                if let Some(true) = secret.create_time.map(|v| v < stale_deadline) {
-                    stale_secrets.push(secret.name);
-                }
+        if let Some("true") = secret.labels.get("integration-test").map(String::as_str) {
+            if let Some(true) = secret.create_time.map(|v| v < stale_deadline) {
+                stale_secrets.push(secret.name);
             }
         }
-        if response.next_page_token.is_empty() {
-            break;
-        }
-        list_request.page_token = response.next_page_token;
     }
 
     let pending = stale_secrets
         .iter()
-        .map(|v| client.delete_secret().set_name(v).send())
+        .map(|v| client.delete_secret(v).send())
         .collect::<Vec<_>>();
 
     // Print the errors, but otherwise ignore them.

--- a/src/integration-tests/tests/mocking.rs
+++ b/src/integration-tests/tests/mocking.rs
@@ -32,8 +32,7 @@ mod mocking {
         id: &str,
     ) -> sm::Result<sm::model::Secret> {
         client
-            .create_secret()
-            .set_parent(format!("projects/{project}/locations/{region}"))
+            .create_secret(format!("projects/{project}/locations/{region}"))
             .set_secret_id(id)
             .send()
             .await


### PR DESCRIPTION
Change the generated code to require any arguments that will be part of
the path parameters. These include optional fields (such as objects)
where it is a sub-field of the parameter that goes into the path
parameter.

Part of the work for #536