### PR TITLE
feat: add try/from trait for conversion between chrono and Duration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,6 +735,7 @@ name = "gcp-sdk-wkt"
 version = "0.1.0-rc2"
 dependencies = [
  "bytes",
+ "chrono",
  "gcp-sdk-wkt",
  "serde",
  "serde_json",

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -39,4 +39,4 @@ bytes      = { version = "1.8.0", features = ["serde"] }
 [dev-dependencies]
 test-case = "3.3.1"
 bytes     = { version = "1.8.0", features = ["serde"] }
-wkt       = { path = ".", package = "gcp-sdk-wkt", features = ["time", "chrono"] }
+wkt       = { path = ".", package = "gcp-sdk-wkt", features = ["chrono", "time"] }

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -24,8 +24,8 @@ keywords.workspace   = true
 categories.workspace = true
 
 [features]
-time = []
 chrono = []
+time = []
 
 [dependencies]
 serde      = { version = "1.0.214", features = ["serde_derive"] }

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -25,16 +25,18 @@ categories.workspace = true
 
 [features]
 time = []
+chrono = []
 
 [dependencies]
 serde      = { version = "1.0.214", features = ["serde_derive"] }
 serde_with = { version = "3.11.0", default-features = false, features = ["base64"] }
 serde_json = "1.0.134"
 time       = { version = "0.3.36", features = ["formatting", "parsing"] }
+chrono     = { version = "0.4.39" }
 thiserror  = "2"
 bytes      = { version = "1.8.0", features = ["serde"] }
 
 [dev-dependencies]
 test-case = "3.3.1"
 bytes     = { version = "1.8.0", features = ["serde"] }
-wkt       = { path = ".", package = "gcp-sdk-wkt", features = ["time"] }
+wkt       = { path = ".", package = "gcp-sdk-wkt", features = ["time", "chrono"] }

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -24,7 +24,7 @@ keywords.workspace   = true
 categories.workspace = true
 
 [features]
-chrono = []
+chrono = ["dep:chrono"]
 time   = []
 
 [dependencies]
@@ -32,7 +32,7 @@ serde      = { version = "1.0.214", features = ["serde_derive"] }
 serde_with = { version = "3.11.0", default-features = false, features = ["base64"] }
 serde_json = "1.0.134"
 time       = { version = "0.3.36", features = ["formatting", "parsing"] }
-chrono     = { version = "0.4.39" }
+chrono     = { version = "0.4.39", optional = true }
 thiserror  = "2"
 bytes      = { version = "1.8.0", features = ["serde"] }
 

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -25,7 +25,7 @@ categories.workspace = true
 
 [features]
 chrono = []
-time = []
+time   = []
 
 [dependencies]
 serde      = { version = "1.0.214", features = ["serde_derive"] }

--- a/src/wkt/src/duration.rs
+++ b/src/wkt/src/duration.rs
@@ -284,13 +284,9 @@ impl std::convert::TryFrom<chrono::Duration> for Duration {
 
 /// Converts from [Duration] to [chrono::Duration].
 #[cfg(feature = "chrono")]
-impl std::convert::TryFrom<Duration> for chrono::Duration {
-    type Error = DurationError;
-    fn try_from(value: Duration) -> Result<Self, Self::Error> {
-        if value.nanos < 0 {
-            return Err(Error::OutOfRange());
-        }
-        Ok(Self::new(value.seconds(), value.nanos() as u32).unwrap())
+impl std::convert::From<Duration> for chrono::Duration {
+    fn from(value: Duration) -> Self {
+        Self::seconds(value.seconds) + Self::nanoseconds(value.nanos as i64)
     }
 }
 
@@ -525,7 +521,7 @@ mod test {
     #[test_case(Duration::new(10_000 * SECONDS_IN_YEAR , 0).unwrap(), chrono::Duration::new(10_000 * SECONDS_IN_YEAR, 0).unwrap() ; "exactly 10,000 years")]
     #[test_case(Duration::new(-10_000 * SECONDS_IN_YEAR , 0).unwrap(), chrono::Duration::new(-10_000 * SECONDS_IN_YEAR, 0).unwrap() ; "exactly negative 10,000 years")]
     fn to_chrono_time_in_range(value: Duration, want: chrono::Duration) -> Result {
-        let got = chrono::Duration::try_from(value)?;
+        let got = chrono::Duration::from(value);
         assert_eq!(got, want);
         Ok(())
     }
@@ -534,12 +530,6 @@ mod test {
     #[test_case(chrono::Duration::new(-10_001 * SECONDS_IN_YEAR, 0).unwrap() ; "below the range")]
     fn from_chrono_time_out_of_range(value: chrono::Duration) {
         let got = Duration::try_from(value);
-        assert_eq!(got, Err(DurationError::OutOfRange()));
-    }
-
-    #[test_case(Duration::new(0, -10_001).unwrap() ; "below the range")]
-    fn to_chrono_time_out_of_range(value: Duration) {
-        let got = chrono::Duration::try_from(value);
         assert_eq!(got, Err(DurationError::OutOfRange()));
     }
 }


### PR DESCRIPTION
For #423.

Add TryFrom trait for conversion between [chrono::time](https://crates.io/crates/chrono) and `Duration`.