### PR TITLE
chore(deps): update reqwest to 0.12.11

### DIFF
--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -35,7 +35,7 @@ version = "0.1.0-rc2"
 # These are used by crates with services.
 'package:async-trait' = 'required-by-services=true,package=async-trait,version=0.1.83'
 'package:lazy_static' = 'required-by-services=true,package=lazy_static,version=1.5.0'
-'package:reqwest'     = 'required-by-services=true,package=reqwest,version=0.12.9,feature=json'
+'package:reqwest'     = 'required-by-services=true,package=reqwest,version=0.12.11,feature=json'
 'package:serde_json'  = 'required-by-services=true,package=serde_json,version=1.0.134'
 'package:tracing'     = 'required-by-services=true,package=tracing,version=0.1.41'
 'package:gax'         = 'required-by-services=true,package=gcp-sdk-gax,path=src/gax,feature=unstable-sdk-client,version=0.1.0-rc2'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1669,9 +1669,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.9"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+checksum = "7fe060fe50f524be480214aba758c71f99f90ee8c83c5a36b5e9e1d568eb4eb3"
 dependencies = [
  "base64",
  "bytes",
@@ -1702,6 +1702,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -26,7 +26,7 @@ categories.workspace = true
 [dependencies]
 async-trait = "0.1.83"
 http        = "1.2.0"
-reqwest     = { version = "0.12.9", features = ["json"] }
+reqwest     = { version = "0.12.11", features = ["json"] }
 serde       = { version = "1.0.214", features = ["derive"] }
 serde_json  = "1.0.134"
 thiserror   = "2"

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -30,7 +30,7 @@ bytes       = "1.8.0"
 futures     = { version = "0.3.31", optional = true }
 http        = "1.1.0"
 pin-project = { version = "1.1.7", optional = true }
-reqwest     = { version = "0.12.9", optional = true }
+reqwest     = { version = "0.12.11", optional = true }
 serde       = "1.0.214"
 serde_json  = "1.0.134"
 serde_with  = { version = "3.11.0", default-features = false, features = ["base64", "macros"] }

--- a/src/generated/cloud/location/Cargo.toml
+++ b/src/generated/cloud/location/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = { version = "0.1.83" }
 bytes      = { version = "1.8.0", features = ["serde"] }
 gax        = { version = "0.1.0-rc2", path = "../../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1.5.0" }
-reqwest    = { version = "0.12.9", features = ["json"] }
+reqwest    = { version = "0.12.11", features = ["json"] }
 serde      = { version = "1.0.214", features = ["serde_derive"] }
 serde_json = { version = "1.0.134" }
 serde_with = { version = "3.11.0", default-features = false, features = ["base64", "macros", "std"] }

--- a/src/generated/cloud/secretmanager/v1/Cargo.toml
+++ b/src/generated/cloud/secretmanager/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.1.0-rc2", path = "../../../../../src/gax", package =
 iam_v1     = { version = "0.1.0-rc2", path = "../../../../../src/generated/iam/v1", package = "gcp-sdk-iam-v1" }
 lazy_static = { version = "1.5.0" }
 location   = { version = "0.1.0-rc2", path = "../../../../../src/generated/cloud/location", package = "gcp-sdk-location" }
-reqwest    = { version = "0.12.9", features = ["json"] }
+reqwest    = { version = "0.12.11", features = ["json"] }
 serde      = { version = "1.0.214", features = ["serde_derive"] }
 serde_json = { version = "1.0.134" }
 serde_with = { version = "3.11.0", default-features = false, features = ["base64", "macros", "std"] }

--- a/src/generated/iam/v1/Cargo.toml
+++ b/src/generated/iam/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1.8.0", features = ["serde"] }
 gax        = { version = "0.1.0-rc2", path = "../../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
 gtype      = { version = "0.1.0-rc2", path = "../../../../src/generated/type", package = "gcp-sdk-type" }
 lazy_static = { version = "1.5.0" }
-reqwest    = { version = "0.12.9", features = ["json"] }
+reqwest    = { version = "0.12.11", features = ["json"] }
 serde      = { version = "1.0.214", features = ["serde_derive"] }
 serde_json = { version = "1.0.134" }
 serde_with = { version = "3.11.0", default-features = false, features = ["base64", "macros", "std"] }

--- a/src/generated/longrunning/Cargo.toml
+++ b/src/generated/longrunning/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = { version = "0.1.83" }
 bytes      = { version = "1.8.0", features = ["serde"] }
 gax        = { version = "0.1.0-rc2", path = "../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1.5.0" }
-reqwest    = { version = "0.12.9", features = ["json"] }
+reqwest    = { version = "0.12.11", features = ["json"] }
 rpc        = { version = "0.1.0-rc2", path = "../../../src/generated/rpc", package = "gcp-sdk-rpc" }
 serde      = { version = "1.0.214", features = ["serde_derive"] }
 serde_json = { version = "1.0.134" }

--- a/src/generated/openapi-validation/Cargo.toml
+++ b/src/generated/openapi-validation/Cargo.toml
@@ -31,7 +31,7 @@ async-trait = { version = "0.1.83" }
 bytes      = { version = "1.8.0", features = ["serde"] }
 gax        = { version = "0.1.0-rc2", path = "../../../src/gax", package = "gcp-sdk-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1.5.0" }
-reqwest    = { version = "0.12.9", features = ["json"] }
+reqwest    = { version = "0.12.11", features = ["json"] }
 serde      = { version = "1.0.214", features = ["serde_derive"] }
 serde_json = { version = "1.0.134" }
 serde_with = { version = "3.11.0", default-features = false, features = ["base64", "macros", "std"] }


### PR DESCRIPTION
So this is a problem with a strict "sidekick always regenerates all the files, including Cargo.toml" we cannot use external tools to update the dependencies for us.

 