### PR TITLE
impl(auth): helper function for ADC path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,8 +599,10 @@ dependencies = [
  "http",
  "mockall",
  "reqwest",
+ "scoped-env",
  "serde",
  "serde_json",
+ "serial_test",
  "test-case",
  "thiserror",
  "time",
@@ -1832,6 +1834,12 @@ checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "scoped-env"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a86338a78d9058ae1bb70bf4ec558e9c51c611b443a356f7d041d29bb6c1c026"
 
 [[package]]
 name = "scopeguard"

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -35,5 +35,7 @@ time        = "0.3.37"
 [dev-dependencies]
 axum      = "0.7.9"
 mockall   = "0.13.1"
+scoped-env  = "2.1.0"
+serial_test = "3.2.0"
 test-case = "3.3.1"
 tokio     = { version = "1.42", features = ["macros", "rt-multi-thread", "test-util"] }

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -33,9 +33,9 @@ thiserror   = "2"
 time        = "0.3.37"
 
 [dev-dependencies]
-axum      = "0.7.9"
-mockall   = "0.13.1"
+axum        = "0.7.9"
+mockall     = "0.13.1"
 scoped-env  = "2.1.0"
 serial_test = "3.2.0"
-test-case = "3.3.1"
-tokio     = { version = "1.42", features = ["macros", "rt-multi-thread", "test-util"] }
+test-case   = "3.3.1"
+tokio       = { version = "1.42", features = ["macros", "rt-multi-thread", "test-util"] }

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -182,10 +182,9 @@ fn adc_path() -> Option<String> {
 /// [AIP-4113]: https://google.aip.dev/auth/4113
 #[cfg(target_os = "windows")]
 fn adc_well_known_path() -> Option<String> {
-    if let Ok(root) = std::env::var("APPDATA") {
-        return Some(root + "/gcloud/application_default_credentials.json");
-    }
-    None
+    std::env::var("APPDATA")
+        .ok()
+        .map(|root| root + "/gcloud/application_default_credentials.json")
 }
 
 /// The well-known path to ADC on Linux and Mac, as specified in [AIP-4113].
@@ -193,10 +192,9 @@ fn adc_well_known_path() -> Option<String> {
 /// [AIP-4113]: https://google.aip.dev/auth/4113
 #[cfg(not(target_os = "windows"))]
 fn adc_well_known_path() -> Option<String> {
-    if let Ok(root) = std::env::var("HOME") {
-        return Some(root + "/.config/gcloud/application_default_credentials.json");
-    }
-    None
+    std::env::var("HOME")
+        .ok()
+        .map(|root| root + "/.config/gcloud/application_default_credentials.json")
 }
 
 #[cfg(test)]
@@ -211,12 +209,12 @@ mod test {
         let _creds = ScopedEnv::remove("GOOGLE_APPLICATION_CREDENTIALS");
         let _appdata = ScopedEnv::set("APPDATA", "C:/Users/foo");
         assert_eq!(
-            adc_well_known_path().unwrap(),
-            "C:/Users/foo/gcloud/application_default_credentials.json"
+            adc_well_known_path(),
+            Some("C:/Users/foo/gcloud/application_default_credentials.json".to_string())
         );
         assert_eq!(
-            adc_path().unwrap(),
-            "C:/Users/foo/gcloud/application_default_credentials.json"
+            adc_path(),
+            Some("C:/Users/foo/gcloud/application_default_credentials.json".to_string())
         );
     }
 
@@ -226,8 +224,8 @@ mod test {
     fn adc_well_known_path_windows_no_appdata() {
         let _creds = ScopedEnv::remove("GOOGLE_APPLICATION_CREDENTIALS");
         let _appdata = ScopedEnv::remove("APPDATA");
-        assert!(adc_well_known_path().is_none());
-        assert!(adc_path().is_none());
+        assert_eq!(adc_well_known_path(), None);
+        assert_eq!(adc_path(), None);
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -237,12 +235,12 @@ mod test {
         let _creds = ScopedEnv::remove("GOOGLE_APPLICATION_CREDENTIALS");
         let _home = ScopedEnv::set("HOME", "/home/foo");
         assert_eq!(
-            adc_well_known_path().unwrap(),
-            "/home/foo/.config/gcloud/application_default_credentials.json"
+            adc_well_known_path(),
+            Some("/home/foo/.config/gcloud/application_default_credentials.json".to_string())
         );
         assert_eq!(
-            adc_path().unwrap(),
-            "/home/foo/.config/gcloud/application_default_credentials.json"
+            adc_path(),
+            Some("/home/foo/.config/gcloud/application_default_credentials.json".to_string())
         );
     }
 
@@ -252,8 +250,8 @@ mod test {
     fn adc_well_known_path_posix_no_home() {
         let _creds = ScopedEnv::remove("GOOGLE_APPLICATION_CREDENTIALS");
         let _appdata = ScopedEnv::remove("HOME");
-        assert!(adc_well_known_path().is_none());
-        assert!(adc_path().is_none());
+        assert_eq!(adc_well_known_path(), None);
+        assert_eq!(adc_path(), None);
     }
 
     #[test]
@@ -264,8 +262,8 @@ mod test {
             "/usr/bar/application_default_credentials.json",
         );
         assert_eq!(
-            adc_path().unwrap(),
-            "/usr/bar/application_default_credentials.json"
+            adc_path(),
+            Some("/usr/bar/application_default_credentials.json".to_string())
         );
     }
 }


### PR DESCRIPTION
Adds a helper function (to be used shortly) that returns the path to look up ADC.

Note that the path changes depending on the OS.

~I do not think our CI exercises the Windows code path. I successfully ran a `cargo test` on my windows machine, if that means anything.~

**EDIT:** Good thing we have Windows coverage thanks to #554.

This is the first use of `scoped_env::ScopedEnv`. I found it helpful: https://docs.rs/scoped-env/latest/scoped_env/index.html