### PR TITLE
test(gax): improve `RequestOptions` coverage

### DIFF
--- a/generator/internal/sidekick/generate.go
+++ b/generator/internal/sidekick/generate.go
@@ -41,7 +41,6 @@ Uses the configuration provided in the command line arguments, and saves it in a
 // generate takes some state and applies it to a template to create a client
 // library.
 func generate(rootConfig *Config, cmdLine *CommandLine) error {
-	generation_year, _, _ := time.Now().Date()
 	local := Config{
 		General: GeneralConfig{
 			Language:            cmdLine.Language,
@@ -52,7 +51,10 @@ func generate(rootConfig *Config, cmdLine *CommandLine) error {
 		Source: maps.Clone(cmdLine.Source),
 		Codec:  maps.Clone(cmdLine.Codec),
 	}
-	local.Codec["copyright-year"] = fmt.Sprintf("%04d", generation_year)
+	if _, ok := local.Codec["copyright-year"]; !ok {
+		generation_year, _, _ := time.Now().Date()
+		local.Codec["copyright-year"] = fmt.Sprintf("%04d", generation_year)
+	}
 
 	if err := writeSidekickToml(cmdLine.Output, &local); err != nil {
 		return err

--- a/src/gax/src/http_client/mod.rs
+++ b/src/gax/src/http_client/mod.rs
@@ -54,7 +54,7 @@ impl ReqwestClient {
         options: crate::options::RequestOptions,
     ) -> Result<O> {
         builder = builder.bearer_auth(Self::fetch_token(&self.cred).await?);
-        if let Some(user_agent) = options.user_agent_prefix() {
+        if let Some(user_agent) = options.user_agent() {
             builder = builder.header(
                 reqwest::header::USER_AGENT,
                 reqwest::header::HeaderValue::from_str(user_agent).map_err(Error::other)?,


### PR DESCRIPTION
Preparing for `RequestOptions` to gain a number of new attributes, it
seems better to improve the coverage. I also noticed an incorrect method
name and fixed it.

Motivated by #437
