### PR TITLE
cleanup: simplify generated code

### DIFF
--- a/generator/internal/language/templates/rust/crate/src/client.rs.mustache
+++ b/generator/internal/language/templates/rust/crate/src/client.rs.mustache
@@ -45,11 +45,11 @@ pub struct {{NameToPascal}} {
 impl {{NameToPascal}} {
     /// Creates a new client with the default configuration.
     pub async fn new() -> Result<Self> {
-        Self::new_with_config(crate::ConfigBuilder::default()).await
+        Self::new_with_config(gax::options::ClientConfig::default()).await
     }
 
     /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
+    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
         let inner = Self::build_inner(conf).await?;
         Ok(Self { inner }) 
     }
@@ -63,18 +63,18 @@ impl {{NameToPascal}} {
         Self { inner: Arc::new(stub) }
     }
 
-    async fn build_inner(conf: crate::ConfigBuilder) -> Result<Arc<dyn crate::traits::dyntraits::{{NameToPascal}}>> {
+    async fn build_inner(conf: gax::options::ClientConfig) -> Result<Arc<dyn crate::traits::dyntraits::{{NameToPascal}}>> {
         if conf.tracing_enabled() {
             return Ok(Arc::new(Self::build_with_tracing(conf).await?));
         }
         Ok(Arc::new(Self::build_transport(conf).await?))
     }
 
-    async fn build_transport(conf: crate::ConfigBuilder) -> Result<impl crate::traits::{{NameToPascal}}> {
+    async fn build_transport(conf: gax::options::ClientConfig) -> Result<impl crate::traits::{{NameToPascal}}> {
         crate::transport::{{NameToPascal}}::new(conf).await
     }
 
-    async fn build_with_tracing(conf: crate::ConfigBuilder) -> Result<impl crate::traits::{{NameToPascal}}> {
+    async fn build_with_tracing(conf: gax::options::ClientConfig) -> Result<impl crate::traits::{{NameToPascal}}> {
         Self::build_transport(conf).await.map(crate::tracing::{{NameToPascal}}::new)
     }
 

--- a/generator/internal/language/templates/rust/crate/src/lib.rs.mustache
+++ b/generator/internal/language/templates/rust/crate/src/lib.rs.mustache
@@ -22,8 +22,7 @@ limitations under the License.
 pub mod model;
 
 {{#HasServices}}
-/// Common error returned by the RPCs in this client library.
-use gax::error::Error;
+pub(crate) use gax::Result;
 
 /// The traits implemented by this client library.
 {{! Google APIs often use angle brackets for <PLACEHOLDERS>, rustdoc does not like those. }}
@@ -61,10 +60,5 @@ pub(crate) mod info {
         };
     }
 }
-
-/// A `Result` alias where the `Err` case is an [Error].
-pub type Result<T> = std::result::Result<T, Error>;
-
-pub type ConfigBuilder = gax::http_client::ClientConfig;
 
 {{/HasServices}}

--- a/generator/testdata/rust/openapi/golden/src/client.rs
+++ b/generator/testdata/rust/openapi/golden/src/client.rs
@@ -37,11 +37,11 @@ pub struct SecretManagerService {
 impl SecretManagerService {
     /// Creates a new client with the default configuration.
     pub async fn new() -> Result<Self> {
-        Self::new_with_config(crate::ConfigBuilder::default()).await
+        Self::new_with_config(gax::options::ClientConfig::default()).await
     }
 
     /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
+    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
         let inner = Self::build_inner(conf).await?;
         Ok(Self { inner }) 
     }
@@ -55,18 +55,18 @@ impl SecretManagerService {
         Self { inner: Arc::new(stub) }
     }
 
-    async fn build_inner(conf: crate::ConfigBuilder) -> Result<Arc<dyn crate::traits::dyntraits::SecretManagerService>> {
+    async fn build_inner(conf: gax::options::ClientConfig) -> Result<Arc<dyn crate::traits::dyntraits::SecretManagerService>> {
         if conf.tracing_enabled() {
             return Ok(Arc::new(Self::build_with_tracing(conf).await?));
         }
         Ok(Arc::new(Self::build_transport(conf).await?))
     }
 
-    async fn build_transport(conf: crate::ConfigBuilder) -> Result<impl crate::traits::SecretManagerService> {
+    async fn build_transport(conf: gax::options::ClientConfig) -> Result<impl crate::traits::SecretManagerService> {
         crate::transport::SecretManagerService::new(conf).await
     }
 
-    async fn build_with_tracing(conf: crate::ConfigBuilder) -> Result<impl crate::traits::SecretManagerService> {
+    async fn build_with_tracing(conf: gax::options::ClientConfig) -> Result<impl crate::traits::SecretManagerService> {
         Self::build_transport(conf).await.map(crate::tracing::SecretManagerService::new)
     }
 

--- a/generator/testdata/rust/openapi/golden/src/lib.rs
+++ b/generator/testdata/rust/openapi/golden/src/lib.rs
@@ -17,8 +17,7 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-/// Common error returned by the RPCs in this client library.
-use gax::error::Error;
+pub(crate) use gax::Result;
 
 /// The traits implemented by this client library.
 #[allow(rustdoc::invalid_html_tags)]
@@ -54,9 +53,4 @@ pub(crate) mod info {
         };
     }
 }
-
-/// A `Result` alias where the `Err` case is an [Error].
-pub type Result<T> = std::result::Result<T, Error>;
-
-pub type ConfigBuilder = gax::http_client::ClientConfig;
 

--- a/generator/testdata/rust/protobuf/golden/iam/v1/src/client.rs
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/src/client.rs
@@ -60,11 +60,11 @@ pub struct IAMPolicy {
 impl IAMPolicy {
     /// Creates a new client with the default configuration.
     pub async fn new() -> Result<Self> {
-        Self::new_with_config(crate::ConfigBuilder::default()).await
+        Self::new_with_config(gax::options::ClientConfig::default()).await
     }
 
     /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
+    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
         let inner = Self::build_inner(conf).await?;
         Ok(Self { inner }) 
     }
@@ -78,18 +78,18 @@ impl IAMPolicy {
         Self { inner: Arc::new(stub) }
     }
 
-    async fn build_inner(conf: crate::ConfigBuilder) -> Result<Arc<dyn crate::traits::dyntraits::IAMPolicy>> {
+    async fn build_inner(conf: gax::options::ClientConfig) -> Result<Arc<dyn crate::traits::dyntraits::IAMPolicy>> {
         if conf.tracing_enabled() {
             return Ok(Arc::new(Self::build_with_tracing(conf).await?));
         }
         Ok(Arc::new(Self::build_transport(conf).await?))
     }
 
-    async fn build_transport(conf: crate::ConfigBuilder) -> Result<impl crate::traits::IAMPolicy> {
+    async fn build_transport(conf: gax::options::ClientConfig) -> Result<impl crate::traits::IAMPolicy> {
         crate::transport::IAMPolicy::new(conf).await
     }
 
-    async fn build_with_tracing(conf: crate::ConfigBuilder) -> Result<impl crate::traits::IAMPolicy> {
+    async fn build_with_tracing(conf: gax::options::ClientConfig) -> Result<impl crate::traits::IAMPolicy> {
         Self::build_transport(conf).await.map(crate::tracing::IAMPolicy::new)
     }
 

--- a/generator/testdata/rust/protobuf/golden/iam/v1/src/lib.rs
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/src/lib.rs
@@ -17,8 +17,7 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-/// Common error returned by the RPCs in this client library.
-use gax::error::Error;
+pub(crate) use gax::Result;
 
 /// The traits implemented by this client library.
 #[allow(rustdoc::invalid_html_tags)]
@@ -54,9 +53,4 @@ pub(crate) mod info {
         };
     }
 }
-
-/// A `Result` alias where the `Err` case is an [Error].
-pub type Result<T> = std::result::Result<T, Error>;
-
-pub type ConfigBuilder = gax::http_client::ClientConfig;
 

--- a/generator/testdata/rust/protobuf/golden/location/src/client.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/client.rs
@@ -40,11 +40,11 @@ pub struct Locations {
 impl Locations {
     /// Creates a new client with the default configuration.
     pub async fn new() -> Result<Self> {
-        Self::new_with_config(crate::ConfigBuilder::default()).await
+        Self::new_with_config(gax::options::ClientConfig::default()).await
     }
 
     /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
+    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
         let inner = Self::build_inner(conf).await?;
         Ok(Self { inner }) 
     }
@@ -58,18 +58,18 @@ impl Locations {
         Self { inner: Arc::new(stub) }
     }
 
-    async fn build_inner(conf: crate::ConfigBuilder) -> Result<Arc<dyn crate::traits::dyntraits::Locations>> {
+    async fn build_inner(conf: gax::options::ClientConfig) -> Result<Arc<dyn crate::traits::dyntraits::Locations>> {
         if conf.tracing_enabled() {
             return Ok(Arc::new(Self::build_with_tracing(conf).await?));
         }
         Ok(Arc::new(Self::build_transport(conf).await?))
     }
 
-    async fn build_transport(conf: crate::ConfigBuilder) -> Result<impl crate::traits::Locations> {
+    async fn build_transport(conf: gax::options::ClientConfig) -> Result<impl crate::traits::Locations> {
         crate::transport::Locations::new(conf).await
     }
 
-    async fn build_with_tracing(conf: crate::ConfigBuilder) -> Result<impl crate::traits::Locations> {
+    async fn build_with_tracing(conf: gax::options::ClientConfig) -> Result<impl crate::traits::Locations> {
         Self::build_transport(conf).await.map(crate::tracing::Locations::new)
     }
 

--- a/generator/testdata/rust/protobuf/golden/location/src/lib.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/lib.rs
@@ -17,8 +17,7 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-/// Common error returned by the RPCs in this client library.
-use gax::error::Error;
+pub(crate) use gax::Result;
 
 /// The traits implemented by this client library.
 #[allow(rustdoc::invalid_html_tags)]
@@ -54,9 +53,4 @@ pub(crate) mod info {
         };
     }
 }
-
-/// A `Result` alias where the `Err` case is an [Error].
-pub type Result<T> = std::result::Result<T, Error>;
-
-pub type ConfigBuilder = gax::http_client::ClientConfig;
 

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/client.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/client.rs
@@ -45,11 +45,11 @@ pub struct SecretManagerService {
 impl SecretManagerService {
     /// Creates a new client with the default configuration.
     pub async fn new() -> Result<Self> {
-        Self::new_with_config(crate::ConfigBuilder::default()).await
+        Self::new_with_config(gax::options::ClientConfig::default()).await
     }
 
     /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
+    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
         let inner = Self::build_inner(conf).await?;
         Ok(Self { inner }) 
     }
@@ -63,18 +63,18 @@ impl SecretManagerService {
         Self { inner: Arc::new(stub) }
     }
 
-    async fn build_inner(conf: crate::ConfigBuilder) -> Result<Arc<dyn crate::traits::dyntraits::SecretManagerService>> {
+    async fn build_inner(conf: gax::options::ClientConfig) -> Result<Arc<dyn crate::traits::dyntraits::SecretManagerService>> {
         if conf.tracing_enabled() {
             return Ok(Arc::new(Self::build_with_tracing(conf).await?));
         }
         Ok(Arc::new(Self::build_transport(conf).await?))
     }
 
-    async fn build_transport(conf: crate::ConfigBuilder) -> Result<impl crate::traits::SecretManagerService> {
+    async fn build_transport(conf: gax::options::ClientConfig) -> Result<impl crate::traits::SecretManagerService> {
         crate::transport::SecretManagerService::new(conf).await
     }
 
-    async fn build_with_tracing(conf: crate::ConfigBuilder) -> Result<impl crate::traits::SecretManagerService> {
+    async fn build_with_tracing(conf: gax::options::ClientConfig) -> Result<impl crate::traits::SecretManagerService> {
         Self::build_transport(conf).await.map(crate::tracing::SecretManagerService::new)
     }
 
@@ -323,11 +323,11 @@ pub struct Locations {
 impl Locations {
     /// Creates a new client with the default configuration.
     pub async fn new() -> Result<Self> {
-        Self::new_with_config(crate::ConfigBuilder::default()).await
+        Self::new_with_config(gax::options::ClientConfig::default()).await
     }
 
     /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
+    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
         let inner = Self::build_inner(conf).await?;
         Ok(Self { inner }) 
     }
@@ -341,18 +341,18 @@ impl Locations {
         Self { inner: Arc::new(stub) }
     }
 
-    async fn build_inner(conf: crate::ConfigBuilder) -> Result<Arc<dyn crate::traits::dyntraits::Locations>> {
+    async fn build_inner(conf: gax::options::ClientConfig) -> Result<Arc<dyn crate::traits::dyntraits::Locations>> {
         if conf.tracing_enabled() {
             return Ok(Arc::new(Self::build_with_tracing(conf).await?));
         }
         Ok(Arc::new(Self::build_transport(conf).await?))
     }
 
-    async fn build_transport(conf: crate::ConfigBuilder) -> Result<impl crate::traits::Locations> {
+    async fn build_transport(conf: gax::options::ClientConfig) -> Result<impl crate::traits::Locations> {
         crate::transport::Locations::new(conf).await
     }
 
-    async fn build_with_tracing(conf: crate::ConfigBuilder) -> Result<impl crate::traits::Locations> {
+    async fn build_with_tracing(conf: gax::options::ClientConfig) -> Result<impl crate::traits::Locations> {
         Self::build_transport(conf).await.map(crate::tracing::Locations::new)
     }
 

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/lib.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/lib.rs
@@ -17,8 +17,7 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-/// Common error returned by the RPCs in this client library.
-use gax::error::Error;
+pub(crate) use gax::Result;
 
 /// The traits implemented by this client library.
 #[allow(rustdoc::invalid_html_tags)]
@@ -54,9 +53,4 @@ pub(crate) mod info {
         };
     }
 }
-
-/// A `Result` alias where the `Err` case is an [Error].
-pub type Result<T> = std::result::Result<T, Error>;
-
-pub type ConfigBuilder = gax::http_client::ClientConfig;
 

--- a/src/gax/src/lib.rs
+++ b/src/gax/src/lib.rs
@@ -28,7 +28,7 @@
 /// An alias of [std::result::Result] where the error is always [crate::error::Error].
 ///
 /// This is the result type used by all functions wrapping RPCs.
-type Result<T> = std::result::Result<T, crate::error::Error>;
+pub type Result<T> = std::result::Result<T, crate::error::Error>;
 
 #[cfg(feature = "unstable-sdk-client")]
 #[doc(hidden)]

--- a/src/generated/cloud/location/src/client.rs
+++ b/src/generated/cloud/location/src/client.rs
@@ -40,11 +40,11 @@ pub struct Locations {
 impl Locations {
     /// Creates a new client with the default configuration.
     pub async fn new() -> Result<Self> {
-        Self::new_with_config(crate::ConfigBuilder::default()).await
+        Self::new_with_config(gax::options::ClientConfig::default()).await
     }
 
     /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
+    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
         let inner = Self::build_inner(conf).await?;
         Ok(Self { inner })
     }
@@ -63,7 +63,7 @@ impl Locations {
     }
 
     async fn build_inner(
-        conf: crate::ConfigBuilder,
+        conf: gax::options::ClientConfig,
     ) -> Result<Arc<dyn crate::traits::dyntraits::Locations>> {
         if conf.tracing_enabled() {
             return Ok(Arc::new(Self::build_with_tracing(conf).await?));
@@ -71,12 +71,14 @@ impl Locations {
         Ok(Arc::new(Self::build_transport(conf).await?))
     }
 
-    async fn build_transport(conf: crate::ConfigBuilder) -> Result<impl crate::traits::Locations> {
+    async fn build_transport(
+        conf: gax::options::ClientConfig,
+    ) -> Result<impl crate::traits::Locations> {
         crate::transport::Locations::new(conf).await
     }
 
     async fn build_with_tracing(
-        conf: crate::ConfigBuilder,
+        conf: gax::options::ClientConfig,
     ) -> Result<impl crate::traits::Locations> {
         Self::build_transport(conf)
             .await

--- a/src/generated/cloud/location/src/lib.rs
+++ b/src/generated/cloud/location/src/lib.rs
@@ -17,8 +17,7 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-/// Common error returned by the RPCs in this client library.
-use gax::error::Error;
+pub(crate) use gax::Result;
 
 /// The traits implemented by this client library.
 #[allow(rustdoc::invalid_html_tags)]
@@ -54,8 +53,3 @@ pub(crate) mod info {
         };
     }
 }
-
-/// A `Result` alias where the `Err` case is an [Error].
-pub type Result<T> = std::result::Result<T, Error>;
-
-pub type ConfigBuilder = gax::http_client::ClientConfig;

--- a/src/generated/cloud/secretmanager/v1/src/client.rs
+++ b/src/generated/cloud/secretmanager/v1/src/client.rs
@@ -45,11 +45,11 @@ pub struct SecretManagerService {
 impl SecretManagerService {
     /// Creates a new client with the default configuration.
     pub async fn new() -> Result<Self> {
-        Self::new_with_config(crate::ConfigBuilder::default()).await
+        Self::new_with_config(gax::options::ClientConfig::default()).await
     }
 
     /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
+    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
         let inner = Self::build_inner(conf).await?;
         Ok(Self { inner })
     }
@@ -68,7 +68,7 @@ impl SecretManagerService {
     }
 
     async fn build_inner(
-        conf: crate::ConfigBuilder,
+        conf: gax::options::ClientConfig,
     ) -> Result<Arc<dyn crate::traits::dyntraits::SecretManagerService>> {
         if conf.tracing_enabled() {
             return Ok(Arc::new(Self::build_with_tracing(conf).await?));
@@ -77,13 +77,13 @@ impl SecretManagerService {
     }
 
     async fn build_transport(
-        conf: crate::ConfigBuilder,
+        conf: gax::options::ClientConfig,
     ) -> Result<impl crate::traits::SecretManagerService> {
         crate::transport::SecretManagerService::new(conf).await
     }
 
     async fn build_with_tracing(
-        conf: crate::ConfigBuilder,
+        conf: gax::options::ClientConfig,
     ) -> Result<impl crate::traits::SecretManagerService> {
         Self::build_transport(conf)
             .await
@@ -283,11 +283,11 @@ pub struct Locations {
 impl Locations {
     /// Creates a new client with the default configuration.
     pub async fn new() -> Result<Self> {
-        Self::new_with_config(crate::ConfigBuilder::default()).await
+        Self::new_with_config(gax::options::ClientConfig::default()).await
     }
 
     /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
+    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
         let inner = Self::build_inner(conf).await?;
         Ok(Self { inner })
     }
@@ -306,7 +306,7 @@ impl Locations {
     }
 
     async fn build_inner(
-        conf: crate::ConfigBuilder,
+        conf: gax::options::ClientConfig,
     ) -> Result<Arc<dyn crate::traits::dyntraits::Locations>> {
         if conf.tracing_enabled() {
             return Ok(Arc::new(Self::build_with_tracing(conf).await?));
@@ -314,12 +314,14 @@ impl Locations {
         Ok(Arc::new(Self::build_transport(conf).await?))
     }
 
-    async fn build_transport(conf: crate::ConfigBuilder) -> Result<impl crate::traits::Locations> {
+    async fn build_transport(
+        conf: gax::options::ClientConfig,
+    ) -> Result<impl crate::traits::Locations> {
         crate::transport::Locations::new(conf).await
     }
 
     async fn build_with_tracing(
-        conf: crate::ConfigBuilder,
+        conf: gax::options::ClientConfig,
     ) -> Result<impl crate::traits::Locations> {
         Self::build_transport(conf)
             .await

--- a/src/generated/cloud/secretmanager/v1/src/lib.rs
+++ b/src/generated/cloud/secretmanager/v1/src/lib.rs
@@ -17,8 +17,7 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-/// Common error returned by the RPCs in this client library.
-use gax::error::Error;
+pub(crate) use gax::Result;
 
 /// The traits implemented by this client library.
 #[allow(rustdoc::invalid_html_tags)]
@@ -54,8 +53,3 @@ pub(crate) mod info {
         };
     }
 }
-
-/// A `Result` alias where the `Err` case is an [Error].
-pub type Result<T> = std::result::Result<T, Error>;
-
-pub type ConfigBuilder = gax::http_client::ClientConfig;

--- a/src/generated/iam/v1/src/client.rs
+++ b/src/generated/iam/v1/src/client.rs
@@ -60,11 +60,11 @@ pub struct IAMPolicy {
 impl IAMPolicy {
     /// Creates a new client with the default configuration.
     pub async fn new() -> Result<Self> {
-        Self::new_with_config(crate::ConfigBuilder::default()).await
+        Self::new_with_config(gax::options::ClientConfig::default()).await
     }
 
     /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
+    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
         let inner = Self::build_inner(conf).await?;
         Ok(Self { inner })
     }
@@ -83,7 +83,7 @@ impl IAMPolicy {
     }
 
     async fn build_inner(
-        conf: crate::ConfigBuilder,
+        conf: gax::options::ClientConfig,
     ) -> Result<Arc<dyn crate::traits::dyntraits::IAMPolicy>> {
         if conf.tracing_enabled() {
             return Ok(Arc::new(Self::build_with_tracing(conf).await?));
@@ -91,12 +91,14 @@ impl IAMPolicy {
         Ok(Arc::new(Self::build_transport(conf).await?))
     }
 
-    async fn build_transport(conf: crate::ConfigBuilder) -> Result<impl crate::traits::IAMPolicy> {
+    async fn build_transport(
+        conf: gax::options::ClientConfig,
+    ) -> Result<impl crate::traits::IAMPolicy> {
         crate::transport::IAMPolicy::new(conf).await
     }
 
     async fn build_with_tracing(
-        conf: crate::ConfigBuilder,
+        conf: gax::options::ClientConfig,
     ) -> Result<impl crate::traits::IAMPolicy> {
         Self::build_transport(conf)
             .await

--- a/src/generated/iam/v1/src/lib.rs
+++ b/src/generated/iam/v1/src/lib.rs
@@ -17,8 +17,7 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-/// Common error returned by the RPCs in this client library.
-use gax::error::Error;
+pub(crate) use gax::Result;
 
 /// The traits implemented by this client library.
 #[allow(rustdoc::invalid_html_tags)]
@@ -54,8 +53,3 @@ pub(crate) mod info {
         };
     }
 }
-
-/// A `Result` alias where the `Err` case is an [Error].
-pub type Result<T> = std::result::Result<T, Error>;
-
-pub type ConfigBuilder = gax::http_client::ClientConfig;

--- a/src/generated/longrunning/src/client.rs
+++ b/src/generated/longrunning/src/client.rs
@@ -46,11 +46,11 @@ pub struct Operations {
 impl Operations {
     /// Creates a new client with the default configuration.
     pub async fn new() -> Result<Self> {
-        Self::new_with_config(crate::ConfigBuilder::default()).await
+        Self::new_with_config(gax::options::ClientConfig::default()).await
     }
 
     /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
+    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
         let inner = Self::build_inner(conf).await?;
         Ok(Self { inner })
     }
@@ -69,7 +69,7 @@ impl Operations {
     }
 
     async fn build_inner(
-        conf: crate::ConfigBuilder,
+        conf: gax::options::ClientConfig,
     ) -> Result<Arc<dyn crate::traits::dyntraits::Operations>> {
         if conf.tracing_enabled() {
             return Ok(Arc::new(Self::build_with_tracing(conf).await?));
@@ -77,12 +77,14 @@ impl Operations {
         Ok(Arc::new(Self::build_transport(conf).await?))
     }
 
-    async fn build_transport(conf: crate::ConfigBuilder) -> Result<impl crate::traits::Operations> {
+    async fn build_transport(
+        conf: gax::options::ClientConfig,
+    ) -> Result<impl crate::traits::Operations> {
         crate::transport::Operations::new(conf).await
     }
 
     async fn build_with_tracing(
-        conf: crate::ConfigBuilder,
+        conf: gax::options::ClientConfig,
     ) -> Result<impl crate::traits::Operations> {
         Self::build_transport(conf)
             .await

--- a/src/generated/longrunning/src/lib.rs
+++ b/src/generated/longrunning/src/lib.rs
@@ -17,8 +17,7 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-/// Common error returned by the RPCs in this client library.
-use gax::error::Error;
+pub(crate) use gax::Result;
 
 /// The traits implemented by this client library.
 #[allow(rustdoc::invalid_html_tags)]
@@ -54,8 +53,3 @@ pub(crate) mod info {
         };
     }
 }
-
-/// A `Result` alias where the `Err` case is an [Error].
-pub type Result<T> = std::result::Result<T, Error>;
-
-pub type ConfigBuilder = gax::http_client::ClientConfig;

--- a/src/generated/openapi-validation/src/client.rs
+++ b/src/generated/openapi-validation/src/client.rs
@@ -37,11 +37,11 @@ pub struct SecretManagerService {
 impl SecretManagerService {
     /// Creates a new client with the default configuration.
     pub async fn new() -> Result<Self> {
-        Self::new_with_config(crate::ConfigBuilder::default()).await
+        Self::new_with_config(gax::options::ClientConfig::default()).await
     }
 
     /// Creates a new client with the specified configuration.
-    pub async fn new_with_config(conf: crate::ConfigBuilder) -> Result<Self> {
+    pub async fn new_with_config(conf: gax::options::ClientConfig) -> Result<Self> {
         let inner = Self::build_inner(conf).await?;
         Ok(Self { inner })
     }
@@ -60,7 +60,7 @@ impl SecretManagerService {
     }
 
     async fn build_inner(
-        conf: crate::ConfigBuilder,
+        conf: gax::options::ClientConfig,
     ) -> Result<Arc<dyn crate::traits::dyntraits::SecretManagerService>> {
         if conf.tracing_enabled() {
             return Ok(Arc::new(Self::build_with_tracing(conf).await?));
@@ -69,13 +69,13 @@ impl SecretManagerService {
     }
 
     async fn build_transport(
-        conf: crate::ConfigBuilder,
+        conf: gax::options::ClientConfig,
     ) -> Result<impl crate::traits::SecretManagerService> {
         crate::transport::SecretManagerService::new(conf).await
     }
 
     async fn build_with_tracing(
-        conf: crate::ConfigBuilder,
+        conf: gax::options::ClientConfig,
     ) -> Result<impl crate::traits::SecretManagerService> {
         Self::build_transport(conf)
             .await

--- a/src/generated/openapi-validation/src/lib.rs
+++ b/src/generated/openapi-validation/src/lib.rs
@@ -17,8 +17,7 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-/// Common error returned by the RPCs in this client library.
-use gax::error::Error;
+pub(crate) use gax::Result;
 
 /// The traits implemented by this client library.
 #[allow(rustdoc::invalid_html_tags)]
@@ -54,8 +53,3 @@ pub(crate) mod info {
         };
     }
 }
-
-/// A `Result` alias where the `Err` case is an [Error].
-pub type Result<T> = std::result::Result<T, Error>;
-
-pub type ConfigBuilder = gax::http_client::ClientConfig;

--- a/src/integration-tests/src/secret_manager/openapi.rs
+++ b/src/integration-tests/src/secret_manager/openapi.rs
@@ -22,7 +22,7 @@ async fn new_client(tracing: bool) -> Result<smo::client::SecretManagerService> 
         return smo::client::SecretManagerService::new().await;
     }
     smo::client::SecretManagerService::new_with_config(
-        smo::ConfigBuilder::default().enable_tracing(),
+        gax::options::ClientConfig::default().enable_tracing(),
     )
     .await
 }

--- a/src/integration-tests/src/secret_manager/openapi_locational.rs
+++ b/src/integration-tests/src/secret_manager/openapi_locational.rs
@@ -26,7 +26,7 @@ pub async fn run(tracing: bool) -> Result<()> {
 
     let location_id = "us-central1".to_string();
 
-    let mut config = smo::ConfigBuilder::new().set_endpoint(format!(
+    let mut config = gax::options::ClientConfig::new().set_endpoint(format!(
         "https://secretmanager.{location_id}.rep.googleapis.com"
     ));
     if tracing {

--- a/src/integration-tests/src/secret_manager/protobuf.rs
+++ b/src/integration-tests/src/secret_manager/protobuf.rs
@@ -23,8 +23,10 @@ async fn new_client(tracing: bool) -> Result<sm::client::SecretManagerService> {
         // constructor.
         return sm::client::SecretManagerService::new().await;
     }
-    sm::client::SecretManagerService::new_with_config(sm::ConfigBuilder::default().enable_tracing())
-        .await
+    sm::client::SecretManagerService::new_with_config(
+        gax::options::ClientConfig::default().enable_tracing(),
+    )
+    .await
 }
 
 pub async fn run(tracing: bool) -> Result<()> {
@@ -45,9 +47,10 @@ pub async fn run(tracing: bool) -> Result<()> {
         .collect();
 
     let client = new_client(tracing).await?;
-    let location_client =
-        sm::client::Locations::new_with_config(sm::ConfigBuilder::default().enable_tracing())
-            .await?;
+    let location_client = sm::client::Locations::new_with_config(
+        gax::options::ClientConfig::default().enable_tracing(),
+    )
+    .await?;
 
     cleanup_stale_secrets(&client, &project_id, &secret_id).await?;
 

--- a/src/integration-tests/tests/mocking.rs
+++ b/src/integration-tests/tests/mocking.rs
@@ -20,7 +20,7 @@ mod mocking {
         #[derive(Debug)]
         SecretManagerService {}
         impl sm::traits::SecretManagerService for SecretManagerService {
-            async fn create_secret(&self, req: sm::model::CreateSecretRequest, _options: gax::options::RequestOptions) -> sm::Result<sm::model::Secret>;
+            async fn create_secret(&self, req: sm::model::CreateSecretRequest, _options: gax::options::RequestOptions) -> gax::Result<sm::model::Secret>;
         }
     }
 
@@ -30,7 +30,7 @@ mod mocking {
         project: &str,
         region: &str,
         id: &str,
-    ) -> sm::Result<sm::model::Secret> {
+    ) -> gax::Result<sm::model::Secret> {
         client
             .create_secret(format!("projects/{project}/locations/{region}"))
             .set_secret_id(id)


### PR DESCRIPTION
We were using an alias of an alias for in the generated code. Just use
the type directly.

Motivated by #437
