### PR TITLE
cleanup(sidekick): revised and simplified http annotation parser

### DIFF
--- a/generator/internal/sidekick/generate.go
+++ b/generator/internal/sidekick/generate.go
@@ -41,7 +41,6 @@ Uses the configuration provided in the command line arguments, and saves it in a
 // generate takes some state and applies it to a template to create a client
 // library.
 func generate(rootConfig *Config, cmdLine *CommandLine) error {
-	generation_year, _, _ := time.Now().Date()
 	local := Config{
 		General: GeneralConfig{
 			Language:            cmdLine.Language,
@@ -52,7 +51,10 @@ func generate(rootConfig *Config, cmdLine *CommandLine) error {
 		Source: maps.Clone(cmdLine.Source),
 		Codec:  maps.Clone(cmdLine.Codec),
 	}
-	local.Codec["copyright-year"] = fmt.Sprintf("%04d", generation_year)
+	if _, ok := local.Codec["copyright-year"]; !ok {
+		generation_year, _, _ := time.Now().Date()
+		local.Codec["copyright-year"] = fmt.Sprintf("%04d", generation_year)
+	}
 
 	if err := writeSidekickToml(cmdLine.Output, &local); err != nil {
 		return err


### PR DESCRIPTION
Followed [@coryan's recommendation](https://github.com/googleapis/google-cloud-rust/pull/545#discussion_r1899849354) on #545 and changed the parser functions to consume as many runes as possible (instead of the full string), and return a counter alongside the successful result. This reduced the number of checks each parser function had to make, and made the code easier to read.
