### PR TITLE
feat(auth): user credentials from ADC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,10 +625,12 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "tempfile",
  "test-case",
  "thiserror",
  "time",
  "tokio",
+ "tokio-test",
 ]
 
 [[package]]
@@ -2302,6 +2326,30 @@ checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -37,5 +37,7 @@ axum        = "0.7.9"
 mockall     = "0.13.1"
 scoped-env  = "2.1.0"
 serial_test = "3.2.0"
+tempfile    = "3.14.0"
 test-case   = "3.3.1"
 tokio       = { version = "1.42", features = ["macros", "rt-multi-thread", "test-util"] }
+tokio-test  = "0.4.4"

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -195,13 +195,15 @@ pub mod traits {
 /// Example usage:
 ///
 /// ```
-/// # tokio_test::block_on(async {
 /// # use gcp_sdk_auth::credentials::create_access_token_credential;
 /// # use gcp_sdk_auth::credentials::traits::Credential;
-/// let mut creds = create_access_token_credential().await.unwrap();
-/// let token = creds.get_token().await.unwrap();
+/// # use gcp_sdk_auth::errors::CredentialError;
+/// # tokio_test::block_on(async {
+/// let mut creds = create_access_token_credential().await?;
+/// let token = creds.get_token().await?;
 /// println!("Token: {}", token.token);
-/// # })
+/// # Ok::<(), CredentialError>(())
+/// # });
 /// ```
 ///
 /// [ADC-link]: https://cloud.google.com/docs/authentication/application-default-credentials

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -15,6 +15,7 @@
 pub(crate) mod mds_credential;
 pub(crate) mod user_credential;
 
+use crate::errors::CredentialError;
 use crate::Result;
 use http::header::{HeaderName, HeaderValue};
 use std::future::Future;
@@ -166,10 +167,86 @@ pub mod traits {
     }
 }
 
+/// Create access token credentials.
+///
+/// Returns [Application Default Credentials (ADC)][ADC-link]. These are the
+/// most commonly used credentials, and are expected to meet the needs of most
+/// applications. They conform to [AIP-4110].
+///
+/// The access tokens returned by these credentials are to be used in the
+/// `Authorization` HTTP header.
+///
+/// Consider using these credentials when:
+///
+/// - Your application is deployed to a GCP environment such as GCE, GKE, or
+///   Cloud Run. Each of these deployment environments provides a default service
+///   account to the application, and offers mechanisms to change the default
+///   credentials without any code changes to your application.
+/// - You are testing or developing the application on a workstation (physical or
+///   virtual). These credentials will use your preferences as set with
+///   [gcloud auth application-default]. These preferences can be your own GCP
+///   user credentials, or some service account.
+/// - Regardless of where your application is running, you can use the
+///   `GOOGLE_APPLICATION_CREDENTIALS` environment variable to override the
+///   defaults. This environment variable should point to a file containing a
+///   service account key file, or a JSON object describing your user
+///   credentials.
+///
+/// Example usage:
+///
+/// ```
+/// # tokio_test::block_on(async {
+/// # use gcp_sdk_auth::credentials::create_access_token_credential;
+/// # use gcp_sdk_auth::credentials::traits::Credential;
+/// let mut creds = create_access_token_credential().await.unwrap();
+/// let token = creds.get_token().await.unwrap();
+/// println!("Token: {}", token.token);
+/// # })
+/// ```
+///
+/// [ADC-link]: https://cloud.google.com/docs/authentication/application-default-credentials
+/// [AIP-4110]: https://google.aip.dev/auth/4110
+/// [gcloud auth application-default]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default
+pub async fn create_access_token_credential() -> Result<Credential> {
+    let adc_path = adc_path().ok_or(
+        // TODO(#442) - This should (successfully) fall back to MDS Credentials. We will temporarily return an error.
+        CredentialError::new(false, Box::from("Unable to find ADC.")),
+    )?;
+
+    let contents = std::fs::read_to_string(adc_path).map_err(|e| {
+        match e.kind() {
+            std::io::ErrorKind::NotFound => {
+                // TODO(#442) - This should (successfully) fall back to MDS Credentials. We will temporarily return an error.
+                CredentialError::new(false, Box::from("Unable to find ADC."))
+            }
+            _ => CredentialError::new(false, e.into()),
+        }
+    })?;
+    let js: serde_json::Value =
+        serde_json::from_str(&contents).map_err(|e| CredentialError::new(false, e.into()))?;
+    let cred_type = js
+        .get("type")
+        .ok_or(CredentialError::new(
+            false,
+            Box::from("Failed to parse ADC. No `type` field found."),
+        ))?
+        .as_str()
+        .ok_or(CredentialError::new(
+            false,
+            Box::from("Failed to parse ADC. `type` field is not a string."),
+        ))?;
+    match cred_type {
+        "authorized_user" => user_credential::creds_from(js),
+        _ => Err(CredentialError::new(
+            false,
+            Box::from(format! {"Unimplemented credential type: {cred_type}"}),
+        )),
+    }
+}
+
 /// The path to Application Default Credentials (ADC), as specified in [AIP-4110].
 ///
 /// [AIP-4110]: https://google.aip.dev/auth/4110
-#[allow(dead_code)] // TODO(#442) - implementation in progress
 fn adc_path() -> Option<String> {
     std::env::var("GOOGLE_APPLICATION_CREDENTIALS")
         .ok()

--- a/src/auth/src/credentials/user_credential.rs
+++ b/src/auth/src/credentials/user_credential.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::credentials::traits::dynamic::Credential;
+use crate::credentials::traits::dynamic::Credential as CredentialTrait;
+use crate::credentials::Credential;
 use crate::credentials::Result;
 use crate::errors::{is_retryable, CredentialError};
 use crate::token::{Token, TokenProvider};
@@ -21,10 +22,16 @@ use reqwest::{Client, Method};
 use std::time::Duration;
 use time::OffsetDateTime;
 
-#[allow(dead_code)] // TODO(#442) - implementation in progress
 const OAUTH2_ENDPOINT: &str = "https://oauth2.googleapis.com/token";
 
-#[allow(dead_code)] // TODO(#442) - implementation in progress
+pub(crate) fn creds_from(js: serde_json::Value) -> Result<Credential> {
+    let tp = UserTokenProvider::from_json(js)?;
+
+    Ok(Credential {
+        inner: Box::new(UserCredential { token_provider: tp }),
+    })
+}
+
 #[derive(Debug, PartialEq)]
 struct UserTokenProvider {
     client_id: String,
@@ -34,7 +41,6 @@ struct UserTokenProvider {
 }
 
 impl UserTokenProvider {
-    #[allow(dead_code)] // TODO(#442) - implementation in progress
     fn from_json(js: serde_json::Value) -> Result<Self> {
         let au: AuthorizedUser =
             serde_json::from_value(js).map_err(|e| CredentialError::new(false, e.into()))?;
@@ -98,7 +104,8 @@ impl TokenProvider for UserTokenProvider {
 }
 
 /// Data model for a UserCredential
-#[allow(dead_code)] // TODO(#442) - implementation in progress
+///
+/// See: https://cloud.google.com/docs/authentication#user-accounts
 pub(crate) struct UserCredential<T>
 where
     T: TokenProvider,
@@ -107,7 +114,7 @@ where
 }
 
 #[async_trait::async_trait]
-impl<T> Credential for UserCredential<T>
+impl<T> CredentialTrait for UserCredential<T>
 where
     T: TokenProvider,
 {

--- a/src/auth/src/credentials/user_credential.rs
+++ b/src/auth/src/credentials/user_credential.rs
@@ -25,10 +25,10 @@ use time::OffsetDateTime;
 const OAUTH2_ENDPOINT: &str = "https://oauth2.googleapis.com/token";
 
 pub(crate) fn creds_from(js: serde_json::Value) -> Result<Credential> {
-    let tp = UserTokenProvider::from_json(js)?;
+    let token_provider = UserTokenProvider::from_json(js)?;
 
     Ok(Credential {
-        inner: Box::new(UserCredential { token_provider: tp }),
+        inner: Box::new(UserCredential { token_provider }),
     })
 }
 

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -29,7 +29,7 @@ mod test {
         let _e3 = ScopedEnv::remove("APPDATA"); // For windows
         let err = create_access_token_credential().await.err().unwrap();
         let msg = err.source().unwrap().to_string();
-        assert!(msg.contains("Unable to find ADC"));
+        assert!(msg.contains("Unable to find Application Default Credentials"));
     }
 
     #[tokio::test]
@@ -39,7 +39,7 @@ mod test {
         let _e = ScopedEnv::set("GOOGLE_APPLICATION_CREDENTIALS", "file-does-not-exist.json");
         let err = create_access_token_credential().await.err().unwrap();
         let msg = err.source().unwrap().to_string();
-        assert!(msg.contains("Unable to find ADC"));
+        assert!(msg.contains("Unable to find Application Default Credentials"));
     }
 
     #[tokio::test]
@@ -53,7 +53,7 @@ mod test {
 
             let err = create_access_token_credential().await.err().unwrap();
             let msg = err.source().unwrap().to_string();
-            assert!(msg.contains("Failed to parse ADC"));
+            assert!(msg.contains("Failed to parse"));
             assert!(msg.contains("`type` field"));
         }
     }

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -1,0 +1,96 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use gcp_sdk_auth::credentials::create_access_token_credential;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use scoped_env::ScopedEnv;
+    use std::error::Error;
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn create_access_token_credential_no_adc_filepath_fallback() {
+        // TODO(#442) - We should (successfully) fall back to MDS Credentials. But for now we are temporarily returning an error.
+        let _e1 = ScopedEnv::remove("GOOGLE_APPLICATION_CREDENTIALS");
+        let _e2 = ScopedEnv::remove("HOME"); // For posix
+        let _e3 = ScopedEnv::remove("APPDATA"); // For windows
+        let err = create_access_token_credential().await.err().unwrap();
+        let msg = err.source().unwrap().to_string();
+        assert!(msg.contains("Unable to find ADC"));
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn create_access_token_credential_no_adc_file_fallback() {
+        // TODO(#442) - We should (successfully) fall back to MDS Credentials. But for now we are temporarily returning an error.
+        let _e = ScopedEnv::set("GOOGLE_APPLICATION_CREDENTIALS", "file-does-not-exist.json");
+        let err = create_access_token_credential().await.err().unwrap();
+        let msg = err.source().unwrap().to_string();
+        assert!(msg.contains("Unable to find ADC"));
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn create_access_token_credential_malformed_adc_is_error() {
+        for contents in ["{}", r#"{"type": 42}"#] {
+            let file = tempfile::NamedTempFile::new().unwrap();
+            let path = file.into_temp_path();
+            std::fs::write(&path, contents).expect("Unable to write to temporary file.");
+            let _e = ScopedEnv::set("GOOGLE_APPLICATION_CREDENTIALS", path.to_str().unwrap());
+
+            let err = create_access_token_credential().await.err().unwrap();
+            let msg = err.source().unwrap().to_string();
+            assert!(msg.contains("Failed to parse ADC"));
+            assert!(msg.contains("`type` field"));
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn create_access_token_credential_adc_unimplemented_credential_type() {
+        let contents = r#"{
+            "type": "some_unknown_credential_type"
+        }"#;
+
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let path = file.into_temp_path();
+        std::fs::write(&path, contents).expect("Unable to write to temporary file.");
+        let _e = ScopedEnv::set("GOOGLE_APPLICATION_CREDENTIALS", path.to_str().unwrap());
+
+        let err = create_access_token_credential().await.err().unwrap();
+        let msg = err.source().unwrap().to_string();
+        assert!(msg.contains("Unimplemented"));
+        assert!(msg.contains("some_unknown_credential_type"));
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn create_access_token_credential_adc_user_credentials() {
+        let contents = r#"{
+            "client_id": "test-client-id",
+            "client_secret": "test-client-secret",
+            "refresh_token": "test-refresh-token",
+            "type": "authorized_user"
+        }"#;
+
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let path = file.into_temp_path();
+        std::fs::write(&path, contents).expect("Unable to write to temporary file.");
+        let _e = ScopedEnv::set("GOOGLE_APPLICATION_CREDENTIALS", path.to_str().unwrap());
+
+        create_access_token_credential().await.unwrap();
+    }
+}


### PR DESCRIPTION
Part of the work for #442 

Load ADC from a file. Parse the contents of the json. If the `type == "authorized_user"`, then create user credentials. In any other case, return an error.

In a follow up, I will hook this thing up to the MDS credentials.

There are still no integration tests. We will just check that Credentials are successfully created, not that tokens are successfully retrieved.