### PR TITLE
feat(auth): fallback to MDS credentials

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -218,12 +218,12 @@ pub async fn create_access_token_credential() -> Result<Credential> {
     let adc_path = match adc_path() {
         Some(path) => path,
         None => {
-            return mds_credential::new();
+            return Ok(mds_credential::new());
         }
     };
     let contents = match std::fs::read_to_string(adc_path) {
         Ok(contents) => contents,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return mds_credential::new(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(mds_credential::new()),
         Err(e) => return Err(CredentialError::new(false, e.into())),
     };
     let js: serde_json::Value =

--- a/src/auth/src/credentials/mds_credential.rs
+++ b/src/auth/src/credentials/mds_credential.rs
@@ -26,17 +26,17 @@ use time::OffsetDateTime;
 
 const METADATA_FLAVOR_VALUE: &str = "Google";
 const METADATA_FLAVOR: &str = "metadata-flavor";
-#[allow(dead_code)] // TODO(#442) - implementation in progress
 const METADATA_ROOT: &str = "http://metadata.google.internal/computeMetadata/v1";
 
-pub(crate) fn new() -> Result<Credential> {
+pub(crate) fn new() -> Credential {
     let token_provider = MDSAccessTokenProvider {
         endpoint: METADATA_ROOT.to_string(),
     };
-    Ok(Credential {
+    Credential {
         inner: Box::new(MDSCredential { token_provider }),
-    })
+    }
 }
+
 struct MDSCredential<T>
 where
     T: TokenProvider,
@@ -66,8 +66,7 @@ where
     }
 }
 
-#[allow(dead_code)] // TODO(#442) - implementation in progress
-#[derive(serde::Deserialize, serde::Serialize, PartialEq, Debug, Clone)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 struct ServiceAccountInfo {
     email: String,
     scopes: Option<Vec<String>>,
@@ -124,7 +123,6 @@ impl MDSAccessTokenProvider {
 }
 
 #[async_trait]
-#[allow(dead_code)]
 impl TokenProvider for MDSAccessTokenProvider {
     async fn get_token(&mut self) -> Result<Token> {
         let client = Client::new();

--- a/src/auth/src/credentials/mds_credential.rs
+++ b/src/auth/src/credentials/mds_credential.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::credentials::traits::dynamic::Credential;
-use crate::credentials::Result;
+use crate::credentials::traits::dynamic::Credential as CredentialTrait;
+use crate::credentials::{Credential, Result};
 use crate::errors::{is_retryable, CredentialError};
 use crate::token::{Token, TokenProvider};
 use async_trait::async_trait;
@@ -29,8 +29,15 @@ const METADATA_FLAVOR: &str = "metadata-flavor";
 #[allow(dead_code)] // TODO(#442) - implementation in progress
 const METADATA_ROOT: &str = "http://metadata.google.internal/computeMetadata/v1";
 
-#[allow(dead_code)] // TODO(#442) - implementation in progress
-pub(crate) struct MDSCredential<T>
+pub(crate) fn new() -> Result<Credential> {
+    let token_provider = MDSAccessTokenProvider {
+        endpoint: METADATA_ROOT.to_string(),
+    };
+    Ok(Credential {
+        inner: Box::new(MDSCredential { token_provider }),
+    })
+}
+struct MDSCredential<T>
 where
     T: TokenProvider,
 {
@@ -38,7 +45,7 @@ where
 }
 
 #[async_trait::async_trait]
-impl<T> Credential for MDSCredential<T>
+impl<T> CredentialTrait for MDSCredential<T>
 where
     T: TokenProvider,
 {
@@ -75,13 +82,12 @@ struct MDSTokenResponse {
     token_type: String,
 }
 
-#[allow(dead_code)] // TODO(#442) - implementation in progress
 struct MDSAccessTokenProvider {
     endpoint: String,
 }
 
-#[allow(dead_code)]
 impl MDSAccessTokenProvider {
+    #[allow(dead_code)]
     async fn get_service_account_info(
         request: &Client,
         metadata_service_endpoint: String,

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -22,10 +22,12 @@ mod test {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn create_access_token_credential_no_adc_filepath_fallback_to_mds() {
+    async fn create_access_token_credential_fallback_to_mds() {
         let _e1 = ScopedEnv::remove("GOOGLE_APPLICATION_CREDENTIALS");
         let _e2 = ScopedEnv::remove("HOME"); // For posix
         let _e3 = ScopedEnv::remove("APPDATA"); // For windows
+
+        // We will assume that if credentials were created successfully, they are MDS Credentials.
         create_access_token_credential().await.unwrap();
     }
 

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -22,24 +22,18 @@ mod test {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn create_access_token_credential_no_adc_filepath_fallback() {
-        // TODO(#442) - We should (successfully) fall back to MDS Credentials. But for now we are temporarily returning an error.
+    async fn create_access_token_credential_no_adc_filepath_fallback_to_mds() {
         let _e1 = ScopedEnv::remove("GOOGLE_APPLICATION_CREDENTIALS");
         let _e2 = ScopedEnv::remove("HOME"); // For posix
         let _e3 = ScopedEnv::remove("APPDATA"); // For windows
-        let err = create_access_token_credential().await.err().unwrap();
-        let msg = err.source().unwrap().to_string();
-        assert!(msg.contains("Unable to find Application Default Credentials"));
+        create_access_token_credential().await.unwrap();
     }
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn create_access_token_credential_no_adc_file_fallback() {
-        // TODO(#442) - We should (successfully) fall back to MDS Credentials. But for now we are temporarily returning an error.
+    async fn create_access_token_credential_no_adc_file_fallback_to_mds() {
         let _e = ScopedEnv::set("GOOGLE_APPLICATION_CREDENTIALS", "file-does-not-exist.json");
-        let err = create_access_token_credential().await.err().unwrap();
-        let msg = err.source().unwrap().to_string();
-        assert!(msg.contains("Unable to find Application Default Credentials"));
+        create_access_token_credential().await.unwrap();
     }
 
     #[tokio::test]

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -31,9 +31,13 @@ mod test {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn create_access_token_credential_no_adc_file_fallback_to_mds() {
+    async fn create_access_token_credential_errors_if_adc_env_is_not_a_file() {
         let _e = ScopedEnv::set("GOOGLE_APPLICATION_CREDENTIALS", "file-does-not-exist.json");
-        create_access_token_credential().await.unwrap();
+        let err = create_access_token_credential().await.err().unwrap();
+        let msg = err.source().unwrap().to_string();
+        assert!(msg.contains("Failed to load Application Default Credentials"));
+        assert!(msg.contains("file-does-not-exist.json"));
+        assert!(msg.contains("GOOGLE_APPLICATION_CREDENTIALS"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Part of the work for #442 

If the ADC path is not known, or the file does not exist, fallback to MDS credentials.

If the ADC path is found, but malformed in some way, we do not fallback, we return the error.

We are desperate for some integration tests. The unit tests just verify that some credentials are successfully made. They cannot tell the difference between MDS and User Credentials. It also wouldn't make sense to try to use the token providers in the unit tests.