### PR TITLE
feat(auth): implement `std::fmt::Debug` trait

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -53,6 +53,7 @@ use std::future::Future;
 /// [Metadata Service]: https://cloud.google.com/compute/docs/metadata/overview
 /// [Google Compute Engine]: https://cloud.google.com/products/compute
 /// [Google Kubernetes Engine]: https://cloud.google.com/kubernetes-engine
+#[derive(Debug)]
 pub struct Credential {
     inner: Box<dyn traits::dynamic::Credential>,
 }
@@ -117,7 +118,7 @@ pub mod traits {
     /// [Metadata Service]: https://cloud.google.com/compute/docs/metadata/overview
     /// [Google Compute Engine]: https://cloud.google.com/products/compute
     /// [Google Kubernetes Engine]: https://cloud.google.com/kubernetes-engine
-    pub trait Credential {
+    pub trait Credential: std::fmt::Debug {
         /// Asynchronously retrieves a token.
         ///
         /// Returns a [Token][crate::token::Token] for the current credentials.
@@ -145,7 +146,7 @@ pub mod traits {
 
         /// A dyn-compatible, crate-private version of `Credential`.
         #[async_trait::async_trait]
-        pub trait Credential: Send + Sync {
+        pub trait Credential: Send + Sync + std::fmt::Debug {
             /// Asynchronously retrieves a token.
             ///
             /// Returns a [Token][crate::token::Token] for the current credentials.

--- a/src/auth/src/credentials/mds_credential.rs
+++ b/src/auth/src/credentials/mds_credential.rs
@@ -37,6 +37,7 @@ pub(crate) fn new() -> Credential {
     }
 }
 
+#[derive(Debug)]
 struct MDSCredential<T>
 where
     T: TokenProvider,
@@ -81,6 +82,7 @@ struct MDSTokenResponse {
     token_type: String,
 }
 
+#[derive(Debug)]
 struct MDSAccessTokenProvider {
     endpoint: String,
 }

--- a/src/auth/src/credentials/user_credential.rs
+++ b/src/auth/src/credentials/user_credential.rs
@@ -32,12 +32,23 @@ pub(crate) fn creds_from(js: serde_json::Value) -> Result<Credential> {
     })
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
 struct UserTokenProvider {
     client_id: String,
     client_secret: String,
     refresh_token: String,
     endpoint: String,
+}
+
+impl std::fmt::Debug for UserTokenProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UserTokenCredential")
+            .field("client_id", &self.client_id)
+            .field("client_secret", &"[censored]")
+            .field("refresh_token", &"[censored]")
+            .field("endpoint", &self.endpoint)
+            .finish()
+    }
 }
 
 impl UserTokenProvider {
@@ -106,6 +117,7 @@ impl TokenProvider for UserTokenProvider {
 /// Data model for a UserCredential
 ///
 /// See: https://cloud.google.com/docs/authentication#user-accounts
+#[derive(Debug)]
 pub(crate) struct UserCredential<T>
 where
     T: TokenProvider,
@@ -180,6 +192,21 @@ mod test {
     use tokio::task::JoinHandle;
 
     type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
+
+    #[test]
+    fn debug_token_provider() {
+        let expected = UserTokenProvider {
+            client_id: "test-client-id".to_string(),
+            client_secret: "test-client-secret".to_string(),
+            refresh_token: "test-refresh-token".to_string(),
+            endpoint: OAUTH2_ENDPOINT.to_string(),
+        };
+        let fmt = format!("{expected:?}");
+        assert!(fmt.contains("test-client-id"), "{fmt}");
+        assert!(!fmt.contains("test-client-secret"), "{fmt}");
+        assert!(!fmt.contains("test-refresh-token"), "{fmt}");
+        assert!(fmt.contains(OAUTH2_ENDPOINT), "{fmt}");
+    }
 
     #[test]
     fn user_token_provider_from_json_success() {

--- a/src/auth/src/errors.rs
+++ b/src/auth/src/errors.rs
@@ -65,13 +65,16 @@ impl std::error::Error for CredentialError {
     }
 }
 
+const RETRYABLE_MSG: &str = "but future attempts may succeed";
+const NON_RETRYABLE_MSG: &str = "and future attempts will not succeed";
+
 impl Display for CredentialError {
     /// Formats the error message to include retryability and source.
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let msg = if self.is_retryable {
-            "but future attempts may succeed"
+            RETRYABLE_MSG
         } else {
-            "and future attempts will not succeed"
+            NON_RETRYABLE_MSG
         };
         write!(
             f,
@@ -123,5 +126,18 @@ mod test {
     #[test_case(StatusCode::PRECONDITION_FAILED)]
     fn non_retryable(c: StatusCode) {
         assert!(!is_retryable(c));
+    }
+
+    #[test]
+    fn fmt() {
+        let e = CredentialError::new(true, "test-only-err-123".to_string().into());
+        let got = format!("{e}");
+        assert!(got.contains("test-only-err-123"), "{got}");
+        assert!(got.contains(RETRYABLE_MSG), "{got}");
+
+        let e = CredentialError::new(false, "test-only-err-123".to_string().into());
+        let got = format!("{e}");
+        assert!(got.contains("test-only-err-123"), "{got}");
+        assert!(got.contains(NON_RETRYABLE_MSG), "{got}");
     }
 }

--- a/src/auth/src/token.rs
+++ b/src/auth/src/token.rs
@@ -41,7 +41,7 @@ pub struct Token {
 
 #[async_trait::async_trait]
 #[allow(dead_code)] // TODO(#442) - implementation in progress
-pub(crate) trait TokenProvider: Send + Sync {
+pub(crate) trait TokenProvider: std::fmt::Debug + Send + Sync {
     async fn get_token(&mut self) -> Result<Token>;
 }
 
@@ -50,6 +50,7 @@ pub(crate) mod test {
     use super::*;
 
     mockall::mock! {
+        #[derive(Debug)]
         pub TokenProvider { }
 
         #[async_trait::async_trait]


### PR DESCRIPTION
Make the credentials easier to troubleshoot. Implementing the `Debug`
traits will help us log their state at runtime, including what specific
token provider is in use.

In some cases we need to censor some fields because they contain
sensitive information. We may consider logging a hash of the field, or
maybe the first N characters of the field and a hash. I decided to be
conservative for now.