### PR TITLE
impl(auth): Credentials have clone

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -56,6 +56,14 @@ use std::sync::Arc;
 /// [Google Kubernetes Engine]: https://cloud.google.com/kubernetes-engine
 #[derive(Clone, Debug)]
 pub struct Credential {
+    // We use an `Arc` to hold the inner implementation.
+    //
+    // Credentials may be shared across threads (`Send + Sync`), so an `Rc`
+    // will not do.
+    //
+    // They also need to derive `Clone`, as the
+    // `gax::http_client::ReqwestClient`s which hold them derive `Clone`. So a
+    // `Box` will not do.
     inner: Arc<dyn traits::dynamic::Credential>,
 }
 

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -19,6 +19,7 @@ use crate::errors::CredentialError;
 use crate::Result;
 use http::header::{HeaderName, HeaderValue};
 use std::future::Future;
+use std::sync::Arc;
 
 /// An implementation of [crate::credentials::traits::Credential].
 ///
@@ -53,23 +54,21 @@ use std::future::Future;
 /// [Metadata Service]: https://cloud.google.com/compute/docs/metadata/overview
 /// [Google Compute Engine]: https://cloud.google.com/products/compute
 /// [Google Kubernetes Engine]: https://cloud.google.com/kubernetes-engine
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Credential {
-    inner: Box<dyn traits::dynamic::Credential>,
+    inner: Arc<dyn traits::dynamic::Credential>,
 }
 
 impl traits::Credential for Credential {
-    fn get_token(&mut self) -> impl Future<Output = Result<crate::token::Token>> + Send {
+    fn get_token(&self) -> impl Future<Output = Result<crate::token::Token>> + Send {
         self.inner.get_token()
     }
 
-    fn get_headers(
-        &mut self,
-    ) -> impl Future<Output = Result<Vec<(HeaderName, HeaderValue)>>> + Send {
+    fn get_headers(&self) -> impl Future<Output = Result<Vec<(HeaderName, HeaderValue)>>> + Send {
         self.inner.get_headers()
     }
 
-    fn get_universe_domain(&mut self) -> impl Future<Output = Option<String>> + Send {
+    fn get_universe_domain(&self) -> impl Future<Output = Option<String>> + Send {
         self.inner.get_universe_domain()
     }
 }
@@ -123,7 +122,7 @@ pub mod traits {
         ///
         /// Returns a [Token][crate::token::Token] for the current credentials.
         /// The underlying implementation refreshes the token as needed.
-        fn get_token(&mut self) -> impl Future<Output = Result<crate::token::Token>> + Send;
+        fn get_token(&self) -> impl Future<Output = Result<crate::token::Token>> + Send;
 
         /// Asynchronously constructs the auth headers.
         ///
@@ -133,11 +132,11 @@ pub mod traits {
         ///
         /// The underlying implementation refreshes the token as needed.
         fn get_headers(
-            &mut self,
+            &self,
         ) -> impl Future<Output = Result<Vec<(HeaderName, HeaderValue)>>> + Send;
 
         /// Retrieves the universe domain associated with the credential, if any.
-        fn get_universe_domain(&mut self) -> impl Future<Output = Option<String>> + Send;
+        fn get_universe_domain(&self) -> impl Future<Output = Option<String>> + Send;
     }
 
     pub(crate) mod dynamic {
@@ -151,7 +150,7 @@ pub mod traits {
             ///
             /// Returns a [Token][crate::token::Token] for the current credentials.
             /// The underlying implementation refreshes the token as needed.
-            async fn get_token(&mut self) -> Result<crate::token::Token>;
+            async fn get_token(&self) -> Result<crate::token::Token>;
 
             /// Asynchronously constructs the auth headers.
             ///
@@ -160,10 +159,10 @@ pub mod traits {
             /// sent with a request.
             ///
             /// The underlying implementation refreshes the token as needed.
-            async fn get_headers(&mut self) -> Result<Vec<(HeaderName, HeaderValue)>>;
+            async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>>;
 
             /// Retrieves the universe domain associated with the credential, if any.
-            async fn get_universe_domain(&mut self) -> Option<String>;
+            async fn get_universe_domain(&self) -> Option<String>;
         }
     }
 }

--- a/src/auth/src/token.rs
+++ b/src/auth/src/token.rs
@@ -40,9 +40,8 @@ pub struct Token {
 }
 
 #[async_trait::async_trait]
-#[allow(dead_code)] // TODO(#442) - implementation in progress
 pub(crate) trait TokenProvider: std::fmt::Debug + Send + Sync {
-    async fn get_token(&mut self) -> Result<Token>;
+    async fn get_token(&self) -> Result<Token>;
 }
 
 #[cfg(test)]
@@ -55,7 +54,7 @@ pub(crate) mod test {
 
         #[async_trait::async_trait]
         impl TokenProvider for TokenProvider {
-            async fn get_token(&mut self) -> Result<Token>;
+            async fn get_token(&self) -> Result<Token>;
         }
     }
 }


### PR DESCRIPTION
Part of the work for #442 

The `gax::http_client::ReqwestClient` has `Clone`. We want it to hold `auth::credential::Credential`. So `Credential` needs `Clone` as well.

We definitely want the interfaces in the `traits::Credential` to take `&self` instead of `&mut self`. We want to be able to call these things in `ReqwestClient::execute(&self, ...)`.

## On changing the `TokenProvider` trait...

This PR also changes the `TokenProvider`'s traits to use `&self` instead of `&mut self`. This is not necessarily what we want in the long term, but it unblocks us for now.

When we introduce caching, we will be mutating some aspect of the token provider. We could have the caching layer hold an interior mutable cache.

I think more likely though, we will want the `*Credential` types to hold an interior mutable token provider.

We can solve the problem when we design the token cache. Note that these APIs are all private outside of the crate, so it is not a big deal.