### PR TITLE
feat(auth): credentials for tests

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -327,6 +327,8 @@ mod test {
     use super::*;
     use scoped_env::ScopedEnv;
     use std::error::Error;
+    use traits::Credential;
+    type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
 
     #[derive(Clone, Debug)]
     pub(crate) struct TestCredential;
@@ -353,6 +355,31 @@ mod test {
         async fn get_universe_domain(&self) -> Option<String> {
             None
         }
+    }
+
+    #[tokio::test]
+    async fn test_test_credentials() -> TestResult {
+        let credentials = super::test_credentials();
+        let token = credentials.get_token().await?;
+        assert!(
+            !token.token.is_empty(),
+            "token={token:?} credentials={credentials:?}"
+        );
+        assert!(
+            !token.token_type.is_empty(),
+            "token={token:?} credentials={credentials:?}"
+        );
+
+        let headers = credentials.get_headers().await?;
+        assert!(
+            headers.is_empty(),
+            "headers={headers:?} credentials={credentials:?}"
+        );
+
+        let ud = credentials.get_universe_domain().await;
+        assert_eq!(ud, None, "credentials={credentials:?}");
+
+        Ok(())
     }
 
     #[cfg(target_os = "windows")]

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -316,10 +316,44 @@ fn adc_well_known_path() -> Option<String> {
 }
 
 #[cfg(test)]
+pub fn test_credentials() -> Credential {
+    Credential {
+        inner: Arc::new(test::TestCredential::new()),
+    }
+}
+
+#[cfg(test)]
 mod test {
     use super::*;
     use scoped_env::ScopedEnv;
     use std::error::Error;
+
+    #[derive(Clone, Debug)]
+    pub(crate) struct TestCredential;
+
+    impl TestCredential {
+        pub fn new() -> Self {
+            Self
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl super::traits::dynamic::Credential for TestCredential {
+        async fn get_token(&self) -> Result<crate::token::Token> {
+            Ok(crate::token::Token {
+                token: "test-token".to_string(),
+                token_type: "Bearer".to_string(),
+                expires_at: None,
+                metadata: None,
+            })
+        }
+        async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
+            Ok(Vec::new())
+        }
+        async fn get_universe_domain(&self) -> Option<String> {
+            None
+        }
+    }
 
     #[cfg(target_os = "windows")]
     #[test]


### PR DESCRIPTION
Tests connecting to a local (usually temporary) server use test
credentials. The generated tokens are not used. We could use mocks, but
those are fairly tedious to set up when token creation is uninteresting.