### PR TITLE
impl: swap out auth implementation in gax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,16 +645,17 @@ version = "0.0.0"
 name = "gcp-sdk-gax"
 version = "0.1.0-rc2"
 dependencies = [
+ "async-trait",
  "axum",
  "base64",
  "built",
  "bytes",
  "echo-server",
  "futures",
+ "gcp-sdk-auth",
  "gcp-sdk-gax",
  "gcp-sdk-rpc",
  "gcp-sdk-wkt",
- "google-cloud-auth",
  "http",
  "mockall",
  "pin-project",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,7 +645,6 @@ version = "0.0.0"
 name = "gcp-sdk-gax"
 version = "0.1.0-rc2"
 dependencies = [
- "async-trait",
  "axum",
  "base64",
  "built",

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -341,7 +341,7 @@ pub mod testing {
     }
 
     #[derive(Debug)]
-    struct TestCredential {}
+    struct TestCredential;
 
     #[async_trait::async_trait]
     impl CredentialTrait for TestCredential {

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -44,7 +44,6 @@ echo-server = { path = "echo-server" }
 # This is a workaround to integration test features of this crate. Open issue
 # https://github.com/rust-lang/cargo/issues/2911.
 gax         = { path = ".", package = "gcp-sdk-gax", features = ["unstable-sdk-client", "unstable-stream"] }
-async-trait = "0.1.83"
 axum        = "0.7.9"
 serial_test = "3.2.0"
 serde       = { version = "1.0.216", features = ["serde_derive"] }

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -35,7 +35,7 @@ serde       = "1.0.216"
 serde_json  = "1.0.134"
 serde_with  = { version = "3.12.0", default-features = false, features = ["base64", "macros"] }
 thiserror   = "2.0.9"
-auth        = { version = "0.1.0", path = "../../auth", package = "google-cloud-auth" }
+auth        = { version = "0.1.0-rc2", path = "../auth", package = "gcp-sdk-auth" }
 rpc         = { version = "0.1.0-rc2", path = "../generated/rpc", package = "gcp-sdk-rpc" }
 wkt         = { version = "0.1.0-rc2", path = "../wkt", package = "gcp-sdk-wkt" }
 
@@ -44,11 +44,12 @@ echo-server = { path = "echo-server" }
 # This is a workaround to integration test features of this crate. Open issue
 # https://github.com/rust-lang/cargo/issues/2911.
 gax         = { path = ".", package = "gcp-sdk-gax", features = ["unstable-sdk-client", "unstable-stream"] }
+async-trait = "0.1.83"
 axum        = "0.7.9"
 serial_test = "3.2.0"
 serde       = { version = "1.0.216", features = ["serde_derive"] }
 test-case   = "3.3.1"
-tokio       = { version = "1.42", features = ["macros", "test-util"] }
+tokio       = { version = "1.42", features = ["macros", "rt-multi-thread", "test-util"] }
 tempfile    = "3.14.0"
 mockall     = "0.13.1"
 

--- a/src/gax/tests/http_client_errors.rs
+++ b/src/gax/tests/http_client_errors.rs
@@ -24,7 +24,8 @@ async fn test_error_with_status() -> Result<()> {
     use serde_json::Value;
     let (endpoint, _server) = echo_server::start().await?;
 
-    let config = ClientConfig::default().set_credential(auth::Credential::test_credentials());
+    let config =
+        ClientConfig::default().set_credential(auth::credentials::testing::test_credentials());
     let client = ReqwestClient::new(config, &endpoint).await?;
 
     let builder = client.builder(reqwest::Method::GET, "/error".into());

--- a/src/gax/tests/paginator.rs
+++ b/src/gax/tests/paginator.rs
@@ -95,7 +95,8 @@ impl PageableResponse for ListFoosResponse {
 
 impl Client {
     pub async fn new(default_endpoint: &str) -> Result<Self> {
-        let config = ClientConfig::default().set_credential(auth::Credential::test_credentials());
+        let config =
+            ClientConfig::default().set_credential(auth::credentials::testing::test_credentials());
         let inner = ReqwestClient::new(config, default_endpoint).await?;
         Ok(Self { inner })
     }

--- a/src/gax/tests/timeout.rs
+++ b/src/gax/tests/timeout.rs
@@ -23,7 +23,8 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 #[tokio::test(start_paused = true)]
 async fn test_no_timeout() -> Result<()> {
     let (endpoint, server) = echo_server::start().await?;
-    let config = ClientConfig::default().set_credential(auth::Credential::test_credentials());
+    let config =
+        ClientConfig::default().set_credential(auth::credentials::testing::test_credentials());
     let client = ReqwestClient::new(config, &endpoint).await?;
 
     let delay = Duration::from_millis(200);
@@ -60,7 +61,8 @@ async fn test_no_timeout() -> Result<()> {
 #[tokio::test(start_paused = true)]
 async fn test_timeout_does_not_expire() -> Result<()> {
     let (endpoint, server) = echo_server::start().await?;
-    let config = ClientConfig::default().set_credential(auth::Credential::test_credentials());
+    let config =
+        ClientConfig::default().set_credential(auth::credentials::testing::test_credentials());
     let client = ReqwestClient::new(config, &endpoint).await?;
 
     let delay = Duration::from_millis(200);
@@ -98,7 +100,8 @@ async fn test_timeout_does_not_expire() -> Result<()> {
 #[tokio::test(start_paused = true)]
 async fn test_timeout_expires() -> Result<()> {
     let (endpoint, server) = echo_server::start().await?;
-    let config = ClientConfig::default().set_credential(auth::Credential::test_credentials());
+    let config =
+        ClientConfig::default().set_credential(auth::credentials::testing::test_credentials());
     let client = ReqwestClient::new(config, &endpoint).await?;
 
     let delay = Duration::from_millis(200);


### PR DESCRIPTION
Fixes #442

Swap out the `gax` implementation of auth from `google-cloud-auth` to `gcp-sdk-auth`.

The GCB build runs integration tests using the `MDSCredentials` written by @harkamaljot.

Also introduces fake credentials in `gcp_sdk_auth::credentials::testing`. I think we need a public module. I don't think this thing gets exported to other crates if we gate it with a `#[cfg(test)]`.

I would like to fix the mocking story for credentials, and use them in the auth unit test. But I will defer that. It is tracked in #593 