### PR TITLE
cleanup(auth): rename traits

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -21,7 +21,7 @@ use http::header::{HeaderName, HeaderValue};
 use std::future::Future;
 use std::sync::Arc;
 
-/// An implementation of [crate::credentials::traits::Credential].
+/// An implementation of [crate::credentials::CredentialTrait].
 ///
 /// Represents a [Credential] used to obtain auth [Token][crate::token::Token]s
 /// and the corresponding request headers.
@@ -64,10 +64,10 @@ pub struct Credential {
     // They also need to derive `Clone`, as the
     // `gax::http_client::ReqwestClient`s which hold them derive `Clone`. So a
     // `Box` will not do.
-    inner: Arc<dyn traits::dynamic::Credential>,
+    inner: Arc<dyn dynamic::CredentialTrait>,
 }
 
-impl traits::Credential for Credential {
+impl CredentialTrait for Credential {
     fn get_token(&self) -> impl Future<Output = Result<crate::token::Token>> + Send {
         self.inner.get_token()
     }
@@ -81,56 +81,77 @@ impl traits::Credential for Credential {
     }
 }
 
-pub mod traits {
-    use super::Future;
+/// Represents a [Credential] used to obtain auth
+/// [Token][crate::token::Token]s and the corresponding request headers.
+///
+/// In general, [Credentials][credentials-link] are "digital object that
+/// provide proof of identity", the archetype may be a username and password
+/// combination, but a private RSA key may be a better example.
+///
+/// Modern authentication protocols do not send the credentials to
+/// authenticate with a service. Even when sent over encrypted transports,
+/// the credentials may be accidentally exposed via logging or may be
+/// captured if there are errors in the transport encryption. Because the
+/// credentials are often long-lived, that risk of exposure is also
+/// long-lived.
+///
+/// Instead, modern authentication protocols exchange the credentials for a
+/// time-limited [Token][token-link], a digital object that shows the caller
+/// was in possession of the credentials. Because tokens are time limited,
+/// risk of misuse is also time limited. Tokens may be further restricted to
+/// only a certain subset of the RPCs in the service, or even to specific
+/// resources, or only when used from a given machine (virtual or not).
+/// Further limiting the risks associated with any leaks of these tokens.
+///
+/// This struct also abstracts token sources that are not backed by a
+/// specific digital object. The canonical example is the
+/// [Metadata Service]. This service is available in many Google Cloud
+/// environments, including [Google Compute Engine], and
+/// [Google Kubernetes Engine].
+///
+/// # Notes
+///
+/// Application developers who directly use the Auth SDK can use this trait
+/// to mock the credentials. Application developers who use the Google Cloud
+/// Rust SDK directly should not need this functionality.
+///
+/// [credentials-link]: https://cloud.google.com/docs/authentication#credentials
+/// [token-link]: https://cloud.google.com/docs/authentication#token
+/// [Metadata Service]: https://cloud.google.com/compute/docs/metadata/overview
+/// [Google Compute Engine]: https://cloud.google.com/products/compute
+/// [Google Kubernetes Engine]: https://cloud.google.com/kubernetes-engine
+pub trait CredentialTrait: std::fmt::Debug {
+    /// Asynchronously retrieves a token.
+    ///
+    /// Returns a [Token][crate::token::Token] for the current credentials.
+    /// The underlying implementation refreshes the token as needed.
+    fn get_token(&self) -> impl Future<Output = Result<crate::token::Token>> + Send;
+
+    /// Asynchronously constructs the auth headers.
+    ///
+    /// Different auth tokens are sent via different headers. The
+    /// [Credential] constructs the headers (and header values) that should be
+    /// sent with a request.
+    ///
+    /// The underlying implementation refreshes the token as needed.
+    fn get_headers(&self) -> impl Future<Output = Result<Vec<(HeaderName, HeaderValue)>>> + Send;
+
+    /// Retrieves the universe domain associated with the credential, if any.
+    fn get_universe_domain(&self) -> impl Future<Output = Option<String>> + Send;
+}
+
+pub(crate) mod dynamic {
     use super::Result;
     use super::{HeaderName, HeaderValue};
 
-    /// Represents a [Credential] used to obtain auth
-    /// [Token][crate::token::Token]s and the corresponding request headers.
-    ///
-    /// In general, [Credentials][credentials-link] are "digital object that
-    /// provide proof of identity", the archetype may be a username and password
-    /// combination, but a private RSA key may be a better example.
-    ///
-    /// Modern authentication protocols do not send the credentials to
-    /// authenticate with a service. Even when sent over encrypted transports,
-    /// the credentials may be accidentally exposed via logging or may be
-    /// captured if there are errors in the transport encryption. Because the
-    /// credentials are often long-lived, that risk of exposure is also
-    /// long-lived.
-    ///
-    /// Instead, modern authentication protocols exchange the credentials for a
-    /// time-limited [Token][token-link], a digital object that shows the caller
-    /// was in possession of the credentials. Because tokens are time limited,
-    /// risk of misuse is also time limited. Tokens may be further restricted to
-    /// only a certain subset of the RPCs in the service, or even to specific
-    /// resources, or only when used from a given machine (virtual or not).
-    /// Further limiting the risks associated with any leaks of these tokens.
-    ///
-    /// This struct also abstracts token sources that are not backed by a
-    /// specific digital object. The canonical example is the
-    /// [Metadata Service]. This service is available in many Google Cloud
-    /// environments, including [Google Compute Engine], and
-    /// [Google Kubernetes Engine].
-    ///
-    /// # Notes
-    ///
-    /// Application developers who directly use the Auth SDK can use this trait
-    /// to mock the credentials. Application developers who use the Google Cloud
-    /// Rust SDK directly should not need this functionality.
-    ///
-    /// [credentials-link]: https://cloud.google.com/docs/authentication#credentials
-    /// [token-link]: https://cloud.google.com/docs/authentication#token
-    /// [Metadata Service]: https://cloud.google.com/compute/docs/metadata/overview
-    /// [Google Compute Engine]: https://cloud.google.com/products/compute
-    /// [Google Kubernetes Engine]: https://cloud.google.com/kubernetes-engine
-    pub trait Credential: std::fmt::Debug {
+    /// A dyn-compatible, crate-private version of `CredentialTrait`.
+    #[async_trait::async_trait]
+    pub trait CredentialTrait: Send + Sync + std::fmt::Debug {
         /// Asynchronously retrieves a token.
         ///
         /// Returns a [Token][crate::token::Token] for the current credentials.
         /// The underlying implementation refreshes the token as needed.
-        fn get_token(&self) -> impl Future<Output = Result<crate::token::Token>> + Send;
+        async fn get_token(&self) -> Result<crate::token::Token>;
 
         /// Asynchronously constructs the auth headers.
         ///
@@ -139,39 +160,10 @@ pub mod traits {
         /// sent with a request.
         ///
         /// The underlying implementation refreshes the token as needed.
-        fn get_headers(
-            &self,
-        ) -> impl Future<Output = Result<Vec<(HeaderName, HeaderValue)>>> + Send;
+        async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>>;
 
         /// Retrieves the universe domain associated with the credential, if any.
-        fn get_universe_domain(&self) -> impl Future<Output = Option<String>> + Send;
-    }
-
-    pub(crate) mod dynamic {
-        use super::Result;
-        use super::{HeaderName, HeaderValue};
-
-        /// A dyn-compatible, crate-private version of `Credential`.
-        #[async_trait::async_trait]
-        pub trait Credential: Send + Sync + std::fmt::Debug {
-            /// Asynchronously retrieves a token.
-            ///
-            /// Returns a [Token][crate::token::Token] for the current credentials.
-            /// The underlying implementation refreshes the token as needed.
-            async fn get_token(&self) -> Result<crate::token::Token>;
-
-            /// Asynchronously constructs the auth headers.
-            ///
-            /// Different auth tokens are sent via different headers. The
-            /// [Credential] constructs the headers (and header values) that should be
-            /// sent with a request.
-            ///
-            /// The underlying implementation refreshes the token as needed.
-            async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>>;
-
-            /// Retrieves the universe domain associated with the credential, if any.
-            async fn get_universe_domain(&self) -> Option<String>;
-        }
+        async fn get_universe_domain(&self) -> Option<String>;
     }
 }
 
@@ -206,7 +198,7 @@ pub mod traits {
 ///
 /// ```
 /// # use gcp_sdk_auth::credentials::create_access_token_credential;
-/// # use gcp_sdk_auth::credentials::traits::Credential;
+/// # use gcp_sdk_auth::credentials::CredentialTrait;
 /// # use gcp_sdk_auth::errors::CredentialError;
 /// # tokio_test::block_on(async {
 /// let mut creds = create_access_token_credential().await?;
@@ -324,7 +316,7 @@ fn adc_well_known_path() -> Option<String> {
 /// external developers (i.e. consumers, not developers of `google-cloud-rust`)
 /// may find it useful.
 pub mod testing {
-    use crate::credentials::traits::dynamic::Credential as CredentialTrait;
+    use crate::credentials::dynamic::CredentialTrait;
     use crate::credentials::Credential;
     use crate::token::Token;
     use crate::Result;

--- a/src/auth/src/credentials/mds_credential.rs
+++ b/src/auth/src/credentials/mds_credential.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::credentials::traits::dynamic::Credential as CredentialTrait;
+use crate::credentials::dynamic::CredentialTrait;
 use crate::credentials::{Credential, Result};
 use crate::errors::{is_retryable, CredentialError};
 use crate::token::{Token, TokenProvider};

--- a/src/auth/src/credentials/user_credential.rs
+++ b/src/auth/src/credentials/user_credential.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::credentials::traits::dynamic::Credential as CredentialTrait;
+use crate::credentials::dynamic::CredentialTrait;
 use crate::credentials::Credential;
 use crate::credentials::Result;
 use crate::errors::{is_retryable, CredentialError};

--- a/src/gax/src/http_client/mod.rs
+++ b/src/gax/src/http_client/mod.rs
@@ -15,7 +15,7 @@
 use crate::error::Error;
 use crate::error::HttpError;
 use crate::Result;
-use auth::credentials::traits::Credential as CredentialTrait;
+use auth::credentials::CredentialTrait;
 use auth::credentials::{create_access_token_credential, Credential};
 
 #[derive(Clone)]

--- a/src/gax/src/options/mod.rs
+++ b/src/gax/src/options/mod.rs
@@ -286,7 +286,7 @@ mod test {
 
     #[tokio::test]
     async fn config_credentials() -> Result {
-        use auth::credentials::traits::Credential;
+        use auth::credentials::CredentialTrait;
         let config =
             ClientConfig::new().set_credential(auth::credentials::testing::test_credentials());
         let cred = config.cred.unwrap();


### PR DESCRIPTION
rename
- `credentials::traits::Credential` -> `credentials::CredentialTrait`
- `credentials::traits::dynamic::Credential` -> `credentials::dynamic::CredentialTrait`

In response to: https://github.com/googleapis/google-cloud-rust/pull/594#discussion_r1903318243