### PR TITLE
fix(generator): crashes reading service config yaml

### DIFF
--- a/generator/internal/parser/openapi.go
+++ b/generator/internal/parser/openapi.go
@@ -79,7 +79,9 @@ func makeAPIForOpenAPI(serviceConfig *serviceconfig.Service, model *libopenapi.D
 	if serviceConfig != nil {
 		result.Name = strings.TrimSuffix(serviceConfig.Name, ".googleapis.com")
 		result.Title = serviceConfig.Title
-		result.Description = serviceConfig.Documentation.Summary
+		if serviceConfig.Documentation != nil {
+			result.Description = serviceConfig.Documentation.Summary
+		}
 	}
 
 	// OpenAPI does not define a service name. The service config may provide

--- a/generator/internal/parser/protobuf.go
+++ b/generator/internal/parser/protobuf.go
@@ -224,7 +224,9 @@ func makeAPIForProtobuf(serviceConfig *serviceconfig.Service, req *pluginpb.Code
 	}
 	if serviceConfig != nil {
 		result.Title = serviceConfig.Title
-		result.Description = serviceConfig.Documentation.Summary
+		if serviceConfig.Documentation != nil {
+			result.Description = serviceConfig.Documentation.Summary
+		}
 		enabledMixinMethods, mixinFileDesc = loadMixins(serviceConfig)
 		packageName := ""
 		for _, api := range serviceConfig.Apis {

--- a/generator/internal/parser/protobuf_test.go
+++ b/generator/internal/parser/protobuf_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/googleapis/google-cloud-rust/generator/internal/api"
 	"google.golang.org/genproto/googleapis/api/annotations"
 	"google.golang.org/genproto/googleapis/api/serviceconfig"
@@ -44,6 +45,23 @@ func TestProtobuf_Info(t *testing.T) {
 	}
 	if diff := cmp.Diff(test.Description, serviceConfig.Documentation.Summary); diff != "" {
 		t.Errorf("description mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+func TestProtobuf_PartialInfo(t *testing.T) {
+	var serviceConfig = &serviceconfig.Service{
+		Name:  "secretmanager.googleapis.com",
+		Title: "Secret Manager API",
+	}
+
+	got := makeAPIForProtobuf(serviceConfig, newTestCodeGeneratorRequest(t, "scalar.proto"))
+	want := &api.API{
+		Name:        "secretmanager",
+		Title:       "Secret Manager API",
+		Description: "",
+	}
+	if diff := cmp.Diff(got, want, cmpopts.IgnoreFields(api.API{}, "Services", "Messages", "Enums", "State")); diff != "" {
+		t.Errorf("mismatched API attributes (-want, +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
Some service config yaml files may be missing the `Description` section.
The generator was crashing in this case. Instead, we generate services
with a missing description for the crate.

Fixes #606
