### PR TITLE
feat(auth): mockable Credentials

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -67,6 +67,17 @@ pub struct Credential {
     inner: Arc<dyn dynamic::CredentialTrait>,
 }
 
+impl<T> std::convert::From<T> for Credential
+where
+    T: crate::credentials::CredentialTrait + Send + Sync + 'static,
+{
+    fn from(value: T) -> Self {
+        Self {
+            inner: Arc::new(value),
+        }
+    }
+}
+
 impl Credential {
     pub async fn get_token(&self) -> Result<crate::token::Token> {
         self.inner.get_token().await
@@ -112,9 +123,9 @@ impl Credential {
 /// # Notes
 ///
 /// Application developers who directly use the Auth SDK can use this trait,
-/// along with [crate::credentials::Credential::from_trait()] to mock the
-/// credentials. Application developers who use the Google Cloud Rust SDK
-/// directly should not need this functionality.
+/// along with [crate::credentials::Credential::from()] to mock the credentials.
+/// Application developers who use the Google Cloud Rust SDK directly should not
+/// need this functionality.
 ///
 /// [credentials-link]: https://cloud.google.com/docs/authentication#credentials
 /// [token-link]: https://cloud.google.com/docs/authentication#token

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -111,9 +111,10 @@ impl Credential {
 ///
 /// # Notes
 ///
-/// Application developers who directly use the Auth SDK can use this trait
-/// to mock the credentials. Application developers who use the Google Cloud
-/// Rust SDK directly should not need this functionality.
+/// Application developers who directly use the Auth SDK can use this trait,
+/// along with [crate::credentials::Credential::from_trait()] to mock the
+/// credentials. Application developers who use the Google Cloud Rust SDK
+/// directly should not need this functionality.
 ///
 /// [credentials-link]: https://cloud.google.com/docs/authentication#credentials
 /// [token-link]: https://cloud.google.com/docs/authentication#token
@@ -164,6 +165,23 @@ pub(crate) mod dynamic {
 
         /// Retrieves the universe domain associated with the credential, if any.
         async fn get_universe_domain(&self) -> Option<String>;
+    }
+
+    /// The public CredentialTrait implements the dyn-compatible CredentialTrait.
+    #[async_trait::async_trait]
+    impl<T> CredentialTrait for T
+    where
+        T: super::CredentialTrait + Send + Sync,
+    {
+        async fn get_token(&self) -> Result<crate::token::Token> {
+            T::get_token(self).await
+        }
+        async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
+            T::get_headers(self).await
+        }
+        async fn get_universe_domain(&self) -> Option<String> {
+            T::get_universe_domain(self).await
+        }
     }
 }
 

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -12,11 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use gcp_sdk_auth::credentials::create_access_token_credential;
+use gcp_sdk_auth::credentials::{create_access_token_credential, Credential, CredentialTrait};
+use gcp_sdk_auth::errors::CredentialError;
+use gcp_sdk_auth::token::Token;
+
+type Result<T> = std::result::Result<T, CredentialError>;
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use http::header::{HeaderName, HeaderValue};
     use scoped_env::ScopedEnv;
     use std::error::Error;
 
@@ -95,5 +100,38 @@ mod test {
         let uc = create_access_token_credential().await.unwrap();
         let fmt = format!("{:?}", uc);
         assert!(fmt.contains("UserCredential"));
+    }
+
+    mockall::mock! {
+        #[derive(Debug)]
+        Credential {}
+
+        impl CredentialTrait for Credential {
+            async fn get_token(&self) -> Result<Token>;
+            async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>>;
+            async fn get_universe_domain(&self) -> Option<String>;
+        }
+    }
+
+    #[tokio::test]
+    async fn mocking() -> Result<()> {
+        let mut mock = MockCredential::new();
+        mock.expect_get_token().return_once(|| {
+            Ok(Token {
+                token: "test-token".to_string(),
+                token_type: "Bearer".to_string(),
+                expires_at: None,
+                metadata: None,
+            })
+        });
+        mock.expect_get_headers().return_once(|| Ok(Vec::new()));
+        mock.expect_get_universe_domain().return_once(|| None);
+
+        let creds = Credential::from_trait(mock);
+        assert_eq!(creds.get_token().await?.token, "test-token");
+        assert!(creds.get_headers().await?.is_empty());
+        assert_eq!(creds.get_universe_domain().await, None);
+
+        Ok(())
     }
 }

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -127,7 +127,7 @@ mod test {
         mock.expect_get_headers().return_once(|| Ok(Vec::new()));
         mock.expect_get_universe_domain().return_once(|| None);
 
-        let creds = Credential::from_trait(mock);
+        let creds = Credential::from(mock);
         assert_eq!(creds.get_token().await?.token, "test-token");
         assert!(creds.get_headers().await?.is_empty());
         assert_eq!(creds.get_universe_domain().await, None);


### PR DESCRIPTION
Most of the work for #593

For things that implement (the public, sync) `CredentialTrait`, add an implementation for (the private, dyn) `dynamic::CredentialTrait`.

Add a constructor to create `Credential` from something that implements `CredentialTrait`.

Add a test (outside the crate) that demonstrates mocking.

Arguably the `mockall::mock! { ... }` belongs in a document somewhere. I will think about that.