### PR TITLE
feat(gax): support passing idempotency as a request option

### DIFF
--- a/src/gax/src/options/mod.rs
+++ b/src/gax/src/options/mod.rs
@@ -49,18 +49,27 @@ pub struct RequestOptions {
 }
 
 impl RequestOptions {
-    /// Treat the RPC underlying this method as idempotent.
-    pub fn set_idempotent(&mut self) {
-        self.idempotent = Some(true);
+    /// Treat the RPC underlying RPC in this method as idempotent.
+    ///
+    /// If a retry policy is configured, the policy may examine the idempotency
+    /// and the error details to decide if the error is retryable. Typically
+    /// [idempotent] RPCs are safe to retry under more error conditions
+    /// than non-idempotent RPCs.
+    ///
+    /// The client libraries provide a default for RPC idempotency, based on the
+    /// HTTP method (`GET`, `POST`, `DELETE`, etc.).
+    ///
+    /// [idempotent]: https://en.wikipedia.org/wiki/Idempotence
+    pub fn set_idempotency(&mut self, value: bool) {
+        self.idempotent = Some(value);
     }
 
-    /// Treat the RPC underlying this method as non-idempotent.
-    pub fn set_not_idempotent(&mut self) {
-        self.idempotent = Some(false);
-    }
-
-    /// Set the idempotency for this method if it is not set already.
-    pub fn set_idempotent_default(mut self, default: bool) -> Self {
+    /// Set the idempotency for the underlying RPC unless it is already set.
+    ///
+    /// If [set_idempotency][Self::set_idempotency] was already called this
+    /// method has no effect. Otherwise it sets the idempotency. The client
+    /// libraries use this to provide a default idempotency value.
+    pub fn set_default_idempotency(mut self, default: bool) -> Self {
         self.idempotent.get_or_insert(default);
         self
     }
@@ -111,11 +120,8 @@ impl RequestOptions {
 /// the resource targeted by the RPC, as well as any options affecting the
 /// request, such as additional headers or timeouts.
 pub trait RequestOptionsBuilder {
-    /// Treat the RPC underlying this method as idempotent.
-    fn with_idempotent(self) -> Self;
-
-    /// Treat the RPC underlying this method as non-idempotent.
-    fn with_not_idempotent(self) -> Self;
+    /// If `v` is `true`, treat the RPC underlying this method as idempotent.
+    fn with_idempotency(self, v: bool) -> Self;
 
     /// Set the user agent header.
     fn with_user_agent<V: Into<String>>(self, v: V) -> Self;
@@ -151,13 +157,8 @@ impl<T> RequestOptionsBuilder for T
 where
     T: RequestBuilder,
 {
-    fn with_idempotent(mut self) -> Self {
-        self.request_options().set_idempotent();
-        self
-    }
-
-    fn with_not_idempotent(mut self) -> Self {
-        self.request_options().set_not_idempotent();
+    fn with_idempotency(mut self, v: bool) -> Self {
+        self.request_options().set_idempotency(v);
         self
     }
 
@@ -303,9 +304,9 @@ mod test {
         let mut opts = RequestOptions::default();
 
         assert_eq!(opts.idempotent, None);
-        opts.set_idempotent();
+        opts.set_idempotency(true);
         assert_eq!(opts.idempotent, Some(true));
-        opts.set_not_idempotent();
+        opts.set_idempotency(false);
         assert_eq!(opts.idempotent, Some(false));
 
         opts.set_user_agent("test-only");
@@ -329,14 +330,14 @@ mod test {
 
     #[test]
     fn request_options_idempotency() {
-        let opts = RequestOptions::default().set_idempotent_default(true);
+        let opts = RequestOptions::default().set_default_idempotency(true);
         assert_eq!(opts.idempotent, Some(true));
-        let opts = opts.set_idempotent_default(false);
+        let opts = opts.set_default_idempotency(false);
         assert_eq!(opts.idempotent, Some(true));
 
-        let opts = RequestOptions::default().set_idempotent_default(false);
+        let opts = RequestOptions::default().set_default_idempotency(false);
         assert_eq!(opts.idempotent, Some(false));
-        let opts = opts.set_idempotent_default(true);
+        let opts = opts.set_default_idempotency(true);
         assert_eq!(opts.idempotent, Some(false));
     }
 
@@ -346,9 +347,9 @@ mod test {
         assert_eq!(builder.request_options().user_agent(), &None);
         assert_eq!(builder.request_options().attempt_timeout(), &None);
 
-        let mut builder = TestBuilder::default().with_idempotent();
+        let mut builder = TestBuilder::default().with_idempotency(true);
         assert_eq!(builder.request_options().idempotent, Some(true));
-        let mut builder = TestBuilder::default().with_not_idempotent();
+        let mut builder = TestBuilder::default().with_idempotency(false);
         assert_eq!(builder.request_options().idempotent, Some(false));
 
         let mut builder = TestBuilder::default().with_user_agent("test-only");


### PR DESCRIPTION
Part of the work for #437
