### PR TITLE
fix(auth): Credential API

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -67,17 +67,17 @@ pub struct Credential {
     inner: Arc<dyn dynamic::CredentialTrait>,
 }
 
-impl CredentialTrait for Credential {
-    fn get_token(&self) -> impl Future<Output = Result<crate::token::Token>> + Send {
-        self.inner.get_token()
+impl Credential {
+    pub async fn get_token(&self) -> Result<crate::token::Token> {
+        self.inner.get_token().await
     }
 
-    fn get_headers(&self) -> impl Future<Output = Result<Vec<(HeaderName, HeaderValue)>>> + Send {
-        self.inner.get_headers()
+    pub async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
+        self.inner.get_headers().await
     }
 
-    fn get_universe_domain(&self) -> impl Future<Output = Option<String>> + Send {
-        self.inner.get_universe_domain()
+    pub async fn get_universe_domain(&self) -> Option<String> {
+        self.inner.get_universe_domain().await
     }
 }
 

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -198,7 +198,6 @@ pub(crate) mod dynamic {
 ///
 /// ```
 /// # use gcp_sdk_auth::credentials::create_access_token_credential;
-/// # use gcp_sdk_auth::credentials::CredentialTrait;
 /// # use gcp_sdk_auth::errors::CredentialError;
 /// # tokio_test::block_on(async {
 /// let mut creds = create_access_token_credential().await?;

--- a/src/gax/src/http_client/mod.rs
+++ b/src/gax/src/http_client/mod.rs
@@ -15,7 +15,6 @@
 use crate::error::Error;
 use crate::error::HttpError;
 use crate::Result;
-use auth::credentials::CredentialTrait;
 use auth::credentials::{create_access_token_credential, Credential};
 
 #[derive(Clone)]

--- a/src/gax/src/options/mod.rs
+++ b/src/gax/src/options/mod.rs
@@ -370,7 +370,6 @@ mod test {
 
     #[tokio::test]
     async fn config_credentials() -> Result {
-        use auth::credentials::CredentialTrait;
         let config =
             ClientConfig::new().set_credential(auth::credentials::testing::test_credentials());
         let cred = config.cred.unwrap();


### PR DESCRIPTION
Part of the work for #593 

`Credential` need not get its public interfaces from `CredentialTrait`.

We want to define
```rs
impl<T> std::convert::From<T> -> Credential
where T: CredentialTrait;
```

But if `Credential` implements `CredentialTrait`, this will conflict with the generic `impl<T> From<T> -> T`. (let `T = Credential` to see the problem).

The fix is to manually define the public interface for `Credential`.

This has some benefits:
1. Consumers do not need to `use auth::credentials::CredentialTrait` to have access to the methods.
1. The interface should read nicer. It is a simple `async fn`, instead of a `fn ... -> impl Future<Output = ...>`