### PR TITLE
feat(generator): capture protobuf LRO options

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -117,6 +117,8 @@ type Method struct {
 	// set to true.
 	ClientSideStreaming bool
 	ServerSideStreaming bool
+	// For methods returning long-running operations
+	OperationInfo *OperationInfo
 }
 
 // Normalized request path information.
@@ -142,6 +144,16 @@ type PathInfo struct {
 	//
 	// If this is empty then the body is not used.
 	BodyFieldPath string
+}
+
+// Normalized long running operation info
+type OperationInfo struct {
+	// The metadata type. If there is no metadata, this is set to
+	// `.google.protobuf.Empty`.
+	MetadataTypeID string
+	// The result type. This is the expected type when the long running
+	// operation completes successfully.
+	ResponseTypeID string
 }
 
 // A path segment is either a string literal (such as "projects") or a field

--- a/generator/internal/language/templates/rust/crate/src/builders.rs.mustache
+++ b/generator/internal/language/templates/rust/crate/src/builders.rs.mustache
@@ -62,6 +62,13 @@ impl {{NameToPascal}} {
     }
 
     /// Sends the request.
+    {{#OperationInfo}}
+    ///
+    /// # Long running operations
+    ///
+    /// This starts, but does not poll, a longrunning operation. More information
+    /// on [{{NameToSnake}}][crate::client::{{ServiceNameToPascal}}::{{NameToSnake}}].
+    {{/OperationInfo}}
     pub async fn send(self) -> Result<{{OutputTypeName}}> {
         self.0.stub.{{NameToSnake}}(self.0.request, self.0.options).await
     }

--- a/generator/internal/language/templates/rust/crate/src/client.rs.mustache
+++ b/generator/internal/language/templates/rust/crate/src/client.rs.mustache
@@ -82,6 +82,35 @@ impl {{NameToPascal}} {
     {{#DocLines}}
     {{{.}}}
     {{/DocLines}}
+    {{#OperationInfo}}
+    ///
+    /// # Long running operations
+    ///
+    /// Calling `send()` on the resulting builder starts a longrunning operation.
+    /// Long running operations run in the background, and the application may
+    /// poll them periodically to find out their completion status.
+    ///
+    /// To poll the operation use the [get_operation] method. Use the [name]
+    /// field in the [Operation] returned from [send()]. When the operation
+    /// completes successfully, the [result] field will contain a
+    /// [{{ResponseType}}]. If the operation completes with an error it will
+    /// contain a `Status` with the error information.
+    ///
+    /// If the operation is still pending, the [metadata] field will contain a
+    /// [{{MetadataType}}]. In many services this provides an indication of
+    /// progress.
+    ///
+    /// Note that most errors on [get_operation] do not indicate that the
+    /// long-running operation failed. Long-running operation failures return
+    /// the error status in the [result] field.
+    ///
+    /// [send()]: crate::builders::{{NameToPascal}}::send
+    /// [get_operation]: crate::client::Operations::get_operation
+    /// [metadata]: longrunning::model::Operation::result
+    /// [name]: longrunning::model::Operation::name
+    /// [Operation]: longrunning::model::Operation
+    /// [result]: longrunning::model::Operation::result
+    {{/OperationInfo}}
     pub fn {{NameToSnake}}(
         &self,
         {{#PathParams}}

--- a/generator/internal/parser/protobuf.go
+++ b/generator/internal/parser/protobuf.go
@@ -288,7 +288,7 @@ func makeAPIForProtobuf(serviceConfig *serviceconfig.Service, req *pluginpb.Code
 			service := processService(state, s, sFQN, f.GetPackage())
 			for _, m := range s.Method {
 				mFQN := sFQN + "." + m.GetName()
-				if method := processMethod(state, m, mFQN); method != nil {
+				if method := processMethod(state, m, mFQN, f.GetPackage()); method != nil {
 					method.Parent = service
 					service.Methods = append(service.Methods, method)
 				}
@@ -337,7 +337,7 @@ func makeAPIForProtobuf(serviceConfig *serviceconfig.Service, req *pluginpb.Code
 				if !enabledMixinMethods[mFQN] {
 					continue
 				}
-				if method := processMethod(state, m, mFQN); method != nil {
+				if method := processMethod(state, m, mFQN, f.GetPackage()); method != nil {
 					method.Parent = service
 					service.Methods = append(service.Methods, method)
 				}
@@ -438,7 +438,7 @@ func processService(state *api.APIState, s *descriptorpb.ServiceDescriptorProto,
 	return service
 }
 
-func processMethod(state *api.APIState, m *descriptorpb.MethodDescriptorProto, mFQN string) *api.Method {
+func processMethod(state *api.APIState, m *descriptorpb.MethodDescriptorProto, mFQN, packagez string) *api.Method {
 	pathInfo, err := parsePathInfo(m, state)
 	if err != nil {
 		slog.Error("unsupported http method", "method", m)
@@ -452,6 +452,7 @@ func processMethod(state *api.APIState, m *descriptorpb.MethodDescriptorProto, m
 		OutputTypeID:        m.GetOutputType(),
 		ClientSideStreaming: m.GetClientStreaming(),
 		ServerSideStreaming: m.GetServerStreaming(),
+		OperationInfo:       parseOperationInfo(packagez, m),
 	}
 	state.MethodByID[mFQN] = method
 	return method

--- a/generator/internal/parser/protobuf_test.go
+++ b/generator/internal/parser/protobuf_test.go
@@ -1196,6 +1196,98 @@ func TestProtobuf_OperationMixin(t *testing.T) {
 	})
 }
 
+func TestProtobuf_OperationInfo(t *testing.T) {
+	var serviceConfig = &serviceconfig.Service{
+		Name:  "test.googleapis.com",
+		Title: "Test API",
+		Documentation: &serviceconfig.Documentation{
+			Summary:  "Used for testing generation.",
+			Overview: "Test Overview",
+			Rules: []*serviceconfig.DocumentationRule{
+				{
+					Selector:    "google.longrunning.Operations.GetOperation",
+					Description: "Custom docs.",
+				},
+			},
+		},
+		Apis: []*apipb.Api{
+			{
+				Name: "google.longrunning.Operations",
+			},
+			{
+				Name: "test.googleapis.com.TestService",
+			},
+		},
+		Http: &annotations.Http{
+			Rules: []*annotations.HttpRule{
+				{
+					Selector: "google.longrunning.Operations.GetOperation",
+					Pattern: &annotations.HttpRule_Get{
+						Get: "/v2/{name=operations/*}",
+					},
+					Body: "*",
+				},
+			},
+		},
+	}
+	test := makeAPIForProtobuf(serviceConfig, newTestCodeGeneratorRequest(t, "test_operation_info.proto"))
+	service, ok := test.State.ServiceByID[".test.LroService"]
+	if !ok {
+		t.Fatalf("Cannot find service %s in API State", ".test.LroService")
+	}
+	checkService(t, service, &api.Service{
+		Documentation: "A service to unit test the protobuf translator.",
+		DefaultHost:   "test.googleapis.com",
+		Name:          "LroService",
+		ID:            ".test.LroService",
+		Package:       "test",
+		Methods: []*api.Method{
+			{
+				Documentation: "Creates a new Foo resource.",
+				Name:          "CreateFoo",
+				ID:            ".test.LroService.CreateFoo",
+				InputTypeID:   ".test.CreateFooRequest",
+				OutputTypeID:  ".google.longrunning.Operation",
+				PathInfo: &api.PathInfo{
+					Verb: "POST",
+					PathTemplate: []api.PathSegment{
+						api.NewLiteralPathSegment("v1"),
+						api.NewFieldPathPathSegment("parent"),
+						api.NewLiteralPathSegment("foos"),
+					},
+					QueryParameters: map[string]bool{},
+					BodyFieldPath:   "foo",
+				},
+				OperationInfo: &api.OperationInfo{
+					MetadataTypeID: ".google.protobuf.Empty",
+					ResponseTypeID: ".test.Foo",
+				},
+			},
+			{
+				Documentation: "Creates a new Foo resource.",
+				Name:          "CreateFooWithProgress",
+				ID:            ".test.LroService.CreateFooWithProgress",
+				InputTypeID:   ".test.CreateFooRequest",
+				OutputTypeID:  ".google.longrunning.Operation",
+				PathInfo: &api.PathInfo{
+					Verb: "POST",
+					PathTemplate: []api.PathSegment{
+						api.NewLiteralPathSegment("v1"),
+						api.NewFieldPathPathSegment("parent"),
+						api.NewLiteralPathSegment("foos"),
+					},
+					QueryParameters: map[string]bool{},
+					BodyFieldPath:   "foo",
+				},
+				OperationInfo: &api.OperationInfo{
+					MetadataTypeID: ".test.CreateMetadata",
+					ResponseTypeID: ".test.Foo",
+				},
+			},
+		},
+	})
+}
+
 func newTestCodeGeneratorRequest(t *testing.T, filename string) *pluginpb.CodeGeneratorRequest {
 	t.Helper()
 	options := map[string]string{

--- a/generator/internal/parser/testdata/test_operation_info.proto
+++ b/generator/internal/parser/testdata/test_operation_info.proto
@@ -1,0 +1,71 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package test;
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "google/longrunning/operations.proto";
+
+// A service to unit test the protobuf translator.
+service LroService {
+    option (google.api.default_host) = "test.googleapis.com";
+    option (google.api.oauth_scopes) =
+        "https://www.googleapis.com/auth/cloud-platform";
+
+  // Creates a new Foo resource.
+  rpc CreateFoo(CreateFooRequest) returns (google.longrunning.Operation) {
+    option (google.api.http) = {
+      post: "/v1/{parent=projects/*}/foos"
+      body: "foo"
+    };
+    option (google.longrunning.operation_info) = {
+        response_type: "test.Foo"
+        metadata_type: "google.protobuf.Empty"
+      };
+  }
+    
+  // Creates a new Foo resource.
+  rpc CreateFooWithProgress(CreateFooRequest) returns (google.longrunning.Operation) {
+    option (google.api.http) = {
+      post: "/v1/{parent=projects/*}/foos"
+      body: "foo"
+    };
+    option (google.longrunning.operation_info) = {
+        response_type: "test.Foo"
+        metadata_type: "test.CreateMetadata"
+      };
+  }
+}
+
+// The Create request
+message CreateFooRequest {
+    // Parent name
+    string parent = 1;
+}
+
+// Test LRO metadata
+message CreateMetadata {
+    // The percentage completed.
+    int32 completed_percent = 1;
+}
+
+// Test LRO response type.
+message Foo {
+    // The resource name.
+    string name = 1;
+}

--- a/generator/internal/sidekick/templatedata.go
+++ b/generator/internal/sidekick/templatedata.go
@@ -91,6 +91,12 @@ type Method struct {
 	ServiceNameToSnake  string
 	InputTypeID         string
 	InputType           *Message
+	OperationInfo       *OperationInfo
+}
+
+type OperationInfo struct {
+	MetadataType string
+	ResponseType string
 }
 
 type OneOf struct {
@@ -250,7 +256,7 @@ func newMessage(m *api.Message, c language.Codec, state *api.APIState) *Message 
 }
 
 func newMethod(m *api.Method, c language.Codec, state *api.APIState) *Method {
-	return &Method{
+	method := &Method{
 		BodyAccessor:      c.BodyAccessor(m, state),
 		DocLines:          c.FormatDocComments(m.Documentation, state),
 		HTTPMethod:        m.PathInfo.Verb,
@@ -275,6 +281,13 @@ func newMethod(m *api.Method, c language.Codec, state *api.APIState) *Method {
 		ServiceNameToSnake:  c.ToSnake(m.Parent.Name),
 		InputTypeID:         m.InputTypeID,
 	}
+	if m.OperationInfo != nil {
+		method.OperationInfo = &OperationInfo{
+			MetadataType: c.MethodInOutTypeName(m.OperationInfo.MetadataTypeID, state),
+			ResponseType: c.MethodInOutTypeName(m.OperationInfo.ResponseTypeID, state),
+		}
+	}
+	return method
 }
 
 func newOneOf(oneOf *api.OneOf, c language.Codec, state *api.APIState) *OneOf {

--- a/generator/testdata/googleapis/google/longrunning/operations.proto
+++ b/generator/testdata/googleapis/google/longrunning/operations.proto
@@ -1,0 +1,246 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.longrunning;
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/protobuf/any.proto";
+import "google/protobuf/descriptor.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/empty.proto";
+import "google/rpc/status.proto";
+
+option cc_enable_arenas = true;
+option csharp_namespace = "Google.LongRunning";
+option go_package = "cloud.google.com/go/longrunning/autogen/longrunningpb;longrunningpb";
+option java_multiple_files = true;
+option java_outer_classname = "OperationsProto";
+option java_package = "com.google.longrunning";
+option objc_class_prefix = "GLRUN";
+option php_namespace = "Google\\LongRunning";
+
+extend google.protobuf.MethodOptions {
+  // Additional information regarding long-running operations.
+  // In particular, this specifies the types that are returned from
+  // long-running operations.
+  //
+  // Required for methods that return `google.longrunning.Operation`; invalid
+  // otherwise.
+  google.longrunning.OperationInfo operation_info = 1049;
+}
+
+// Manages long-running operations with an API service.
+//
+// When an API method normally takes long time to complete, it can be designed
+// to return [Operation][google.longrunning.Operation] to the client, and the
+// client can use this interface to receive the real response asynchronously by
+// polling the operation resource, or pass the operation resource to another API
+// (such as Pub/Sub API) to receive the response.  Any API service that returns
+// long-running operations should implement the `Operations` interface so
+// developers can have a consistent client experience.
+service Operations {
+  option (google.api.default_host) = "longrunning.googleapis.com";
+
+  // Lists operations that match the specified filter in the request. If the
+  // server doesn't support this method, it returns `UNIMPLEMENTED`.
+  rpc ListOperations(ListOperationsRequest) returns (ListOperationsResponse) {
+    option (google.api.http) = {
+      get: "/v1/{name=operations}"
+    };
+    option (google.api.method_signature) = "name,filter";
+  }
+
+  // Gets the latest state of a long-running operation.  Clients can use this
+  // method to poll the operation result at intervals as recommended by the API
+  // service.
+  rpc GetOperation(GetOperationRequest) returns (Operation) {
+    option (google.api.http) = {
+      get: "/v1/{name=operations/**}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Deletes a long-running operation. This method indicates that the client is
+  // no longer interested in the operation result. It does not cancel the
+  // operation. If the server doesn't support this method, it returns
+  // `google.rpc.Code.UNIMPLEMENTED`.
+  rpc DeleteOperation(DeleteOperationRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/v1/{name=operations/**}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Starts asynchronous cancellation on a long-running operation.  The server
+  // makes a best effort to cancel the operation, but success is not
+  // guaranteed.  If the server doesn't support this method, it returns
+  // `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+  // [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+  // other methods to check whether the cancellation succeeded or whether the
+  // operation completed despite cancellation. On successful cancellation,
+  // the operation is not deleted; instead, it becomes an operation with
+  // an [Operation.error][google.longrunning.Operation.error] value with a
+  // [google.rpc.Status.code][google.rpc.Status.code] of `1`, corresponding to
+  // `Code.CANCELLED`.
+  rpc CancelOperation(CancelOperationRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      post: "/v1/{name=operations/**}:cancel"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Waits until the specified long-running operation is done or reaches at most
+  // a specified timeout, returning the latest state.  If the operation is
+  // already done, the latest state is immediately returned.  If the timeout
+  // specified is greater than the default HTTP/RPC timeout, the HTTP/RPC
+  // timeout is used.  If the server does not support this method, it returns
+  // `google.rpc.Code.UNIMPLEMENTED`.
+  // Note that this method is on a best-effort basis.  It may return the latest
+  // state before the specified timeout (including immediately), meaning even an
+  // immediate response is no guarantee that the operation is done.
+  rpc WaitOperation(WaitOperationRequest) returns (Operation) {}
+}
+
+// This resource represents a long-running operation that is the result of a
+// network API call.
+message Operation {
+  // The server-assigned name, which is only unique within the same service that
+  // originally returns it. If you use the default HTTP mapping, the
+  // `name` should be a resource name ending with `operations/{unique_id}`.
+  string name = 1;
+
+  // Service-specific metadata associated with the operation.  It typically
+  // contains progress information and common metadata such as create time.
+  // Some services might not provide such metadata.  Any method that returns a
+  // long-running operation should document the metadata type, if any.
+  google.protobuf.Any metadata = 2;
+
+  // If the value is `false`, it means the operation is still in progress.
+  // If `true`, the operation is completed, and either `error` or `response` is
+  // available.
+  bool done = 3;
+
+  // The operation result, which can be either an `error` or a valid `response`.
+  // If `done` == `false`, neither `error` nor `response` is set.
+  // If `done` == `true`, exactly one of `error` or `response` can be set.
+  // Some services might not provide the result.
+  oneof result {
+    // The error result of the operation in case of failure or cancellation.
+    google.rpc.Status error = 4;
+
+    // The normal, successful response of the operation.  If the original
+    // method returns no data on success, such as `Delete`, the response is
+    // `google.protobuf.Empty`.  If the original method is standard
+    // `Get`/`Create`/`Update`, the response should be the resource.  For other
+    // methods, the response should have the type `XxxResponse`, where `Xxx`
+    // is the original method name.  For example, if the original method name
+    // is `TakeSnapshot()`, the inferred response type is
+    // `TakeSnapshotResponse`.
+    google.protobuf.Any response = 5;
+  }
+}
+
+// The request message for
+// [Operations.GetOperation][google.longrunning.Operations.GetOperation].
+message GetOperationRequest {
+  // The name of the operation resource.
+  string name = 1;
+}
+
+// The request message for
+// [Operations.ListOperations][google.longrunning.Operations.ListOperations].
+message ListOperationsRequest {
+  // The name of the operation's parent resource.
+  string name = 4;
+
+  // The standard list filter.
+  string filter = 1;
+
+  // The standard list page size.
+  int32 page_size = 2;
+
+  // The standard list page token.
+  string page_token = 3;
+}
+
+// The response message for
+// [Operations.ListOperations][google.longrunning.Operations.ListOperations].
+message ListOperationsResponse {
+  // A list of operations that matches the specified filter in the request.
+  repeated Operation operations = 1;
+
+  // The standard List next-page token.
+  string next_page_token = 2;
+}
+
+// The request message for
+// [Operations.CancelOperation][google.longrunning.Operations.CancelOperation].
+message CancelOperationRequest {
+  // The name of the operation resource to be cancelled.
+  string name = 1;
+}
+
+// The request message for
+// [Operations.DeleteOperation][google.longrunning.Operations.DeleteOperation].
+message DeleteOperationRequest {
+  // The name of the operation resource to be deleted.
+  string name = 1;
+}
+
+// The request message for
+// [Operations.WaitOperation][google.longrunning.Operations.WaitOperation].
+message WaitOperationRequest {
+  // The name of the operation resource to wait on.
+  string name = 1;
+
+  // The maximum duration to wait before timing out. If left blank, the wait
+  // will be at most the time permitted by the underlying HTTP/RPC protocol.
+  // If RPC context deadline is also specified, the shorter one will be used.
+  google.protobuf.Duration timeout = 2;
+}
+
+// A message representing the message types used by a long-running operation.
+//
+// Example:
+//
+//     rpc Export(ExportRequest) returns (google.longrunning.Operation) {
+//       option (google.longrunning.operation_info) = {
+//         response_type: "ExportResponse"
+//         metadata_type: "ExportMetadata"
+//       };
+//     }
+message OperationInfo {
+  // Required. The message name of the primary return type for this
+  // long-running operation.
+  // This type will be used to deserialize the LRO's response.
+  //
+  // If the response is in a different package from the rpc, a fully-qualified
+  // message name must be used (e.g. `google.protobuf.Struct`).
+  //
+  // Note: Altering this value constitutes a breaking change.
+  string response_type = 1;
+
+  // Required. The message name of the metadata type for this long-running
+  // operation.
+  //
+  // If the response is in a different package from the rpc, a fully-qualified
+  // message name must be used (e.g. `google.protobuf.Struct`).
+  //
+  // Note: Altering this value constitutes a breaking change.
+  string metadata_type = 2;
+}

--- a/generator/testdata/googleapis/google/rpc/status.proto
+++ b/generator/testdata/googleapis/google/rpc/status.proto
@@ -1,0 +1,49 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.rpc;
+
+import "google/protobuf/any.proto";
+
+option cc_enable_arenas = true;
+option go_package = "google.golang.org/genproto/googleapis/rpc/status;status";
+option java_multiple_files = true;
+option java_outer_classname = "StatusProto";
+option java_package = "com.google.rpc";
+option objc_class_prefix = "RPC";
+
+// The `Status` type defines a logical error model that is suitable for
+// different programming environments, including REST APIs and RPC APIs. It is
+// used by [gRPC](https://github.com/grpc). Each `Status` message contains
+// three pieces of data: error code, error message, and error details.
+//
+// You can find out more about this error model and how to work with it in the
+// [API Design Guide](https://cloud.google.com/apis/design/errors).
+message Status {
+  // The status code, which should be an enum value of
+  // [google.rpc.Code][google.rpc.Code].
+  int32 code = 1;
+
+  // A developer-facing error message, which should be in English. Any
+  // user-facing error message should be localized and sent in the
+  // [google.rpc.Status.details][google.rpc.Status.details] field, or localized
+  // by the client.
+  string message = 2;
+
+  // A list of messages that carry the error details.  There is a common set of
+  // message types for APIs to use.
+  repeated google.protobuf.Any details = 3;
+}

--- a/generator/testdata/rust/protobuf/golden/module/rpc/mod.rs
+++ b/generator/testdata/rust/protobuf/golden/module/rpc/mod.rs
@@ -607,6 +607,61 @@ impl LocalizedMessage {
     }
 }
 
+/// The `Status` type defines a logical error model that is suitable for
+/// different programming environments, including REST APIs and RPC APIs. It is
+/// used by [gRPC](https://github.com/grpc). Each `Status` message contains
+/// three pieces of data: error code, error message, and error details.
+///
+/// You can find out more about this error model and how to work with it in the
+/// [API Design Guide](https://cloud.google.com/apis/design/errors).
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct Status {
+
+    /// The status code, which should be an enum value of
+    /// [google.rpc.Code][google.rpc.Code].
+    ///
+    /// [google.rpc.Code]: crate::error::rpc::generated::Code
+    pub code: i32,
+
+    /// A developer-facing error message, which should be in English. Any
+    /// user-facing error message should be localized and sent in the
+    /// [google.rpc.Status.details][google.rpc.Status.details] field, or localized
+    /// by the client.
+    ///
+    /// [google.rpc.Status.details]: crate::error::rpc::generated::Status::details
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub message: String,
+
+    /// A list of messages that carry the error details.  There is a common set of
+    /// message types for APIs to use.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub details: Vec<wkt::Any>,
+}
+
+impl Status {
+
+    /// Sets the value of `code`.
+    pub fn set_code<T: Into<i32>>(mut self, v: T) -> Self {
+        self.code = v.into();
+        self
+    }
+
+    /// Sets the value of `message`.
+    pub fn set_message<T: Into<String>>(mut self, v: T) -> Self {
+        self.message = v.into();
+        self
+    }
+
+    /// Sets the value of `details`.
+    pub fn set_details<T: Into<Vec<wkt::Any>>>(mut self, v: T) -> Self {
+        self.details = v.into();
+        self
+    }
+}
+
 /// The canonical error codes for gRPC APIs.
 ///
 ///

--- a/src/generated/cloud/workflows/v1/src/builders.rs
+++ b/src/generated/cloud/workflows/v1/src/builders.rs
@@ -170,6 +170,11 @@ impl CreateWorkflow {
     }
 
     /// Sends the request.
+    ///
+    /// # Long running operations
+    ///
+    /// This starts, but does not poll, a longrunning operation. More information
+    /// on [create_workflow][crate::client::Workflows::create_workflow].
     pub async fn send(self) -> Result<longrunning::model::Operation> {
         self.0
             .stub
@@ -218,6 +223,11 @@ impl DeleteWorkflow {
     }
 
     /// Sends the request.
+    ///
+    /// # Long running operations
+    ///
+    /// This starts, but does not poll, a longrunning operation. More information
+    /// on [delete_workflow][crate::client::Workflows::delete_workflow].
     pub async fn send(self) -> Result<longrunning::model::Operation> {
         self.0
             .stub
@@ -254,6 +264,11 @@ impl UpdateWorkflow {
     }
 
     /// Sends the request.
+    ///
+    /// # Long running operations
+    ///
+    /// This starts, but does not poll, a longrunning operation. More information
+    /// on [update_workflow][crate::client::Workflows::update_workflow].
     pub async fn send(self) -> Result<longrunning::model::Operation> {
         self.0
             .stub

--- a/src/generated/cloud/workflows/v1/src/client.rs
+++ b/src/generated/cloud/workflows/v1/src/client.rs
@@ -98,6 +98,33 @@ impl Workflows {
     /// exists in the specified project and location, the long running operation
     /// returns a [ALREADY_EXISTS][google.rpc.Code.ALREADY_EXISTS] error.
     ///
+    ///
+    /// # Long running operations
+    ///
+    /// Calling `send()` on the resulting builder starts a longrunning operation.
+    /// Long running operations run in the background, and the application may
+    /// poll them periodically to find out their completion status.
+    ///
+    /// To poll the operation use the [get_operation] method. Use the [name]
+    /// field in the [Operation] returned from [send()]. When the operation
+    /// completes successfully, the [result] field will contain a
+    /// [crate::model::Workflow]. If the operation completes with an error it will
+    /// contain a `Status` with the error information.
+    ///
+    /// If the operation is still pending, the [metadata] field will contain a
+    /// [crate::model::OperationMetadata]. In many services this provides an indication of
+    /// progress.
+    ///
+    /// Note that most errors on [get_operation] do not indicate that the
+    /// long-running operation failed. Long-running operation failures return
+    /// the error status in the [result] field.
+    ///
+    /// [send()]: crate::builders::CreateWorkflow::send
+    /// [get_operation]: crate::client::Operations::get_operation
+    /// [metadata]: longrunning::model::Operation::result
+    /// [name]: longrunning::model::Operation::name
+    /// [Operation]: longrunning::model::Operation
+    /// [result]: longrunning::model::Operation::result
     pub fn create_workflow(&self, parent: impl Into<String>) -> crate::builders::CreateWorkflow {
         crate::builders::CreateWorkflow::new(self.inner.clone()).set_parent(parent.into())
     }
@@ -105,6 +132,33 @@ impl Workflows {
     /// Deletes a workflow with the specified name.
     /// This method also cancels and deletes all running executions of the
     /// workflow.
+    ///
+    /// # Long running operations
+    ///
+    /// Calling `send()` on the resulting builder starts a longrunning operation.
+    /// Long running operations run in the background, and the application may
+    /// poll them periodically to find out their completion status.
+    ///
+    /// To poll the operation use the [get_operation] method. Use the [name]
+    /// field in the [Operation] returned from [send()]. When the operation
+    /// completes successfully, the [result] field will contain a
+    /// [wkt::Empty]. If the operation completes with an error it will
+    /// contain a `Status` with the error information.
+    ///
+    /// If the operation is still pending, the [metadata] field will contain a
+    /// [crate::model::OperationMetadata]. In many services this provides an indication of
+    /// progress.
+    ///
+    /// Note that most errors on [get_operation] do not indicate that the
+    /// long-running operation failed. Long-running operation failures return
+    /// the error status in the [result] field.
+    ///
+    /// [send()]: crate::builders::DeleteWorkflow::send
+    /// [get_operation]: crate::client::Operations::get_operation
+    /// [metadata]: longrunning::model::Operation::result
+    /// [name]: longrunning::model::Operation::name
+    /// [Operation]: longrunning::model::Operation
+    /// [result]: longrunning::model::Operation::result
     pub fn delete_workflow(&self, name: impl Into<String>) -> crate::builders::DeleteWorkflow {
         crate::builders::DeleteWorkflow::new(self.inner.clone()).set_name(name.into())
     }
@@ -114,6 +168,33 @@ impl Workflows {
     /// workflow. A new revision of the workflow might be created as a result of a
     /// successful update operation. In that case, the new revision is used
     /// in new workflow executions.
+    ///
+    /// # Long running operations
+    ///
+    /// Calling `send()` on the resulting builder starts a longrunning operation.
+    /// Long running operations run in the background, and the application may
+    /// poll them periodically to find out their completion status.
+    ///
+    /// To poll the operation use the [get_operation] method. Use the [name]
+    /// field in the [Operation] returned from [send()]. When the operation
+    /// completes successfully, the [result] field will contain a
+    /// [crate::model::Workflow]. If the operation completes with an error it will
+    /// contain a `Status` with the error information.
+    ///
+    /// If the operation is still pending, the [metadata] field will contain a
+    /// [crate::model::OperationMetadata]. In many services this provides an indication of
+    /// progress.
+    ///
+    /// Note that most errors on [get_operation] do not indicate that the
+    /// long-running operation failed. Long-running operation failures return
+    /// the error status in the [result] field.
+    ///
+    /// [send()]: crate::builders::UpdateWorkflow::send
+    /// [get_operation]: crate::client::Operations::get_operation
+    /// [metadata]: longrunning::model::Operation::result
+    /// [name]: longrunning::model::Operation::name
+    /// [Operation]: longrunning::model::Operation
+    /// [result]: longrunning::model::Operation::result
     pub fn update_workflow(
         &self,
         workflow: impl Into<crate::model::Workflow>,


### PR DESCRIPTION
If a method has the LRO annotations, capture them into the model and the
mustache templates model.

Mostly to convince myself this is working: generate better documentation using
these annotations. We cannot generate LRO helpers, but we can tell callers what
types to expect in the LRO.

Fixes #561 