### PR TITLE
feat(generator): provide default idempotency

### DIFF
--- a/generator/internal/language/templates/rust/crate/src/transport.rs.mustache
+++ b/generator/internal/language/templates/rust/crate/src/transport.rs.mustache
@@ -54,6 +54,7 @@ impl crate::traits::{{NameToPascal}} for {{NameToPascal}} {
         req: {{InputTypeName}},
         options: gax::options::RequestOptions,
     ) -> Result<{{OutputTypeName}}> {
+        let options = options.set_default_idempotency(reqwest::Method::{{HTTPMethod}}.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::{{HTTPMethod}}, format!("{{HTTPPathFmt}}"
                {{#HTTPPathArgs}}

--- a/generator/testdata/rust/openapi/golden/src/transport.rs
+++ b/generator/testdata/rust/openapi/golden/src/transport.rs
@@ -45,6 +45,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::ListLocationsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListLocationsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/locations"
                , req.project
@@ -66,6 +67,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::GetLocationRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Location> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/locations/{}"
                , req.project
@@ -85,6 +87,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::ListSecretsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/secrets"
                , req.project
@@ -106,6 +109,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::CreateSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/secrets"
                , req.project
@@ -125,6 +129,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::ListSecretsByProjectAndLocationRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/locations/{}/secrets"
                , req.project
@@ -147,6 +152,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::CreateSecretByProjectAndLocationRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/locations/{}/secrets"
                , req.project
@@ -167,6 +173,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::AddSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/secrets/{}:addVersion"
                , req.project
@@ -186,6 +193,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::AddSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/locations/{}/secrets/{}:addVersion"
                , req.project
@@ -206,6 +214,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::GetSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/secrets/{}"
                , req.project
@@ -225,6 +234,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::DeleteSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Empty> {
+        let options = options.set_default_idempotency(reqwest::Method::DELETE.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::DELETE, format!("/v1/projects/{}/secrets/{}"
                , req.project
@@ -245,6 +255,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::UpdateSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
+        let options = options.set_default_idempotency(reqwest::Method::PATCH.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::PATCH, format!("/v1/projects/{}/secrets/{}"
                , req.project
@@ -265,6 +276,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::GetSecretByProjectAndLocationAndSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/locations/{}/secrets/{}"
                , req.project
@@ -285,6 +297,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::DeleteSecretByProjectAndLocationAndSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Empty> {
+        let options = options.set_default_idempotency(reqwest::Method::DELETE.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::DELETE, format!("/v1/projects/{}/locations/{}/secrets/{}"
                , req.project
@@ -306,6 +319,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::UpdateSecretByProjectAndLocationAndSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
+        let options = options.set_default_idempotency(reqwest::Method::PATCH.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::PATCH, format!("/v1/projects/{}/locations/{}/secrets/{}"
                , req.project
@@ -327,6 +341,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::ListSecretVersionsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretVersionsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/secrets/{}/versions"
                , req.project
@@ -349,6 +364,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretVersionsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/locations/{}/secrets/{}/versions"
                , req.project
@@ -372,6 +388,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::GetSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/secrets/{}/versions/{}"
                , req.project
@@ -392,6 +409,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/locations/{}/secrets/{}/versions/{}"
                , req.project
@@ -413,6 +431,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::AccessSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::AccessSecretVersionResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/secrets/{}/versions/{}:access"
                , req.project
@@ -433,6 +452,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::AccessSecretVersionResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/locations/{}/secrets/{}/versions/{}:access"
                , req.project
@@ -454,6 +474,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::DisableSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/secrets/{}/versions/{}:disable"
                , req.project
@@ -474,6 +495,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::DisableSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/locations/{}/secrets/{}/versions/{}:disable"
                , req.project
@@ -495,6 +517,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::EnableSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/secrets/{}/versions/{}:enable"
                , req.project
@@ -515,6 +538,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::EnableSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/locations/{}/secrets/{}/versions/{}:enable"
                , req.project
@@ -536,6 +560,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::DestroySecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/secrets/{}/versions/{}:destroy"
                , req.project
@@ -556,6 +581,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::DestroySecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/locations/{}/secrets/{}/versions/{}:destroy"
                , req.project
@@ -577,6 +603,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::SetIamPolicyRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/secrets/{}:setIamPolicy"
                , req.project
@@ -596,6 +623,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::SetIamPolicyRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/locations/{}/secrets/{}:setIamPolicy"
                , req.project
@@ -616,6 +644,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::GetIamPolicyRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/secrets/{}:getIamPolicy"
                , req.project
@@ -636,6 +665,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/projects/{}/locations/{}/secrets/{}:getIamPolicy"
                , req.project
@@ -657,6 +687,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::TestIamPermissionsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::TestIamPermissionsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/secrets/{}:testIamPermissions"
                , req.project
@@ -676,6 +707,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::TestIamPermissionsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::TestIamPermissionsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/projects/{}/locations/{}/secrets/{}:testIamPermissions"
                , req.project

--- a/generator/testdata/rust/protobuf/golden/iam/v1/src/transport.rs
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/src/transport.rs
@@ -45,6 +45,7 @@ impl crate::traits::IAMPolicy for IAMPolicy {
         req: crate::model::SetIamPolicyRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/{}:setIamPolicy"
                , req.resource
@@ -63,6 +64,7 @@ impl crate::traits::IAMPolicy for IAMPolicy {
         req: crate::model::GetIamPolicyRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/{}:getIamPolicy"
                , req.resource
@@ -81,6 +83,7 @@ impl crate::traits::IAMPolicy for IAMPolicy {
         req: crate::model::TestIamPermissionsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::TestIamPermissionsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/{}:testIamPermissions"
                , req.resource

--- a/generator/testdata/rust/protobuf/golden/location/src/transport.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/transport.rs
@@ -45,6 +45,7 @@ impl crate::traits::Locations for Locations {
         req: crate::model::ListLocationsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListLocationsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/{}"
                , req.name
@@ -66,6 +67,7 @@ impl crate::traits::Locations for Locations {
         req: crate::model::GetLocationRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Location> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/{}"
                , req.name

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/transport.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/transport.rs
@@ -45,6 +45,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::ListSecretsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/{}/secrets"
                , req.parent
@@ -66,6 +67,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::CreateSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/{}/secrets"
                , req.parent
@@ -85,6 +87,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::AddSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/{}:addVersion"
                , req.parent
@@ -103,6 +106,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::GetSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/{}"
                , req.name
@@ -121,6 +125,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::UpdateSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
+        let options = options.set_default_idempotency(reqwest::Method::PATCH.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::PATCH, format!("/v1/{}"
                , gax::path_parameter::PathParameter::required(&req.secret, "secret").map_err(Error::other)?.name
@@ -140,6 +145,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::DeleteSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<wkt::Empty> {
+        let options = options.set_default_idempotency(reqwest::Method::DELETE.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::DELETE, format!("/v1/{}"
                , req.name
@@ -159,6 +165,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::ListSecretVersionsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretVersionsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/{}/versions"
                , req.parent
@@ -180,6 +187,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::GetSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/{}"
                , req.name
@@ -198,6 +206,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::AccessSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::AccessSecretVersionResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/{}:access"
                , req.name
@@ -216,6 +225,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::DisableSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/{}:disable"
                , req.name
@@ -234,6 +244,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::EnableSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/{}:enable"
                , req.name
@@ -252,6 +263,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::DestroySecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/{}:destroy"
                , req.name
@@ -270,6 +282,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: iam::model::SetIamPolicyRequest,
         options: gax::options::RequestOptions,
     ) -> Result<iam::model::Policy> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/{}:setIamPolicy"
                , req.resource
@@ -288,6 +301,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: iam::model::GetIamPolicyRequest,
         options: gax::options::RequestOptions,
     ) -> Result<iam::model::Policy> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/{}:getIamPolicy"
                , req.resource
@@ -307,6 +321,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: iam::model::TestIamPermissionsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<iam::model::TestIamPermissionsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::POST, format!("/v1/{}:testIamPermissions"
                , req.resource
@@ -349,6 +364,7 @@ impl crate::traits::Locations for Locations {
         req: location::model::ListLocationsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<location::model::ListLocationsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/{}/locations"
                , req.name
@@ -370,6 +386,7 @@ impl crate::traits::Locations for Locations {
         req: location::model::GetLocationRequest,
         options: gax::options::RequestOptions,
     ) -> Result<location::model::Location> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self.inner.builder(
             reqwest::Method::GET, format!("/v1/{}"
                , req.name

--- a/src/generated/cloud/location/src/transport.rs
+++ b/src/generated/cloud/location/src/transport.rs
@@ -45,6 +45,7 @@ impl crate::traits::Locations for Locations {
         req: crate::model::ListLocationsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListLocationsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
@@ -69,6 +70,7 @@ impl crate::traits::Locations for Locations {
         req: crate::model::GetLocationRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Location> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))

--- a/src/generated/cloud/secretmanager/v1/src/transport.rs
+++ b/src/generated/cloud/secretmanager/v1/src/transport.rs
@@ -45,6 +45,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::ListSecretsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/secrets", req.parent))
@@ -69,6 +70,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::CreateSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}/secrets", req.parent))
@@ -87,6 +89,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::AddSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -106,6 +109,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::GetSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
@@ -124,6 +128,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::UpdateSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
+        let options = options.set_default_idempotency(reqwest::Method::PATCH.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -154,6 +159,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::DeleteSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<wkt::Empty> {
+        let options = options.set_default_idempotency(reqwest::Method::DELETE.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
@@ -174,6 +180,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::ListSecretVersionsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretVersionsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/versions", req.parent))
@@ -198,6 +205,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::GetSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
@@ -216,6 +224,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::AccessSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::AccessSecretVersionResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}:access", req.name))
@@ -234,6 +243,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::DisableSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:disable", req.name))
@@ -250,6 +260,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::EnableSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:enable", req.name))
@@ -266,6 +277,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::DestroySecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:destroy", req.name))
@@ -282,6 +294,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: iam_v1::model::SetIamPolicyRequest,
         options: gax::options::RequestOptions,
     ) -> Result<iam_v1::model::Policy> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -301,6 +314,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: iam_v1::model::GetIamPolicyRequest,
         options: gax::options::RequestOptions,
     ) -> Result<iam_v1::model::Policy> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -328,6 +342,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: iam_v1::model::TestIamPermissionsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<iam_v1::model::TestIamPermissionsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -370,6 +385,7 @@ impl crate::traits::Locations for Locations {
         req: location::model::ListLocationsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<location::model::ListLocationsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
@@ -394,6 +410,7 @@ impl crate::traits::Locations for Locations {
         req: location::model::GetLocationRequest,
         options: gax::options::RequestOptions,
     ) -> Result<location::model::Location> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))

--- a/src/generated/cloud/workflows/v1/src/transport.rs
+++ b/src/generated/cloud/workflows/v1/src/transport.rs
@@ -45,6 +45,7 @@ impl crate::traits::Workflows for Workflows {
         req: crate::model::ListWorkflowsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListWorkflowsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -74,6 +75,7 @@ impl crate::traits::Workflows for Workflows {
         req: crate::model::GetWorkflowRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Workflow> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
@@ -94,6 +96,7 @@ impl crate::traits::Workflows for Workflows {
         req: crate::model::CreateWorkflowRequest,
         options: gax::options::RequestOptions,
     ) -> Result<longrunning::model::Operation> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -117,6 +120,7 @@ impl crate::traits::Workflows for Workflows {
         req: crate::model::DeleteWorkflowRequest,
         options: gax::options::RequestOptions,
     ) -> Result<longrunning::model::Operation> {
+        let options = options.set_default_idempotency(reqwest::Method::DELETE.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
@@ -135,6 +139,7 @@ impl crate::traits::Workflows for Workflows {
         req: crate::model::UpdateWorkflowRequest,
         options: gax::options::RequestOptions,
     ) -> Result<longrunning::model::Operation> {
+        let options = options.set_default_idempotency(reqwest::Method::PATCH.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -190,6 +195,7 @@ impl crate::traits::Locations for Locations {
         req: location::model::ListLocationsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<location::model::ListLocationsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
@@ -214,6 +220,7 @@ impl crate::traits::Locations for Locations {
         req: location::model::GetLocationRequest,
         options: gax::options::RequestOptions,
     ) -> Result<location::model::Location> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
@@ -255,6 +262,7 @@ impl crate::traits::Operations for Operations {
         req: longrunning::model::ListOperationsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<longrunning::model::ListOperationsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
@@ -279,6 +287,7 @@ impl crate::traits::Operations for Operations {
         req: longrunning::model::GetOperationRequest,
         options: gax::options::RequestOptions,
     ) -> Result<longrunning::model::Operation> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
@@ -297,6 +306,7 @@ impl crate::traits::Operations for Operations {
         req: longrunning::model::DeleteOperationRequest,
         options: gax::options::RequestOptions,
     ) -> Result<wkt::Empty> {
+        let options = options.set_default_idempotency(reqwest::Method::DELETE.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))

--- a/src/generated/iam/v1/src/transport.rs
+++ b/src/generated/iam/v1/src/transport.rs
@@ -45,6 +45,7 @@ impl crate::traits::IAMPolicy for IAMPolicy {
         req: crate::model::SetIamPolicyRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -64,6 +65,7 @@ impl crate::traits::IAMPolicy for IAMPolicy {
         req: crate::model::GetIamPolicyRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -83,6 +85,7 @@ impl crate::traits::IAMPolicy for IAMPolicy {
         req: crate::model::TestIamPermissionsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::TestIamPermissionsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(

--- a/src/generated/longrunning/src/transport.rs
+++ b/src/generated/longrunning/src/transport.rs
@@ -45,6 +45,7 @@ impl crate::traits::Operations for Operations {
         req: crate::model::ListOperationsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListOperationsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
@@ -69,6 +70,7 @@ impl crate::traits::Operations for Operations {
         req: crate::model::GetOperationRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Operation> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
@@ -87,6 +89,7 @@ impl crate::traits::Operations for Operations {
         req: crate::model::DeleteOperationRequest,
         options: gax::options::RequestOptions,
     ) -> Result<wkt::Empty> {
+        let options = options.set_default_idempotency(reqwest::Method::DELETE.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
@@ -105,6 +108,7 @@ impl crate::traits::Operations for Operations {
         req: crate::model::CancelOperationRequest,
         options: gax::options::RequestOptions,
     ) -> Result<wkt::Empty> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))

--- a/src/generated/openapi-validation/src/transport.rs
+++ b/src/generated/openapi-validation/src/transport.rs
@@ -45,6 +45,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::ListLocationsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListLocationsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -72,6 +73,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::GetLocationRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Location> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -93,6 +95,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::ListSecretsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -120,6 +123,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::CreateSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -143,6 +147,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::ListSecretsByProjectAndLocationRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -173,6 +178,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::CreateSecretByProjectAndLocationRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -199,6 +205,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::AddSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -221,6 +228,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::AddSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -243,6 +251,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::GetSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -264,6 +273,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::DeleteSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Empty> {
+        let options = options.set_default_idempotency(reqwest::Method::DELETE.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -287,6 +297,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::UpdateSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
+        let options = options.set_default_idempotency(reqwest::Method::PATCH.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -314,6 +325,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::GetSecretByProjectAndLocationAndSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -338,6 +350,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::DeleteSecretByProjectAndLocationAndSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Empty> {
+        let options = options.set_default_idempotency(reqwest::Method::DELETE.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -364,6 +377,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::UpdateSecretByProjectAndLocationAndSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
+        let options = options.set_default_idempotency(reqwest::Method::PATCH.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -394,6 +408,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::ListSecretVersionsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretVersionsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -424,6 +439,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretVersionsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -454,6 +470,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::GetSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -478,6 +495,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -502,6 +520,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::AccessSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::AccessSecretVersionResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -526,6 +545,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::AccessSecretVersionResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -550,6 +570,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::DisableSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -572,6 +593,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::DisableSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -594,6 +616,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::EnableSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -616,6 +639,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::EnableSecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -638,6 +662,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::DestroySecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -660,6 +685,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::DestroySecretVersionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -682,6 +708,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::SetIamPolicyRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -704,6 +731,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::SetIamPolicyRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -726,6 +754,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::GetIamPolicyRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -756,6 +785,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
+        let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -786,6 +816,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::TestIamPermissionsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::TestIamPermissionsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(
@@ -808,6 +839,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         req: crate::model::TestIamPermissionsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::TestIamPermissionsResponse> {
+        let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
         let builder = self
             .inner
             .builder(


### PR DESCRIPTION
Note that there is no default retry policy, so this has no effect
beyond reducing the amount of code customers have to write to enable
retry loops.

Part of the work for #437
