### PR TITLE
cleanup(gax): unused code with a feature combo

### DIFF
--- a/src/gax/src/paginator.rs
+++ b/src/gax/src/paginator.rs
@@ -174,6 +174,7 @@ where
 #[cfg(feature = "unstable-sdk-client")]
 pub use sdk_util::*;
 
+#[cfg(feature = "unstable-sdk-client")]
 mod sdk_util {
     /// Extracts a token value from the input provided.
     pub fn extract_token<T>(input: T) -> String


### PR DESCRIPTION
This only comes up under:

```
cargo clippy -p gcp-sdk-gax --features unstable-stream
```

That is a rarely used feature combo. I was trying to test all feature
combos.