### PR TITLE
cleanup(auth): simpler test credentials

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -348,7 +348,7 @@ pub mod testing {
     use crate::credentials::Credential;
     use crate::token::Token;
     use crate::Result;
-    use http::header::{HeaderName, HeaderValue, AUTHORIZATION};
+    use http::header::{HeaderName, HeaderValue};
     use std::sync::Arc;
 
     /// A simple credentials implementation to use in tests where authentication does not matter.
@@ -375,14 +375,11 @@ pub mod testing {
         }
 
         async fn get_headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>> {
-            Ok(vec![(
-                AUTHORIZATION,
-                HeaderValue::from_static("Bearer: test-only-token"),
-            )])
+            Ok(Vec::new())
         }
 
         async fn get_universe_domain(&self) -> Option<String> {
-            Some("googleapis.com".to_string())
+            None
         }
     }
 }

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use gcp_sdk_auth::credentials::testing::test_credentials;
 use gcp_sdk_auth::credentials::{create_access_token_credential, Credential, CredentialTrait};
 use gcp_sdk_auth::errors::CredentialError;
 use gcp_sdk_auth::token::Token;
@@ -132,6 +133,15 @@ mod test {
         assert!(creds.get_headers().await?.is_empty());
         assert_eq!(creds.get_universe_domain().await, None);
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn testing_credentials() -> Result<()> {
+        let creds = test_credentials();
+        assert_eq!(creds.get_token().await?.token, "test-only-token");
+        assert!(creds.get_headers().await?.is_empty());
+        assert_eq!(creds.get_universe_domain().await, None);
         Ok(())
     }
 }


### PR DESCRIPTION
It is simpler to return an empty vector (which @coryan did in #592).

We were using `test_credentials()` in gax's unit test for auth, and relying on there being an `Authorization` header to verify the credentials. Now (after #631) we no longer use the `test_credentials()`, so we can simplify the `test_credentials()`.

Also add tests because this is a public interface.