### PR TITLE
feat(wkt): supporting traits for better `Any`

### DIFF
--- a/src/wkt/src/any.rs
+++ b/src/wkt/src/any.rs
@@ -76,7 +76,7 @@ impl AnyError {
     }
 
     pub(crate) fn deser<T: Into<BoxedError>>(v: T) -> Self {
-        Self::SerializationError(v.into())
+        Self::DeserializationError(v.into())
     }
 }
 
@@ -84,6 +84,41 @@ type BoxedError = Box<dyn std::error::Error + Send + Sync>;
 type Error = AnyError;
 
 impl Any {
+    /// Creates a new [Any] from any [Message][crate::message::Message] that
+    /// also supports serialization to JSON.
+    pub fn try_from<T>(message: &T) -> Result<Self, Error>
+    where
+        T: serde::ser::Serialize + crate::message::Message,
+    {
+        use serde_json::{Map, Value};
+
+        let value = serde_json::to_value(message).map_err(Error::ser)?;
+        let value = match value {
+            Value::Object(mut map) => {
+                map.insert(
+                    "@type".to_string(),
+                    Value::String(T::typename().to_string()),
+                );
+                map
+            }
+            Value::String(s) => {
+                // Only a few well-known messages are serialized into something
+                // other than a object. In all cases, they are serialized using
+                // a small JSON object, with the string in the `value` field.
+                let map: Map<String, serde_json::Value> =
+                    [("@type", T::typename().to_string()), ("value", s)]
+                        .into_iter()
+                        .map(|(k, v)| (k.to_string(), Value::String(v)))
+                        .collect();
+                map
+            }
+            _ => {
+                return Err(Self::unexpected_json_type());
+            }
+        };
+        Ok(Any(value))
+    }
+
     /// Creates a new [Any] from any object that supports serialization to JSON.
     // TODO(#98) - each message should have a type value
     pub fn from<T>(message: &T) -> Result<Self, Error>
@@ -131,6 +166,7 @@ impl Any {
             .map_err(Error::deser)?;
         if r#type.starts_with("type.googleapis.com/google.protobuf.")
             && r#type != "type.googleapis.com/google.protobuf.Empty"
+            && r#type != "type.googleapis.com/google.protobuf.FieldMask"
         {
             return map
                 .get("value")
@@ -176,6 +212,8 @@ mod test {
     use super::*;
     use crate::duration::*;
     use crate::empty::Empty;
+    use crate::field_mask::*;
+    use crate::timestamp::*;
     use serde_json::json;
     type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
@@ -192,16 +230,17 @@ mod test {
     #[test]
     fn serialize_duration() -> Result {
         let d = Duration::clamp(60, 0);
-        let any = Any::from(&d)?;
+        let any = Any::try_from(&d)?;
         let got = serde_json::to_value(any)?;
-        let want = json!({"@type": "type.googleapis.com/google.protobuf.", "value": "60s"});
+        let want = json!({"@type": "type.googleapis.com/google.protobuf.Duration", "value": "60s"});
         assert_eq!(got, want);
         Ok(())
     }
 
     #[test]
     fn deserialize_duration() -> Result {
-        let input = json!({"@type": "type.googleapis.com/google.protobuf.", "value": "60s"});
+        let input =
+            json!({"@type": "type.googleapis.com/google.protobuf.Duration", "value": "60s"});
         let any = Any(input.as_object().unwrap().clone());
         let d = any.try_into_message::<Duration>()?;
         assert_eq!(d, Duration::clamp(60, 0));
@@ -211,10 +250,9 @@ mod test {
     #[test]
     fn serialize_empty() -> Result {
         let empty = Empty::default();
-        let any = Any::from(&empty)?;
+        let any = Any::try_from(&empty)?;
         let got = serde_json::to_value(any)?;
-        // TODO(#98) - this should be "type.googleapis.com/google.protobuf.Empty"
-        let want = json!({"@type": ""});
+        let want = json!({"@type": "type.googleapis.com/google.protobuf.Empty"});
         assert_eq!(got, want);
         Ok(())
     }
@@ -225,6 +263,49 @@ mod test {
         let any = Any(input.as_object().unwrap().clone());
         let empty = any.try_into_message::<Empty>()?;
         assert_eq!(empty, Empty::default());
+        Ok(())
+    }
+
+    #[test]
+    fn serialize_field_mask() -> Result {
+        let d = FieldMask::default().set_paths(["a", "b"].map(str::to_string).to_vec());
+        let any = Any::try_from(&d)?;
+        let got = serde_json::to_value(any)?;
+        let want =
+            json!({"@type": "type.googleapis.com/google.protobuf.FieldMask", "paths": "a,b"});
+        assert_eq!(got, want);
+        Ok(())
+    }
+
+    #[test]
+    fn deserialize_field_mask() -> Result {
+        let input =
+            json!({"@type": "type.googleapis.com/google.protobuf.FieldMask", "paths": "a,b"});
+        let any = Any(input.as_object().unwrap().clone());
+        let d = any.try_into_message::<FieldMask>()?;
+        assert_eq!(
+            d,
+            FieldMask::default().set_paths(["a", "b"].map(str::to_string).to_vec())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn serialize_timestamp() -> Result {
+        let d = Timestamp::clamp(123, 0);
+        let any = Any::try_from(&d)?;
+        let got = serde_json::to_value(any)?;
+        let want = json!({"@type": "type.googleapis.com/google.protobuf.Timestamp", "value": "1970-01-01T00:02:03Z"});
+        assert_eq!(got, want);
+        Ok(())
+    }
+
+    #[test]
+    fn deserialize_timestamp() -> Result {
+        let input = json!({"@type": "type.googleapis.com/google.protobuf.Timestamp", "value": "1970-01-01T00:02:03Z"});
+        let any = Any(input.as_object().unwrap().clone());
+        let d = any.try_into_message::<Timestamp>()?;
+        assert_eq!(d, Timestamp::clamp(123, 0));
         Ok(())
     }
 

--- a/src/wkt/src/any.rs
+++ b/src/wkt/src/any.rs
@@ -359,6 +359,23 @@ mod test {
         Ok(())
     }
 
+    #[derive(Default, serde::Serialize)]
+    struct DetectBadMessages(serde_json::Value);
+    impl crate::message::Message for DetectBadMessages {
+        fn typename() -> &'static str {
+            "not used"
+        }
+    }
+
+    #[test]
+    fn try_from_error() -> Result {
+        let input = DetectBadMessages(json!([2, 3]));
+        let got = Any::try_from(&input);
+        assert!(got.is_err(), "{got:?}");
+
+        Ok(())
+    }
+
     #[test]
     fn deserialize_error() -> Result {
         let input = json!({"@type-is-missing": ""});

--- a/src/wkt/src/duration.rs
+++ b/src/wkt/src/duration.rs
@@ -164,6 +164,12 @@ impl Duration {
     }
 }
 
+impl crate::message::Message for Duration {
+    fn typename() -> &'static str {
+        "type.googleapis.com/google.protobuf.Duration"
+    }
+}
+
 /// Converts a [Duration] to its [String] representation.
 impl std::convert::From<&Duration> for String {
     fn from(duration: &Duration) -> String {

--- a/src/wkt/src/empty.rs
+++ b/src/wkt/src/empty.rs
@@ -25,6 +25,12 @@
 #[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Empty {}
 
+impl crate::message::Message for Empty {
+    fn typename() -> &'static str {
+        "type.googleapis.com/google.protobuf.Empty"
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/wkt/src/field_mask.rs
+++ b/src/wkt/src/field_mask.rs
@@ -253,6 +253,12 @@ impl FieldMask {
     }
 }
 
+impl crate::message::Message for FieldMask {
+    fn typename() -> &'static str {
+        "type.googleapis.com/google.protobuf.FieldMask"
+    }
+}
+
 /// Implement [`serde`](::serde) serialization for [FieldMask]
 impl serde::ser::Serialize for FieldMask {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>

--- a/src/wkt/src/lib.rs
+++ b/src/wkt/src/lib.rs
@@ -35,3 +35,4 @@ mod timestamp;
 pub use crate::timestamp::*;
 mod wrappers;
 pub use crate::wrappers::*;
+pub mod message;

--- a/src/wkt/src/message.rs
+++ b/src/wkt/src/message.rs
@@ -1,0 +1,25 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Define traits required of all messages.
+
+/// A trait that must be implemented by all messages.
+///
+/// Messages sent to and received from Google Cloud services may be wrapped in
+/// [Any][crate::any::Any]. `Any` uses a `@type` field to encoding the type
+/// name and then validates extraction and insertion against this type.
+pub trait Message {
+    /// The typename of this message.
+    fn typename() -> &'static str;
+}

--- a/src/wkt/src/timestamp.rs
+++ b/src/wkt/src/timestamp.rs
@@ -165,6 +165,12 @@ impl Timestamp {
     }
 }
 
+impl crate::message::Message for Timestamp {
+    fn typename() -> &'static str {
+        "type.googleapis.com/google.protobuf.Timestamp"
+    }
+}
+
 use time::format_description::well_known::Rfc3339;
 const NS: i128 = 1_000_000_000;
 


### PR DESCRIPTION
Introduce a trait that all messages will (eventually) implement. `Any`
uses this trait to correctly set the `@type` field.

Part of the work for #98, I will be sending the generator changes after this PR, and then finally fixing the issue, see #642 to see the full picture.
