### PR TITLE
cleanup(gax): move `convert_headers()`

### DIFF
--- a/src/gax/src/error/http_error.rs
+++ b/src/gax/src/error/http_error.rs
@@ -73,20 +73,6 @@ impl std::fmt::Display for HttpError {
 
 impl std::error::Error for HttpError {}
 
-#[cfg(feature = "unstable-sdk-client")]
-/// A helpers to convert [reqwest::header::HeaderMap] to [std::collections::HashMap].
-pub fn convert_headers(
-    header_map: &reqwest::header::HeaderMap,
-) -> std::collections::HashMap<String, String> {
-    let mut headers = std::collections::HashMap::new();
-    for (key, value) in header_map {
-        if let Ok(value) = value.to_str() {
-            headers.insert(key.to_string(), value.to_string());
-        }
-    }
-    headers
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/gax/tests/errors.rs
+++ b/src/gax/tests/errors.rs
@@ -75,29 +75,6 @@ mod test {
     }
 }
 
-#[tokio::test]
-async fn client_http_error() -> Result<(), Box<dyn std::error::Error>> {
-    let http_resp = http::Response::builder()
-        .header("Content-Type", "application/json")
-        .status(400)
-        .body(r#"{"error": "bad request"}"#)?;
-
-    // Into reqwest response, like our clients use.
-    let resp: reqwest::Response = http_resp.into();
-
-    assert!(resp.status().is_client_error());
-
-    let status = resp.status().as_u16();
-    let headers = gcp_sdk_gax::error::convert_headers(resp.headers());
-    let body = resp.bytes().await?;
-
-    let http_err = HttpError::new(status, headers, Some(body));
-    assert!(http_err.status_code() == 400);
-    assert!(http_err.headers()["content-type"] == "application/json");
-    assert!(http_err.payload().unwrap() == r#"{"error": "bad request"}"#.as_bytes());
-    Ok(())
-}
-
 #[test]
 fn http_error_to_status() -> Result<(), Box<dyn std::error::Error>> {
     let json = serde_json::json!({


### PR DESCRIPTION
The function to convert HTTP headers into something we can use in
`HttpError` was used only in `http_client/mod.rs`, so move it there and
make it private.

In the process, I noticed we were printing sensitive headers, so I
changed the code to avoid doing so. I am not sure if any incoming
headers are labeled sensitive, but it does not hurt to prevent
embarrassing leaks.

I had to move some test code, which motivated some changes to it:
instead of testing that we can create an `HttpError` from a response,
verify that the `ReqwestClient` does this and verify its output.