### PR TITLE
cleanup(gax): remove unused function

### DIFF
--- a/src/gax/src/error/rpc/mod.rs
+++ b/src/gax/src/error/rpc/mod.rs
@@ -381,12 +381,6 @@ pub enum StatusDetails {
     Other(wkt::Any),
 }
 
-impl Default for StatusDetails {
-    fn default() -> Self {
-        Self::Other(wkt::Any::default())
-    }
-}
-
 impl From<wkt::Any> for StatusDetails {
     fn from(value: wkt::Any) -> Self {
         use rpc::model::*;


### PR DESCRIPTION
`StatusDetails::default()` is not used anywhere, and I think it is
unlikely to be used.  The `StatusDetails` should only be initialized
if once has a valid `Any` or a valid error detail type.