### PR TITLE
feat(gax): use `ServiceError` for responses

### DIFF
--- a/src/gax/src/error/core_error.rs
+++ b/src/gax/src/error/core_error.rs
@@ -70,7 +70,7 @@ impl Error {
     /// # use gcp_sdk_gax::error::Error;
     /// # use gcp_sdk_gax::error::HttpError;
     /// # use std::collections::HashMap;
-    /// let error: Error = HttpError::new(404, HashMap::new(), None).into();
+    /// let error = Error::rpc(HttpError::new(404, HashMap::new(), None));
     /// if let Some(e) = error.as_inner::<HttpError>() {
     ///     assert_eq!(e.status_code(), 404);
     /// }
@@ -95,12 +95,6 @@ impl std::fmt::Display for Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(self.source.as_ref())
-    }
-}
-
-impl From<crate::error::HttpError> for Error {
-    fn from(e: super::http_error::HttpError) -> Self {
-        Error::rpc(e)
     }
 }
 

--- a/src/gax/src/error/mod.rs
+++ b/src/gax/src/error/mod.rs
@@ -35,11 +35,11 @@ pub use service_error::*;
 /// # use std::result::Result;
 /// # use gcp_sdk_gax::error;
 /// use error::Error;
-/// use error::HttpError;
+/// use error::ServiceError;
 /// use error::rpc::Status;
 /// fn handle_error(e: Error) {
-///     if let Some(e) = e.as_inner::<HttpError>() {
-///         let status = Status::try_from(e).unwrap();
+///     if let Some(e) = e.as_inner::<ServiceError>() {
+///         let status : Status = e.status().clone();
 ///         println!("{status:?}")
 ///     }
 /// }

--- a/src/gax/src/retry_policy.rs
+++ b/src/gax/src/retry_policy.rs
@@ -38,8 +38,7 @@
 //!
 //! [idempotent]: https://en.wikipedia.org/wiki/Idempotence
 
-use crate::error::rpc::Status;
-use crate::error::{Error, HttpError};
+use crate::error::Error;
 use std::sync::Arc;
 
 /// The result of a retry policy decision.
@@ -247,11 +246,22 @@ impl RetryPolicy for Aip194Strict {
         idempotent: bool,
         error: Error,
     ) -> RetryFlow {
+        if let Some(svc) = error.as_inner::<crate::error::ServiceError>() {
+            if !idempotent {
+                return RetryFlow::Permanent(error);
+            }
+            return if svc.status().status.as_deref() == Some("UNAVAILABLE") {
+                RetryFlow::Continue(error)
+            } else {
+                RetryFlow::Permanent(error)
+            };
+        }
+
         if let Some(http) = error.as_inner::<crate::error::HttpError>() {
             if !idempotent {
                 return RetryFlow::Permanent(error);
             }
-            return if match_status_code_string(http, "UNAVAILABLE") {
+            return if http.status_code() == reqwest::StatusCode::SERVICE_UNAVAILABLE {
                 RetryFlow::Continue(error)
             } else {
                 RetryFlow::Permanent(error)
@@ -275,14 +285,6 @@ impl RetryPolicy for Aip194Strict {
             ErrorKind::Other => RetryFlow::Permanent(error),
         }
     }
-}
-
-// A helper function to simplify `Api194Strict::on_error()`:
-fn match_status_code_string(http: &HttpError, code: &str) -> bool {
-    Status::try_from(http)
-        .ok()
-        .map(|v| v.status.as_deref() == Some(code))
-        .unwrap_or(false)
 }
 
 /// A retry policy that retries all errors.
@@ -587,21 +589,21 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::error::rpc::Status;
+    use crate::error::{rpc::Status, ServiceError};
 
     #[test]
     fn retry_flow() {
-        let flow = RetryFlow::Permanent(unavailable());
+        let flow = RetryFlow::Permanent(http_unavailable());
         assert!(flow.is_permanent(), "{flow:?}");
         assert!(!flow.is_exhausted(), "{flow:?}");
         assert!(!flow.is_continue(), "{flow:?}");
 
-        let flow = RetryFlow::Exhausted(unavailable());
+        let flow = RetryFlow::Exhausted(http_unavailable());
         assert!(!flow.is_permanent(), "{flow:?}");
         assert!(flow.is_exhausted(), "{flow:?}");
         assert!(!flow.is_continue(), "{flow:?}");
 
-        let flow = RetryFlow::Continue(unavailable());
+        let flow = RetryFlow::Continue(http_unavailable());
         assert!(!flow.is_permanent(), "{flow:?}");
         assert!(!flow.is_exhausted(), "{flow:?}");
         assert!(flow.is_continue(), "{flow:?}");
@@ -629,6 +631,17 @@ mod tests {
         assert!(p.on_error(now, 0, true, permission_denied()).is_permanent());
         assert!(p
             .on_error(now, 0, false, permission_denied())
+            .is_permanent());
+
+        assert!(p.on_error(now, 0, true, http_unavailable()).is_continue());
+        assert!(p.on_error(now, 0, false, http_unavailable()).is_permanent());
+        assert!(p.on_throttle(now, 0).is_none());
+
+        assert!(p
+            .on_error(now, 0, true, http_permission_denied())
+            .is_permanent());
+        assert!(p
+            .on_error(now, 0, false, http_permission_denied())
             .is_permanent());
 
         assert!(p
@@ -666,12 +679,19 @@ mod tests {
         let p = AlwaysRetry;
 
         let now = std::time::Instant::now();
-        assert!(p.on_error(now, 0, true, unavailable()).is_continue());
-        assert!(p.on_error(now, 0, false, unavailable()).is_continue());
+        assert!(p.on_error(now, 0, true, http_unavailable()).is_continue());
+        assert!(p.on_error(now, 0, false, http_unavailable()).is_continue());
         assert!(p.on_throttle(now, 0).is_none());
 
-        assert!(p.on_error(now, 0, true, permission_denied()).is_continue());
-        assert!(p.on_error(now, 0, false, permission_denied()).is_continue());
+        assert!(p.on_error(now, 0, true, unavailable()).is_continue());
+        assert!(p.on_error(now, 0, false, unavailable()).is_continue());
+
+        assert!(p
+            .on_error(now, 0, true, http_permission_denied())
+            .is_continue());
+        assert!(p
+            .on_error(now, 0, false, http_permission_denied())
+            .is_continue());
 
         assert!(p
             .on_error(now, 0, true, Error::io("err".to_string()))
@@ -714,7 +734,7 @@ mod tests {
         Error::rpc(http)
     }
 
-    fn unavailable() -> Error {
+    fn http_unavailable() -> Error {
         let mut status = Status::default();
         status.code = 503;
         status.message = "SERVICE UNAVAILABLE".to_string();
@@ -722,12 +742,28 @@ mod tests {
         from_status(status)
     }
 
-    fn permission_denied() -> Error {
+    fn http_permission_denied() -> Error {
         let mut status = Status::default();
         status.code = 403;
         status.message = "PERMISSION DENIED".to_string();
         status.status = Some("PERMISSION_DENIED".to_string());
         from_status(status)
+    }
+
+    fn unavailable() -> Error {
+        use crate::error::rpc::Code;
+        let status = rpc::model::Status::default()
+            .set_code(Code::Unavailable as i32)
+            .set_message("UNAVAILABLE");
+        Error::rpc(ServiceError::from(status))
+    }
+
+    fn permission_denied() -> Error {
+        use crate::error::rpc::Code;
+        let status = rpc::model::Status::default()
+            .set_code(Code::PermissionDenied as i32)
+            .set_message("PERMISSION_DENIED");
+        Error::rpc(ServiceError::from(status))
     }
 
     mockall::mock! {

--- a/src/gax/tests/errors.rs
+++ b/src/gax/tests/errors.rs
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use gcp_sdk_gax::error::rpc::Status;
 use gcp_sdk_gax::error::Error;
-use gcp_sdk_gax::error::HttpError;
-use std::collections::HashMap;
 
 #[cfg(test)]
 mod test {
@@ -73,42 +70,4 @@ mod test {
         assert!(inner_err.is_none());
         Ok(())
     }
-}
-
-#[test]
-fn http_error_to_status() -> Result<(), Box<dyn std::error::Error>> {
-    let json = serde_json::json!({
-        "code": 9,
-        "message": "msg",
-        "details": [
-            {"@type": "google.rpc.QuotaFailure", "violations": [{"type": "type", "subject": "subject", "description": "desc"}]},
-        ]
-    });
-    let json = serde_json::json!({"error": json});
-    let http_err = HttpError::new(
-        400,
-        HashMap::from_iter([("content-type".to_string(), "application/json".to_string())]),
-        Some(json.to_string().into()),
-    );
-
-    let status = Status::try_from(&http_err)?;
-    assert_eq!(status.code, 9);
-    assert_eq!(status.message, "msg");
-    assert_eq!(status.details.len(), 1);
-
-    let html = r#"<!DOCTYPE html>
-<html lang=en>
-<meta charset=utf-8>
-<title>Error 500!!!</title>"#
-        .as_bytes();
-    let http_err = HttpError::new(
-        500,
-        HashMap::from_iter([("content-type".to_string(), "text/html".to_string())]),
-        Some(html.into()),
-    );
-
-    let status = Status::try_from(&http_err);
-    assert!(status.is_err());
-
-    Ok(())
 }


### PR DESCRIPTION
Return a `ServiceError` when the response includes a `Status`, and
reserve `HttpError` for responses that just have a blob of bytes.

Part of the work for #438
