### PR TITLE
feat(auth): support quota project in UserCredentials

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -21,6 +21,8 @@ use http::header::{HeaderName, HeaderValue};
 use std::future::Future;
 use std::sync::Arc;
 
+pub(crate) const QUOTA_PROJECT_KEY: &str = "x-goog-user-project";
+
 /// An implementation of [crate::credentials::CredentialTrait].
 ///
 /// Represents a [Credential] used to obtain auth [Token][crate::token::Token]s


### PR DESCRIPTION
Fixes #651

Parse `quota_project_id` if it is part of an Authorized User Credential in ADC.

Include the quota project in requests as the `x-goog-user-project` header.