### PR TITLE
impl(internal/language): refactor TestGo_MessageNames

### DIFF
--- a/generator/internal/language/golang.go
+++ b/generator/internal/language/golang.go
@@ -187,9 +187,9 @@ func (*GoCodec) MessageAttributes(*api.Message, *api.APIState) []string {
 	return []string{}
 }
 
-func (c *GoCodec) MessageName(m *api.Message, state *api.APIState) string {
+func (c *GoCodec) MessageName(m *api.Message, _ *api.APIState) string {
 	if m.Parent != nil {
-		return c.MessageName(m.Parent, state) + "_" + strcase.ToCamel(m.Name)
+		return c.MessageName(m.Parent, nil) + "_" + strcase.ToCamel(m.Name)
 	}
 	if imp, ok := c.ImportMap[m.Package]; ok {
 		return imp.Name + "." + c.ToPascal(m.Name)
@@ -197,8 +197,8 @@ func (c *GoCodec) MessageName(m *api.Message, state *api.APIState) string {
 	return c.ToPascal(m.Name)
 }
 
-func (c *GoCodec) FQMessageName(m *api.Message, state *api.APIState) string {
-	return c.MessageName(m, state)
+func (c *GoCodec) FQMessageName(m *api.Message, _ *api.APIState) string {
+	return c.MessageName(m, nil)
 }
 
 func (c *GoCodec) EnumName(e *api.Enum, state *api.APIState) string {

--- a/generator/internal/language/golang_test.go
+++ b/generator/internal/language/golang_test.go
@@ -58,7 +58,7 @@ func TestGo_ToPascal(t *testing.T) {
 }
 
 func TestGo_MessageNames(t *testing.T) {
-	message := &api.Message{
+	replication := &api.Message{
 		Name: "Replication",
 		ID:   "..Replication",
 		Fields: []*api.Field{
@@ -71,26 +71,28 @@ func TestGo_MessageNames(t *testing.T) {
 			},
 		},
 	}
-	nested := &api.Message{
-		Name: "Automatic",
-		ID:   "..Replication.Automatic",
+	automatic := &api.Message{
+		Parent: replication,
+		Name:   "Automatic",
+		ID:     "..Replication.Automatic",
 	}
 
-	api := newTestAPI([]*api.Message{message, nested}, []*api.Enum{}, []*api.Service{})
-
-	c := &GoCodec{}
-	if got := c.MessageName(message, api.State); got != "Replication" {
-		t.Errorf("mismatched message name, want=Replication, got=%s", got)
-	}
-	if got := c.FQMessageName(message, api.State); got != "Replication" {
-		t.Errorf("mismatched message name, want=Replication, got=%s", got)
-	}
-
-	if got := c.MessageName(nested, api.State); got != "Replication_Automatic" {
-		t.Errorf("mismatched message name, want=SecretVersion_Automatic, got=%s", got)
-	}
-	if got := c.FQMessageName(nested, api.State); got != "Replication_Automatic" {
-		t.Errorf("mismatched message name, want=Replication_Automatic, got=%s", got)
+	for _, test := range []struct {
+		message *api.Message
+		want    string
+	}{
+		{replication, "Replication"},
+		{automatic, "Replication_Automatic"},
+	} {
+		t.Run(test.want, func(t *testing.T) {
+			c := &GoCodec{}
+			if got := c.MessageName(test.message, nil); got != test.want {
+				t.Errorf("c.MessageName = %q, want = %q", got, test.want)
+			}
+			if got := c.FQMessageName(test.message, nil); got != test.want {
+				t.Errorf("c.FQMessageName = %q, want = %q", got, test.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Refactor `TestGo_MessageNames` into a parameterized test, and remove the use of `newTestAPI` since the `state` argument is unnecessary. The `state` parameter exists solely because `GoCodec` needs to implement the `Codec` interface. 

Additionally, explicitly document that `state` is not utilized by either `GoCodec.MessageName` or `GoCodec.FQMessageName`.