### PR TITLE
impl(language): delete GenerateClientRequest

### DIFF
--- a/generator/internal/sidekick/refresh.go
+++ b/generator/internal/sidekick/refresh.go
@@ -53,12 +53,12 @@ func refreshDir(rootConfig *Config, cmdLine *CommandLine, output string) error {
 		return fmt.Errorf("must provide general.specification-source")
 	}
 
-	var a *api.API
+	var model *api.API
 	switch config.General.SpecificationFormat {
 	case "openapi":
-		a, err = parser.ParseOpenAPI(config.General.SpecificationSource, config.General.ServiceConfig, config.Source)
+		model, err = parser.ParseOpenAPI(config.General.SpecificationSource, config.General.ServiceConfig, config.Source)
 	case "protobuf":
-		a, err = parser.ParseProtobuf(config.General.SpecificationSource, config.General.ServiceConfig, config.Source)
+		model, err = parser.ParseProtobuf(config.General.SpecificationSource, config.General.ServiceConfig, config.Source)
 	default:
 		return fmt.Errorf("unknown parser %q", config.General.SpecificationFormat)
 	}
@@ -78,17 +78,11 @@ func refreshDir(rootConfig *Config, cmdLine *CommandLine, output string) error {
 	if err != nil {
 		return err
 	}
-	if err := codec.Validate(a); err != nil {
+	if err := codec.Validate(model); err != nil {
 		return err
-	}
-
-	request := &language.GenerateClientRequest{
-		API:    a,
-		Codec:  codec,
-		OutDir: output,
 	}
 	if cmdLine.DryRun {
 		return nil
 	}
-	return language.GenerateClient(request)
+	return language.GenerateClient(model, codec, output)
 }


### PR DESCRIPTION
The GenerateClientRequest struct currently contains only three fields. To simplify the code, eliminate the struct and pass its fields directly as arguments to the GenerateClient function.