### PR TITLE
impl(language): convert Rust codec methods to functions

### DIFF
--- a/generator/internal/language/client.go
+++ b/generator/internal/language/client.go
@@ -41,14 +41,14 @@ func GenerateClient(model *api.API, language, outdir string, options map[string]
 	)
 	switch language {
 	case "rust":
-		codec, err := newRustCodec(outdir, options)
+		codec, err := newRustCodec(options)
 		if err != nil {
 			return err
 		}
 		if err := codec.validate(model); err != nil {
 			return err
 		}
-		data = newRustTemplateData(model, codec)
+		data = newRustTemplateData(model, codec, outdir)
 		provider = rustTemplatesProvider()
 		generatedFiles = codec.generatedFiles()
 	case "go":

--- a/generator/internal/language/rusttemplate_test.go
+++ b/generator/internal/language/rusttemplate_test.go
@@ -26,11 +26,11 @@ func TestPackageNames(t *testing.T) {
 		[]*api.Service{{Name: "Workflows", Package: "gcp-sdk-workflows-v1"}})
 	// Override the default name for test APIs ("Test").
 	model.Name = "workflows-v1"
-	codec, err := newRustCodec(t.TempDir(), map[string]string{})
+	codec, err := newRustCodec(map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	got := newRustTemplateData(model, codec)
+	got := newRustTemplateData(model, codec, "")
 	want := "gcp_sdk_workflows_v1"
 	if got.PackageNamespace != want {
 		t.Errorf("mismatched package namespace, want=%s, got=%s", want, got.PackageNamespace)


### PR DESCRIPTION
Convert several Rust codec methods to functions, as a step towards removing the Rust codec.