### PR TITLE
feat(lro): new crate for LRO helper support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,6 +608,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "gcp-sdk-lro"
+version = "0.0.0"
+dependencies = [
+ "axum",
+ "futures",
+ "gcp-sdk-auth",
+ "gcp-sdk-gax",
+ "gcp-sdk-longrunning",
+ "gcp-sdk-lro",
+ "gcp-sdk-rpc",
+ "gcp-sdk-wkt",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "gcp-sdk-rpc"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
   "src/generated/rpc",
   "src/generated/type",
   "src/integration-tests",
+  "src/lro",
   "src/root",
   "src/wkt",
   "tools/check-copyright",

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -1,0 +1,44 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name                 = "gcp-sdk-lro"
+version              = "0.0.0"
+description          = "Google Cloud Client Libraries for Rust - LRO Helpers"
+edition.workspace    = true
+authors.workspace    = true
+license.workspace    = true
+repository.workspace = true
+keywords.workspace   = true
+categories.workspace = true
+
+[dependencies]
+gax         = { version = "0.1.0", path = "../gax", package = "gcp-sdk-gax" }
+longrunning = { version = "0.1.0", path = "../generated/longrunning", package = "gcp-sdk-longrunning" }
+rpc         = { version = "0.1.0", path = "../generated/rpc", package = "gcp-sdk-rpc" }
+wkt         = { version = "0.1.0", path = "../wkt", package = "gcp-sdk-wkt" }
+serde       = "1.0.216"
+futures     = { version = "0.3.31", optional = true }
+pin-project = { version = "1.1.8", optional = true }
+
+[features]
+unstable-stream     = ["dep:futures", "dep:pin-project"]
+
+[dev-dependencies]
+auth        = { path = "../auth", package = "gcp-sdk-auth" }
+lro         = { path = ".", package = "gcp-sdk-lro", features = ["unstable-stream"] }
+axum        = "0.8.1"
+tokio       = { version = "1.42", features = ["test-util"] }
+serde_json  = "1.0.134"
+reqwest     = "0.12.11"

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -33,12 +33,12 @@ futures     = { version = "0.3.31", optional = true }
 pin-project = { version = "1.1.8", optional = true }
 
 [features]
-unstable-stream     = ["dep:futures", "dep:pin-project"]
+unstable-stream = ["dep:futures", "dep:pin-project"]
 
 [dev-dependencies]
-auth        = { path = "../auth", package = "gcp-sdk-auth" }
-lro         = { path = ".", package = "gcp-sdk-lro", features = ["unstable-stream"] }
-axum        = "0.8.1"
-tokio       = { version = "1.42", features = ["test-util"] }
-serde_json  = "1.0.134"
-reqwest     = "0.12.11"
+auth       = { path = "../auth", package = "gcp-sdk-auth" }
+lro        = { path = ".", package = "gcp-sdk-lro", features = ["unstable-stream"] }
+axum       = "0.8.1"
+tokio      = { version = "1.42", features = ["test-util"] }
+serde_json = "1.0.134"
+reqwest    = "0.12.11"

--- a/src/lro/src/details.rs
+++ b/src/lro/src/details.rs
@@ -16,7 +16,9 @@
 
 use super::*;
 
-pub(crate) fn handle_start<R, M>(result: Result<Operation<R, M>>) -> (Option<String>, PollingResult<R, M>)
+pub(crate) fn handle_start<R, M>(
+    result: Result<Operation<R, M>>,
+) -> (Option<String>, PollingResult<R, M>)
 where
     R: wkt::message::Message + serde::de::DeserializeOwned,
     M: wkt::message::Message + serde::de::DeserializeOwned,
@@ -27,7 +29,9 @@ where
     }
 }
 
-pub(crate) fn handle_poll<R, M>(result: Result<Operation<R, M>>) -> (Option<String>, PollingResult<R, M>)
+pub(crate) fn handle_poll<R, M>(
+    result: Result<Operation<R, M>>,
+) -> (Option<String>, PollingResult<R, M>)
 where
     R: wkt::message::Message + serde::de::DeserializeOwned,
     M: wkt::message::Message + serde::de::DeserializeOwned,

--- a/src/lro/src/details.rs
+++ b/src/lro/src/details.rs
@@ -227,6 +227,23 @@ mod test {
     }
 
     #[test]
+    fn extract_result_with_error() -> TestResult {
+        use longrunning::model::*;
+        type R = wkt::Duration;
+        type M = wkt::Timestamp;
+        type O = TypedOperation<R, M>;
+        let op = Operation::default().set_result(operation::Result::Error(
+            rpc::model::Status::default().set_message("test only"),
+        ));
+        let op = O::new(op);
+        let result = as_result(op);
+        let err = result.err().unwrap();
+        assert_eq!(err.kind(), gax::error::ErrorKind::Rpc, "{err}");
+
+        Ok(())
+    }
+
+    #[test]
     fn extract_result_bad_type() -> TestResult {
         use longrunning::model::*;
         type R = wkt::Duration;

--- a/src/lro/src/details.rs
+++ b/src/lro/src/details.rs
@@ -1,0 +1,305 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Simplifies the implementation of `PollerImpl`
+
+use super::*;
+
+pub(crate) fn handle_start<O, R, M>(result: Result<O>) -> (Option<String>, PollingResult<R, M>)
+where
+    O: super::Operation<ResponseType = R, MetadataType = M>,
+    R: wkt::message::Message + serde::de::DeserializeOwned,
+    M: wkt::message::Message + serde::de::DeserializeOwned,
+{
+    match result {
+        Err(e) => (None, PollingResult::Completed(Err(e))),
+        Ok(op) => handle_common(op),
+    }
+}
+
+pub(crate) fn handle_poll<O, R, M>(result: Result<O>) -> (Option<String>, PollingResult<R, M>)
+where
+    O: super::Operation<ResponseType = R, MetadataType = M>,
+    R: wkt::message::Message + serde::de::DeserializeOwned,
+    M: wkt::message::Message + serde::de::DeserializeOwned,
+{
+    match result {
+        Err(e) => (None, PollingResult::PollingError(e)),
+        Ok(op) => handle_common(op),
+    }
+}
+
+fn handle_common<O, R, M>(op: O) -> (Option<String>, PollingResult<R, M>)
+where
+    O: super::Operation<ResponseType = R, MetadataType = M>,
+    R: wkt::message::Message + serde::de::DeserializeOwned,
+    M: wkt::message::Message + serde::de::DeserializeOwned,
+{
+    if op.done() {
+        let result = as_result(op);
+        return (None, PollingResult::Completed(result));
+    }
+    let name = op.name().clone();
+    let metadata = as_metadata(op);
+    (Some(name), PollingResult::InProgress(metadata))
+}
+
+fn as_result<O, R, M>(op: O) -> Result<R>
+where
+    O: super::Operation<ResponseType = R, MetadataType = M>,
+    R: wkt::message::Message + serde::de::DeserializeOwned,
+    M: wkt::message::Message + serde::de::DeserializeOwned,
+{
+    if let Some(any) = op.response() {
+        return any.try_into_message::<R>().map_err(Error::other);
+    }
+    if let Some(e) = op.error() {
+        return Err(Error::rpc(gax::error::ServiceError::from(e.clone())));
+    }
+    Err(Error::other("missing result in completed operation"))
+}
+
+fn as_metadata<O, R, M>(op: O) -> Option<M>
+where
+    O: super::Operation<ResponseType = R, MetadataType = M>,
+    R: wkt::message::Message + serde::de::DeserializeOwned,
+    M: wkt::message::Message + serde::de::DeserializeOwned,
+{
+    op.metadata().and_then(|a| a.try_into_message::<M>().ok())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use wkt::Any;
+
+    type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
+
+    #[test]
+    fn start_success() -> TestResult {
+        use longrunning::model::*;
+        type R = wkt::Duration;
+        type M = wkt::Timestamp;
+        type O = TypedOperation<R, M>;
+        let op = Operation::default()
+            .set_name("test-only-name")
+            .set_metadata(wkt::Any::try_from(&wkt::Timestamp::clamp(123, 0))?);
+        let op = TypedOperation::new(op);
+        let result = Ok::<O, Error>(op);
+        let (name, poll) = handle_start(result);
+        assert_eq!(name.as_deref(), Some("test-only-name"));
+        match poll {
+            PollingResult::InProgress(m) => {
+                assert_eq!(m, Some(wkt::Timestamp::clamp(123, 0)));
+            }
+            _ => assert!(false, "{poll:?}"),
+        };
+        Ok(())
+    }
+
+    #[test]
+    fn start_error() {
+        type R = wkt::Duration;
+        type M = wkt::Timestamp;
+        type O = TypedOperation<R, M>;
+        let result = Err::<O, Error>(Error::other("test-only-error"));
+        let (name, poll) = handle_start(result);
+        assert_eq!(name, None);
+        match poll {
+            PollingResult::Completed(r) => {
+                let e = r.err().unwrap();
+                assert_eq!(e.kind(), gax::error::ErrorKind::Other, "{e}")
+            }
+            _ => assert!(false, "{poll:?}"),
+        };
+    }
+
+    #[test]
+    fn poll_success() -> TestResult {
+        use longrunning::model::*;
+        type R = wkt::Duration;
+        type M = wkt::Timestamp;
+        type O = TypedOperation<R, M>;
+        let op = Operation::default()
+            .set_name("test-only-name")
+            .set_metadata(wkt::Any::try_from(&wkt::Timestamp::clamp(123, 0))?);
+        let op = TypedOperation::new(op);
+        let result = Ok::<O, Error>(op);
+        let (name, poll) = handle_poll(result);
+        assert_eq!(name.as_deref(), Some("test-only-name"));
+        match poll {
+            PollingResult::InProgress(m) => {
+                assert_eq!(m, Some(wkt::Timestamp::clamp(123, 0)));
+            }
+            _ => assert!(false, "{poll:?}"),
+        };
+        Ok(())
+    }
+
+    #[test]
+    fn poll_error() {
+        type R = wkt::Duration;
+        type M = wkt::Timestamp;
+        type O = TypedOperation<R, M>;
+        let result = Err::<O, Error>(Error::other("test-only-error"));
+        let (name, poll) = handle_poll(result);
+        assert_eq!(name, None);
+        match poll {
+            PollingResult::PollingError(e) => {
+                assert_eq!(e.kind(), gax::error::ErrorKind::Other, "{e}")
+            }
+            _ => assert!(false, "{poll:?}"),
+        };
+    }
+
+    #[test]
+    fn common_done() -> TestResult {
+        use longrunning::model::*;
+        type R = wkt::Duration;
+        type M = wkt::Timestamp;
+        type O = TypedOperation<R, M>;
+        let op = Operation::default()
+            .set_name("test-only-name")
+            .set_done(true)
+            .set_metadata(wkt::Any::try_from(&wkt::Timestamp::clamp(123, 0))?)
+            .set_result(operation::Result::Response(wkt::Any::try_from(
+                &wkt::Duration::clamp(234, 0),
+            )?));
+        let op = O::new(op);
+        let (name, polling) = handle_common(op);
+        assert_eq!(name, None);
+        match polling {
+            PollingResult::Completed(r) => {
+                let response = r?;
+                assert_eq!(response, wkt::Duration::clamp(234, 0));
+            }
+            _ => assert!(false, "{polling:?}"),
+        };
+        Ok(())
+    }
+
+    #[test]
+    fn common_not_done() -> TestResult {
+        use longrunning::model::*;
+        type R = wkt::Duration;
+        type M = wkt::Timestamp;
+        type O = TypedOperation<R, M>;
+        let op = Operation::default()
+            .set_name("test-only-name")
+            .set_metadata(wkt::Any::try_from(&wkt::Timestamp::clamp(123, 0))?);
+        let op = O::new(op);
+        let (name, polling) = handle_common(op);
+        assert_eq!(name.as_deref(), Some("test-only-name"));
+        match &polling {
+            PollingResult::InProgress(m) => {
+                assert_eq!(m, &Some(wkt::Timestamp::clamp(123, 0)));
+            }
+            _ => assert!(false, "{polling:?}"),
+        };
+        Ok(())
+    }
+
+    #[test]
+    fn extract_result() -> TestResult {
+        use longrunning::model::*;
+        type R = wkt::Duration;
+        type M = wkt::Timestamp;
+        type O = TypedOperation<R, M>;
+        let op = Operation::default().set_result(operation::Result::Response(Any::try_from(
+            &wkt::Duration::clamp(123, 0),
+        )?));
+        let op = O::new(op);
+        let result = as_result(op)?;
+        assert_eq!(result, wkt::Duration::clamp(123, 0));
+
+        Ok(())
+    }
+
+    #[test]
+    fn extract_result_bad_type() -> TestResult {
+        use longrunning::model::*;
+        type R = wkt::Duration;
+        type M = wkt::Timestamp;
+        type O = TypedOperation<R, M>;
+        let op = Operation::default().set_result(operation::Result::Response(Any::try_from(
+            &wkt::Timestamp::clamp(123, 0),
+        )?));
+        let op = O::new(op);
+        let err = as_result(op).err().unwrap();
+        assert_eq!(err.kind(), gax::error::ErrorKind::Other, "{err}");
+        assert!(
+            format!("{err}").contains("/google.protobuf.Timestamp"),
+            "{err}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn extract_result_not_set() -> TestResult {
+        type R = wkt::Duration;
+        type M = wkt::Timestamp;
+        type O = TypedOperation<R, M>;
+        let op = longrunning::model::Operation::default();
+        let op = O::new(op);
+        let err = as_result(op).err().unwrap();
+        assert_eq!(err.kind(), gax::error::ErrorKind::Other, "{err}");
+        assert!(format!("{err}").contains("missing result"), "{err}");
+
+        Ok(())
+    }
+
+    #[test]
+    fn extract_metadata() -> TestResult {
+        type R = wkt::Duration;
+        type M = wkt::Timestamp;
+        type O = TypedOperation<R, M>;
+        let op = longrunning::model::Operation::default()
+            .set_metadata(Any::try_from(&wkt::Timestamp::clamp(123, 0))?);
+
+        let op = O::new(op);
+
+        let metadata = as_metadata(op);
+        assert_eq!(metadata, Some(wkt::Timestamp::clamp(123, 0)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn extract_metadata_bad_type() -> TestResult {
+        type R = wkt::Duration;
+        type M = wkt::Timestamp;
+        type O = TypedOperation<R, M>;
+        let op = longrunning::model::Operation::default()
+            .set_metadata(Any::try_from(&wkt::Duration::clamp(123, 0))?);
+        let op = O::new(op);
+        let metadata = as_metadata(op);
+        assert_eq!(metadata, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn extract_metadata_not_set() -> TestResult {
+        type R = wkt::Duration;
+        type M = wkt::Timestamp;
+        type O = TypedOperation<R, M>;
+        let op = longrunning::model::Operation::default();
+        let op = O::new(op);
+        let metadata = as_metadata(op);
+        assert_eq!(metadata, None);
+
+        Ok(())
+    }
+}

--- a/src/lro/src/details.rs
+++ b/src/lro/src/details.rs
@@ -16,9 +16,8 @@
 
 use super::*;
 
-pub(crate) fn handle_start<O, R, M>(result: Result<O>) -> (Option<String>, PollingResult<R, M>)
+pub(crate) fn handle_start<R, M>(result: Result<Operation<R, M>>) -> (Option<String>, PollingResult<R, M>)
 where
-    O: super::Operation<ResponseType = R, MetadataType = M>,
     R: wkt::message::Message + serde::de::DeserializeOwned,
     M: wkt::message::Message + serde::de::DeserializeOwned,
 {
@@ -28,9 +27,8 @@ where
     }
 }
 
-pub(crate) fn handle_poll<O, R, M>(result: Result<O>) -> (Option<String>, PollingResult<R, M>)
+pub(crate) fn handle_poll<R, M>(result: Result<Operation<R, M>>) -> (Option<String>, PollingResult<R, M>)
 where
-    O: super::Operation<ResponseType = R, MetadataType = M>,
     R: wkt::message::Message + serde::de::DeserializeOwned,
     M: wkt::message::Message + serde::de::DeserializeOwned,
 {
@@ -40,9 +38,8 @@ where
     }
 }
 
-fn handle_common<O, R, M>(op: O) -> (Option<String>, PollingResult<R, M>)
+fn handle_common<R, M>(op: Operation<R, M>) -> (Option<String>, PollingResult<R, M>)
 where
-    O: super::Operation<ResponseType = R, MetadataType = M>,
     R: wkt::message::Message + serde::de::DeserializeOwned,
     M: wkt::message::Message + serde::de::DeserializeOwned,
 {
@@ -55,9 +52,8 @@ where
     (Some(name), PollingResult::InProgress(metadata))
 }
 
-fn as_result<O, R, M>(op: O) -> Result<R>
+fn as_result<R, M>(op: Operation<R, M>) -> Result<R>
 where
-    O: super::Operation<ResponseType = R, MetadataType = M>,
     R: wkt::message::Message + serde::de::DeserializeOwned,
     M: wkt::message::Message + serde::de::DeserializeOwned,
 {
@@ -70,9 +66,8 @@ where
     Err(Error::other("missing result in completed operation"))
 }
 
-fn as_metadata<O, R, M>(op: O) -> Option<M>
+fn as_metadata<R, M>(op: Operation<R, M>) -> Option<M>
 where
-    O: super::Operation<ResponseType = R, MetadataType = M>,
     R: wkt::message::Message + serde::de::DeserializeOwned,
     M: wkt::message::Message + serde::de::DeserializeOwned,
 {
@@ -91,11 +86,11 @@ mod test {
         use longrunning::model::*;
         type R = wkt::Duration;
         type M = wkt::Timestamp;
-        type O = TypedOperation<R, M>;
+        type O = super::Operation<R, M>;
         let op = Operation::default()
             .set_name("test-only-name")
             .set_metadata(wkt::Any::try_from(&wkt::Timestamp::clamp(123, 0))?);
-        let op = TypedOperation::new(op);
+        let op = super::Operation::new(op);
         let result = Ok::<O, Error>(op);
         let (name, poll) = handle_start(result);
         assert_eq!(name.as_deref(), Some("test-only-name"));
@@ -112,7 +107,7 @@ mod test {
     fn start_error() {
         type R = wkt::Duration;
         type M = wkt::Timestamp;
-        type O = TypedOperation<R, M>;
+        type O = Operation<R, M>;
         let result = Err::<O, Error>(Error::other("test-only-error"));
         let (name, poll) = handle_start(result);
         assert_eq!(name, None);
@@ -130,11 +125,11 @@ mod test {
         use longrunning::model::*;
         type R = wkt::Duration;
         type M = wkt::Timestamp;
-        type O = TypedOperation<R, M>;
+        type O = super::Operation<R, M>;
         let op = Operation::default()
             .set_name("test-only-name")
             .set_metadata(wkt::Any::try_from(&wkt::Timestamp::clamp(123, 0))?);
-        let op = TypedOperation::new(op);
+        let op = super::Operation::new(op);
         let result = Ok::<O, Error>(op);
         let (name, poll) = handle_poll(result);
         assert_eq!(name.as_deref(), Some("test-only-name"));
@@ -151,7 +146,7 @@ mod test {
     fn poll_error() {
         type R = wkt::Duration;
         type M = wkt::Timestamp;
-        type O = TypedOperation<R, M>;
+        type O = super::Operation<R, M>;
         let result = Err::<O, Error>(Error::other("test-only-error"));
         let (name, poll) = handle_poll(result);
         assert_eq!(name, None);
@@ -168,7 +163,7 @@ mod test {
         use longrunning::model::*;
         type R = wkt::Duration;
         type M = wkt::Timestamp;
-        type O = TypedOperation<R, M>;
+        type O = super::Operation<R, M>;
         let op = Operation::default()
             .set_name("test-only-name")
             .set_done(true)
@@ -194,7 +189,7 @@ mod test {
         use longrunning::model::*;
         type R = wkt::Duration;
         type M = wkt::Timestamp;
-        type O = TypedOperation<R, M>;
+        type O = super::Operation<R, M>;
         let op = Operation::default()
             .set_name("test-only-name")
             .set_metadata(wkt::Any::try_from(&wkt::Timestamp::clamp(123, 0))?);
@@ -215,7 +210,7 @@ mod test {
         use longrunning::model::*;
         type R = wkt::Duration;
         type M = wkt::Timestamp;
-        type O = TypedOperation<R, M>;
+        type O = super::Operation<R, M>;
         let op = Operation::default().set_result(operation::Result::Response(Any::try_from(
             &wkt::Duration::clamp(123, 0),
         )?));
@@ -231,7 +226,7 @@ mod test {
         use longrunning::model::*;
         type R = wkt::Duration;
         type M = wkt::Timestamp;
-        type O = TypedOperation<R, M>;
+        type O = super::Operation<R, M>;
         let op = Operation::default().set_result(operation::Result::Error(
             rpc::model::Status::default().set_message("test only"),
         ));
@@ -248,7 +243,7 @@ mod test {
         use longrunning::model::*;
         type R = wkt::Duration;
         type M = wkt::Timestamp;
-        type O = TypedOperation<R, M>;
+        type O = super::Operation<R, M>;
         let op = Operation::default().set_result(operation::Result::Response(Any::try_from(
             &wkt::Timestamp::clamp(123, 0),
         )?));
@@ -267,7 +262,7 @@ mod test {
     fn extract_result_not_set() -> TestResult {
         type R = wkt::Duration;
         type M = wkt::Timestamp;
-        type O = TypedOperation<R, M>;
+        type O = Operation<R, M>;
         let op = longrunning::model::Operation::default();
         let op = O::new(op);
         let err = as_result(op).err().unwrap();
@@ -281,7 +276,7 @@ mod test {
     fn extract_metadata() -> TestResult {
         type R = wkt::Duration;
         type M = wkt::Timestamp;
-        type O = TypedOperation<R, M>;
+        type O = Operation<R, M>;
         let op = longrunning::model::Operation::default()
             .set_metadata(Any::try_from(&wkt::Timestamp::clamp(123, 0))?);
 
@@ -297,7 +292,7 @@ mod test {
     fn extract_metadata_bad_type() -> TestResult {
         type R = wkt::Duration;
         type M = wkt::Timestamp;
-        type O = TypedOperation<R, M>;
+        type O = Operation<R, M>;
         let op = longrunning::model::Operation::default()
             .set_metadata(Any::try_from(&wkt::Duration::clamp(123, 0))?);
         let op = O::new(op);
@@ -311,7 +306,7 @@ mod test {
     fn extract_metadata_not_set() -> TestResult {
         type R = wkt::Duration;
         type M = wkt::Timestamp;
-        type O = TypedOperation<R, M>;
+        type O = Operation<R, M>;
         let op = longrunning::model::Operation::default();
         let op = O::new(op);
         let metadata = as_metadata(op);

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -173,16 +173,14 @@ where
         O::MetadataType: wkt::message::Message + serde::de::DeserializeOwned,
     {
         use futures::stream::unfold;
-        let poller = self;
-        let stream = unfold(Some(poller), move |state| async move {
+        unfold(Some(self), move |state| async move {
             if let Some(mut poller) = state {
                 if let Some(pr) = poller.poll().await {
                     return Some((pr, Some(poller)));
                 }
             };
             None
-        });
-        return stream;
+        })
     }
 }
 

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -50,6 +50,10 @@ pub enum PollingResult<R, M> {
 }
 
 /// A wrapper around [longrunning::model::Operation] with typed responses.
+///
+/// This is intended as an implementation detail of the generated clients.
+/// Applications should have no need to create or use this struct.
+#[doc(hidden)]
 pub struct Operation<R, M> {
     inner: longrunning::model::Operation,
     response: std::marker::PhantomData<R>,
@@ -108,6 +112,10 @@ pub trait Poller<R, M> {
     fn to_stream(self) -> impl futures::Stream<Item = PollingResult<R, M>>;
 }
 
+/// Creates a new `impl Poller<R, M>` from the closures created by the generator.
+/// 
+/// This is intended as an implementation detail of the generated clients.
+/// Applications should have no need to create or use this struct.
 #[doc(hidden)]
 pub fn new_poller<ResponseType, MetadataType, S, SF, Q, QF>(
     start: S,

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -113,7 +113,7 @@ pub trait Poller<R, M> {
 }
 
 /// Creates a new `impl Poller<R, M>` from the closures created by the generator.
-/// 
+///
 /// This is intended as an implementation detail of the generated clients.
 /// Applications should have no need to create or use this struct.
 #[doc(hidden)]

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -235,7 +235,11 @@ mod test {
         assert!(matches!(op.metadata(), Some(_)));
         assert!(matches!(op.response(), None));
         assert!(matches!(op.error(), None));
-        let got = op.metadata().unwrap().try_into_message::<wkt::Timestamp>().map_err(Error::other)?;
+        let got = op
+            .metadata()
+            .unwrap()
+            .try_into_message::<wkt::Timestamp>()
+            .map_err(Error::other)?;
         assert_eq!(got, wkt::Timestamp::clamp(123, 0));
 
         Ok(())
@@ -254,7 +258,11 @@ mod test {
         assert!(matches!(op.metadata(), None));
         assert!(matches!(op.response(), Some(_)));
         assert!(matches!(op.error(), None));
-        let got = op.response().unwrap().try_into_message::<wkt::Duration>().map_err(Error::other)?;
+        let got = op
+            .response()
+            .unwrap()
+            .try_into_message::<wkt::Duration>()
+            .map_err(Error::other)?;
         assert_eq!(got, wkt::Duration::clamp(23, 0));
 
         Ok(())
@@ -262,7 +270,9 @@ mod test {
 
     #[test]
     fn typed_operation_with_error() -> Result<()> {
-        let rpc = rpc::model::Status::default().set_message("test only").set_code(16);
+        let rpc = rpc::model::Status::default()
+            .set_message("test only")
+            .set_code(16);
         let op = longrunning::model::Operation::default()
             .set_name("test-only-name")
             .set_result(longrunning::model::operation::Result::Error(rpc.clone()));

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -1,0 +1,276 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Types and functions to make LROs easier to use and to require less boilerplate.
+
+use gax::error::Error;
+use gax::Result;
+use std::future::Future;
+use std::marker::PhantomData;
+
+/// The result of polling a Long-Running Operation (LRO).
+///
+/// # Parameters
+/// * `R` - the response type. This is the type returned when the LRO completes
+///   successfully.
+/// * `M` - the metadata type. While operations are in progress the LRO may
+///   return values of this type.
+#[derive(Debug)]
+pub enum PollingResult<R, M> {
+    /// The operation is still in progress.
+    InProgress(Option<M>),
+    /// The operation completed. This includes the result.
+    Completed(Result<R>),
+    /// An error trying to poll the LRO.
+    ///
+    /// Not all errors indicate that the operation failed. For example, this
+    /// may fail because it was not possible to connect to Google Cloud. Such
+    /// transient errors may disappear in the next polling attempt.
+    ///
+    /// Other errors will never recover. For example, a [ServiceError] with
+    /// a [NOT_FOUND], [ABORTED], or [PERMISSION_DENIED] code will never
+    /// recover.
+    ///
+    /// [ServiceError]: gax::error::ServiceError
+    /// [NOT_FOUND]: rpc::model::code::NOT_FOUND
+    /// [ABORTED]: rpc::model::code::ABORTED
+    /// [PERMISSION_DENIED]: rpc::model::code::PERMISSION_DENIED
+    PollingError(Error),
+}
+
+/// The result of starting and polling a long-running operation.
+///
+/// In most cases this is backed by [Operation][longrunning::model::Operation].
+pub trait Operation {
+    type ResponseType;
+    type MetadataType;
+
+    fn name(&self) -> String;
+    fn done(&self) -> bool;
+    fn metadata(&self) -> Option<&wkt::Any>;
+    fn response(&self) -> Option<&wkt::Any>;
+    fn error(&self) -> Option<&rpc::model::Status>;
+}
+
+/// Implements [Operation] using [longrunning::model::Operation].
+pub struct TypedOperation<R, M> {
+    inner: longrunning::model::Operation,
+    response: std::marker::PhantomData<R>,
+    metadata: std::marker::PhantomData<M>,
+}
+
+impl<R, M> TypedOperation<R, M> {
+    pub fn new(inner: longrunning::model::Operation) -> Self {
+        Self {
+            inner,
+            response: PhantomData,
+            metadata: PhantomData,
+        }
+    }
+}
+
+impl<R, M> Operation for TypedOperation<R, M> {
+    type ResponseType = R;
+    type MetadataType = M;
+
+    fn name(&self) -> String {
+        self.inner.name.clone()
+    }
+    fn done(&self) -> bool {
+        self.inner.done
+    }
+    fn metadata(&self) -> Option<&wkt::Any> {
+        self.inner.metadata.as_ref()
+    }
+    fn response(&self) -> Option<&wkt::Any> {
+        use longrunning::model::operation::Result;
+        self.inner.result.as_ref().and_then(|r| match r {
+            Result::Error(_) => None,
+            Result::Response(r) => Some(r),
+            _ => None,
+        })
+    }
+    fn error(&self) -> Option<&rpc::model::Status> {
+        use longrunning::model::operation::Result;
+        self.inner.result.as_ref().and_then(|r| match r {
+            Result::Error(rpc) => Some(rpc),
+            Result::Response(_) => None,
+            _ => None,
+        })
+    }
+}
+
+/// The trait implemented by LRO helpers.
+pub trait Poller<R, M> {
+    fn poll(&mut self) -> impl Future<Output = Option<PollingResult<R, M>>>;
+}
+
+/// An implementation of `Poller` based on closures.
+///
+/// Thanks to this implementation, the code generator (`sidekick`) needs to
+/// produce two closures: one to start the operation, and one to query progress.
+///
+/// Applications should not need to create this type, or use it directly. It is
+/// only public so the generated code can use it.
+///
+/// # Parameters
+/// - `O` - the operation type. Typically this is a `TypedOperation<R, M>`, so
+///   it encodes the types of the response and metadata.
+/// - `S` - the start closure. Starts a LRO. This implementation expects that
+///   all necessary parameters, and request options, including retry options
+///   are captured by this function.
+/// - `SF` - the type of future returned by `S`.
+/// - `Q` - the query closure. Queries the status of the LRO created by `start`.
+///   It receives the name of the operation as its only input parameter. It
+///   should have captured any stubs and request options.
+/// - `QF` - the type of future returned by `Q`.
+pub struct PollerImpl<O, S, SF, Q, QF>
+where
+    O: Operation,
+    S: FnOnce() -> SF + Send + Sync,
+    SF: std::future::Future<Output = Result<O>> + Send + 'static,
+    Q: Fn(String) -> QF + Send + Sync + Clone,
+    QF: std::future::Future<Output = Result<O>> + Send + 'static,
+{
+    start: Option<S>,
+    query: Q,
+    operation: Option<String>,
+}
+
+impl<O, S, SF, Q, QF> PollerImpl<O, S, SF, Q, QF>
+where
+    O: Operation,
+    S: FnOnce() -> SF + Send + Sync,
+    SF: std::future::Future<Output = Result<O>> + Send + 'static,
+    Q: Fn(String) -> QF + Send + Sync + Clone,
+    QF: std::future::Future<Output = Result<O>> + Send + 'static,
+{
+    pub fn new(start: S, query: Q) -> Self {
+        Self {
+            start: Some(start),
+            query,
+            operation: None,
+        }
+    }
+
+    #[cfg(feature = "unstable-stream")]
+    pub fn to_stream(
+        self,
+    ) -> impl futures::Stream<Item = PollingResult<O::ResponseType, O::MetadataType>>
+    where
+        O::ResponseType: wkt::message::Message + serde::de::DeserializeOwned,
+        O::MetadataType: wkt::message::Message + serde::de::DeserializeOwned,
+    {
+        use futures::stream::unfold;
+        let poller = self;
+        let stream = unfold(Some(poller), move |state| async move {
+            if let Some(mut poller) = state {
+                if let Some(pr) = poller.poll().await {
+                    return Some((pr, Some(poller)));
+                }
+            };
+            None
+        });
+        return stream;
+    }
+}
+
+impl<O, S, SF, P, PF> Poller<O::ResponseType, O::MetadataType> for PollerImpl<O, S, SF, P, PF>
+where
+    O: Operation,
+    O::ResponseType: wkt::message::Message + serde::de::DeserializeOwned,
+    O::MetadataType: wkt::message::Message + serde::de::DeserializeOwned,
+    S: FnOnce() -> SF + Send + Sync,
+    SF: std::future::Future<Output = Result<O>> + Send + 'static,
+    P: Fn(String) -> PF + Send + Sync + Clone,
+    PF: std::future::Future<Output = Result<O>> + Send + 'static,
+{
+    async fn poll(&mut self) -> Option<PollingResult<O::ResponseType, O::MetadataType>> {
+        if let Some(start) = self.start.take() {
+            let result = start().await;
+            let (op, poll) = details::handle_start(result);
+            self.operation = op;
+            return Some(poll);
+        }
+        if let Some(name) = self.operation.take() {
+            let query = self.query.clone();
+            let result = query(name).await;
+            let (op, poll) = details::handle_poll(result);
+            self.operation = op;
+            return Some(poll);
+        }
+        None
+    }
+}
+
+mod details;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    type ResponseType = wkt::Duration;
+    type MetadataType = wkt::Timestamp;
+    type TestOperation = TypedOperation<ResponseType, MetadataType>;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn poll_basic_flow() {
+        let start = || async move {
+            let any = wkt::Any::try_from(&wkt::Timestamp::clamp(123, 0))
+                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+            let op = longrunning::model::Operation::default()
+                .set_name("test-only-name")
+                .set_metadata(any);
+            let op = TestOperation::new(op);
+            Ok::<TestOperation, Error>(op)
+        };
+
+        let query = |_: String| async move {
+            let any = wkt::Any::try_from(&wkt::Duration::clamp(234, 0))
+                .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
+            let result = longrunning::model::operation::Result::Response(any);
+            let op = longrunning::model::Operation::default()
+                .set_done(true)
+                .set_result(result);
+            let op = TestOperation::new(op);
+
+            Ok::<TestOperation, Error>(op)
+        };
+
+        let mut poller = PollerImpl::new(start, query);
+        let p0 = poller.poll().await;
+        match p0.unwrap() {
+            PollingResult::InProgress(m) => {
+                assert_eq!(m, Some(wkt::Timestamp::clamp(123, 0)));
+            }
+            r => {
+                assert!(false, "{r:?}");
+            }
+        }
+
+        let p1 = poller.poll().await;
+        match p1.unwrap() {
+            PollingResult::Completed(r) => {
+                let response = r.unwrap();
+                assert_eq!(response, wkt::Duration::clamp(234, 0));
+            }
+            r => {
+                assert!(false, "{r:?}");
+            }
+        }
+
+        let p2 = poller.poll().await;
+        assert!(p2.is_none(), "{p2:?}");
+    }
+}

--- a/src/lro/tests/fake_library/builders.rs
+++ b/src/lro/tests/fake_library/builders.rs
@@ -63,10 +63,8 @@ impl CreateResource {
         self,
     ) -> impl gcp_sdk_lro::Poller<super::model::Resource, super::model::CreateResourceMetadata>
     {
-        type Operation = gcp_sdk_lro::Operation<
-            super::model::Resource,
-            super::model::CreateResourceMetadata,
-        >;
+        type Operation =
+            gcp_sdk_lro::Operation<super::model::Resource, super::model::CreateResourceMetadata>;
 
         let stub = self.stub.clone();
         let options = self.options.clone()

--- a/src/lro/tests/fake_library/builders.rs
+++ b/src/lro/tests/fake_library/builders.rs
@@ -1,0 +1,170 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Model the sidekick-generated builders for a service using LROs.
+
+use super::*;
+use gax::http_client::ReqwestClient;
+
+#[derive(Clone, Debug)]
+pub struct CreateResource {
+    stub: ReqwestClient,
+    request: model::CreateResourceRequest,
+    options: gax::options::RequestOptions,
+}
+
+impl CreateResource {
+    pub fn new(stub: ReqwestClient) -> Self {
+        Self {
+            stub,
+            request: model::CreateResourceRequest::default(),
+            options: gax::options::RequestOptions::default(),
+        }
+    }
+
+    pub fn set_parent(mut self, v: impl Into<String>) -> Self {
+        self.request.parent = v.into();
+        self
+    }
+
+    pub fn set_id(mut self, v: impl Into<String>) -> Self {
+        self.request.id = v.into();
+        self
+    }
+
+    pub async fn send(self) -> gax::Result<longrunning::model::Operation> {
+        let builder = self
+            .stub
+            .builder(reqwest::Method::POST, "/create".to_string())
+            .query(&[("alt", "json")]);
+        let r = self
+            .stub
+            .execute(
+                builder,
+                None::<gax::http_client::NoBody>,
+                gax::options::RequestOptions::default(),
+            )
+            .await?;
+        Ok(r)
+    }
+
+    pub fn poller(
+        self,
+    ) -> impl gcp_sdk_lro::Poller<super::model::Resource, super::model::CreateResourceMetadata>
+    {
+        type Operation = gcp_sdk_lro::TypedOperation<
+            super::model::Resource,
+            super::model::CreateResourceMetadata,
+        >;
+
+        let stub = self.stub.clone();
+        let options = self.options.clone()
+            // TODO(684) - use NoRetries policy here.
+            ;
+        let query = move |name| {
+            let stub = stub.clone();
+            let options = options.clone();
+            async {
+                let op = super::builders::GetOperation::new(stub)
+                    .set_name(name)
+                    .with_request_options(options)
+                    .send()
+                    .await?;
+                Ok(Operation::new(op))
+            }
+        };
+
+        let start = move || async {
+            let op = self.send().await?;
+            Ok(Operation::new(op))
+        };
+        gcp_sdk_lro::PollerImpl::new(start, query)
+    }
+
+    pub async fn until_done(self) -> Result<super::model::Resource> {
+        use gcp_sdk_lro::Poller;
+        use gcp_sdk_lro::PollingResult;
+        use std::time::Duration;
+        let duration = Duration::from_secs(1);
+        let mut poller = self.poller();
+        while let Some(p) = poller.poll().await {
+            match p {
+                PollingResult::Completed(result) => {
+                    return result;
+                }
+                PollingResult::PollingError(e) => {
+                    // TODO: use policy...
+                    if let Some(svc) = e.as_inner::<gax::error::ServiceError>() {
+                        if svc.status().code == gax::error::rpc::Code::Unavailable as i32 {
+                            continue;
+                        }
+                    }
+                    return Err(e);
+                }
+                PollingResult::InProgress(_) => {}
+            }
+
+            // TODO: use policy
+            let duration = if duration > Duration::from_secs(60) {
+                duration
+            } else {
+                duration.saturating_mul(2)
+            };
+            tokio::time::sleep(duration).await;
+        }
+        return Err(gax::error::Error::other("no response"));
+    }
+}
+
+pub struct GetOperation {
+    inner: ReqwestClient,
+    request: longrunning::model::GetOperationRequest,
+    options: gax::options::RequestOptions,
+}
+
+impl GetOperation {
+    pub fn new(inner: ReqwestClient) -> Self {
+        Self {
+            inner,
+            request: longrunning::model::GetOperationRequest::default(),
+            options: gax::options::RequestOptions::default(),
+        }
+    }
+
+    pub fn with_request_options<V: Into<gax::options::RequestOptions>>(mut self, v: V) -> Self {
+        self.options = v.into();
+        self
+    }
+
+    pub fn set_name(mut self, v: impl Into<String>) -> Self {
+        self.request.name = v.into();
+        self
+    }
+
+    pub async fn send(self) -> gax::Result<longrunning::model::Operation> {
+        let builder = self
+            .inner
+            .builder(reqwest::Method::GET, "/poll".to_string())
+            .query(&[("alt", "json")]);
+        let r = self
+            .inner
+            .execute(
+                builder,
+                None::<gax::http_client::NoBody>,
+                gax::options::RequestOptions::default(),
+            )
+            .await?;
+        Ok(r)
+    }
+}

--- a/src/lro/tests/fake_library/builders.rs
+++ b/src/lro/tests/fake_library/builders.rs
@@ -63,7 +63,7 @@ impl CreateResource {
         self,
     ) -> impl gcp_sdk_lro::Poller<super::model::Resource, super::model::CreateResourceMetadata>
     {
-        type Operation = gcp_sdk_lro::TypedOperation<
+        type Operation = gcp_sdk_lro::Operation<
             super::model::Resource,
             super::model::CreateResourceMetadata,
         >;
@@ -89,7 +89,7 @@ impl CreateResource {
             let op = self.send().await?;
             Ok(Operation::new(op))
         };
-        gcp_sdk_lro::PollerImpl::new(start, query)
+        gcp_sdk_lro::new_poller(start, query)
     }
 
     pub async fn until_done(self) -> Result<super::model::Resource> {

--- a/src/lro/tests/fake_library/client.rs
+++ b/src/lro/tests/fake_library/client.rs
@@ -1,0 +1,44 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use gax::http_client::ReqwestClient;
+pub struct Client {
+    // A sidekick-generated client contains a `Arc<dyn T>`. The code
+    // in this test skips some layers of abstraction.
+    inner: ReqwestClient,
+}
+
+impl Client {
+    pub async fn new(endpoint: String) -> Result<Self> {
+        let config = gax::options::ClientConfig::default()
+            .set_credential(auth::credentials::testing::test_credentials());
+        let inner = ReqwestClient::new(config, &endpoint).await?;
+        Ok(Self { inner })
+    }
+
+    pub fn create_resource(
+        &self,
+        parent: impl Into<String>,
+        id: impl Into<String>,
+    ) -> builders::CreateResource {
+        builders::CreateResource::new(self.inner.clone())
+            .set_parent(parent)
+            .set_id(id)
+    }
+
+    pub fn get_operation(&self, name: impl Into<String>) -> builders::GetOperation {
+        builders::GetOperation::new(self.inner.clone()).set_name(name)
+    }
+}

--- a/src/lro/tests/fake_library/mod.rs
+++ b/src/lro/tests/fake_library/mod.rs
@@ -1,0 +1,21 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implement a fake library to test LROs.
+
+pub use gax::Result;
+
+pub mod builders;
+pub mod client;
+pub mod model;

--- a/src/lro/tests/fake_library/model.rs
+++ b/src/lro/tests/fake_library/model.rs
@@ -1,0 +1,46 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Partially implement the types from a service that uses LROs.
+
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateResourceRequest {
+    pub parent: String,
+    pub id: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Resource {
+    pub name: String,
+}
+
+impl wkt::message::Message for Resource {
+    fn typename() -> &'static str {
+        "test-only/Resource"
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateResourceMetadata {
+    pub percent: u32,
+}
+
+impl wkt::message::Message for CreateResourceMetadata {
+    fn typename() -> &'static str {
+        "test-only/CreateResourceMetadata"
+    }
+}

--- a/src/lro/tests/fake_responses/mod.rs
+++ b/src/lro/tests/fake_responses/mod.rs
@@ -1,0 +1,59 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::fake_library::model;
+use axum::http::StatusCode;
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+pub fn success(
+    name: impl Into<String>,
+    resource: impl Into<String>,
+) -> Result<(StatusCode, String)> {
+    let resource = model::Resource {
+        name: resource.into(),
+    };
+    let metadata = model::CreateResourceMetadata { percent: 100 };
+    let metadata = wkt::Any::try_from(&metadata)?;
+    let result = longrunning::model::operation::Result::Response(wkt::Any::try_from(&resource)?);
+    let operation = longrunning::model::Operation::default()
+        .set_name(name)
+        .set_metadata(metadata)
+        .set_done(true)
+        .set_result(result);
+    let payload = serde_json::to_string(&operation)?;
+    Ok((StatusCode::OK, payload))
+}
+
+pub fn pending(name: impl Into<String>, percent: u32) -> Result<(StatusCode, String)> {
+    let metadata = model::CreateResourceMetadata { percent };
+    let metadata = wkt::Any::try_from(&metadata)?;
+    let operation = longrunning::model::Operation::default()
+        .set_name(name)
+        .set_metadata(metadata);
+    let payload = serde_json::to_string(&operation)?;
+    Ok((StatusCode::OK, payload))
+}
+
+pub fn operation_error(name: impl Into<String>) -> Result<(StatusCode, String)> {
+    let error = rpc::model::Status::default()
+        .set_code(gax::error::rpc::Code::AlreadyExists as i32)
+        .set_message(format!("The resource  already exists"));
+    let result = longrunning::model::operation::Result::Response(wkt::Any::try_from(&error)?);
+    let operation = longrunning::model::Operation::default()
+        .set_name(name)
+        .set_done(true)
+        .set_result(result);
+    let payload = serde_json::to_string(&operation)?;
+    Ok((StatusCode::OK, payload))
+}

--- a/src/lro/tests/fake_service/mod.rs
+++ b/src/lro/tests/fake_service/mod.rs
@@ -1,0 +1,60 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use std::sync::{Arc, Mutex};
+use tokio::task::JoinHandle;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+pub struct ServerState {
+    pub create: std::collections::VecDeque<(StatusCode, String)>,
+    pub poll: std::collections::VecDeque<(StatusCode, String)>,
+}
+
+type SharedServerState = Arc<Mutex<ServerState>>;
+
+pub async fn start(initial_state: ServerState) -> Result<(String, JoinHandle<()>)> {
+    let state = Arc::new(Mutex::new(initial_state));
+    let app = axum::Router::new()
+        .route("/create", axum::routing::post(create_handler))
+        .route("/poll", axum::routing::get(poll_handler))
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let server = tokio::spawn(async {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    Ok((format!("http://{}:{}", addr.ip(), addr.port()), server))
+}
+
+async fn create_handler(State(state): State<SharedServerState>) -> (StatusCode, String) {
+    let mut state = state.lock().expect("shared state is poisoned");
+    state.create.pop_front().unwrap_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            "exhausted create responses".to_string(),
+        )
+    })
+}
+
+async fn poll_handler(State(state): State<SharedServerState>) -> (StatusCode, String) {
+    let mut state = state.lock().expect("shared state is poisoned");
+    state
+        .poll
+        .pop_front()
+        .unwrap_or_else(|| (StatusCode::BAD_REQUEST, "exhausted poll data".to_string()))
+}

--- a/src/lro/tests/integration.rs
+++ b/src/lro/tests/integration.rs
@@ -1,0 +1,407 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(test)]
+mod fake_library;
+#[cfg(test)]
+mod fake_responses;
+#[cfg(test)]
+mod fake_service;
+
+#[cfg(test)]
+mod test {
+    use super::fake_library::client;
+    use super::fake_library::model;
+    use super::fake_responses;
+    use super::fake_service::*;
+    use gcp_sdk_lro as lro;
+    use lro::Poller;
+
+    type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn until_done_immediate_success() -> TestResult {
+        let create = vec![fake_responses::success("op/001", "p/test-p/r/r-001")?];
+        let poll = vec![];
+        let (endpoint, _server) = start(ServerState {
+            create: create.into(),
+            poll: poll.into(),
+        })
+        .await?;
+
+        let client = client::Client::new(endpoint).await?;
+        let response = client
+            .create_resource("test-p", "r-001")
+            .until_done()
+            .await?;
+        assert_eq!(
+            response,
+            model::Resource {
+                name: "p/test-p/r/r-001".into()
+            }
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn until_done_immediate_error() -> TestResult {
+        let create = vec![fake_responses::operation_error("op/001")?];
+        let poll = vec![];
+        let (endpoint, _server) = start(ServerState {
+            create: create.into(),
+            poll: poll.into(),
+        })
+        .await?;
+
+        let client = client::Client::new(endpoint).await?;
+        let result = client.create_resource("test-p", "r-001").until_done().await;
+        let error = result.err().unwrap();
+        assert_eq!(error.kind(), gax::error::ErrorKind::Other);
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn until_done_success() -> TestResult {
+        let create = vec![fake_responses::pending("op/001", 25)?];
+        let poll = vec![
+            fake_responses::pending("op/001", 75)?,
+            fake_responses::success("op/001", "p/test-p/r/r-001")?,
+        ];
+        let (endpoint, _server) = start(ServerState {
+            create: create.into(),
+            poll: poll.into(),
+        })
+        .await?;
+
+        let client = client::Client::new(endpoint).await?;
+        let response = client
+            .create_resource("test-p", "r-001")
+            .until_done()
+            .await?;
+        assert_eq!(
+            response,
+            model::Resource {
+                name: "p/test-p/r/r-001".to_string()
+            }
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn until_done_error() -> TestResult {
+        let create = vec![fake_responses::pending("op/001", 25)?];
+        let poll = vec![
+            fake_responses::pending("op/001", 75)?,
+            fake_responses::operation_error("op/001")?,
+        ];
+        let (endpoint, _server) = start(ServerState {
+            create: create.into(),
+            poll: poll.into(),
+        })
+        .await?;
+
+        let client = client::Client::new(endpoint).await?;
+        let result = client.create_resource("test-p", "r-001").until_done().await;
+        let error = result.err().unwrap();
+        assert_eq!(error.kind(), gax::error::ErrorKind::Other);
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn poller_immediate_success() -> TestResult {
+        let create = vec![fake_responses::success("op/001", "p/test-p/r/r-001")?];
+        let poll = vec![];
+        let (endpoint, _server) = start(ServerState {
+            create: create.into(),
+            poll: poll.into(),
+        })
+        .await?;
+
+        let client = client::Client::new(endpoint).await?;
+        let mut poller = client.create_resource("test-p", "r-001").poller();
+        while let Some(status) = poller.poll().await {
+            match status {
+                lro::PollingResult::InProgress(_) => {
+                    assert!(false, "unexpected InProgress {status:?}")
+                }
+                lro::PollingResult::PollingError(_) => { /* ignored */ }
+                lro::PollingResult::Completed(result) => {
+                    let response = result?;
+                    assert_eq!(
+                        response,
+                        model::Resource {
+                            name: "p/test-p/r/r-001".into()
+                        }
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn poller_immediate_error() -> TestResult {
+        let create = vec![fake_responses::operation_error("op/001")?];
+        let poll = vec![];
+        let (endpoint, _server) = start(ServerState {
+            create: create.into(),
+            poll: poll.into(),
+        })
+        .await?;
+
+        let client = client::Client::new(endpoint).await?;
+        let mut poller = client.create_resource("test-p", "r-001").poller();
+        while let Some(status) = poller.poll().await {
+            match status {
+                lro::PollingResult::InProgress(_) => {
+                    assert!(false, "unexpected InProgress {status:?}")
+                }
+                lro::PollingResult::PollingError(_) => { /* ignored */ }
+                lro::PollingResult::Completed(result) => {
+                    let response = result;
+                    assert!(response.is_err(), "{response:?}");
+                    let error = response.err().unwrap();
+                    assert_eq!(error.kind(), gax::error::ErrorKind::Other);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn poller_success() -> TestResult {
+        let create = vec![fake_responses::pending("op/001", 25)?];
+        let poll = vec![
+            fake_responses::pending("op/001", 75)?,
+            fake_responses::success("op/001", "p/test-p/r/r-001")?,
+        ];
+        let (endpoint, _server) = start(ServerState {
+            create: create.into(),
+            poll: poll.into(),
+        })
+        .await?;
+
+        let client = client::Client::new(endpoint).await?;
+        let mut poller = client.create_resource("test-p", "r-001").poller();
+        let status = poller.poll().await.unwrap();
+        assert!(
+            matches!(
+                &status,
+                lro::PollingResult::InProgress(Some(model::CreateResourceMetadata { percent: 25 }))
+            ),
+            "{status:?}"
+        );
+
+        let status = poller.poll().await.unwrap();
+        assert!(
+            matches!(
+                &status,
+                lro::PollingResult::InProgress(Some(model::CreateResourceMetadata { percent: 75 }))
+            ),
+            "{status:?}"
+        );
+
+        let status = poller.poll().await.unwrap();
+        assert!(
+            matches!(&status, lro::PollingResult::Completed(_)),
+            "{status:?}"
+        );
+        let response = match status {
+            lro::PollingResult::Completed(r) => r.ok(),
+            _ => None,
+        };
+        assert_eq!(
+            response,
+            Some(model::Resource {
+                name: "p/test-p/r/r-001".to_string()
+            })
+        );
+
+        let status = poller.poll().await;
+        assert!(status.is_none(), "{status:?}");
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn poller_error() -> TestResult {
+        let create = vec![fake_responses::pending("op/001", 25)?];
+        let poll = vec![
+            fake_responses::pending("op/001", 75)?,
+            fake_responses::operation_error("op/001")?,
+        ];
+        let (endpoint, _server) = start(ServerState {
+            create: create.into(),
+            poll: poll.into(),
+        })
+        .await?;
+
+        let client = client::Client::new(endpoint).await?;
+        let mut poller = client.create_resource("test-p", "r-001").poller();
+        let status = poller.poll().await.unwrap();
+        assert!(
+            matches!(
+                &status,
+                lro::PollingResult::InProgress(Some(model::CreateResourceMetadata { percent: 25 }))
+            ),
+            "{status:?}"
+        );
+
+        let status = poller.poll().await.unwrap();
+        assert!(
+            matches!(
+                &status,
+                lro::PollingResult::InProgress(Some(model::CreateResourceMetadata { percent: 75 }))
+            ),
+            "{status:?}"
+        );
+
+        let status = poller.poll().await.unwrap();
+        assert!(
+            matches!(&status, lro::PollingResult::Completed(_)),
+            "{status:?}"
+        );
+        let error = match status {
+            lro::PollingResult::Completed(r) => r.err(),
+            _ => None,
+        };
+        let error = error.unwrap();
+        assert_eq!(error.kind(), gax::error::ErrorKind::Other);
+
+        let status = poller.poll().await;
+        assert!(status.is_none(), "{status:?}");
+
+        Ok(())
+    }
+
+    // The manual tests are here to validate all the test infrastructure.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn manual_immediate_success() -> TestResult {
+        let create = vec![fake_responses::success("op/001", "p/test-p/r/r-001")?];
+        let poll = vec![];
+        let (endpoint, _server) = start(ServerState {
+            create: create.into(),
+            poll: poll.into(),
+        })
+        .await?;
+
+        let client = client::Client::new(endpoint).await?;
+        let op = client.create_resource("test-p", "r-001").send().await?;
+        assert_eq!(op.name, "op/001", "{op:?}");
+        assert!(op.done, "{op:?}");
+
+        let metadata = op
+            .metadata
+            .map(|any| any.try_into_message::<model::CreateResourceMetadata>())
+            .transpose()?;
+        assert_eq!(
+            metadata,
+            Some(model::CreateResourceMetadata { percent: 100 })
+        );
+
+        use longrunning::model::operation;
+        match op.result.unwrap() {
+            operation::Result::Error(e) => assert!(false, "unexpected error {e:?}"),
+            operation::Result::Response(any) => {
+                let response = any.try_into_message::<model::Resource>()?;
+                assert_eq!(
+                    response,
+                    model::Resource {
+                        name: "p/test-p/r/r-001".into()
+                    }
+                );
+            }
+            _ => panic!("longrunning::model::operation::Result has an unexpected branch"),
+        };
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn manual_success() -> TestResult {
+        let create = vec![fake_responses::pending("op/001", 25)?];
+        let poll = vec![
+            fake_responses::pending("op/001", 50)?,
+            fake_responses::success("op/001", "p/test-p/r/r-001")?,
+        ];
+        let (endpoint, _server) = start(ServerState {
+            create: create.into(),
+            poll: poll.into(),
+        })
+        .await?;
+
+        let client = client::Client::new(endpoint).await?;
+        let op = client.create_resource("test-p", "r-001").send().await?;
+        assert_eq!(op.name, "op/001", "{op:?}");
+        assert_eq!(op.done, false, "{op:?}");
+
+        let metadata = op
+            .metadata
+            .map(|any| any.try_into_message::<model::CreateResourceMetadata>())
+            .transpose()?;
+        assert_eq!(
+            metadata,
+            Some(model::CreateResourceMetadata { percent: 25 })
+        );
+
+        let name = op.name;
+
+        let op = client.get_operation(&name).send().await?;
+        assert_eq!(op.name, "op/001", "{op:?}");
+        assert_eq!(op.done, false, "{op:?}");
+        let metadata = op
+            .metadata
+            .map(|any| any.try_into_message::<model::CreateResourceMetadata>())
+            .transpose()?;
+        assert_eq!(
+            metadata,
+            Some(model::CreateResourceMetadata { percent: 50 })
+        );
+
+        let op = client.get_operation(&name).send().await?;
+        assert_eq!(op.name, "op/001", "{op:?}");
+        assert_eq!(op.done, true, "{op:?}");
+        let metadata = op
+            .metadata
+            .map(|any| any.try_into_message::<model::CreateResourceMetadata>())
+            .transpose()?;
+        assert_eq!(
+            metadata,
+            Some(model::CreateResourceMetadata { percent: 100 })
+        );
+
+        use longrunning::model::operation;
+        match op.result.unwrap() {
+            operation::Result::Error(e) => assert!(false, "unexpected error {e:?}"),
+            operation::Result::Response(any) => {
+                let response = any.try_into_message::<model::Resource>()?;
+                assert_eq!(
+                    response,
+                    model::Resource {
+                        name: "p/test-p/r/r-001".into()
+                    }
+                );
+            }
+            _ => panic!("longrunning::model::operation::Result has an unexpected branch"),
+        };
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Introduce a new crate to support LRO helpers. The key abstraction is
`gcp_sdk_lro::Poller`: a type to poll LROs and automatically decode the
metadata and response types.

Fixes #683 