### PR TITLE
feat(generator/rust): named features for used pkgs

### DIFF
--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -33,12 +33,12 @@ version = "0.1.0"
 'package:serde'      = 'force-used=true,package=serde,version=1.0.216,feature=serde_derive'
 'package:serde_with' = 'force-used=true,package=serde_with,version=3.12.0,default-features=false,feature=base64,feature=macros,feature=std'
 # These are used by crates with services.
-'package:async-trait' = 'required-by-services=true,package=async-trait,version=0.1.84'
-'package:lazy_static' = 'required-by-services=true,package=lazy_static,version=1.5.0'
-'package:reqwest'     = 'required-by-services=true,package=reqwest,version=0.12.12,feature=json'
-'package:serde_json'  = 'required-by-services=true,package=serde_json,version=1.0.134'
-'package:tracing'     = 'required-by-services=true,package=tracing,version=0.1.41'
-'package:gax'         = 'required-by-services=true,package=gcp-sdk-gax,path=src/gax,feature=unstable-sdk-client,version=0.1.0'
+'package:async-trait' = 'used-if=services,package=async-trait,version=0.1.84'
+'package:lazy_static' = 'used-if=services,package=lazy_static,version=1.5.0'
+'package:reqwest'     = 'used-if=services,package=reqwest,version=0.12.12,feature=json'
+'package:serde_json'  = 'used-if=services,package=serde_json,version=1.0.134'
+'package:tracing'     = 'used-if=services,package=tracing,version=0.1.41'
+'package:gax'         = 'used-if=services,package=gcp-sdk-gax,path=src/gax,feature=unstable-sdk-client,version=0.1.0'
 # These are crates in `google-cloud-rust`. If not used, `sidekick` prunes them
 # from the list of depedencies.
 'package:gtype'       = 'package=gcp-sdk-type,source=google.type,path=src/generated/type,version=0.1.0'

--- a/generator/internal/language/rust_test.go
+++ b/generator/internal/language/rust_test.go
@@ -239,6 +239,164 @@ func TestWellKnownTypesExist(t *testing.T) {
 	}
 }
 
+func TestUsedByServicesWithServices(t *testing.T) {
+	service := &api.Service{
+		Name: "TestService",
+		ID:   ".test.Service",
+	}
+	model := newTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
+	c, err := newRustCodec(t.TempDir(), map[string]string{
+		"package:tracing":  "used-if=services,package=tracing,version=0.1.41",
+		"package:location": "package=gcp-sdk-location,source=google.cloud.location,path=src/generated/cloud/location,version=0.1.0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.loadWellKnownTypes(model.State)
+	c.resolveUsedPackages(model)
+	want := []*rustPackage{
+		{
+			name:            "location",
+			packageName:     "gcp-sdk-location",
+			path:            "src/generated/cloud/location",
+			version:         "0.1.0",
+			defaultFeatures: true,
+		},
+		{
+			name:            "tracing",
+			packageName:     "tracing",
+			version:         "0.1.41",
+			used:            true,
+			usedIf:          []string{"services"},
+			defaultFeatures: true,
+		},
+	}
+	less := func(a, b *rustPackage) bool { return a.name < b.name }
+	if diff := cmp.Diff(want, c.extraPackages, cmp.AllowUnexported(rustPackage{}), cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("mismatched query parameters (-want, +got):\n%s", diff)
+	}
+}
+
+func TestUsedByServicesNoServices(t *testing.T) {
+	model := newTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
+	c, err := newRustCodec(t.TempDir(), map[string]string{
+		"package:tracing":  "used-if=services,package=tracing,version=0.1.41",
+		"package:location": "package=gcp-sdk-location,source=google.cloud.location,path=src/generated/cloud/location,version=0.1.0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.loadWellKnownTypes(model.State)
+	c.resolveUsedPackages(model)
+	want := []*rustPackage{
+		{
+			name:            "location",
+			packageName:     "gcp-sdk-location",
+			path:            "src/generated/cloud/location",
+			version:         "0.1.0",
+			defaultFeatures: true,
+		},
+		{
+			name:            "tracing",
+			packageName:     "tracing",
+			version:         "0.1.41",
+			usedIf:          []string{"services"},
+			defaultFeatures: true,
+		},
+	}
+	less := func(a, b *rustPackage) bool { return a.name < b.name }
+	if diff := cmp.Diff(want, c.extraPackages, cmp.AllowUnexported(rustPackage{}), cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("mismatched query parameters (-want, +got):\n%s", diff)
+	}
+}
+
+func TestUsedByLROsWithLRO(t *testing.T) {
+	method := &api.Method{
+		Name:          "CreateResource",
+		OperationInfo: &api.OperationInfo{},
+	}
+	service := &api.Service{
+		Name:    "TestService",
+		ID:      ".test.Service",
+		Methods: []*api.Method{method},
+	}
+	model := newTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
+	c, err := newRustCodec(t.TempDir(), map[string]string{
+		"package:location": "package=gcp-sdk-location,source=google.cloud.location,path=src/generated/cloud/location,version=0.1.0",
+		"package:lro":      "used-if=lro,package=gcp-sdk-lro,path=src/lro,version=0.1.0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.loadWellKnownTypes(model.State)
+	c.resolveUsedPackages(model)
+	want := []*rustPackage{
+		{
+			name:            "location",
+			packageName:     "gcp-sdk-location",
+			path:            "src/generated/cloud/location",
+			version:         "0.1.0",
+			defaultFeatures: true,
+		},
+		{
+			name:            "lro",
+			packageName:     "gcp-sdk-lro",
+			path:            "src/lro",
+			version:         "0.1.0",
+			used:            true,
+			usedIf:          []string{"lro"},
+			defaultFeatures: true,
+		},
+	}
+	less := func(a, b *rustPackage) bool { return a.name < b.name }
+	if diff := cmp.Diff(want, c.extraPackages, cmp.AllowUnexported(rustPackage{}), cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("mismatched query parameters (-want, +got):\n%s", diff)
+	}
+}
+
+func TestUsedByLROsWithoutLRO(t *testing.T) {
+	method := &api.Method{
+		Name: "CreateResource",
+	}
+	service := &api.Service{
+		Name:    "TestService",
+		ID:      ".test.Service",
+		Methods: []*api.Method{method},
+	}
+	model := newTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
+	c, err := newRustCodec(t.TempDir(), map[string]string{
+		"package:location": "package=gcp-sdk-location,source=google.cloud.location,path=src/generated/cloud/location,version=0.1.0",
+		"package:lro":      "used-if=lro,package=gcp-sdk-lro,path=src/lro,version=0.1.0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.loadWellKnownTypes(model.State)
+	c.resolveUsedPackages(model)
+	want := []*rustPackage{
+		{
+			name:            "location",
+			packageName:     "gcp-sdk-location",
+			path:            "src/generated/cloud/location",
+			version:         "0.1.0",
+			defaultFeatures: true,
+		},
+		{
+			name:            "lro",
+			packageName:     "gcp-sdk-lro",
+			path:            "src/lro",
+			version:         "0.1.0",
+			used:            false,
+			usedIf:          []string{"lro"},
+			defaultFeatures: true,
+		},
+	}
+	less := func(a, b *rustPackage) bool { return a.name < b.name }
+	if diff := cmp.Diff(want, c.extraPackages, cmp.AllowUnexported(rustPackage{}), cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("mismatched query parameters (-want, +got):\n%s", diff)
+	}
+}
+
 func TestRust_NoStreamingFeature(t *testing.T) {
 	codec := &rustCodec{
 		modulePath:     "model",

--- a/generator/internal/language/rusttemplate.go
+++ b/generator/internal/language/rusttemplate.go
@@ -148,6 +148,7 @@ type RustEnumValue struct {
 // [Template.Services] field.
 func newRustTemplateData(model *api.API, c *rustCodec) *RustTemplateData {
 	c.loadWellKnownTypes(model.State)
+	c.resolveUsedPackages(model)
 	data := &RustTemplateData{
 		Name:           model.Name,
 		Title:          model.Title,


### PR DESCRIPTION
Use named features to decide what packages are used. Makes it easier to
accomodate LRO helpers, and maybe other upcoming features, such as
streaming RPCs and gRPC-based libraries.

Part of the work for #438
