### PR TITLE
impl: use `gcp-sdk-lro` as a named feature

### DIFF
--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -39,6 +39,8 @@ version = "0.1.0"
 'package:serde_json'  = 'used-if=services,package=serde_json,version=1.0.134'
 'package:tracing'     = 'used-if=services,package=tracing,version=0.1.41'
 'package:gax'         = 'used-if=services,package=gcp-sdk-gax,path=src/gax,feature=unstable-sdk-client,version=0.1.0'
+# Only used if LROs are present
+'package:lro' = 'used-if=lro,package=gcp-sdk-lro,path=src/lro,version=0.0.0'
 # These are crates in `google-cloud-rust`. If not used, `sidekick` prunes them
 # from the list of depedencies.
 'package:gtype'       = 'package=gcp-sdk-type,source=google.type,path=src/generated/type,version=0.1.0'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,6 +688,7 @@ dependencies = [
  "gcp-sdk-gax",
  "gcp-sdk-location",
  "gcp-sdk-longrunning",
+ "gcp-sdk-lro",
  "gcp-sdk-wkt",
  "lazy_static",
  "reqwest",

--- a/src/generated/cloud/workflows/v1/Cargo.toml
+++ b/src/generated/cloud/workflows/v1/Cargo.toml
@@ -32,6 +32,7 @@ gax        = { version = "0.1.0", path = "../../../../../src/gax", package = "gc
 lazy_static = { version = "1.5.0" }
 location   = { version = "0.1.0", path = "../../../../../src/generated/cloud/location", package = "gcp-sdk-location" }
 longrunning = { version = "0.1.0", path = "../../../../../src/generated/longrunning", package = "gcp-sdk-longrunning" }
+lro        = { version = "0.0.0", path = "../../../../../src/lro", package = "gcp-sdk-lro" }
 reqwest    = { version = "0.12.12", features = ["json"] }
 serde      = { version = "1.0.216", features = ["serde_derive"] }
 serde_json = { version = "1.0.134" }


### PR DESCRIPTION
Now that the `gcp-sdk-lro` crate exists, configure `sidekick` to
automatically add this as a dependency of any generated crate with LROs.

Fixes #688 