### PR TITLE
feat(lro): use polling policy on success

### DIFF
--- a/src/lro/src/details.rs
+++ b/src/lro/src/details.rs
@@ -60,7 +60,9 @@ where
                         Some(e) => (None, PollingResult::Completed(Err(e))),
                     }
                 }
-                PollingResult::PollingError(_) => panic!(),
+                PollingResult::PollingError(_) => {
+                    unreachable!("handle_common never returns PollingResult::PollingError")
+                }
             }
         }
     }


### PR DESCRIPTION
We want to stop the polling loop if it has been running for too long, or
it has made too many polling attempts.

Part of the work for #713
