### PR TITLE
cleanup(generator): annotate `api.Field` types

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -285,6 +285,8 @@ type Field struct {
 	// some helper fields. These need to be marked so they can be excluded
 	// from serialized messages and in other places.
 	Synthetic bool
+	// A placeholder to put language specific annotations.
+	Codec any
 }
 
 // Pair is a key-value pair.
@@ -308,4 +310,6 @@ type OneOf struct {
 	Fields []*Field
 	// Parent returns the ancestor of this node, if any.
 	Parent *Message
+	// A placeholder to put language specific annotations.
+	Codec any
 }

--- a/generator/internal/language/templates/rust/common/message.mustache
+++ b/generator/internal/language/templates/rust/common/message.mustache
@@ -24,41 +24,38 @@ limitations under the License.
 pub struct {{Name}} {
     {{#BasicFields}}
 
-    {{#DocLines}}
+    {{#Codec.DocLines}}
     {{{.}}}
-    {{/DocLines}}
-    {{#FieldAttributes}}
+    {{/Codec.DocLines}}
+    {{#Codec.Attributes}}
     {{{.}}}
-    {{/FieldAttributes}}
-    pub {{NameToSnake}}: {{{FieldType}}},
+    {{/Codec.Attributes}}
+    pub {{Codec.FieldName}}: {{{Codec.FieldType}}},
     {{/BasicFields}}
     {{#ExplicitOneOfs}}
 
-    {{#DocLines}}
+    {{#Codec.DocLines}}
     {{{.}}}
-    {{/DocLines}}
-    {{#FieldAttributes}}
-    {{{.}}}
-    {{/FieldAttributes}}
+    {{/Codec.DocLines}}
     #[serde(flatten, skip_serializing_if = "std::option::Option::is_none")]
-    pub {{NameToSnake}}: std::option::Option<{{{FieldType}}}>,
+    pub {{Codec.FieldName}}: std::option::Option<{{{Codec.FieldType}}}>,
     {{/ExplicitOneOfs}}
 }
 
 impl {{Name}} {
     {{#BasicFields}}
 
-    /// Sets the value of `{{NameToSnake}}`.
-    pub fn set_{{NameToSnakeNoMangling}}<T: std::convert::Into<{{{FieldType}}}>>(mut self, v: T) -> Self {
-        self.{{NameToSnake}} = v.into();
+    /// Sets the value of `{{Codec.FieldName}}`.
+    pub fn set_{{Codec.SetterName}}<T: std::convert::Into<{{{Codec.FieldType}}}>>(mut self, v: T) -> Self {
+        self.{{Codec.FieldName}} = v.into();
         self
     }
     {{/BasicFields}}
     {{#ExplicitOneOfs}}
 
-    /// Sets the value of `{{NameToSnake}}`.
-    pub fn set_{{NameToSnakeNoMangling}}<T: std::convert::Into<std::option::Option<{{{FieldType}}}>>>(mut self, v: T) ->Self {
-        self.{{NameToSnake}} = v.into();
+    /// Sets the value of `{{Codec.FieldName}}`.
+    pub fn set_{{Codec.SetterName}}<T: std::convert::Into<std::option::Option<{{{Codec.FieldType}}}>>>(mut self, v: T) ->Self {
+        self.{{Codec.FieldName}} = v.into();
         self
     }
     {{/ExplicitOneOfs}}
@@ -76,10 +73,10 @@ impl wkt::message::Message for {{Name}} {
 #[cfg(feature = "unstable-stream")]
 impl gax::paginator::PageableResponse for {{Name}} {
     {{#PageableItem}}
-    type PageItem = {{{PrimitiveFieldType}}};
+    type PageItem = {{{Codec.PrimitiveFieldType}}};
 
     fn items(self) -> std::vec::Vec<Self::PageItem> {
-        self.{{{NameToSnake}}}
+        self.{{{Codec.FieldName}}}
     }
 
     {{/PageableItem}}

--- a/generator/internal/language/templates/rust/common/oneof.mustache
+++ b/generator/internal/language/templates/rust/common/oneof.mustache
@@ -14,17 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 }}
 
-{{#DocLines}}
+{{#Codec.DocLines}}
 {{{.}}}
-{{/DocLines}}
+{{/Codec.DocLines}}
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-pub enum {{NameToPascal}} {
+pub enum {{Codec.EnumName}} {
     {{#Fields}}
-    {{#DocLines}}
+    {{#Codec.DocLines}}
     {{{.}}}
-    {{/DocLines}}
-    {{NameToPascal}}{{{FieldType}}},
+    {{/Codec.DocLines}}
+    {{Codec.BranchName}}{{{Codec.FieldType}}},
     {{/Fields}}
 }

--- a/generator/internal/language/templates/rust/crate/src/builders.rs.mustache
+++ b/generator/internal/language/templates/rust/crate/src/builders.rs.mustache
@@ -128,17 +128,17 @@ pub mod {{NameToSnake}} {
         {{/OperationInfo}}
         {{#InputType.BasicFields}}
 
-        /// Sets the value of `{{NameToSnake}}`.
-        pub fn set_{{NameToSnakeNoMangling}}<T: Into<{{{FieldType}}}>>(mut self, v: T) -> Self {
-            self.0.request.{{NameToSnake}} = v.into();
+        /// Sets the value of `{{Codec.FieldName}}`.
+        pub fn set_{{Codec.SetterName}}<T: Into<{{{Codec.FieldType}}}>>(mut self, v: T) -> Self {
+            self.0.request.{{Codec.FieldName}} = v.into();
             self
         }
         {{/InputType.BasicFields}}
         {{#InputType.ExplicitOneOfs}}
 
-        /// Sets the value of `{{NameToSnake}}`.
-        pub fn set_{{NameToSnakeNoMangling}}<T: Into<Option<{{{FieldType}}}>>>(mut self, v: T) ->Self {
-            self.0.request.{{NameToSnake}} = v.into();
+        /// Sets the value of `{{Codec.FieldName}}`.
+        pub fn set_{{Codec.SetterName}}<T: Into<Option<{{{Codec.FieldType}}}>>>(mut self, v: T) ->Self {
+            self.0.request.{{Codec.FieldName}} = v.into();
             self
         }
         {{/InputType.ExplicitOneOfs}}

--- a/generator/internal/language/templates/rust/crate/src/client.rs.mustache
+++ b/generator/internal/language/templates/rust/crate/src/client.rs.mustache
@@ -176,13 +176,13 @@ impl {{NameToPascal}} {
     pub fn {{NameToSnake}}(
         &self,
         {{#PathParams}}
-        {{{NameToSnake}}}: impl Into<{{{PrimitiveFieldType}}}>,
+        {{{Codec.FieldName}}}: impl Into<{{{Codec.PrimitiveFieldType}}}>,
         {{/PathParams}}
     ) -> crate::builders::{{ServiceNameToSnake}}::{{NameToPascal}}
     {
         crate::builders::{{ServiceNameToSnake}}::{{NameToPascal}}::new(self.inner.clone())
         {{#PathParams}}
-            .set_{{NameToSnakeNoMangling}} ( {{NameToSnake}}.into() )
+            .set_{{Codec.SetterName}} ( {{Codec.FieldName}}.into() )
         {{/PathParams}}
     }
 

--- a/generator/internal/language/templates/rust/crate/src/transport.rs.mustache
+++ b/generator/internal/language/templates/rust/crate/src/transport.rs.mustache
@@ -64,7 +64,7 @@ impl crate::traits::{{NameToPascal}} for {{NameToPascal}} {
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         {{#QueryParams}}
-        {{{AddQueryParameter}}}
+        {{{Codec.AddQueryParameter}}}
         {{/QueryParams}}
         self.inner.execute(
             builder,


### PR DESCRIPTION
Start a cleanup of the `rusttemplate.go` file. The idea is to minimize
duplication with the `api.*` types. Instead we attach a number of
annotations to `api.Field` that represent the Rust-specific thing.

Other languages will attach different annotation objects. The type of
the annotation is `any` to support this case.

Part of the work for #653, helps with #655, and from there #610 and #482 