### PR TITLE
test(gax): update tests for query parameters

### DIFF
--- a/src/gax/tests/query_parameters.rs
+++ b/src/gax/tests/query_parameters.rs
@@ -12,233 +12,582 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+#[cfg(test)]
+mod test {
+    use gcp_sdk_gax as gax;
+    type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-// We use this to simulate a request and how it is used in query parameters.
-#[serde_with::skip_serializing_none]
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FakeRequest {
-    // Typically the struct would have at least one path parameter.
-    pub parent: String,
-    // Most query parameter fields are optional.
-    pub count: Option<i32>,
-    pub boolean: Option<bool>,
-    pub filter_expression: Option<String>,
-    pub get_mask: Option<wkt::FieldMask>,
-    pub ttl: Option<wkt::Duration>,
-    pub expiration: Option<wkt::Timestamp>,
-    // Some query parameter fields are required.
-    pub required: String,
+    // We use this to simulate a request and how it is used in query parameters.
+    #[serde_with::skip_serializing_none]
+    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct FakeRequest {
+        // Typically the struct would have at least one path parameter.
+        pub parent: String,
 
-    pub repeated_int32: Vec<i32>,
-    pub repeated_duration: Vec<wkt::Duration>,
+        // Most query parameter fields are optional.
+        pub boolean: Option<bool>,
+        pub filter_expression: Option<String>,
 
-    pub nested: Option<NestedOptions>,
-}
+        // Some query parameter fields are required or repeated. Use String and
+        // int32 because those are the most common and good representatives for
+        // all primitive types.
+        pub required_string: String,
+        pub optional_string: Option<String>,
+        pub repeated_string: Vec<String>,
 
-#[serde_with::skip_serializing_none]
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct NestedOptions {
-    pub repeated_nested_string: Vec<String>,
-    pub repeated_double_nested: Vec<DoubleNestedOptions>,
-}
+        pub required_int32: i32,
+        pub optional_int32: Option<i32>,
+        pub repeated_int32: Vec<i32>,
 
-#[serde_with::skip_serializing_none]
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DoubleNestedOptions {
-    pub repeated_string: Vec<String>,
-}
+        // Enums may also appear as well query parameters.
+        pub required_enum_value: State,
+        pub optional_enum_value: Option<State>,
+        pub repeated_enum_value: Vec<State>,
 
-fn with_query_parameters(request: &FakeRequest) -> Result<reqwest::RequestBuilder> {
-    let client = reqwest::Client::builder().build()?;
-    let builder = client.get("https://test.googleapis.com/v1/unused");
-    let builder = gcp_sdk_gax::query_parameter::add(builder, "count", &request.count)?;
-    let builder = gcp_sdk_gax::query_parameter::add(builder, "boolean", &request.boolean)?;
-    let builder =
-        gcp_sdk_gax::query_parameter::add(builder, "filterExpression", &request.filter_expression)?;
-    let builder = gcp_sdk_gax::query_parameter::add(builder, "getMask", &request.get_mask)?;
-    let builder = gcp_sdk_gax::query_parameter::add(builder, "ttl", &request.ttl)?;
-    let builder = gcp_sdk_gax::query_parameter::add(builder, "expiration", &request.expiration)?;
-    let builder = gcp_sdk_gax::query_parameter::add(builder, "required", &request.required)?;
-    let builder =
-        gcp_sdk_gax::query_parameter::add(builder, "repeatedInt32", &request.repeated_int32)?;
-    let builder =
-        gcp_sdk_gax::query_parameter::add(builder, "repeatedDuration", &request.repeated_duration)?;
-    let builder = gcp_sdk_gax::query_parameter::add(
-        builder,
-        "nested",
-        &serde_json::to_value(&request.nested)?,
-    )?;
-    Ok(builder)
-}
+        // Messages (including well-known-types) are always optional or
+        // repeated. However, the specification says:
+        //
+        // > Note that fields which are mapped to URL query parameters must
+        // > have a primitive type or a repeated primitive type or a
+        // > **non-repeated** message type.
+        //
+        // https://github.com/googleapis/googleapis/blob/3776db131e34e42ec8d287203020cb4282166aa5/google/api/http.proto#L114-L119
+        //
+        pub duration: Option<wkt::Duration>,
+        pub timestamp: Option<wkt::Timestamp>,
 
-#[test]
-fn make_reqwest_no_query() -> Result<()> {
-    let client = reqwest::Client::builder().build()?;
-    let empty: [Option<(&str, String)>; 0] = [];
-    let builder = client
-        .get("https://test.googleapis.com/v1/unused")
-        .query(&empty.into_iter().flatten().collect::<Vec<(&str, String)>>());
+        // FieldMask is different from `Duration` and `Timestamp`. Message types
+        // are mapped according to:
+        //
+        // > In the case of a message type, each field of the message is mapped
+        // > to a separate parameter,
+        //
+        // The JSON representation of `Duration` and `Timestamp` are simply
+        // strings.  FieldMask is mapped to a JSON object with a single `paths`
+        // field.
+        pub field_mask: Option<wkt::FieldMask>,
 
-    let r = builder.build()?;
-    assert_eq!(None, r.url().query());
+        // In OpenAPI-derived client libraries this appears as a required field.
+        // This may be a bug in the OpenAPI parser, but let's make sure the code
+        // compiles and works until that is fixed.
+        pub required_field_mask: wkt::FieldMask,
 
-    Ok(())
-}
+        // Sometimes query parameters appear inside fields that are object
+        // fields.
+        pub optional_nested: Option<NestedOptions>,
+    }
 
-#[test]
-fn basic_query() -> Result<()> {
-    // Create a basic request.
-    let request = FakeRequest {
-        parent: "projects/test-only-invalid".into(),
-        filter_expression: Some("only-the-good-stuff".into()),
-        ..Default::default()
-    };
-    let builder = with_query_parameters(&request)?;
+    #[serde_with::skip_serializing_none]
+    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct NestedOptions {
+        pub required_int32: i32,
+        pub optional_int32: Option<i32>,
+        pub repeated_int32: Vec<i32>,
+        pub double_nested: Option<DoubleNestedOptions>,
+    }
 
-    let r = builder.build()?;
-    assert_eq!(
-        Some("filterExpression=only-the-good-stuff&required="),
-        r.url().query()
-    );
+    #[serde_with::skip_serializing_none]
+    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct DoubleNestedOptions {
+        pub repeated_string: Vec<String>,
+    }
 
-    Ok(())
-}
+    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    pub struct State(String);
 
-#[test]
-fn with_fieldmask() -> Result<()> {
-    // Create a basic request.
-    let request = FakeRequest {
-        parent: "projects/test-only-invalid".into(),
-        get_mask: Some(
-            wkt::FieldMask::default().set_paths(["f0", "f1"].map(str::to_string).to_vec()),
-        ),
-        ..Default::default()
-    };
-    let builder = with_query_parameters(&request)?;
+    impl State {
+        /// Sets the enum value.
+        pub fn set_value<T: Into<String>>(mut self, v: T) -> Self {
+            self.0 = v.into();
+            self
+        }
 
-    let r = builder.build()?;
-    // %2C is the URL-safe encoding for comma (`,`)
-    assert_eq!(Some("getMask=f0%2Cf1&required="), r.url().query());
+        /// Gets the enum value.
+        pub fn value(&self) -> &str {
+            &self.0
+        }
+    }
 
-    Ok(())
-}
+    pub mod state {
+        pub const DISABLED: &str = "DISABLED";
+        pub const DESTROYED: &str = "DESTROYED";
+    }
 
-#[test]
-fn with_duration() -> Result<()> {
-    // Create a basic request.
-    let request = FakeRequest {
-        parent: "projects/test-only-invalid".into(),
-        ttl: Some(wkt::Duration::clamp(12, 345_678_900)),
-        ..Default::default()
-    };
-    let builder = with_query_parameters(&request)?;
+    // A new version of the generator will generate code as follows for query parameters.
+    fn add_query_parameters(request: &FakeRequest) -> Result<reqwest::RequestBuilder> {
+        let client = reqwest::Client::builder().build()?;
+        let builder = client.get("https://test.googleapis.com/v1/unused");
 
-    let r = builder.build()?;
-    // %2C is the URL-safe encoding for comma (`,`)
-    assert_eq!(Some("ttl=12.345678900s&required="), r.url().query());
+        let builder = request
+            .boolean
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("boolean", p)]));
+        let builder = request
+            .filter_expression
+            .iter()
+            .fold(builder, |builder, p| {
+                builder.query(&[("filterExpression", p)])
+            });
 
-    Ok(())
-}
+        let builder = builder.query(&[("requiredString", &request.required_string)]);
+        let builder = request.optional_string.iter().fold(builder, |builder, p| {
+            builder.query(&[("optionalString", p)])
+        });
+        let builder = request.repeated_string.iter().fold(builder, |builder, p| {
+            builder.query(&[("repeatedString", p)])
+        });
 
-#[test]
-fn with_timestamp() -> Result<()> {
-    // Create a basic request.
-    let request = FakeRequest {
-        parent: "projects/test-only-invalid".into(),
-        expiration: Some(wkt::Timestamp::new(12, 345_678_900)?),
-        ..Default::default()
-    };
-    let builder = with_query_parameters(&request)?;
+        let builder = builder.query(&[("requiredInt32", &request.required_int32)]);
+        let builder = request
+            .optional_int32
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("optionalInt32", p)]));
+        let builder = request
+            .repeated_int32
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("repeatedInt32", p)]));
 
-    let r = builder.build()?;
-    // %3A is the URL-safe encoding for colon (`:`)
-    assert_eq!(
-        Some("expiration=1970-01-01T00%3A00%3A12.3456789Z&required="),
-        r.url().query()
-    );
+        let builder = builder.query(&[("requiredEnumValue", &request.required_enum_value.value())]);
+        let builder = request
+            .optional_enum_value
+            .iter()
+            .fold(builder, |builder, p| {
+                builder.query(&[("optionalEnumValue", &p.value())])
+            });
+        let builder = request
+            .repeated_enum_value
+            .iter()
+            .fold(builder, |builder, p| {
+                builder.query(&[("repeatedEnumValue", &p.value())])
+            });
 
-    Ok(())
-}
+        let builder = request.duration.iter().try_fold(builder, |builder, p| {
+            use gax::error::Error;
+            use gax::query_parameter::QueryParameter;
+            serde_json::to_value(&p)
+                .map_err(Error::serde)?
+                .add(builder, "optionalDuration")
+                .map_err(Error::other)
+        })?;
 
-#[test]
-fn with_repeated_int32() -> Result<()> {
-    let request = FakeRequest {
-        parent: "projects/test-only-invalid".into(),
-        repeated_int32: vec![2_i32, 3_i32, 5_i32],
-        ..Default::default()
-    };
-    let builder = with_query_parameters(&request)?;
+        let builder = request.field_mask.iter().try_fold(builder, |builder, p| {
+            use gax::error::Error;
+            use gax::query_parameter::QueryParameter;
+            serde_json::to_value(&p)
+                .map_err(Error::serde)?
+                .add(builder, "fieldMask")
+                .map_err(Error::other)
+        })?;
+        let builder = {
+            use gax::error::Error;
+            use gax::query_parameter::QueryParameter;
+            serde_json::to_value(&request.required_field_mask)
+                .map_err(Error::serde)?
+                .add(builder, "requiredFieldMask")
+                .map_err(Error::other)?
+        };
 
-    let r = builder.build()?;
-    // %3A is the URL-safe encoding for colon (`:`)
-    assert_eq!(
-        Some("required=&repeatedInt32=2&repeatedInt32=3&repeatedInt32=5"),
-        r.url().query()
-    );
+        let builder = request.timestamp.iter().try_fold(builder, |builder, p| {
+            use gax::error::Error;
+            use gax::query_parameter::QueryParameter;
+            serde_json::to_value(&p)
+                .map_err(Error::serde)?
+                .add(builder, "expiration")
+                .map_err(Error::other)
+        })?;
 
-    Ok(())
-}
+        let builder = request
+            .optional_nested
+            .iter()
+            .try_fold(builder, |builder, p| {
+                use gax::error::Error;
+                use gax::query_parameter::QueryParameter;
+                serde_json::to_value(&p)
+                    .map_err(Error::serde)?
+                    .add(builder, "optionalNested")
+                    .map_err(Error::other)
+            })?;
 
-#[test]
-fn with_repeated_duration() -> Result<()> {
-    let request = FakeRequest {
-        parent: "projects/test-only-invalid".into(),
-        repeated_duration: [2, 3, 5].map(|s| wkt::Duration::clamp(s, 0)).to_vec(),
-        ..Default::default()
-    };
-    let builder = with_query_parameters(&request)?;
+        Ok(builder)
+    }
 
-    let r = builder.build()?;
-    assert_eq!(
-        Some("required=&repeatedDuration=2s&repeatedDuration=3s&repeatedDuration=5s"),
-        r.url().query()
-    );
+    fn split_query(r: &reqwest::Request) -> Vec<&str> {
+        r.url()
+            .query()
+            .unwrap_or_default()
+            .split("&")
+            // Remove repetitive elements to make the tests cleaner.
+            .filter(|p| {
+                *p != "requiredString="
+                    && *p != "requiredInt32=0"
+                    && *p != "requiredEnumValue="
+                    && *p != "requiredFieldMask.paths="
+            })
+            .collect()
+    }
 
-    Ok(())
-}
+    #[test]
+    fn default() -> Result<()> {
+        let request = FakeRequest {
+            parent: "projects/test-only-invalid".into(),
+            ..Default::default()
+        };
+        let builder = add_query_parameters(&request)?;
 
-#[test]
-fn with_nested() -> Result<()> {
-    let request = FakeRequest {
-        parent: "projects/test-only-invalid".into(),
-        nested: Some(NestedOptions {
-            repeated_nested_string: ["a", "b", "c"].map(str::to_string).to_vec(),
-            repeated_double_nested: vec![
-                DoubleNestedOptions {
-                    repeated_string: ["e", "d"].map(str::to_string).to_vec(),
-                },
-                DoubleNestedOptions {
-                    repeated_string: ["f", "g"].map(str::to_string).to_vec(),
-                },
+        let r = builder.build()?;
+        assert_eq!(split_query(&r), Vec::<&str>::new());
+
+        Ok(())
+    }
+
+    #[test]
+    fn boolean() -> Result<()> {
+        let request = FakeRequest {
+            parent: "projects/test-only-invalid".into(),
+            boolean: Some(true),
+            ..Default::default()
+        };
+        let builder = add_query_parameters(&request)?;
+
+        let r = builder.build()?;
+        assert_eq!(split_query(&r), vec!["boolean=true"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn filter_expression() -> Result<()> {
+        let request = FakeRequest {
+            parent: "projects/test-only-invalid".into(),
+            filter_expression: Some("goodies".into()),
+            ..Default::default()
+        };
+        let builder = add_query_parameters(&request)?;
+
+        let r = builder.build()?;
+        assert_eq!(split_query(&r), vec!["filterExpression=goodies"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn required_string() -> Result<()> {
+        let request = FakeRequest {
+            parent: "projects/test-only-invalid".into(),
+            required_string: "value".into(),
+            ..Default::default()
+        };
+        let builder = add_query_parameters(&request)?;
+
+        let r = builder.build()?;
+        assert_eq!(split_query(&r), vec!["requiredString=value"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn optional_string() -> Result<()> {
+        let request = FakeRequest {
+            parent: "projects/test-only-invalid".into(),
+            optional_string: Some("value".into()),
+            ..Default::default()
+        };
+        let builder = add_query_parameters(&request)?;
+
+        let r = builder.build()?;
+        assert_eq!(split_query(&r), vec!["optionalString=value"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn repeated_string() -> Result<()> {
+        let request = FakeRequest {
+            parent: "projects/test-only-invalid".into(),
+            repeated_string: vec!["s0".into(), "s1".into()],
+            ..Default::default()
+        };
+        let builder = add_query_parameters(&request)?;
+
+        let r = builder.build()?;
+        assert_eq!(
+            split_query(&r),
+            vec!["repeatedString=s0", "repeatedString=s1"]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn required_int32() -> Result<()> {
+        let request = FakeRequest {
+            parent: "projects/test-only-invalid".into(),
+            required_int32: 123,
+            ..Default::default()
+        };
+        let builder = add_query_parameters(&request)?;
+
+        let r = builder.build()?;
+        assert_eq!(split_query(&r), vec!["requiredInt32=123"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn optional_int32() -> Result<()> {
+        let request = FakeRequest {
+            parent: "projects/test-only-invalid".into(),
+            optional_int32: Some(234),
+            ..Default::default()
+        };
+        let builder = add_query_parameters(&request)?;
+
+        let r = builder.build()?;
+        assert_eq!(split_query(&r), vec!["optionalInt32=234"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn repeated_int32() -> Result<()> {
+        let request = FakeRequest {
+            parent: "projects/test-only-invalid".into(),
+            repeated_int32: vec![123, 345, 567],
+            ..Default::default()
+        };
+        let builder = add_query_parameters(&request)?;
+
+        let r = builder.build()?;
+        assert_eq!(
+            split_query(&r),
+            vec![
+                "repeatedInt32=123",
+                "repeatedInt32=345",
+                "repeatedInt32=567",
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn required_enum_value() -> Result<()> {
+        let request = FakeRequest {
+            parent: "projects/test-only-invalid".into(),
+            required_enum_value: State::default().set_value(state::DESTROYED),
+            ..Default::default()
+        };
+        let builder = add_query_parameters(&request)?;
+
+        let r = builder.build()?;
+        assert_eq!(split_query(&r), vec!["requiredEnumValue=DESTROYED"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn optional_enum_value() -> Result<()> {
+        let request = FakeRequest {
+            parent: "projects/test-only-invalid".into(),
+            optional_enum_value: State::default().set_value(state::DISABLED).into(),
+            ..Default::default()
+        };
+        let builder = add_query_parameters(&request)?;
+
+        let r = builder.build()?;
+        assert_eq!(split_query(&r), vec!["optionalEnumValue=DISABLED"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn repeated_enum_value() -> Result<()> {
+        let request = FakeRequest {
+            parent: "projects/test-only-invalid".into(),
+            repeated_enum_value: vec![
+                State::default().set_value(state::DISABLED),
+                State::default().set_value(state::DESTROYED),
             ],
-        }),
-        ..Default::default()
-    };
-    let builder = with_query_parameters(&request)?;
+            ..Default::default()
+        };
+        let builder = add_query_parameters(&request)?;
 
-    let r = builder.build()?;
-    let got = r.url().query().unwrap();
-    let mut got = got.split('&').map(str::to_string).collect::<Vec<_>>();
-    got.sort();
-    let got = got;
-    let mut want = vec![
-        "required=",
-        "nested.repeatedNestedString=a",
-        "nested.repeatedNestedString=b",
-        "nested.repeatedNestedString=c",
-        "nested.repeatedDoubleNested.repeatedString=e",
-        "nested.repeatedDoubleNested.repeatedString=d",
-        "nested.repeatedDoubleNested.repeatedString=f",
-        "nested.repeatedDoubleNested.repeatedString=g",
-    ];
-    want.sort();
-    let want = want;
+        let r = builder.build()?;
+        assert_eq!(
+            split_query(&r),
+            vec!["repeatedEnumValue=DISABLED", "repeatedEnumValue=DESTROYED",]
+        );
 
-    assert_eq!(got, want);
+        Ok(())
+    }
 
-    Ok(())
+    #[test]
+    fn optional_duration() -> Result<()> {
+        let request = FakeRequest {
+            parent: "projects/test-only-invalid".into(),
+            duration: Some(wkt::Duration::clamp(123, 0)),
+            ..Default::default()
+        };
+        let builder = add_query_parameters(&request)?;
+
+        let r = builder.build()?;
+        assert_eq!(split_query(&r), vec!["optionalDuration=123s"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn timestamp() -> Result<()> {
+        let request = FakeRequest {
+            parent: "projects/test-only-invalid".into(),
+            timestamp: Some(wkt::Timestamp::clamp(3654, 0)),
+            ..Default::default()
+        };
+        let builder = add_query_parameters(&request)?;
+
+        let r = builder.build()?;
+        assert_eq!(split_query(&r), vec!["expiration=1970-01-01T01%3A00%3A54Z"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn field_mask() -> Result<()> {
+        let request = FakeRequest {
+            parent: "projects/test-only-invalid".into(),
+            field_mask: Some(
+                wkt::FieldMask::default().set_paths(vec!["a".to_string(), "b".to_string()]),
+            ),
+            ..Default::default()
+        };
+        let builder = add_query_parameters(&request)?;
+
+        let r = builder.build()?;
+        // TODO(#736) - the `.paths` field here may not be correct, investigate
+        assert_eq!(split_query(&r), vec!["fieldMask.paths=a%2Cb"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn required_field_mask() -> Result<()> {
+        let request = FakeRequest {
+            parent: "projects/test-only-invalid".into(),
+            required_field_mask: wkt::FieldMask::default()
+                .set_paths(vec!["a".to_string(), "b".to_string()]),
+            ..Default::default()
+        };
+        let builder = add_query_parameters(&request)?;
+
+        let r = builder.build()?;
+        // TODO(#736) - the `.paths` field here may not be correct, investigate
+        assert_eq!(split_query(&r), vec!["requiredFieldMask.paths=a%2Cb"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn optional_nested_required_int32() -> Result<()> {
+        let request = FakeRequest {
+            parent: "projects/test-only-invalid".into(),
+            optional_nested: Some(NestedOptions {
+                required_int32: 123,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let builder = add_query_parameters(&request)?;
+
+        let r = builder.build()?;
+        assert_eq!(split_query(&r), vec!["optionalNested.requiredInt32=123"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn optional_nested_optional_int32() -> Result<()> {
+        let request = FakeRequest {
+            parent: "projects/test-only-invalid".into(),
+            optional_nested: Some(NestedOptions {
+                optional_int32: Some(123),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let builder = add_query_parameters(&request)?;
+
+        let r = builder.build()?;
+        let mut got = split_query(&r);
+        got.sort();
+        assert_eq!(
+            got,
+            vec![
+                "optionalNested.optionalInt32=123",
+                "optionalNested.requiredInt32=0"
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn optional_nested_repeated_int32() -> Result<()> {
+        let request = FakeRequest {
+            parent: "projects/test-only-invalid".into(),
+            optional_nested: Some(NestedOptions {
+                repeated_int32: vec![1, 3, 5, 7],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let builder = add_query_parameters(&request)?;
+
+        let r = builder.build()?;
+        let mut got = split_query(&r);
+        got.sort();
+        assert_eq!(
+            got,
+            vec![
+                "optionalNested.repeatedInt32=1",
+                "optionalNested.repeatedInt32=3",
+                "optionalNested.repeatedInt32=5",
+                "optionalNested.repeatedInt32=7",
+                "optionalNested.requiredInt32=0",
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn optional_nested_double_nested() -> Result<()> {
+        let request = FakeRequest {
+            parent: "projects/test-only-invalid".into(),
+            optional_nested: Some(NestedOptions {
+                double_nested: Some(DoubleNestedOptions {
+                    repeated_string: ["a", "b"].map(str::to_string).to_vec(),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let builder = add_query_parameters(&request)?;
+
+        let r = builder.build()?;
+        let mut got = split_query(&r);
+        got.sort();
+        assert_eq!(
+            got,
+            vec![
+                "optionalNested.doubleNested.repeatedString=a",
+                "optionalNested.doubleNested.repeatedString=b",
+                "optionalNested.requiredInt32=0",
+            ]
+        );
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
I am about to change how the generator handles query parameters. Before
doing so, I updated the query parameters test to verify the generated
code will work as we need it to. I also expanded the test to cover more
cases.

Part of the work for #610
