### PR TITLE
feat(generator/rust): handle enum query parameters

### DIFF
--- a/generator/internal/language/rusttemplate.go
+++ b/generator/internal/language/rusttemplate.go
@@ -132,7 +132,7 @@ type RustField struct {
 	FieldType             string
 	PrimitiveFieldType    string
 	JSONName              string
-	AsQueryParameter      string
+	AddQueryParameter     string
 }
 
 type RustEnum struct {
@@ -378,7 +378,7 @@ func newRustField(field *api.Field, state *api.APIState, modulePath, sourceSpeci
 		FieldType:             rustFieldType(field, state, false, modulePath, sourceSpecificationPackageName, packageMapping),
 		PrimitiveFieldType:    rustFieldType(field, state, true, modulePath, sourceSpecificationPackageName, packageMapping),
 		JSONName:              field.JSONName,
-		AsQueryParameter:      rustAsQueryParameter(field),
+		AddQueryParameter:     rustAddQueryParameter(field),
 	}
 }
 

--- a/generator/internal/language/templates/rust/crate/src/transport.rs.mustache
+++ b/generator/internal/language/templates/rust/crate/src/transport.rs.mustache
@@ -64,7 +64,7 @@ impl crate::traits::{{NameToPascal}} for {{NameToPascal}} {
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         {{#QueryParams}}
-        let builder = gax::query_parameter::add(builder, "{{JSONName}}", {{{AsQueryParameter}}}).map_err(Error::other)?;
+        {{{AddQueryParameter}}}
         {{/QueryParams}}
         self.inner.execute(
             builder,

--- a/generator/testdata/rust/openapi/golden/src/transport.rs
+++ b/generator/testdata/rust/openapi/golden/src/transport.rs
@@ -52,9 +52,9 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        let builder = gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token).map_err(Error::other)?;
+        let builder = req.filter.iter().fold(builder, |builder, p| builder.query(&[("filter", p)]));
+        let builder = req.page_size.iter().fold(builder, |builder, p| builder.query(&[("pageSize", p)]));
+        let builder = req.page_token.iter().fold(builder, |builder, p| builder.query(&[("pageToken", p)]));
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
@@ -94,9 +94,9 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        let builder = gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
+        let builder = req.page_size.iter().fold(builder, |builder, p| builder.query(&[("pageSize", p)]));
+        let builder = req.page_token.iter().fold(builder, |builder, p| builder.query(&[("pageToken", p)]));
+        let builder = req.filter.iter().fold(builder, |builder, p| builder.query(&[("filter", p)]));
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
@@ -116,7 +116,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        let builder = gax::query_parameter::add(builder, "secretId", &req.secret_id).map_err(Error::other)?;
+        let builder = builder.query(&[("secretId", &req.secret_id)]);
         self.inner.execute(
             builder,
             Some(req.request_body),
@@ -137,9 +137,9 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        let builder = gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
+        let builder = req.page_size.iter().fold(builder, |builder, p| builder.query(&[("pageSize", p)]));
+        let builder = req.page_token.iter().fold(builder, |builder, p| builder.query(&[("pageToken", p)]));
+        let builder = req.filter.iter().fold(builder, |builder, p| builder.query(&[("filter", p)]));
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
@@ -160,7 +160,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        let builder = gax::query_parameter::add(builder, "secretId", &req.secret_id).map_err(Error::other)?;
+        let builder = builder.query(&[("secretId", &req.secret_id)]);
         self.inner.execute(
             builder,
             Some(req.request_body),
@@ -242,7 +242,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        let builder = gax::query_parameter::add(builder, "etag", &req.etag).map_err(Error::other)?;
+        let builder = req.etag.iter().fold(builder, |builder, p| builder.query(&[("etag", p)]));
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
@@ -263,7 +263,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        let builder = gax::query_parameter::add(builder, "updateMask", &serde_json::to_value(&req.update_mask).map_err(Error::serde)?).map_err(Error::other)?;
+        let builder = { use gax::query_parameter::QueryParameter; serde_json::to_value(&req.update_mask).map_err(Error::serde)?.add(builder, "updateMask").map_err(Error::other)? };
         self.inner.execute(
             builder,
             Some(req.request_body),
@@ -306,7 +306,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        let builder = gax::query_parameter::add(builder, "etag", &req.etag).map_err(Error::other)?;
+        let builder = req.etag.iter().fold(builder, |builder, p| builder.query(&[("etag", p)]));
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
@@ -328,7 +328,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        let builder = gax::query_parameter::add(builder, "updateMask", &serde_json::to_value(&req.update_mask).map_err(Error::serde)?).map_err(Error::other)?;
+        let builder = { use gax::query_parameter::QueryParameter; serde_json::to_value(&req.update_mask).map_err(Error::serde)?.add(builder, "updateMask").map_err(Error::other)? };
         self.inner.execute(
             builder,
             Some(req.request_body),
@@ -349,9 +349,9 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        let builder = gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
+        let builder = req.page_size.iter().fold(builder, |builder, p| builder.query(&[("pageSize", p)]));
+        let builder = req.page_token.iter().fold(builder, |builder, p| builder.query(&[("pageToken", p)]));
+        let builder = req.filter.iter().fold(builder, |builder, p| builder.query(&[("filter", p)]));
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
@@ -373,9 +373,9 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        let builder = gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
+        let builder = req.page_size.iter().fold(builder, |builder, p| builder.query(&[("pageSize", p)]));
+        let builder = req.page_token.iter().fold(builder, |builder, p| builder.query(&[("pageToken", p)]));
+        let builder = req.filter.iter().fold(builder, |builder, p| builder.query(&[("filter", p)]));
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
@@ -652,7 +652,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        let builder = gax::query_parameter::add(builder, "options.requestedPolicyVersion", &req.options_requested_policy_version).map_err(Error::other)?;
+        let builder = req.options_requested_policy_version.iter().fold(builder, |builder, p| builder.query(&[("options.requestedPolicyVersion", p)]));
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
@@ -674,7 +674,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        let builder = gax::query_parameter::add(builder, "options.requestedPolicyVersion", &req.options_requested_policy_version).map_err(Error::other)?;
+        let builder = req.options_requested_policy_version.iter().fold(builder, |builder, p| builder.query(&[("options.requestedPolicyVersion", p)]));
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,

--- a/generator/testdata/rust/protobuf/golden/location/src/transport.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/transport.rs
@@ -52,9 +52,9 @@ impl crate::traits::Locations for Locations {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        let builder = gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token).map_err(Error::other)?;
+        let builder = builder.query(&[("filter", &req.filter)]);
+        let builder = builder.query(&[("pageSize", &req.page_size)]);
+        let builder = builder.query(&[("pageToken", &req.page_token)]);
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/transport.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/transport.rs
@@ -52,9 +52,9 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        let builder = gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
+        let builder = builder.query(&[("pageSize", &req.page_size)]);
+        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = builder.query(&[("filter", &req.filter)]);
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
@@ -74,7 +74,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        let builder = gax::query_parameter::add(builder, "secretId", &req.secret_id).map_err(Error::other)?;
+        let builder = builder.query(&[("secretId", &req.secret_id)]);
         self.inner.execute(
             builder,
             Some(req.secret),
@@ -132,7 +132,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        let builder = gax::query_parameter::add(builder, "updateMask", &serde_json::to_value(&req.update_mask).map_err(Error::serde)?).map_err(Error::other)?;
+        let builder = req.update_mask.iter().try_fold(builder, |builder, p| { use gax::query_parameter::QueryParameter; serde_json::to_value(p).map_err(Error::serde)?.add(builder, "updateMask").map_err(Error::other) })?;
         self.inner.execute(
             builder,
             Some(req.secret),
@@ -152,7 +152,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        let builder = gax::query_parameter::add(builder, "etag", &req.etag).map_err(Error::other)?;
+        let builder = builder.query(&[("etag", &req.etag)]);
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
@@ -172,9 +172,9 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        let builder = gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
+        let builder = builder.query(&[("pageSize", &req.page_size)]);
+        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = builder.query(&[("filter", &req.filter)]);
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
@@ -308,7 +308,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        let builder = gax::query_parameter::add(builder, "options", &serde_json::to_value(&req.options).map_err(Error::serde)?).map_err(Error::other)?;
+        let builder = req.options.iter().try_fold(builder, |builder, p| { use gax::query_parameter::QueryParameter; serde_json::to_value(p).map_err(Error::serde)?.add(builder, "options").map_err(Error::other) })?;
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,
@@ -347,9 +347,9 @@ impl crate::traits::SecretManagerService for SecretManagerService {
             ))
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        let builder = gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token).map_err(Error::other)?;
+        let builder = builder.query(&[("filter", &req.filter)]);
+        let builder = builder.query(&[("pageSize", &req.page_size)]);
+        let builder = builder.query(&[("pageToken", &req.page_token)]);
         self.inner.execute(
             builder,
             None::<gax::http_client::NoBody>,

--- a/src/generated/cloud/location/src/transport.rs
+++ b/src/generated/cloud/location/src/transport.rs
@@ -54,12 +54,9 @@ impl crate::traits::Locations for Locations {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder =
-            gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
-        let builder =
-            gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token)
-            .map_err(Error::other)?;
+        let builder = builder.query(&[("filter", &req.filter)]);
+        let builder = builder.query(&[("pageSize", &req.page_size)]);
+        let builder = builder.query(&[("pageToken", &req.page_token)]);
         self.inner
             .execute(builder, None::<gax::http_client::NoBody>, options)
             .await

--- a/src/generated/cloud/secretmanager/v1/src/transport.rs
+++ b/src/generated/cloud/secretmanager/v1/src/transport.rs
@@ -54,12 +54,9 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder =
-            gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token)
-            .map_err(Error::other)?;
-        let builder =
-            gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
+        let builder = builder.query(&[("pageSize", &req.page_size)]);
+        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = builder.query(&[("filter", &req.filter)]);
         self.inner
             .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
@@ -79,8 +76,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder =
-            gax::query_parameter::add(builder, "secretId", &req.secret_id).map_err(Error::other)?;
+        let builder = builder.query(&[("secretId", &req.secret_id)]);
         self.inner.execute(builder, Some(req.secret), options).await
     }
 
@@ -145,12 +141,13 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = gax::query_parameter::add(
-            builder,
-            "updateMask",
-            &serde_json::to_value(&req.update_mask).map_err(Error::serde)?,
-        )
-        .map_err(Error::other)?;
+        let builder = req.update_mask.iter().try_fold(builder, |builder, p| {
+            use gax::query_parameter::QueryParameter;
+            serde_json::to_value(p)
+                .map_err(Error::serde)?
+                .add(builder, "updateMask")
+                .map_err(Error::other)
+        })?;
         self.inner.execute(builder, Some(req.secret), options).await
     }
 
@@ -168,8 +165,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder =
-            gax::query_parameter::add(builder, "etag", &req.etag).map_err(Error::other)?;
+        let builder = builder.query(&[("etag", &req.etag)]);
         self.inner
             .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
@@ -189,12 +185,9 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder =
-            gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token)
-            .map_err(Error::other)?;
-        let builder =
-            gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
+        let builder = builder.query(&[("pageSize", &req.page_size)]);
+        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = builder.query(&[("filter", &req.filter)]);
         self.inner
             .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
@@ -326,12 +319,13 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = gax::query_parameter::add(
-            builder,
-            "options",
-            &serde_json::to_value(&req.options).map_err(Error::serde)?,
-        )
-        .map_err(Error::other)?;
+        let builder = req.options.iter().try_fold(builder, |builder, p| {
+            use gax::query_parameter::QueryParameter;
+            serde_json::to_value(p)
+                .map_err(Error::serde)?
+                .add(builder, "options")
+                .map_err(Error::other)
+        })?;
         self.inner
             .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
@@ -371,12 +365,9 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder =
-            gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
-        let builder =
-            gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token)
-            .map_err(Error::other)?;
+        let builder = builder.query(&[("filter", &req.filter)]);
+        let builder = builder.query(&[("pageSize", &req.page_size)]);
+        let builder = builder.query(&[("pageToken", &req.page_token)]);
         self.inner
             .execute(builder, None::<gax::http_client::NoBody>, options)
             .await

--- a/src/generated/cloud/workflows/v1/src/transport.rs
+++ b/src/generated/cloud/workflows/v1/src/transport.rs
@@ -57,14 +57,10 @@ impl crate::traits::Workflows for Workflows {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder =
-            gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token)
-            .map_err(Error::other)?;
-        let builder =
-            gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
-        let builder =
-            gax::query_parameter::add(builder, "orderBy", &req.order_by).map_err(Error::other)?;
+        let builder = builder.query(&[("pageSize", &req.page_size)]);
+        let builder = builder.query(&[("pageToken", &req.page_token)]);
+        let builder = builder.query(&[("filter", &req.filter)]);
+        let builder = builder.query(&[("orderBy", &req.order_by)]);
         self.inner
             .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
@@ -84,8 +80,7 @@ impl crate::traits::Workflows for Workflows {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = gax::query_parameter::add(builder, "revisionId", &req.revision_id)
-            .map_err(Error::other)?;
+        let builder = builder.query(&[("revisionId", &req.revision_id)]);
         self.inner
             .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
@@ -108,8 +103,7 @@ impl crate::traits::Workflows for Workflows {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = gax::query_parameter::add(builder, "workflowId", &req.workflow_id)
-            .map_err(Error::other)?;
+        let builder = builder.query(&[("workflowId", &req.workflow_id)]);
         self.inner
             .execute(builder, Some(req.workflow), options)
             .await
@@ -156,12 +150,13 @@ impl crate::traits::Workflows for Workflows {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = gax::query_parameter::add(
-            builder,
-            "updateMask",
-            &serde_json::to_value(&req.update_mask).map_err(Error::serde)?,
-        )
-        .map_err(Error::other)?;
+        let builder = req.update_mask.iter().try_fold(builder, |builder, p| {
+            use gax::query_parameter::QueryParameter;
+            serde_json::to_value(p)
+                .map_err(Error::serde)?
+                .add(builder, "updateMask")
+                .map_err(Error::other)
+        })?;
         self.inner
             .execute(builder, Some(req.workflow), options)
             .await
@@ -181,12 +176,9 @@ impl crate::traits::Workflows for Workflows {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder =
-            gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
-        let builder =
-            gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token)
-            .map_err(Error::other)?;
+        let builder = builder.query(&[("filter", &req.filter)]);
+        let builder = builder.query(&[("pageSize", &req.page_size)]);
+        let builder = builder.query(&[("pageToken", &req.page_token)]);
         self.inner
             .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
@@ -225,12 +217,9 @@ impl crate::traits::Workflows for Workflows {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder =
-            gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
-        let builder =
-            gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token)
-            .map_err(Error::other)?;
+        let builder = builder.query(&[("filter", &req.filter)]);
+        let builder = builder.query(&[("pageSize", &req.page_size)]);
+        let builder = builder.query(&[("pageToken", &req.page_token)]);
         self.inner
             .execute(builder, None::<gax::http_client::NoBody>, options)
             .await

--- a/src/generated/longrunning/src/transport.rs
+++ b/src/generated/longrunning/src/transport.rs
@@ -54,12 +54,9 @@ impl crate::traits::Operations for Operations {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder =
-            gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
-        let builder =
-            gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token)
-            .map_err(Error::other)?;
+        let builder = builder.query(&[("filter", &req.filter)]);
+        let builder = builder.query(&[("pageSize", &req.page_size)]);
+        let builder = builder.query(&[("pageToken", &req.page_token)]);
         self.inner
             .execute(builder, None::<gax::http_client::NoBody>, options)
             .await

--- a/src/generated/openapi-validation/src/transport.rs
+++ b/src/generated/openapi-validation/src/transport.rs
@@ -57,12 +57,18 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder =
-            gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
-        let builder =
-            gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token)
-            .map_err(Error::other)?;
+        let builder = req
+            .filter
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("filter", p)]));
+        let builder = req
+            .page_size
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("pageSize", p)]));
+        let builder = req
+            .page_token
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("pageToken", p)]));
         self.inner
             .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
@@ -107,12 +113,18 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder =
-            gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token)
-            .map_err(Error::other)?;
-        let builder =
-            gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
+        let builder = req
+            .page_size
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("pageSize", p)]));
+        let builder = req
+            .page_token
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("pageToken", p)]));
+        let builder = req
+            .filter
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("filter", p)]));
         self.inner
             .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
@@ -135,8 +147,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder =
-            gax::query_parameter::add(builder, "secretId", &req.secret_id).map_err(Error::other)?;
+        let builder = builder.query(&[("secretId", &req.secret_id)]);
         self.inner
             .execute(builder, Some(req.request_body), options)
             .await
@@ -162,12 +173,18 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder =
-            gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token)
-            .map_err(Error::other)?;
-        let builder =
-            gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
+        let builder = req
+            .page_size
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("pageSize", p)]));
+        let builder = req
+            .page_token
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("pageToken", p)]));
+        let builder = req
+            .filter
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("filter", p)]));
         self.inner
             .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
@@ -193,8 +210,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder =
-            gax::query_parameter::add(builder, "secretId", &req.secret_id).map_err(Error::other)?;
+        let builder = builder.query(&[("secretId", &req.secret_id)]);
         self.inner
             .execute(builder, Some(req.request_body), options)
             .await
@@ -285,8 +301,10 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder =
-            gax::query_parameter::add(builder, "etag", &req.etag).map_err(Error::other)?;
+        let builder = req
+            .etag
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("etag", p)]));
         self.inner
             .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
@@ -309,12 +327,13 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = gax::query_parameter::add(
-            builder,
-            "updateMask",
-            &serde_json::to_value(&req.update_mask).map_err(Error::serde)?,
-        )
-        .map_err(Error::other)?;
+        let builder = {
+            use gax::query_parameter::QueryParameter;
+            serde_json::to_value(&req.update_mask)
+                .map_err(Error::serde)?
+                .add(builder, "updateMask")
+                .map_err(Error::other)?
+        };
         self.inner
             .execute(builder, Some(req.request_body), options)
             .await
@@ -365,8 +384,10 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder =
-            gax::query_parameter::add(builder, "etag", &req.etag).map_err(Error::other)?;
+        let builder = req
+            .etag
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("etag", p)]));
         self.inner
             .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
@@ -392,12 +413,13 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = gax::query_parameter::add(
-            builder,
-            "updateMask",
-            &serde_json::to_value(&req.update_mask).map_err(Error::serde)?,
-        )
-        .map_err(Error::other)?;
+        let builder = {
+            use gax::query_parameter::QueryParameter;
+            serde_json::to_value(&req.update_mask)
+                .map_err(Error::serde)?
+                .add(builder, "updateMask")
+                .map_err(Error::other)?
+        };
         self.inner
             .execute(builder, Some(req.request_body), options)
             .await
@@ -423,12 +445,18 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder =
-            gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token)
-            .map_err(Error::other)?;
-        let builder =
-            gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
+        let builder = req
+            .page_size
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("pageSize", p)]));
+        let builder = req
+            .page_token
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("pageToken", p)]));
+        let builder = req
+            .filter
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("filter", p)]));
         self.inner
             .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
@@ -454,12 +482,18 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder =
-            gax::query_parameter::add(builder, "pageSize", &req.page_size).map_err(Error::other)?;
-        let builder = gax::query_parameter::add(builder, "pageToken", &req.page_token)
-            .map_err(Error::other)?;
-        let builder =
-            gax::query_parameter::add(builder, "filter", &req.filter).map_err(Error::other)?;
+        let builder = req
+            .page_size
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("pageSize", p)]));
+        let builder = req
+            .page_token
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("pageToken", p)]));
+        let builder = req
+            .filter
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("filter", p)]));
         self.inner
             .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
@@ -769,12 +803,12 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = gax::query_parameter::add(
-            builder,
-            "options.requestedPolicyVersion",
-            &req.options_requested_policy_version,
-        )
-        .map_err(Error::other)?;
+        let builder = req
+            .options_requested_policy_version
+            .iter()
+            .fold(builder, |builder, p| {
+                builder.query(&[("options.requestedPolicyVersion", p)])
+            });
         self.inner
             .execute(builder, None::<gax::http_client::NoBody>, options)
             .await
@@ -800,12 +834,12 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = gax::query_parameter::add(
-            builder,
-            "options.requestedPolicyVersion",
-            &req.options_requested_policy_version,
-        )
-        .map_err(Error::other)?;
+        let builder = req
+            .options_requested_policy_version
+            .iter()
+            .fold(builder, |builder, p| {
+                builder.query(&[("options.requestedPolicyVersion", p)])
+            });
         self.inner
             .execute(builder, None::<gax::http_client::NoBody>, options)
             .await


### PR DESCRIPTION
Support enum query parameters. In the process, simplify the emitted code to
handle the case of optional and repeated parameters.

Part of the work for #610. Effectively enum query parameters work now, but I want to remove some unused code before declaring success (#739 if you want to see what is coming).