### PR TITLE
feat(generator/rust): disambiguate calls via Arc

### DIFF
--- a/generator/internal/language/templates/rust/crate/src/builders.rs.mustache
+++ b/generator/internal/language/templates/rust/crate/src/builders.rs.mustache
@@ -75,7 +75,13 @@ pub mod {{NameToSnake}} {
         /// on [{{NameToSnake}}][crate::client::{{ServiceNameToPascal}}::{{NameToSnake}}].
         {{/OperationInfo}}
         pub async fn send(self) -> Result<{{OutputTypeName}}> {
-            self.0.stub.{{NameToSnake}}(self.0.request, self.0.options).await
+            {{!
+                In rare cases `self.0.stub.foo` is ambiguous: we are calling
+                via `Arc<dyn T>` which implements `T` but also implements other
+                traits (e.g. `std::clone::Clone`) making the call ambiguous.
+                Using `*self.0.stub` makes the call not-ambiguous.
+            }}
+            (*self.0.stub).{{NameToSnake}}(self.0.request, self.0.options).await
         }
         {{#IsPageable}}
 

--- a/generator/testdata/rust/openapi/golden/src/builders.rs
+++ b/generator/testdata/rust/openapi/golden/src/builders.rs
@@ -62,7 +62,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListLocationsResponse> {
-            self.0.stub.list_locations(self.0.request, self.0.options).await
+            (*self.0.stub).list_locations(self.0.request, self.0.options).await
         }
 
         /// Streams the responses back.
@@ -133,7 +133,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Location> {
-            self.0.stub.get_location(self.0.request, self.0.options).await
+            (*self.0.stub).get_location(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `project`.
@@ -180,7 +180,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListSecretsResponse> {
-            self.0.stub.list_secrets(self.0.request, self.0.options).await
+            (*self.0.stub).list_secrets(self.0.request, self.0.options).await
         }
 
         /// Streams the responses back.
@@ -251,7 +251,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Secret> {
-            self.0.stub.create_secret(self.0.request, self.0.options).await
+            (*self.0.stub).create_secret(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `request_body`.
@@ -304,7 +304,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListSecretsResponse> {
-            self.0.stub.list_secrets_by_project_and_location(self.0.request, self.0.options).await
+            (*self.0.stub).list_secrets_by_project_and_location(self.0.request, self.0.options).await
         }
 
         /// Streams the responses back.
@@ -381,7 +381,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Secret> {
-            self.0.stub.create_secret_by_project_and_location(self.0.request, self.0.options).await
+            (*self.0.stub).create_secret_by_project_and_location(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `request_body`.
@@ -440,7 +440,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0.stub.add_secret_version(self.0.request, self.0.options).await
+            (*self.0.stub).add_secret_version(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `payload`.
@@ -499,7 +499,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0.stub.add_secret_version_by_project_and_location_and_secret(self.0.request, self.0.options).await
+            (*self.0.stub).add_secret_version_by_project_and_location_and_secret(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `payload`.
@@ -558,7 +558,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Secret> {
-            self.0.stub.get_secret(self.0.request, self.0.options).await
+            (*self.0.stub).get_secret(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `project`.
@@ -605,7 +605,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Empty> {
-            self.0.stub.delete_secret(self.0.request, self.0.options).await
+            (*self.0.stub).delete_secret(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `project`.
@@ -658,7 +658,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Secret> {
-            self.0.stub.update_secret(self.0.request, self.0.options).await
+            (*self.0.stub).update_secret(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `request_body`.
@@ -717,7 +717,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Secret> {
-            self.0.stub.get_secret_by_project_and_location_and_secret(self.0.request, self.0.options).await
+            (*self.0.stub).get_secret_by_project_and_location_and_secret(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `project`.
@@ -770,7 +770,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Empty> {
-            self.0.stub.delete_secret_by_project_and_location_and_secret(self.0.request, self.0.options).await
+            (*self.0.stub).delete_secret_by_project_and_location_and_secret(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `project`.
@@ -829,7 +829,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Secret> {
-            self.0.stub.update_secret_by_project_and_location_and_secret(self.0.request, self.0.options).await
+            (*self.0.stub).update_secret_by_project_and_location_and_secret(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `request_body`.
@@ -894,7 +894,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListSecretVersionsResponse> {
-            self.0.stub.list_secret_versions(self.0.request, self.0.options).await
+            (*self.0.stub).list_secret_versions(self.0.request, self.0.options).await
         }
 
         /// Streams the responses back.
@@ -971,7 +971,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListSecretVersionsResponse> {
-            self.0.stub.list_secret_versions_by_project_and_location_and_secret(self.0.request, self.0.options).await
+            (*self.0.stub).list_secret_versions_by_project_and_location_and_secret(self.0.request, self.0.options).await
         }
 
         /// Streams the responses back.
@@ -1054,7 +1054,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0.stub.get_secret_version(self.0.request, self.0.options).await
+            (*self.0.stub).get_secret_version(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `project`.
@@ -1107,7 +1107,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0.stub.get_secret_version_by_project_and_location_and_secret_and_version(self.0.request, self.0.options).await
+            (*self.0.stub).get_secret_version_by_project_and_location_and_secret_and_version(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `project`.
@@ -1166,7 +1166,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::AccessSecretVersionResponse> {
-            self.0.stub.access_secret_version(self.0.request, self.0.options).await
+            (*self.0.stub).access_secret_version(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `project`.
@@ -1219,7 +1219,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::AccessSecretVersionResponse> {
-            self.0.stub.access_secret_version_by_project_and_location_and_secret_and_version(self.0.request, self.0.options).await
+            (*self.0.stub).access_secret_version_by_project_and_location_and_secret_and_version(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `project`.
@@ -1278,7 +1278,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0.stub.disable_secret_version(self.0.request, self.0.options).await
+            (*self.0.stub).disable_secret_version(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `etag`.
@@ -1343,7 +1343,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0.stub.disable_secret_version_by_project_and_location_and_secret_and_version(self.0.request, self.0.options).await
+            (*self.0.stub).disable_secret_version_by_project_and_location_and_secret_and_version(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `etag`.
@@ -1408,7 +1408,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0.stub.enable_secret_version(self.0.request, self.0.options).await
+            (*self.0.stub).enable_secret_version(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `etag`.
@@ -1473,7 +1473,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0.stub.enable_secret_version_by_project_and_location_and_secret_and_version(self.0.request, self.0.options).await
+            (*self.0.stub).enable_secret_version_by_project_and_location_and_secret_and_version(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `etag`.
@@ -1538,7 +1538,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0.stub.destroy_secret_version(self.0.request, self.0.options).await
+            (*self.0.stub).destroy_secret_version(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `etag`.
@@ -1603,7 +1603,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0.stub.destroy_secret_version_by_project_and_location_and_secret_and_version(self.0.request, self.0.options).await
+            (*self.0.stub).destroy_secret_version_by_project_and_location_and_secret_and_version(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `etag`.
@@ -1668,7 +1668,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Policy> {
-            self.0.stub.set_iam_policy(self.0.request, self.0.options).await
+            (*self.0.stub).set_iam_policy(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `policy`.
@@ -1733,7 +1733,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Policy> {
-            self.0.stub.set_iam_policy_by_project_and_location_and_secret(self.0.request, self.0.options).await
+            (*self.0.stub).set_iam_policy_by_project_and_location_and_secret(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `policy`.
@@ -1798,7 +1798,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Policy> {
-            self.0.stub.get_iam_policy(self.0.request, self.0.options).await
+            (*self.0.stub).get_iam_policy(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `project`.
@@ -1851,7 +1851,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Policy> {
-            self.0.stub.get_iam_policy_by_project_and_location_and_secret(self.0.request, self.0.options).await
+            (*self.0.stub).get_iam_policy_by_project_and_location_and_secret(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `project`.
@@ -1910,7 +1910,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::TestIamPermissionsResponse> {
-            self.0.stub.test_iam_permissions(self.0.request, self.0.options).await
+            (*self.0.stub).test_iam_permissions(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `permissions`.
@@ -1969,7 +1969,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::TestIamPermissionsResponse> {
-            self.0.stub.test_iam_permissions_by_project_and_location_and_secret(self.0.request, self.0.options).await
+            (*self.0.stub).test_iam_permissions_by_project_and_location_and_secret(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `permissions`.

--- a/generator/testdata/rust/protobuf/golden/iam/v1/src/builders.rs
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/src/builders.rs
@@ -62,7 +62,7 @@ pub mod iam_policy {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Policy> {
-            self.0.stub.set_iam_policy(self.0.request, self.0.options).await
+            (*self.0.stub).set_iam_policy(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `resource`.
@@ -115,7 +115,7 @@ pub mod iam_policy {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Policy> {
-            self.0.stub.get_iam_policy(self.0.request, self.0.options).await
+            (*self.0.stub).get_iam_policy(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `resource`.
@@ -162,7 +162,7 @@ pub mod iam_policy {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::TestIamPermissionsResponse> {
-            self.0.stub.test_iam_permissions(self.0.request, self.0.options).await
+            (*self.0.stub).test_iam_permissions(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `resource`.

--- a/generator/testdata/rust/protobuf/golden/location/src/builders.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/builders.rs
@@ -62,7 +62,7 @@ pub mod locations {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListLocationsResponse> {
-            self.0.stub.list_locations(self.0.request, self.0.options).await
+            (*self.0.stub).list_locations(self.0.request, self.0.options).await
         }
 
         /// Streams the responses back.
@@ -133,7 +133,7 @@ pub mod locations {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Location> {
-            self.0.stub.get_location(self.0.request, self.0.options).await
+            (*self.0.stub).get_location(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `name`.

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/builders.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/builders.rs
@@ -62,7 +62,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListSecretsResponse> {
-            self.0.stub.list_secrets(self.0.request, self.0.options).await
+            (*self.0.stub).list_secrets(self.0.request, self.0.options).await
         }
 
         /// Streams the responses back.
@@ -133,7 +133,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Secret> {
-            self.0.stub.create_secret(self.0.request, self.0.options).await
+            (*self.0.stub).create_secret(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `parent`.
@@ -186,7 +186,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0.stub.add_secret_version(self.0.request, self.0.options).await
+            (*self.0.stub).add_secret_version(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `parent`.
@@ -233,7 +233,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Secret> {
-            self.0.stub.get_secret(self.0.request, self.0.options).await
+            (*self.0.stub).get_secret(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `name`.
@@ -274,7 +274,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Secret> {
-            self.0.stub.update_secret(self.0.request, self.0.options).await
+            (*self.0.stub).update_secret(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `secret`.
@@ -321,7 +321,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<wkt::Empty> {
-            self.0.stub.delete_secret(self.0.request, self.0.options).await
+            (*self.0.stub).delete_secret(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `name`.
@@ -368,7 +368,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListSecretVersionsResponse> {
-            self.0.stub.list_secret_versions(self.0.request, self.0.options).await
+            (*self.0.stub).list_secret_versions(self.0.request, self.0.options).await
         }
 
         /// Streams the responses back.
@@ -439,7 +439,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0.stub.get_secret_version(self.0.request, self.0.options).await
+            (*self.0.stub).get_secret_version(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `name`.
@@ -480,7 +480,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::AccessSecretVersionResponse> {
-            self.0.stub.access_secret_version(self.0.request, self.0.options).await
+            (*self.0.stub).access_secret_version(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `name`.
@@ -521,7 +521,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0.stub.disable_secret_version(self.0.request, self.0.options).await
+            (*self.0.stub).disable_secret_version(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `name`.
@@ -568,7 +568,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0.stub.enable_secret_version(self.0.request, self.0.options).await
+            (*self.0.stub).enable_secret_version(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `name`.
@@ -615,7 +615,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0.stub.destroy_secret_version(self.0.request, self.0.options).await
+            (*self.0.stub).destroy_secret_version(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `name`.
@@ -662,7 +662,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<iam::model::Policy> {
-            self.0.stub.set_iam_policy(self.0.request, self.0.options).await
+            (*self.0.stub).set_iam_policy(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `resource`.
@@ -715,7 +715,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<iam::model::Policy> {
-            self.0.stub.get_iam_policy(self.0.request, self.0.options).await
+            (*self.0.stub).get_iam_policy(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `resource`.
@@ -762,7 +762,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<iam::model::TestIamPermissionsResponse> {
-            self.0.stub.test_iam_permissions(self.0.request, self.0.options).await
+            (*self.0.stub).test_iam_permissions(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `resource`.
@@ -809,7 +809,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<location::model::ListLocationsResponse> {
-            self.0.stub.list_locations(self.0.request, self.0.options).await
+            (*self.0.stub).list_locations(self.0.request, self.0.options).await
         }
 
         /// Streams the responses back.
@@ -880,7 +880,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<location::model::Location> {
-            self.0.stub.get_location(self.0.request, self.0.options).await
+            (*self.0.stub).get_location(self.0.request, self.0.options).await
         }
 
         /// Sets the value of `name`.

--- a/src/generated/cloud/location/src/builders.rs
+++ b/src/generated/cloud/location/src/builders.rs
@@ -62,8 +62,7 @@ pub mod locations {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListLocationsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_locations(self.0.request, self.0.options)
                 .await
         }
@@ -137,8 +136,7 @@ pub mod locations {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Location> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_location(self.0.request, self.0.options)
                 .await
         }

--- a/src/generated/cloud/secretmanager/v1/src/builders.rs
+++ b/src/generated/cloud/secretmanager/v1/src/builders.rs
@@ -62,8 +62,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListSecretsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_secrets(self.0.request, self.0.options)
                 .await
         }
@@ -137,8 +136,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Secret> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .create_secret(self.0.request, self.0.options)
                 .await
         }
@@ -197,8 +195,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .add_secret_version(self.0.request, self.0.options)
                 .await
         }
@@ -248,7 +245,9 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Secret> {
-            self.0.stub.get_secret(self.0.request, self.0.options).await
+            (*self.0.stub)
+                .get_secret(self.0.request, self.0.options)
+                .await
         }
 
         /// Sets the value of `name`.
@@ -287,8 +286,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Secret> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .update_secret(self.0.request, self.0.options)
                 .await
         }
@@ -341,8 +339,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<wkt::Empty> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .delete_secret(self.0.request, self.0.options)
                 .await
         }
@@ -392,8 +389,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListSecretVersionsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_secret_versions(self.0.request, self.0.options)
                 .await
         }
@@ -470,8 +466,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_secret_version(self.0.request, self.0.options)
                 .await
         }
@@ -515,8 +510,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::AccessSecretVersionResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .access_secret_version(self.0.request, self.0.options)
                 .await
         }
@@ -560,8 +554,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .disable_secret_version(self.0.request, self.0.options)
                 .await
         }
@@ -611,8 +604,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .enable_secret_version(self.0.request, self.0.options)
                 .await
         }
@@ -662,8 +654,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .destroy_secret_version(self.0.request, self.0.options)
                 .await
         }
@@ -710,8 +701,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<iam_v1::model::Policy> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .set_iam_policy(self.0.request, self.0.options)
                 .await
         }
@@ -770,8 +760,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<iam_v1::model::Policy> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_iam_policy(self.0.request, self.0.options)
                 .await
         }
@@ -824,8 +813,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<iam_v1::model::TestIamPermissionsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .test_iam_permissions(self.0.request, self.0.options)
                 .await
         }
@@ -878,8 +866,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<location::model::ListLocationsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_locations(self.0.request, self.0.options)
                 .await
         }
@@ -953,8 +940,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<location::model::Location> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_location(self.0.request, self.0.options)
                 .await
         }

--- a/src/generated/cloud/workflows/v1/src/builders.rs
+++ b/src/generated/cloud/workflows/v1/src/builders.rs
@@ -62,8 +62,7 @@ pub mod workflows {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListWorkflowsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_workflows(self.0.request, self.0.options)
                 .await
         }
@@ -143,8 +142,7 @@ pub mod workflows {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Workflow> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_workflow(self.0.request, self.0.options)
                 .await
         }
@@ -196,8 +194,7 @@ pub mod workflows {
         /// This starts, but does not poll, a longrunning operation. More information
         /// on [create_workflow][crate::client::Workflows::create_workflow].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .create_workflow(self.0.request, self.0.options)
                 .await
         }
@@ -291,8 +288,7 @@ pub mod workflows {
         /// This starts, but does not poll, a longrunning operation. More information
         /// on [delete_workflow][crate::client::Workflows::delete_workflow].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .delete_workflow(self.0.request, self.0.options)
                 .await
         }
@@ -368,8 +364,7 @@ pub mod workflows {
         /// This starts, but does not poll, a longrunning operation. More information
         /// on [update_workflow][crate::client::Workflows::update_workflow].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .update_workflow(self.0.request, self.0.options)
                 .await
         }
@@ -458,8 +453,7 @@ pub mod workflows {
 
         /// Sends the request.
         pub async fn send(self) -> Result<location::model::ListLocationsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_locations(self.0.request, self.0.options)
                 .await
         }
@@ -533,8 +527,7 @@ pub mod workflows {
 
         /// Sends the request.
         pub async fn send(self) -> Result<location::model::Location> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_location(self.0.request, self.0.options)
                 .await
         }
@@ -578,8 +571,7 @@ pub mod workflows {
 
         /// Sends the request.
         pub async fn send(self) -> Result<longrunning::model::ListOperationsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_operations(self.0.request, self.0.options)
                 .await
         }
@@ -656,8 +648,7 @@ pub mod workflows {
 
         /// Sends the request.
         pub async fn send(self) -> Result<longrunning::model::Operation> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_operation(self.0.request, self.0.options)
                 .await
         }
@@ -701,8 +692,7 @@ pub mod workflows {
 
         /// Sends the request.
         pub async fn send(self) -> Result<wkt::Empty> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .delete_operation(self.0.request, self.0.options)
                 .await
         }

--- a/src/generated/iam/v1/src/builders.rs
+++ b/src/generated/iam/v1/src/builders.rs
@@ -62,8 +62,7 @@ pub mod iam_policy {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Policy> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .set_iam_policy(self.0.request, self.0.options)
                 .await
         }
@@ -122,8 +121,7 @@ pub mod iam_policy {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Policy> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_iam_policy(self.0.request, self.0.options)
                 .await
         }
@@ -176,8 +174,7 @@ pub mod iam_policy {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::TestIamPermissionsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .test_iam_permissions(self.0.request, self.0.options)
                 .await
         }

--- a/src/generated/longrunning/src/builders.rs
+++ b/src/generated/longrunning/src/builders.rs
@@ -62,8 +62,7 @@ pub mod operations {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListOperationsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_operations(self.0.request, self.0.options)
                 .await
         }
@@ -137,8 +136,7 @@ pub mod operations {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Operation> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_operation(self.0.request, self.0.options)
                 .await
         }
@@ -179,8 +177,7 @@ pub mod operations {
 
         /// Sends the request.
         pub async fn send(self) -> Result<wkt::Empty> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .delete_operation(self.0.request, self.0.options)
                 .await
         }
@@ -221,8 +218,7 @@ pub mod operations {
 
         /// Sends the request.
         pub async fn send(self) -> Result<wkt::Empty> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .cancel_operation(self.0.request, self.0.options)
                 .await
         }

--- a/src/generated/openapi-validation/src/builders.rs
+++ b/src/generated/openapi-validation/src/builders.rs
@@ -62,8 +62,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListLocationsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_locations(self.0.request, self.0.options)
                 .await
         }
@@ -143,8 +142,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Location> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_location(self.0.request, self.0.options)
                 .await
         }
@@ -191,8 +189,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListSecretsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_secrets(self.0.request, self.0.options)
                 .await
         }
@@ -272,8 +269,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Secret> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .create_secret(self.0.request, self.0.options)
                 .await
         }
@@ -334,8 +330,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListSecretsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_secrets_by_project_and_location(self.0.request, self.0.options)
                 .await
         }
@@ -426,8 +421,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Secret> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .create_secret_by_project_and_location(self.0.request, self.0.options)
                 .await
         }
@@ -492,8 +486,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .add_secret_version(self.0.request, self.0.options)
                 .await
         }
@@ -560,8 +553,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .add_secret_version_by_project_and_location_and_secret(
                     self.0.request,
                     self.0.options,
@@ -626,7 +618,9 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Secret> {
-            self.0.stub.get_secret(self.0.request, self.0.options).await
+            (*self.0.stub)
+                .get_secret(self.0.request, self.0.options)
+                .await
         }
 
         /// Sets the value of `project`.
@@ -671,8 +665,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Empty> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .delete_secret(self.0.request, self.0.options)
                 .await
         }
@@ -725,8 +718,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Secret> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .update_secret(self.0.request, self.0.options)
                 .await
         }
@@ -795,8 +787,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Secret> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_secret_by_project_and_location_and_secret(self.0.request, self.0.options)
                 .await
         }
@@ -856,8 +847,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Empty> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .delete_secret_by_project_and_location_and_secret(self.0.request, self.0.options)
                 .await
         }
@@ -923,8 +913,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Secret> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .update_secret_by_project_and_location_and_secret(self.0.request, self.0.options)
                 .await
         }
@@ -995,8 +984,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListSecretVersionsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_secret_versions(self.0.request, self.0.options)
                 .await
         }
@@ -1089,8 +1077,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListSecretVersionsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_secret_versions_by_project_and_location_and_secret(
                     self.0.request,
                     self.0.options,
@@ -1188,8 +1175,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_secret_version(self.0.request, self.0.options)
                 .await
         }
@@ -1251,8 +1237,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_secret_version_by_project_and_location_and_secret_and_version(
                     self.0.request,
                     self.0.options,
@@ -1317,8 +1302,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::AccessSecretVersionResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .access_secret_version(self.0.request, self.0.options)
                 .await
         }
@@ -1380,8 +1364,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::AccessSecretVersionResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .access_secret_version_by_project_and_location_and_secret_and_version(
                     self.0.request,
                     self.0.options,
@@ -1446,8 +1429,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .disable_secret_version(self.0.request, self.0.options)
                 .await
         }
@@ -1517,8 +1499,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .disable_secret_version_by_project_and_location_and_secret_and_version(
                     self.0.request,
                     self.0.options,
@@ -1589,8 +1570,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .enable_secret_version(self.0.request, self.0.options)
                 .await
         }
@@ -1660,8 +1640,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .enable_secret_version_by_project_and_location_and_secret_and_version(
                     self.0.request,
                     self.0.options,
@@ -1732,8 +1711,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .destroy_secret_version(self.0.request, self.0.options)
                 .await
         }
@@ -1803,8 +1781,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::SecretVersion> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .destroy_secret_version_by_project_and_location_and_secret_and_version(
                     self.0.request,
                     self.0.options,
@@ -1872,8 +1849,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Policy> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .set_iam_policy(self.0.request, self.0.options)
                 .await
         }
@@ -1946,8 +1922,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Policy> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .set_iam_policy_by_project_and_location_and_secret(self.0.request, self.0.options)
                 .await
         }
@@ -2018,8 +1993,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Policy> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_iam_policy(self.0.request, self.0.options)
                 .await
         }
@@ -2082,8 +2056,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Policy> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_iam_policy_by_project_and_location_and_secret(self.0.request, self.0.options)
                 .await
         }
@@ -2148,8 +2121,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::TestIamPermissionsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .test_iam_permissions(self.0.request, self.0.options)
                 .await
         }
@@ -2216,8 +2188,7 @@ pub mod secret_manager_service {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::TestIamPermissionsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .test_iam_permissions_by_project_and_location_and_secret(
                     self.0.request,
                     self.0.options,

--- a/src/generated/spanner/admin/database/v1/src/builders.rs
+++ b/src/generated/spanner/admin/database/v1/src/builders.rs
@@ -62,8 +62,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListDatabasesResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_databases(self.0.request, self.0.options)
                 .await
         }
@@ -136,8 +135,7 @@ pub mod database_admin {
         /// This starts, but does not poll, a longrunning operation. More information
         /// on [create_database][crate::client::DatabaseAdmin::create_database].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .create_database(self.0.request, self.0.options)
                 .await
         }
@@ -253,8 +251,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Database> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_database(self.0.request, self.0.options)
                 .await
         }
@@ -300,8 +297,7 @@ pub mod database_admin {
         /// This starts, but does not poll, a longrunning operation. More information
         /// on [update_database][crate::client::DatabaseAdmin::update_database].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .update_database(self.0.request, self.0.options)
                 .await
         }
@@ -396,8 +392,7 @@ pub mod database_admin {
         /// This starts, but does not poll, a longrunning operation. More information
         /// on [update_database_ddl][crate::client::DatabaseAdmin::update_database_ddl].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .update_database_ddl(self.0.request, self.0.options)
                 .await
         }
@@ -488,8 +483,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<wkt::Empty> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .drop_database(self.0.request, self.0.options)
                 .await
         }
@@ -530,8 +524,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::GetDatabaseDdlResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_database_ddl(self.0.request, self.0.options)
                 .await
         }
@@ -572,8 +565,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<iam_v1::model::Policy> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .set_iam_policy(self.0.request, self.0.options)
                 .await
         }
@@ -632,8 +624,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<iam_v1::model::Policy> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_iam_policy(self.0.request, self.0.options)
                 .await
         }
@@ -686,8 +677,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<iam_v1::model::TestIamPermissionsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .test_iam_permissions(self.0.request, self.0.options)
                 .await
         }
@@ -742,8 +732,7 @@ pub mod database_admin {
         /// This starts, but does not poll, a longrunning operation. More information
         /// on [create_backup][crate::client::DatabaseAdmin::create_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .create_backup(self.0.request, self.0.options)
                 .await
         }
@@ -848,8 +837,7 @@ pub mod database_admin {
         /// This starts, but does not poll, a longrunning operation. More information
         /// on [copy_backup][crate::client::DatabaseAdmin::copy_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .copy_backup(self.0.request, self.0.options)
                 .await
         }
@@ -954,7 +942,9 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Backup> {
-            self.0.stub.get_backup(self.0.request, self.0.options).await
+            (*self.0.stub)
+                .get_backup(self.0.request, self.0.options)
+                .await
         }
 
         /// Sets the value of `name`.
@@ -993,8 +983,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Backup> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .update_backup(self.0.request, self.0.options)
                 .await
         }
@@ -1047,8 +1036,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<wkt::Empty> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .delete_backup(self.0.request, self.0.options)
                 .await
         }
@@ -1089,8 +1077,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListBackupsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_backups(self.0.request, self.0.options)
                 .await
         }
@@ -1169,8 +1156,7 @@ pub mod database_admin {
         /// This starts, but does not poll, a longrunning operation. More information
         /// on [restore_database][crate::client::DatabaseAdmin::restore_database].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .restore_database(self.0.request, self.0.options)
                 .await
         }
@@ -1274,8 +1260,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListDatabaseOperationsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_database_operations(self.0.request, self.0.options)
                 .await
         }
@@ -1354,8 +1339,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListBackupOperationsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_backup_operations(self.0.request, self.0.options)
                 .await
         }
@@ -1432,8 +1416,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListDatabaseRolesResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_database_roles(self.0.request, self.0.options)
                 .await
         }
@@ -1504,8 +1487,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::BackupSchedule> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .create_backup_schedule(self.0.request, self.0.options)
                 .await
         }
@@ -1564,8 +1546,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::BackupSchedule> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_backup_schedule(self.0.request, self.0.options)
                 .await
         }
@@ -1609,8 +1590,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::BackupSchedule> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .update_backup_schedule(self.0.request, self.0.options)
                 .await
         }
@@ -1666,8 +1646,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<wkt::Empty> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .delete_backup_schedule(self.0.request, self.0.options)
                 .await
         }
@@ -1711,8 +1690,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListBackupSchedulesResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_backup_schedules(self.0.request, self.0.options)
                 .await
         }
@@ -1783,8 +1761,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<longrunning::model::ListOperationsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_operations(self.0.request, self.0.options)
                 .await
         }
@@ -1861,8 +1838,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<longrunning::model::Operation> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_operation(self.0.request, self.0.options)
                 .await
         }
@@ -1906,8 +1882,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<wkt::Empty> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .delete_operation(self.0.request, self.0.options)
                 .await
         }
@@ -1951,8 +1926,7 @@ pub mod database_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<wkt::Empty> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .cancel_operation(self.0.request, self.0.options)
                 .await
         }

--- a/src/generated/spanner/admin/instance/v1/src/builders.rs
+++ b/src/generated/spanner/admin/instance/v1/src/builders.rs
@@ -65,8 +65,7 @@ pub mod instance_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListInstanceConfigsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_instance_configs(self.0.request, self.0.options)
                 .await
         }
@@ -137,8 +136,7 @@ pub mod instance_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::InstanceConfig> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_instance_config(self.0.request, self.0.options)
                 .await
         }
@@ -187,8 +185,7 @@ pub mod instance_admin {
         /// This starts, but does not poll, a longrunning operation. More information
         /// on [create_instance_config][crate::client::InstanceAdmin::create_instance_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .create_instance_config(self.0.request, self.0.options)
                 .await
         }
@@ -294,8 +291,7 @@ pub mod instance_admin {
         /// This starts, but does not poll, a longrunning operation. More information
         /// on [update_instance_config][crate::client::InstanceAdmin::update_instance_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .update_instance_config(self.0.request, self.0.options)
                 .await
         }
@@ -393,8 +389,7 @@ pub mod instance_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<wkt::Empty> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .delete_instance_config(self.0.request, self.0.options)
                 .await
         }
@@ -452,8 +447,7 @@ pub mod instance_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListInstanceConfigOperationsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_instance_config_operations(self.0.request, self.0.options)
                 .await
         }
@@ -529,8 +523,7 @@ pub mod instance_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListInstancesResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_instances(self.0.request, self.0.options)
                 .await
         }
@@ -616,8 +609,7 @@ pub mod instance_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListInstancePartitionsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_instance_partitions(self.0.request, self.0.options)
                 .await
         }
@@ -696,8 +688,7 @@ pub mod instance_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::Instance> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_instance(self.0.request, self.0.options)
                 .await
         }
@@ -752,8 +743,7 @@ pub mod instance_admin {
         /// This starts, but does not poll, a longrunning operation. More information
         /// on [create_instance][crate::client::InstanceAdmin::create_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .create_instance(self.0.request, self.0.options)
                 .await
         }
@@ -848,8 +838,7 @@ pub mod instance_admin {
         /// This starts, but does not poll, a longrunning operation. More information
         /// on [update_instance][crate::client::InstanceAdmin::update_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .update_instance(self.0.request, self.0.options)
                 .await
         }
@@ -936,8 +925,7 @@ pub mod instance_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<wkt::Empty> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .delete_instance(self.0.request, self.0.options)
                 .await
         }
@@ -978,8 +966,7 @@ pub mod instance_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<iam_v1::model::Policy> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .set_iam_policy(self.0.request, self.0.options)
                 .await
         }
@@ -1038,8 +1025,7 @@ pub mod instance_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<iam_v1::model::Policy> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_iam_policy(self.0.request, self.0.options)
                 .await
         }
@@ -1092,8 +1078,7 @@ pub mod instance_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<iam_v1::model::TestIamPermissionsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .test_iam_permissions(self.0.request, self.0.options)
                 .await
         }
@@ -1146,8 +1131,7 @@ pub mod instance_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::InstancePartition> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_instance_partition(self.0.request, self.0.options)
                 .await
         }
@@ -1198,8 +1182,7 @@ pub mod instance_admin {
         /// This starts, but does not poll, a longrunning operation. More information
         /// on [create_instance_partition][crate::client::InstanceAdmin::create_instance_partition].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .create_instance_partition(self.0.request, self.0.options)
                 .await
         }
@@ -1300,8 +1283,7 @@ pub mod instance_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<wkt::Empty> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .delete_instance_partition(self.0.request, self.0.options)
                 .await
         }
@@ -1358,8 +1340,7 @@ pub mod instance_admin {
         /// This starts, but does not poll, a longrunning operation. More information
         /// on [update_instance_partition][crate::client::InstanceAdmin::update_instance_partition].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .update_instance_partition(self.0.request, self.0.options)
                 .await
         }
@@ -1457,8 +1438,7 @@ pub mod instance_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<crate::model::ListInstancePartitionOperationsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_instance_partition_operations(self.0.request, self.0.options)
                 .await
         }
@@ -1548,8 +1528,7 @@ pub mod instance_admin {
         /// This starts, but does not poll, a longrunning operation. More information
         /// on [move_instance][crate::client::InstanceAdmin::move_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .move_instance(self.0.request, self.0.options)
                 .await
         }
@@ -1635,8 +1614,7 @@ pub mod instance_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<longrunning::model::ListOperationsResponse> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .list_operations(self.0.request, self.0.options)
                 .await
         }
@@ -1713,8 +1691,7 @@ pub mod instance_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<longrunning::model::Operation> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .get_operation(self.0.request, self.0.options)
                 .await
         }
@@ -1758,8 +1735,7 @@ pub mod instance_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<wkt::Empty> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .delete_operation(self.0.request, self.0.options)
                 .await
         }
@@ -1803,8 +1779,7 @@ pub mod instance_admin {
 
         /// Sends the request.
         pub async fn send(self) -> Result<wkt::Empty> {
-            self.0
-                .stub
+            (*self.0.stub)
                 .cancel_operation(self.0.request, self.0.options)
                 .await
         }


### PR DESCRIPTION
We hold the `stub` in an `Arc<dyn T>`. That implements both `T` and
`std::clone::Clone` (and other traits) which makes calls to `.clone()`
ambiguous. Using `*stub` turns it into a call via `T` which is under
our control and (hopefully) leads to less ambiguity.

Fixes #770