### PR TITLE
chore: update googleapis circa 2025-01-21

### DIFF
--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -17,8 +17,8 @@ language             = 'rust'
 specification-format = 'protobuf'
 
 [source]
-googleapis-root             = 'https://github.com/googleapis/googleapis/archive/eabc14c4be8d2f5aac5188ccb65f8b3400831eb4.tar.gz'
-googleapis-sha256           = 'af788bc255eea94939a059bdeb4cc27bbd850ef41b5f96eb83cb8a7553b69f35'
+googleapis-root             = 'https://github.com/googleapis/googleapis/archive/318818b22ec2bd44ebe43fe662418b7dff032abf.tar.gz'
+googleapis-sha256           = 'c5428093a005df7899007d6809d0cc3223589154c78d9526a137063d802e9d31'
 extra-protos-root           = 'https://github.com/googleapis/gapic-showcase/archive/refs/tags/v0.35.5.tar.gz'
 extra-protos-sha256         = 'fd3c1b33080a75987433db924a576d576fa622aff4f14eee86b1dc959e7aef63'
 extra-protos-extracted-name = 'gapic-showcase-0.35.5'

--- a/.typos.toml
+++ b/.typos.toml
@@ -29,5 +29,3 @@ ser = "ser"
 [type.rust.extend-words]
 # The upstream comments for src/generated/type say "Requestor", `typos` recommends `Requester`.
 requestor = "requestor"
-# Spanner has a typo, needs to be fixed upstream.
-timzeone = "timzeone"

--- a/src/generated/spanner/admin/database/v1/src/model.rs
+++ b/src/generated/spanner/admin/database/v1/src/model.rs
@@ -1765,7 +1765,7 @@ pub mod backup_schedule {
 pub struct CrontabSpec {
     /// Required. Textual representation of the crontab. User can customize the
     /// backup frequency and the backup version time using the cron
-    /// expression. The version time must be in UTC timzeone.
+    /// expression. The version time must be in UTC timezone.
     ///
     /// The backup will contain an externally consistent copy of the
     /// database at the version time. Allowed frequencies are 12 hour, 1 day,


### PR DESCRIPTION
Incidentally this removes the need to override some typos in `.typos.toml`
