### PR TITLE
impl(gax): simplify errors on missing path parameter

### DIFF
--- a/src/gax/src/path_parameter.rs
+++ b/src/gax/src/path_parameter.rs
@@ -73,4 +73,17 @@ mod tests {
         assert_eq!("value", got);
         Ok(())
     }
+
+    #[test]
+    fn missing() {
+        let e = super::missing("abc123");
+        let fmt = format!("{e}");
+        assert!(fmt.contains("abc123"), "{e:?}");
+        let inner = e.as_inner::<super::Error>().unwrap();
+        match inner {
+            Error::MissingRequiredParameter(s) => {
+                assert_eq!(s.as_str(), "abc123");
+            }
+        }
+    }
 }

--- a/src/gax/src/path_parameter.rs
+++ b/src/gax/src/path_parameter.rs
@@ -41,6 +41,10 @@ pub enum Error {
     MissingRequiredParameter(String),
 }
 
+pub fn missing(name: &str) -> crate::error::Error {
+    crate::error::Error::other(Error::MissingRequiredParameter(name.to_string()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Part of the work for #764, #655, and #482 