### PR TITLE
feat(generator): improve http path management

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -144,6 +144,8 @@ type PathInfo struct {
 	//
 	// If this is empty then the body is not used.
 	BodyFieldPath string
+	// Language specific annotations
+	Codec any
 }
 
 // Normalized long running operation info

--- a/generator/internal/language/templates/rust/crate/src/transport.rs.mustache
+++ b/generator/internal/language/templates/rust/crate/src/transport.rs.mustache
@@ -54,13 +54,23 @@ impl crate::traits::{{NameToPascal}} for {{NameToPascal}} {
         req: {{InputTypeName}},
         options: gax::options::RequestOptions,
     ) -> Result<{{OutputTypeName}}> {
-        let options = options.set_default_idempotency(reqwest::Method::{{HTTPMethod}}.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::{{HTTPMethod}}, format!("{{HTTPPathFmt}}"
-               {{#HTTPPathArgs}}
-               , {{{.}}}
-               {{/HTTPPathArgs}}
-            ))
+        let options = options.set_default_idempotency(reqwest::Method::{{PathInfo.Codec.Method}}.is_idempotent());
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::{{PathInfo.Codec.Method}},
+                {{^PathInfo.Codec.HasPathArgs}}
+                {{! Sometimes there are no path args and `format!()` produces warnings }}
+                "{{PathInfo.Codec.PathFmt}}".to_string()
+                {{/PathInfo.Codec.HasPathArgs}}
+                {{#PathInfo.Codec.HasPathArgs}}
+                format!("{{PathInfo.Codec.PathFmt}}"
+                    {{#PathInfo.Codec.PathArgs}}
+                        , req{{{.}}}
+                    {{/PathInfo.Codec.PathArgs}}
+                )
+                {{/PathInfo.Codec.HasPathArgs}}
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         {{#QueryParams}}
@@ -68,7 +78,8 @@ impl crate::traits::{{NameToPascal}} for {{NameToPascal}} {
         {{/QueryParams}}
         self.inner.execute(
             builder,
-            {{#HasBody}}Some(req{{BodyAccessor}}){{/HasBody}}{{^HasBody}}None::<gax::http_client::NoBody>{{/HasBody}},
+            {{#PathInfo.Codec.HasBody}}Some(req{{BodyAccessor}}){{/PathInfo.Codec.HasBody}}
+            {{^PathInfo.Codec.HasBody}}None::<gax::http_client::NoBody>{{/PathInfo.Codec.HasBody}},
             options,
         ).await
     }

--- a/generator/testdata/rust/openapi/golden/src/transport.rs
+++ b/generator/testdata/rust/openapi/golden/src/transport.rs
@@ -46,10 +46,14 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListLocationsResponse> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/projects/{}/locations"
-               , req.project
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/projects/{}/locations"
+                        , req.project
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.filter.iter().fold(builder, |builder, p| builder.query(&[("filter", p)]));
@@ -57,6 +61,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder = req.page_token.iter().fold(builder, |builder, p| builder.query(&[("pageToken", p)]));
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -68,15 +73,20 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Location> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/projects/{}/locations/{}"
-               , req.project
-               , req.location
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/projects/{}/locations/{}"
+                        , req.project
+                        , req.location
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -88,10 +98,14 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretsResponse> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/projects/{}/secrets"
-               , req.project
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/projects/{}/secrets"
+                        , req.project
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.page_size.iter().fold(builder, |builder, p| builder.query(&[("pageSize", p)]));
@@ -99,6 +113,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder = req.filter.iter().fold(builder, |builder, p| builder.query(&[("filter", p)]));
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -110,16 +125,21 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/projects/{}/secrets"
-               , req.project
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/projects/{}/secrets"
+                        , req.project
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("secretId", &req.secret_id)]);
         self.inner.execute(
             builder,
-            Some(req.request_body),
+            Some(req.request_body)
+            ,
             options,
         ).await
     }
@@ -130,11 +150,15 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretsResponse> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/projects/{}/locations/{}/secrets"
-               , req.project
-               , req.location
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/projects/{}/locations/{}/secrets"
+                        , req.project
+                        , req.location
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.page_size.iter().fold(builder, |builder, p| builder.query(&[("pageSize", p)]));
@@ -142,6 +166,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder = req.filter.iter().fold(builder, |builder, p| builder.query(&[("filter", p)]));
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -153,17 +178,22 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/projects/{}/locations/{}/secrets"
-               , req.project
-               , req.location
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/projects/{}/locations/{}/secrets"
+                        , req.project
+                        , req.location
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("secretId", &req.secret_id)]);
         self.inner.execute(
             builder,
-            Some(req.request_body),
+            Some(req.request_body)
+            ,
             options,
         ).await
     }
@@ -174,16 +204,21 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/projects/{}/secrets/{}:addVersion"
-               , req.project
-               , req.secret
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/projects/{}/secrets/{}:addVersion"
+                        , req.project
+                        , req.secret
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
-            Some(req),
+            Some(req)
+            ,
             options,
         ).await
     }
@@ -194,17 +229,22 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/projects/{}/locations/{}/secrets/{}:addVersion"
-               , req.project
-               , req.location
-               , req.secret
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/projects/{}/locations/{}/secrets/{}:addVersion"
+                        , req.project
+                        , req.location
+                        , req.secret
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
-            Some(req),
+            Some(req)
+            ,
             options,
         ).await
     }
@@ -215,15 +255,20 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/projects/{}/secrets/{}"
-               , req.project
-               , req.secret
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/projects/{}/secrets/{}"
+                        , req.project
+                        , req.secret
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -235,16 +280,21 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Empty> {
         let options = options.set_default_idempotency(reqwest::Method::DELETE.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::DELETE, format!("/v1/projects/{}/secrets/{}"
-               , req.project
-               , req.secret
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::DELETE,
+                format!("/v1/projects/{}/secrets/{}"
+                        , req.project
+                        , req.secret
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.etag.iter().fold(builder, |builder, p| builder.query(&[("etag", p)]));
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -256,17 +306,22 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let options = options.set_default_idempotency(reqwest::Method::PATCH.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::PATCH, format!("/v1/projects/{}/secrets/{}"
-               , req.project
-               , req.secret
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::PATCH,
+                format!("/v1/projects/{}/secrets/{}"
+                        , req.project
+                        , req.secret
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = { use gax::query_parameter::QueryParameter; serde_json::to_value(&req.update_mask).map_err(Error::serde)?.add(builder, "updateMask") };
         self.inner.execute(
             builder,
-            Some(req.request_body),
+            Some(req.request_body)
+            ,
             options,
         ).await
     }
@@ -277,16 +332,21 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/projects/{}/locations/{}/secrets/{}"
-               , req.project
-               , req.location
-               , req.secret
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/projects/{}/locations/{}/secrets/{}"
+                        , req.project
+                        , req.location
+                        , req.secret
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -298,17 +358,22 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Empty> {
         let options = options.set_default_idempotency(reqwest::Method::DELETE.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::DELETE, format!("/v1/projects/{}/locations/{}/secrets/{}"
-               , req.project
-               , req.location
-               , req.secret
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::DELETE,
+                format!("/v1/projects/{}/locations/{}/secrets/{}"
+                        , req.project
+                        , req.location
+                        , req.secret
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.etag.iter().fold(builder, |builder, p| builder.query(&[("etag", p)]));
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -320,18 +385,23 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let options = options.set_default_idempotency(reqwest::Method::PATCH.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::PATCH, format!("/v1/projects/{}/locations/{}/secrets/{}"
-               , req.project
-               , req.location
-               , req.secret
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::PATCH,
+                format!("/v1/projects/{}/locations/{}/secrets/{}"
+                        , req.project
+                        , req.location
+                        , req.secret
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = { use gax::query_parameter::QueryParameter; serde_json::to_value(&req.update_mask).map_err(Error::serde)?.add(builder, "updateMask") };
         self.inner.execute(
             builder,
-            Some(req.request_body),
+            Some(req.request_body)
+            ,
             options,
         ).await
     }
@@ -342,11 +412,15 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretVersionsResponse> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/projects/{}/secrets/{}/versions"
-               , req.project
-               , req.secret
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/projects/{}/secrets/{}/versions"
+                        , req.project
+                        , req.secret
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.page_size.iter().fold(builder, |builder, p| builder.query(&[("pageSize", p)]));
@@ -354,6 +428,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder = req.filter.iter().fold(builder, |builder, p| builder.query(&[("filter", p)]));
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -365,12 +440,16 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretVersionsResponse> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/projects/{}/locations/{}/secrets/{}/versions"
-               , req.project
-               , req.location
-               , req.secret
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/projects/{}/locations/{}/secrets/{}/versions"
+                        , req.project
+                        , req.location
+                        , req.secret
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.page_size.iter().fold(builder, |builder, p| builder.query(&[("pageSize", p)]));
@@ -378,6 +457,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder = req.filter.iter().fold(builder, |builder, p| builder.query(&[("filter", p)]));
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -389,16 +469,21 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/projects/{}/secrets/{}/versions/{}"
-               , req.project
-               , req.secret
-               , req.version
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/projects/{}/secrets/{}/versions/{}"
+                        , req.project
+                        , req.secret
+                        , req.version
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -410,17 +495,22 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/projects/{}/locations/{}/secrets/{}/versions/{}"
-               , req.project
-               , req.location
-               , req.secret
-               , req.version
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/projects/{}/locations/{}/secrets/{}/versions/{}"
+                        , req.project
+                        , req.location
+                        , req.secret
+                        , req.version
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -432,16 +522,21 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::AccessSecretVersionResponse> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/projects/{}/secrets/{}/versions/{}:access"
-               , req.project
-               , req.secret
-               , req.version
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/projects/{}/secrets/{}/versions/{}:access"
+                        , req.project
+                        , req.secret
+                        , req.version
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -453,17 +548,22 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::AccessSecretVersionResponse> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/projects/{}/locations/{}/secrets/{}/versions/{}:access"
-               , req.project
-               , req.location
-               , req.secret
-               , req.version
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/projects/{}/locations/{}/secrets/{}/versions/{}:access"
+                        , req.project
+                        , req.location
+                        , req.secret
+                        , req.version
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -475,17 +575,22 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/projects/{}/secrets/{}/versions/{}:disable"
-               , req.project
-               , req.secret
-               , req.version
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/projects/{}/secrets/{}/versions/{}:disable"
+                        , req.project
+                        , req.secret
+                        , req.version
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
-            Some(req),
+            Some(req)
+            ,
             options,
         ).await
     }
@@ -496,18 +601,23 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/projects/{}/locations/{}/secrets/{}/versions/{}:disable"
-               , req.project
-               , req.location
-               , req.secret
-               , req.version
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/projects/{}/locations/{}/secrets/{}/versions/{}:disable"
+                        , req.project
+                        , req.location
+                        , req.secret
+                        , req.version
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
-            Some(req),
+            Some(req)
+            ,
             options,
         ).await
     }
@@ -518,17 +628,22 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/projects/{}/secrets/{}/versions/{}:enable"
-               , req.project
-               , req.secret
-               , req.version
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/projects/{}/secrets/{}/versions/{}:enable"
+                        , req.project
+                        , req.secret
+                        , req.version
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
-            Some(req),
+            Some(req)
+            ,
             options,
         ).await
     }
@@ -539,18 +654,23 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/projects/{}/locations/{}/secrets/{}/versions/{}:enable"
-               , req.project
-               , req.location
-               , req.secret
-               , req.version
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/projects/{}/locations/{}/secrets/{}/versions/{}:enable"
+                        , req.project
+                        , req.location
+                        , req.secret
+                        , req.version
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
-            Some(req),
+            Some(req)
+            ,
             options,
         ).await
     }
@@ -561,17 +681,22 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/projects/{}/secrets/{}/versions/{}:destroy"
-               , req.project
-               , req.secret
-               , req.version
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/projects/{}/secrets/{}/versions/{}:destroy"
+                        , req.project
+                        , req.secret
+                        , req.version
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
-            Some(req),
+            Some(req)
+            ,
             options,
         ).await
     }
@@ -582,18 +707,23 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/projects/{}/locations/{}/secrets/{}/versions/{}:destroy"
-               , req.project
-               , req.location
-               , req.secret
-               , req.version
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/projects/{}/locations/{}/secrets/{}/versions/{}:destroy"
+                        , req.project
+                        , req.location
+                        , req.secret
+                        , req.version
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
-            Some(req),
+            Some(req)
+            ,
             options,
         ).await
     }
@@ -604,16 +734,21 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/projects/{}/secrets/{}:setIamPolicy"
-               , req.project
-               , req.secret
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/projects/{}/secrets/{}:setIamPolicy"
+                        , req.project
+                        , req.secret
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
-            Some(req),
+            Some(req)
+            ,
             options,
         ).await
     }
@@ -624,17 +759,22 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/projects/{}/locations/{}/secrets/{}:setIamPolicy"
-               , req.project
-               , req.location
-               , req.secret
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/projects/{}/locations/{}/secrets/{}:setIamPolicy"
+                        , req.project
+                        , req.location
+                        , req.secret
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
-            Some(req),
+            Some(req)
+            ,
             options,
         ).await
     }
@@ -645,16 +785,21 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/projects/{}/secrets/{}:getIamPolicy"
-               , req.project
-               , req.secret
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/projects/{}/secrets/{}:getIamPolicy"
+                        , req.project
+                        , req.secret
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.options_requested_policy_version.iter().fold(builder, |builder, p| builder.query(&[("options.requestedPolicyVersion", p)]));
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -666,17 +811,22 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/projects/{}/locations/{}/secrets/{}:getIamPolicy"
-               , req.project
-               , req.location
-               , req.secret
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/projects/{}/locations/{}/secrets/{}:getIamPolicy"
+                        , req.project
+                        , req.location
+                        , req.secret
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.options_requested_policy_version.iter().fold(builder, |builder, p| builder.query(&[("options.requestedPolicyVersion", p)]));
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -688,16 +838,21 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::TestIamPermissionsResponse> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/projects/{}/secrets/{}:testIamPermissions"
-               , req.project
-               , req.secret
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/projects/{}/secrets/{}:testIamPermissions"
+                        , req.project
+                        , req.secret
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
-            Some(req),
+            Some(req)
+            ,
             options,
         ).await
     }
@@ -708,17 +863,22 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::TestIamPermissionsResponse> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/projects/{}/locations/{}/secrets/{}:testIamPermissions"
-               , req.project
-               , req.location
-               , req.secret
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/projects/{}/locations/{}/secrets/{}:testIamPermissions"
+                        , req.project
+                        , req.location
+                        , req.secret
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
-            Some(req),
+            Some(req)
+            ,
             options,
         ).await
     }

--- a/generator/testdata/rust/protobuf/golden/iam/v1/src/transport.rs
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/src/transport.rs
@@ -46,15 +46,20 @@ impl crate::traits::IAMPolicy for IAMPolicy {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/{}:setIamPolicy"
-               , req.resource
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/{}:setIamPolicy"
+                        , req.resource
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
-            Some(req),
+            Some(req)
+            ,
             options,
         ).await
     }
@@ -65,15 +70,20 @@ impl crate::traits::IAMPolicy for IAMPolicy {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Policy> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/{}:getIamPolicy"
-               , req.resource
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/{}:getIamPolicy"
+                        , req.resource
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
-            Some(req),
+            Some(req)
+            ,
             options,
         ).await
     }
@@ -84,15 +94,20 @@ impl crate::traits::IAMPolicy for IAMPolicy {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::TestIamPermissionsResponse> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/{}:testIamPermissions"
-               , req.resource
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/{}:testIamPermissions"
+                        , req.resource
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
-            Some(req),
+            Some(req)
+            ,
             options,
         ).await
     }

--- a/generator/testdata/rust/protobuf/golden/location/src/transport.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/transport.rs
@@ -46,10 +46,14 @@ impl crate::traits::Locations for Locations {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListLocationsResponse> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/{}"
-               , req.name
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/{}"
+                        , req.name
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("filter", &req.filter)]);
@@ -57,6 +61,7 @@ impl crate::traits::Locations for Locations {
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -68,14 +73,19 @@ impl crate::traits::Locations for Locations {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Location> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/{}"
-               , req.name
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/{}"
+                        , req.name
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/transport.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/transport.rs
@@ -46,10 +46,14 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretsResponse> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/{}/secrets"
-               , req.parent
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/{}/secrets"
+                        , req.parent
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("pageSize", &req.page_size)]);
@@ -57,6 +61,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder = builder.query(&[("filter", &req.filter)]);
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -68,16 +73,21 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/{}/secrets"
-               , req.parent
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/{}/secrets"
+                        , req.parent
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("secretId", &req.secret_id)]);
         self.inner.execute(
             builder,
-            Some(req.secret),
+            Some(req.secret)
+            ,
             options,
         ).await
     }
@@ -88,15 +98,20 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/{}:addVersion"
-               , req.parent
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/{}:addVersion"
+                        , req.parent
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
-            Some(req),
+            Some(req)
+            ,
             options,
         ).await
     }
@@ -107,14 +122,19 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/{}"
-               , req.name
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/{}"
+                        , req.name
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -126,16 +146,21 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::Secret> {
         let options = options.set_default_idempotency(reqwest::Method::PATCH.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::PATCH, format!("/v1/{}"
-               , gax::path_parameter::PathParameter::required(&req.secret, "secret").map_err(Error::other)?.name
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::PATCH,
+                format!("/v1/{}"
+                        , req.secret.as_ref().ok_or_else(|| gax::path_parameter::missing("secret"))?.name
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.update_mask.as_ref().map(|p| serde_json::to_value(p).map_err(Error::serde) ).transpose()?.into_iter().fold(builder, |builder, v| { use gax::query_parameter::QueryParameter; v.add(builder, "updateMask") });
         self.inner.execute(
             builder,
-            Some(req.secret),
+            Some(req.secret)
+            ,
             options,
         ).await
     }
@@ -146,15 +171,20 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<wkt::Empty> {
         let options = options.set_default_idempotency(reqwest::Method::DELETE.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::DELETE, format!("/v1/{}"
-               , req.name
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::DELETE,
+                format!("/v1/{}"
+                        , req.name
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("etag", &req.etag)]);
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -166,10 +196,14 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::ListSecretVersionsResponse> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/{}/versions"
-               , req.parent
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/{}/versions"
+                        , req.parent
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("pageSize", &req.page_size)]);
@@ -177,6 +211,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder = builder.query(&[("filter", &req.filter)]);
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -188,14 +223,19 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/{}"
-               , req.name
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/{}"
+                        , req.name
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -207,14 +247,19 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::AccessSecretVersionResponse> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/{}:access"
-               , req.name
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/{}:access"
+                        , req.name
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -226,15 +271,20 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/{}:disable"
-               , req.name
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/{}:disable"
+                        , req.name
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
-            Some(req),
+            Some(req)
+            ,
             options,
         ).await
     }
@@ -245,15 +295,20 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/{}:enable"
-               , req.name
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/{}:enable"
+                        , req.name
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
-            Some(req),
+            Some(req)
+            ,
             options,
         ).await
     }
@@ -264,15 +319,20 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<crate::model::SecretVersion> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/{}:destroy"
-               , req.name
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/{}:destroy"
+                        , req.name
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
-            Some(req),
+            Some(req)
+            ,
             options,
         ).await
     }
@@ -283,15 +343,20 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<iam::model::Policy> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/{}:setIamPolicy"
-               , req.resource
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/{}:setIamPolicy"
+                        , req.resource
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
-            Some(req),
+            Some(req)
+            ,
             options,
         ).await
     }
@@ -302,15 +367,20 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<iam::model::Policy> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/{}:getIamPolicy"
-               , req.resource
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/{}:getIamPolicy"
+                        , req.resource
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = req.options.as_ref().map(|p| serde_json::to_value(p).map_err(Error::serde) ).transpose()?.into_iter().fold(builder, |builder, v| { use gax::query_parameter::QueryParameter; v.add(builder, "options") });
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -322,15 +392,20 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<iam::model::TestIamPermissionsResponse> {
         let options = options.set_default_idempotency(reqwest::Method::POST.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::POST, format!("/v1/{}:testIamPermissions"
-               , req.resource
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::POST,
+                format!("/v1/{}:testIamPermissions"
+                        , req.resource
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
-            Some(req),
+            Some(req)
+            ,
             options,
         ).await
     }
@@ -341,10 +416,14 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<location::model::ListLocationsResponse> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/{}/locations"
-               , req.name
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/{}/locations"
+                        , req.name
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         let builder = builder.query(&[("filter", &req.filter)]);
@@ -352,6 +431,7 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await
@@ -363,14 +443,19 @@ impl crate::traits::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<location::model::Location> {
         let options = options.set_default_idempotency(reqwest::Method::GET.is_idempotent());
-        let builder = self.inner.builder(
-            reqwest::Method::GET, format!("/v1/{}"
-               , req.name
-            ))
+        let builder = self
+            .inner
+            .builder(
+                reqwest::Method::GET,
+                format!("/v1/{}"
+                        , req.name
+                )
+            )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
         self.inner.execute(
             builder,
+            
             None::<gax::http_client::NoBody>,
             options,
         ).await

--- a/src/generated/cloud/secretmanager/v1/src/transport.rs
+++ b/src/generated/cloud/secretmanager/v1/src/transport.rs
@@ -131,8 +131,9 @@ impl crate::traits::SecretManagerService for SecretManagerService {
                 reqwest::Method::PATCH,
                 format!(
                     "/v1/{}",
-                    gax::path_parameter::PathParameter::required(&req.secret, "secret")
-                        .map_err(Error::other)?
+                    req.secret
+                        .as_ref()
+                        .ok_or_else(|| gax::path_parameter::missing("secret"))?
                         .name
                 ),
             )

--- a/src/generated/cloud/workflows/v1/src/transport.rs
+++ b/src/generated/cloud/workflows/v1/src/transport.rs
@@ -140,8 +140,9 @@ impl crate::traits::Workflows for Workflows {
                 reqwest::Method::PATCH,
                 format!(
                     "/v1/{}",
-                    gax::path_parameter::PathParameter::required(&req.workflow, "workflow")
-                        .map_err(Error::other)?
+                    req.workflow
+                        .as_ref()
+                        .ok_or_else(|| gax::path_parameter::missing("workflow"))?
                         .name
                 ),
             )

--- a/src/generated/spanner/admin/database/v1/src/transport.rs
+++ b/src/generated/spanner/admin/database/v1/src/transport.rs
@@ -115,8 +115,9 @@ impl crate::traits::DatabaseAdmin for DatabaseAdmin {
                 reqwest::Method::PATCH,
                 format!(
                     "/v1/{}",
-                    gax::path_parameter::PathParameter::required(&req.database, "database")
-                        .map_err(Error::other)?
+                    req.database
+                        .as_ref()
+                        .ok_or_else(|| gax::path_parameter::missing("database"))?
                         .name
                 ),
             )
@@ -334,8 +335,9 @@ impl crate::traits::DatabaseAdmin for DatabaseAdmin {
                 reqwest::Method::PATCH,
                 format!(
                     "/v1/{}",
-                    gax::path_parameter::PathParameter::required(&req.backup, "backup")
-                        .map_err(Error::other)?
+                    req.backup
+                        .as_ref()
+                        .ok_or_else(|| gax::path_parameter::missing("backup"))?
                         .name
                 ),
             )
@@ -546,12 +548,10 @@ impl crate::traits::DatabaseAdmin for DatabaseAdmin {
                 reqwest::Method::PATCH,
                 format!(
                     "/v1/{}",
-                    gax::path_parameter::PathParameter::required(
-                        &req.backup_schedule,
-                        "backup_schedule"
-                    )
-                    .map_err(Error::other)?
-                    .name
+                    req.backup_schedule
+                        .as_ref()
+                        .ok_or_else(|| gax::path_parameter::missing("backup_schedule"))?
+                        .name
                 ),
             )
             .query(&[("alt", "json")])

--- a/src/generated/spanner/admin/instance/v1/src/transport.rs
+++ b/src/generated/spanner/admin/instance/v1/src/transport.rs
@@ -115,12 +115,10 @@ impl crate::traits::InstanceAdmin for InstanceAdmin {
                 reqwest::Method::PATCH,
                 format!(
                     "/v1/{}",
-                    gax::path_parameter::PathParameter::required(
-                        &req.instance_config,
-                        "instance_config"
-                    )
-                    .map_err(Error::other)?
-                    .name
+                    req.instance_config
+                        .as_ref()
+                        .ok_or_else(|| gax::path_parameter::missing("instance_config"))?
+                        .name
                 ),
             )
             .query(&[("alt", "json")])
@@ -307,8 +305,9 @@ impl crate::traits::InstanceAdmin for InstanceAdmin {
                 reqwest::Method::PATCH,
                 format!(
                     "/v1/{}",
-                    gax::path_parameter::PathParameter::required(&req.instance, "instance")
-                        .map_err(Error::other)?
+                    req.instance
+                        .as_ref()
+                        .ok_or_else(|| gax::path_parameter::missing("instance"))?
                         .name
                 ),
             )
@@ -470,12 +469,10 @@ impl crate::traits::InstanceAdmin for InstanceAdmin {
                 reqwest::Method::PATCH,
                 format!(
                     "/v1/{}",
-                    gax::path_parameter::PathParameter::required(
-                        &req.instance_partition,
-                        "instance_partition"
-                    )
-                    .map_err(Error::other)?
-                    .name
+                    req.instance_partition
+                        .as_ref()
+                        .ok_or_else(|| gax::path_parameter::missing("instance_partition"))?
+                        .name
                 ),
             )
             .query(&[("alt", "json")])


### PR DESCRIPTION
I need to support RPCs where the path is fixed (no parameters). It was easier
to fix the management of optional fields and enums at the same time.

Fixes #764 and helps with #655 and #482 