### PR TITLE
feat(generator): discover self-referential fields

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -291,6 +291,10 @@ type Field struct {
 	// some helper fields. These need to be marked so they can be excluded
 	// from serialized messages and in other places.
 	Synthetic bool
+	// Some fields have a type that refers (sometimes indirectly) to the
+	// containing message. That triggers slightly different code generation for
+	// some languages.
+	IsRecursive bool
 	// A placeholder to put language specific annotations.
 	Codec any
 }

--- a/generator/internal/api/recursive.go
+++ b/generator/internal/api/recursive.go
@@ -1,0 +1,45 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+func LabelRecursiveFields(model *API) {
+	for _, message := range model.State.MessageByID {
+		for _, field := range message.Fields {
+			field.IsRecursive = field.recursivelyReferences(message.ID, model)
+		}
+	}
+}
+
+func (field *Field) recursivelyReferences(messageID string, model *API) bool {
+	if field.Typez != MESSAGE_TYPE {
+		return false
+	}
+	if field.TypezID == messageID || field.IsRecursive {
+		return true
+	}
+	if fieldMessage, ok := model.State.MessageByID[field.TypezID]; ok {
+		return fieldMessage.recursivelyReferences(messageID, model)
+	}
+	return false
+}
+
+func (message *Message) recursivelyReferences(messageID string, model *API) bool {
+	for _, field := range message.Fields {
+		if field.recursivelyReferences(messageID, model) {
+			return true
+		}
+	}
+	return false
+}

--- a/generator/internal/api/recursive_test.go
+++ b/generator/internal/api/recursive_test.go
@@ -1,0 +1,158 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"testing"
+)
+
+func TestSimple(t *testing.T) {
+	field0 := &Field{
+		Name:  "a",
+		Typez: STRING_TYPE,
+	}
+	field1 := &Field{
+		Name:     "b",
+		Typez:    MESSAGE_TYPE,
+		TypezID:  ".test.Message",
+		Optional: true,
+	}
+	messages := []*Message{
+		{
+			Name: "Message",
+			ID:   ".test.Message",
+			Fields: []*Field{
+				field0, field1,
+			},
+		},
+	}
+	model := NewTestAPI(messages, []*Enum{}, []*Service{})
+	LabelRecursiveFields(model)
+	if field0.IsRecursive {
+		t.Errorf("mismatched IsRecursive field for %v", field0)
+	}
+	if !field1.IsRecursive {
+		t.Errorf("mismatched IsRecursive field for %v", field1)
+	}
+}
+
+func TestIndirect(t *testing.T) {
+	field0 := &Field{
+		Name:     "child",
+		Typez:    MESSAGE_TYPE,
+		TypezID:  ".test.ChildMessage",
+		Optional: true,
+	}
+	field1 := &Field{
+		Name:     "grand_child",
+		Typez:    MESSAGE_TYPE,
+		TypezID:  ".test.GrandChildMessage",
+		Optional: true,
+	}
+	field2 := &Field{
+		Name:     "back_to_grand_parent",
+		Typez:    MESSAGE_TYPE,
+		TypezID:  ".test.Message",
+		Optional: true,
+	}
+	messages := []*Message{
+		{
+			Name:   "Message",
+			ID:     ".test.Message",
+			Fields: []*Field{field0},
+		},
+		{
+			Name:   "ChildMessage",
+			ID:     ".test.ChildMessage",
+			Fields: []*Field{field1},
+		},
+		{
+			Name:   "GrandChildMessage",
+			ID:     ".test.GrandChildMessage",
+			Fields: []*Field{field2},
+		},
+	}
+	model := NewTestAPI(messages, []*Enum{}, []*Service{})
+	LabelRecursiveFields(model)
+	for _, field := range []*Field{field0, field1, field2} {
+		if !field.IsRecursive {
+			t.Errorf("IsRecursive should be true for field %s", field.Name)
+		}
+	}
+}
+
+func TestViaMap(t *testing.T) {
+	field0 := &Field{
+		Name:    "parent",
+		ID:      ".test.ChildMessage.parent",
+		Typez:   MESSAGE_TYPE,
+		TypezID: ".test.ParentMessage",
+	}
+	child := &Message{
+		Name:   "ChildMessage",
+		ID:     ".test.ChildMessage",
+		Fields: []*Field{field0},
+	}
+
+	field1 := &Field{
+		Repeated: false,
+		Optional: false,
+		Name:     "children",
+		ID:       ".test.ParentMessage.children",
+		Typez:    MESSAGE_TYPE,
+		TypezID:  ".test.ParentMessage.SingularMapEntry",
+	}
+	parent := &Message{
+		Name:   "ParentMessage",
+		ID:     ".test.ParentMessage",
+		Fields: []*Field{field1},
+	}
+
+	key := &Field{
+		Repeated: false,
+		Optional: false,
+		Name:     "key",
+		JSONName: "key",
+		ID:       ".test.ParentMessage.SingularMapEntry.key",
+		Typez:    STRING_TYPE,
+	}
+	value := &Field{
+		Repeated: false,
+		Optional: false,
+		Name:     "value",
+		JSONName: "value",
+		ID:       ".test.ParentMessage.SingularMapEntry.value",
+		Typez:    MESSAGE_TYPE,
+		TypezID:  ".test.ChildMessage",
+	}
+	map_message := &Message{
+		Name:    "SingularMapEntry",
+		Package: "test",
+		ID:      ".test.ParentMessage.SingularMapEntry",
+		IsMap:   true,
+		Fields:  []*Field{key, value},
+	}
+
+	model := NewTestAPI([]*Message{parent, child, map_message}, []*Enum{}, []*Service{})
+	LabelRecursiveFields(model)
+	for _, field := range []*Field{value, field0, field1} {
+		if !field.IsRecursive {
+			t.Errorf("expected IsRecursive to be true for field %s", field.ID)
+		}
+	}
+	if key.IsRecursive {
+		t.Errorf("expected IsRecursive to be false for field %s", key.ID)
+	}
+}

--- a/generator/internal/api/test.go
+++ b/generator/internal/api/test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,20 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package language
+package api
 
-import (
-	"strings"
+import "strings"
 
-	"github.com/googleapis/google-cloud-rust/generator/internal/api"
-)
-
-func newTestAPI(messages []*api.Message, enums []*api.Enum, services []*api.Service) *api.API {
-	state := &api.APIState{
-		MessageByID: make(map[string]*api.Message),
-		MethodByID:  make(map[string]*api.Method),
-		EnumByID:    make(map[string]*api.Enum),
-		ServiceByID: make(map[string]*api.Service),
+func NewTestAPI(messages []*Message, enums []*Enum, services []*Service) *API {
+	state := &APIState{
+		MessageByID: make(map[string]*Message),
+		MethodByID:  make(map[string]*Method),
+		EnumByID:    make(map[string]*Enum),
+		ServiceByID: make(map[string]*Service),
 	}
 	for _, m := range messages {
 		state.MessageByID[m.ID] = m
@@ -58,7 +54,7 @@ func newTestAPI(messages []*api.Message, enums []*api.Enum, services []*api.Serv
 		}
 	}
 
-	return &api.API{
+	return &API{
 		Name:     "Test",
 		Messages: messages,
 		Enums:    enums,

--- a/generator/internal/language/codec_test.go
+++ b/generator/internal/language/codec_test.go
@@ -63,7 +63,7 @@ func TestQueryParams(t *testing.T) {
 			},
 		},
 	}
-	test := newTestAPI(
+	test := api.NewTestAPI(
 		[]*api.Message{options, request},
 		[]*api.Enum{},
 		[]*api.Service{
@@ -161,7 +161,7 @@ func TestPathParams(t *testing.T) {
 			QueryParameters: map[string]bool{},
 		},
 	}
-	test := newTestAPI(
+	test := api.NewTestAPI(
 		[]*api.Message{secret, updateRequest, createRequest},
 		[]*api.Enum{},
 		[]*api.Service{

--- a/generator/internal/language/golang_test.go
+++ b/generator/internal/language/golang_test.go
@@ -94,7 +94,7 @@ func TestGo_EnumNames(t *testing.T) {
 		ID:   "..SecretVersion.State",
 	}
 
-	_ = newTestAPI([]*api.Message{message}, []*api.Enum{nested}, []*api.Service{})
+	_ = api.NewTestAPI([]*api.Message{message}, []*api.Enum{nested}, []*api.Service{})
 	if got := goEnumName(nested, nil); got != "SecretVersion_State" {
 		t.Errorf("mismatched message name, want=SecretVersion_Automatic, got=%s", got)
 	}
@@ -146,7 +146,7 @@ Maybe they wanted to show some JSON:
 }
 
 func TestGo_Validate(t *testing.T) {
-	api := newTestAPI(
+	api := api.NewTestAPI(
 		[]*api.Message{{Name: "m1", Package: "p1"}},
 		[]*api.Enum{{Name: "e1", Package: "p1"}},
 		[]*api.Service{{Name: "s1", Package: "p1"}})
@@ -157,7 +157,7 @@ func TestGo_Validate(t *testing.T) {
 
 func TestGo_ValidateMessageMismatch(t *testing.T) {
 	const sourceSpecificationPackageName = "p1"
-	test := newTestAPI(
+	test := api.NewTestAPI(
 		[]*api.Message{{Name: "m1", Package: "p1"}, {Name: "m2", Package: "p2"}},
 		[]*api.Enum{{Name: "e1", Package: "p1"}},
 		[]*api.Service{{Name: "s1", Package: "p1"}})
@@ -165,7 +165,7 @@ func TestGo_ValidateMessageMismatch(t *testing.T) {
 		t.Errorf("expected an error in API validation got=%s", sourceSpecificationPackageName)
 	}
 
-	test = newTestAPI(
+	test = api.NewTestAPI(
 		[]*api.Message{{Name: "m1", Package: "p1"}},
 		[]*api.Enum{{Name: "e1", Package: "p1"}, {Name: "e2", Package: "p2"}},
 		[]*api.Service{{Name: "s1", Package: "p1"}})
@@ -173,7 +173,7 @@ func TestGo_ValidateMessageMismatch(t *testing.T) {
 		t.Errorf("expected an error in API validation got=%s", sourceSpecificationPackageName)
 	}
 
-	test = newTestAPI(
+	test = api.NewTestAPI(
 		[]*api.Message{{Name: "m1", Package: "p1"}},
 		[]*api.Enum{{Name: "e1", Package: "p1"}},
 		[]*api.Service{{Name: "s1", Package: "p1"}, {Name: "s2", Package: "p2"}})

--- a/generator/internal/language/gotemplate_test.go
+++ b/generator/internal/language/gotemplate_test.go
@@ -45,7 +45,7 @@ func Test_GoEnumAnnotations(t *testing.T) {
 		Values:        []*api.EnumValue{v0, v1, v2},
 	}
 
-	model := newTestAPI(
+	model := api.NewTestAPI(
 		[]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
 	_, err := newGoTemplateData(model, map[string]string{})
 	if err != nil {

--- a/generator/internal/language/rust_test.go
+++ b/generator/internal/language/rust_test.go
@@ -186,7 +186,7 @@ func checkRustPackages(t *testing.T, got *rustCodec, want *rustCodec) {
 }
 
 func TestRust_Validate(t *testing.T) {
-	model := newTestAPI(
+	model := api.NewTestAPI(
 		[]*api.Message{{Name: "m1", Package: "p1"}},
 		[]*api.Enum{{Name: "e1", Package: "p1"}},
 		[]*api.Service{{Name: "s1", Package: "p1"}})
@@ -196,7 +196,7 @@ func TestRust_Validate(t *testing.T) {
 }
 
 func TestRust_ValidateMessageMismatch(t *testing.T) {
-	test := newTestAPI(
+	test := api.NewTestAPI(
 		[]*api.Message{{Name: "m1", Package: "p1"}, {Name: "m2", Package: "p2"}},
 		[]*api.Enum{{Name: "e1", Package: "p1"}},
 		[]*api.Service{{Name: "s1", Package: "p1"}})
@@ -205,7 +205,7 @@ func TestRust_ValidateMessageMismatch(t *testing.T) {
 		t.Errorf("expected an error in API validation got=%s", c.sourceSpecificationPackageName)
 	}
 
-	test = newTestAPI(
+	test = api.NewTestAPI(
 		[]*api.Message{{Name: "m1", Package: "p1"}},
 		[]*api.Enum{{Name: "e1", Package: "p1"}, {Name: "e2", Package: "p2"}},
 		[]*api.Service{{Name: "s1", Package: "p1"}})
@@ -214,7 +214,7 @@ func TestRust_ValidateMessageMismatch(t *testing.T) {
 		t.Errorf("expected an error in API validation got=%s", c.sourceSpecificationPackageName)
 	}
 
-	test = newTestAPI(
+	test = api.NewTestAPI(
 		[]*api.Message{{Name: "m1", Package: "p1"}},
 		[]*api.Enum{{Name: "e1", Package: "p1"}},
 		[]*api.Service{{Name: "s1", Package: "p1"}, {Name: "s2", Package: "p2"}})
@@ -225,7 +225,7 @@ func TestRust_ValidateMessageMismatch(t *testing.T) {
 }
 
 func TestWellKnownTypesExist(t *testing.T) {
-	model := newTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	rustLoadWellKnownTypes(model.State)
 	for _, name := range []string{"Any", "Duration", "Empty", "FieldMask", "Timestamp"} {
 		if _, ok := model.State.MessageByID[fmt.Sprintf(".google.protobuf.%s", name)]; !ok {
@@ -239,7 +239,7 @@ func TestUsedByServicesWithServices(t *testing.T) {
 		Name: "TestService",
 		ID:   ".test.Service",
 	}
-	model := newTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
 	c, err := newRustCodec(map[string]string{
 		"package:tracing":  "used-if=services,package=tracing,version=0.1.41",
 		"package:location": "package=gcp-sdk-location,source=google.cloud.location,path=src/generated/cloud/location,version=0.1.0",
@@ -273,7 +273,7 @@ func TestUsedByServicesWithServices(t *testing.T) {
 }
 
 func TestUsedByServicesNoServices(t *testing.T) {
-	model := newTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	c, err := newRustCodec(map[string]string{
 		"package:tracing":  "used-if=services,package=tracing,version=0.1.41",
 		"package:location": "package=gcp-sdk-location,source=google.cloud.location,path=src/generated/cloud/location,version=0.1.0",
@@ -315,7 +315,7 @@ func TestUsedByLROsWithLRO(t *testing.T) {
 		ID:      ".test.Service",
 		Methods: []*api.Method{method},
 	}
-	model := newTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
 	c, err := newRustCodec(map[string]string{
 		"package:location": "package=gcp-sdk-location,source=google.cloud.location,path=src/generated/cloud/location,version=0.1.0",
 		"package:lro":      "used-if=lro,package=gcp-sdk-lro,path=src/lro,version=0.1.0",
@@ -358,7 +358,7 @@ func TestUsedByLROsWithoutLRO(t *testing.T) {
 		ID:      ".test.Service",
 		Methods: []*api.Method{method},
 	}
-	model := newTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{service})
 	c, err := newRustCodec(map[string]string{
 		"package:location": "package=gcp-sdk-location,source=google.cloud.location,path=src/generated/cloud/location,version=0.1.0",
 		"package:lro":      "used-if=lro,package=gcp-sdk-lro,path=src/lro,version=0.1.0",
@@ -396,7 +396,7 @@ func TestRust_NoStreamingFeature(t *testing.T) {
 	codec := &rustCodec{
 		extraPackages: []*rustPackage{},
 	}
-	model := newTestAPI([]*api.Message{
+	model := api.NewTestAPI([]*api.Message{
 		{Name: "CreateResource", IsPageableResponse: false},
 	}, []*api.Enum{}, []*api.Service{})
 	rustLoadWellKnownTypes(model.State)
@@ -465,7 +465,7 @@ func TestRust_StreamingFeature(t *testing.T) {
 func checkRustContext(t *testing.T, codec *rustCodec, wantFeatures string) {
 	t.Helper()
 
-	model := newTestAPI([]*api.Message{
+	model := api.NewTestAPI([]*api.Message{
 		{Name: "ListResources", IsPageableResponse: true},
 	}, []*api.Enum{}, []*api.Service{})
 	rustLoadWellKnownTypes(model.State)
@@ -482,7 +482,7 @@ func checkRustContext(t *testing.T, codec *rustCodec, wantFeatures string) {
 }
 
 func TestRust_WellKnownTypesAsMethod(t *testing.T) {
-	model := newTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	c := createRustCodec()
 	rustLoadWellKnownTypes(model.State)
 
@@ -503,7 +503,7 @@ func TestRust_MethodInOut(t *testing.T) {
 		ID:     "..Target.Nested",
 		Parent: message,
 	}
-	model := newTestAPI([]*api.Message{message, nested}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{message, nested}, []*api.Enum{}, []*api.Service{})
 	c := createRustCodec()
 	rustLoadWellKnownTypes(model.State)
 
@@ -592,7 +592,7 @@ func TestRust_FieldAttributes(t *testing.T) {
 			},
 		},
 	}
-	model := newTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
 
 	expectedAttributes := map[string]string{
 		"f_int64":          `#[serde_as(as = "serde_with::DisplayFromStr")]`,
@@ -725,7 +725,7 @@ func TestRust_MapFieldAttributes(t *testing.T) {
 			},
 		},
 	}
-	model := newTestAPI([]*api.Message{target, map1, map2, map3, map4, message}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{target, map1, map2, map3, map4, message}, []*api.Enum{}, []*api.Service{})
 
 	expectedAttributes := map[string]string{
 		"target":      `#[serde(skip_serializing_if = "std::option::Option::is_none")]`,
@@ -797,7 +797,7 @@ func TestRust_WktFieldAttributes(t *testing.T) {
 			},
 		},
 	}
-	model := newTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
 
 	expectedAttributes := map[string]string{
 		"f_int64":        `#[serde(skip_serializing_if = "std::option::Option::is_none")]` + "\n" + `#[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]`,
@@ -843,7 +843,7 @@ func TestRust_FieldLossyName(t *testing.T) {
 			},
 		},
 	}
-	model := newTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
 
 	expectedAttributes := map[string]string{
 		"data": `#[serde(skip_serializing_if = "bytes::Bytes::is_empty")]` + "\n" +
@@ -893,7 +893,7 @@ func TestRust_SyntheticField(t *testing.T) {
 			},
 		},
 	}
-	model := newTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
 
 	expectedAttributes := map[string]string{
 		"updateMask":  `#[serde(skip_serializing_if = "std::option::Option::is_none")]`,
@@ -988,7 +988,7 @@ func TestRust_FieldType(t *testing.T) {
 			},
 		},
 	}
-	model := newTestAPI([]*api.Message{target, message}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{target, message}, []*api.Enum{}, []*api.Service{})
 
 	expectedTypes := map[string]string{
 		"f_int32":              "i32",
@@ -1109,7 +1109,7 @@ func TestRust_AsQueryParameter(t *testing.T) {
 			requiredFieldMaskField, optionalFieldMaskField,
 		},
 	}
-	model := newTestAPI(
+	model := api.NewTestAPI(
 		[]*api.Message{options, request},
 		[]*api.Enum{},
 		[]*api.Service{})
@@ -1233,7 +1233,7 @@ Maybe they wanted to show some JSON:
 		"/// ```",
 	}
 
-	model := newTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	c := &rustCodec{}
 	got := rustFormatDocComments(input, model.State, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping)
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -1259,7 +1259,7 @@ func TestRust_FormatDocCommentsBullets(t *testing.T) {
 		"///   value in the third email_addresses message.)",
 	}
 
-	model := newTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	c := createRustCodec()
 	got := rustFormatDocComments(input, model.State, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping)
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -1335,7 +1335,7 @@ block:
 		"/// ```",
 	}
 
-	model := newTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	c := &rustCodec{}
 	got := rustFormatDocComments(input, model.State, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping)
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -1356,7 +1356,7 @@ func TestRust_FormatDocCommentsImplicitBlockQuoteClosing(t *testing.T) {
 		"/// ```",
 	}
 
-	model := newTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	c := &rustCodec{}
 	got := rustFormatDocComments(input, model.State, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping)
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -1453,7 +1453,7 @@ Second [example][].
 		"/// [Third]: https://www.third.com",
 	}
 
-	model := newTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	c := &rustCodec{}
 	got := rustFormatDocComments(input, model.State, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping)
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -1513,7 +1513,7 @@ func makeApiForRustFormatDocCommentsCrossLinks() *api.API {
 			{Name: "CreateBar", ID: ".test.v1.SomeService.CreateBar"},
 		},
 	}
-	a := newTestAPI(
+	a := api.NewTestAPI(
 		[]*api.Message{someMessage},
 		[]*api.Enum{someEnum},
 		[]*api.Service{someService})
@@ -1615,7 +1615,7 @@ func TestRust_MessageNames(t *testing.T) {
 		Package: "test",
 	}
 
-	model := newTestAPI([]*api.Message{message, nested}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{message, nested}, []*api.Enum{}, []*api.Service{})
 	model.PackageName = "test"
 
 	c := createRustCodec()
@@ -1665,7 +1665,7 @@ func TestRust_EnumNames(t *testing.T) {
 		Package: "test",
 	}
 
-	model := newTestAPI([]*api.Message{parent}, []*api.Enum{nested, non_nested}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{parent}, []*api.Enum{nested, non_nested}, []*api.Service{})
 	model.PackageName = "test"
 	c := createRustCodec()
 	c.sourceSpecificationPackageName = model.Messages[0].Package
@@ -1766,7 +1766,7 @@ func Test_RustPathArgs(t *testing.T) {
 		ID:      ".test.Service",
 		Methods: []*api.Method{method},
 	}
-	model := newTestAPI([]*api.Message{subMessage, message}, []*api.Enum{}, []*api.Service{service})
+	model := api.NewTestAPI([]*api.Message{subMessage, message}, []*api.Enum{}, []*api.Service{service})
 
 	for _, test := range []struct {
 		want     []string

--- a/generator/internal/language/rusttemplate_test.go
+++ b/generator/internal/language/rusttemplate_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestPackageNames(t *testing.T) {
-	model := newTestAPI(
+	model := api.NewTestAPI(
 		[]*api.Message{}, []*api.Enum{},
 		[]*api.Service{{Name: "Workflows", Package: "gcp-sdk-workflows-v1"}})
 	// Override the default name for test APIs ("Test").
@@ -65,7 +65,7 @@ func Test_RustEnumAnnotations(t *testing.T) {
 		Values:        []*api.EnumValue{v0, v1, v2},
 	}
 
-	model := newTestAPI(
+	model := api.NewTestAPI(
 		[]*api.Message{}, []*api.Enum{enum}, []*api.Service{})
 	codec, err := newRustCodec(map[string]string{})
 	if err != nil {


### PR DESCRIPTION
Message fields may refer to the same message, directly or indirectly. With this
change the fields are annotated with a `IsRecursive` field, the Codecs may use
this to change the field type. For example, in Rust we will need to use
`Option<Box<T>>`.

Part of the work for #586 