### PR TITLE
chore: unpin and update `serde_json`

### DIFF
--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -36,7 +36,7 @@ version = "0.1.0"
 'package:async-trait' = 'used-if=services,package=async-trait,version=0.1.84'
 'package:lazy_static' = 'used-if=services,package=lazy_static,version=1.5.0'
 'package:reqwest'     = 'used-if=services,package=reqwest,version=0.12.12,feature=json'
-'package:serde_json'  = 'used-if=services,package=serde_json,version=1.0.134'
+'package:serde_json'  = 'used-if=services,package=serde_json,version=1'
 'package:tracing'     = 'used-if=services,package=tracing,version=0.1.41'
 'package:gax'         = 'used-if=services,package=gcp-sdk-gax,path=src/gax,feature=unstable-sdk-client,version=0.1.0'
 # Only used if LROs are present

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.12.0"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f409eb70b561706bf8abba8ca9c112729c481595893fd06a2dd9af8ed8441148"
+checksum = "4c2b7ddaa2c56a367ad27a094ad8ef4faacf8a617c2575acb2ba88949df999ca"
 dependencies = [
  "aws-lc-sys",
  "paste",
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923ded50f602b3007e5e63e3f094c479d9c8a9b42d7f4034e4afe456aa48bfd2"
+checksum = "71b2ddd3ada61a305e1d8bb6c005d1eaa7d14d903681edfc400406d523a9b491"
 dependencies = [
  "bindgen",
  "cc",
@@ -223,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "built"
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.7"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",
@@ -1090,7 +1090,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1424,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -1462,9 +1462,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "itertools"
@@ -1492,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1561,9 +1561,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "matchit"
@@ -1591,9 +1591,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
@@ -1936,9 +1936,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483f8c21f64f3ea09fe0f30f5d48c3e8eefe5dac9129f0075f76593b4c1da705"
+checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1946,9 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -2132,9 +2132,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.43"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags",
  "errno",
@@ -2145,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.20"
+version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2274,9 +2274,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
@@ -2300,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",
@@ -2342,7 +2342,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2482,9 +2482,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.95"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2877,9 +2877,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -2910,20 +2910,21 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -2935,9 +2936,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2948,9 +2949,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2958,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2971,15 +2972,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -28,7 +28,7 @@ async-trait    = "0.1.84"
 http           = "1.2.0"
 reqwest        = { version = "0.12.11", features = ["json"] }
 serde          = { version = "1.0.216", features = ["derive"] }
-serde_json     = "1.0.134"
+serde_json     = "1"
 thiserror      = "2"
 time           = { version = "0.3.37", features = ["serde"] }
 rustls         = "0.23.20"

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -33,7 +33,7 @@ pin-project = { version = "1.1.8", optional = true }
 rand        = "0.8.5"
 reqwest     = { version = "0.12.11", optional = true }
 serde       = "1.0.216"
-serde_json  = "1.0.134"
+serde_json  = "1"
 serde_with  = { version = "3.12.0", default-features = false, features = ["base64", "macros"] }
 thiserror   = "2.0.11"
 tokio       = { version = "1.42", features = ["macros", "rt-multi-thread"] }

--- a/src/gax/echo-server/Cargo.toml
+++ b/src/gax/echo-server/Cargo.toml
@@ -21,7 +21,7 @@ publish           = false
 
 [dependencies]
 axum       = "0.8.1"
-serde_json = "1.0.133"
+serde_json = "1"
 tokio      = { version = "1.42", features = ["macros"] }
 gax        = { path = "..", package = "gcp-sdk-gax", features = ["unstable-sdk-client", "unstable-stream"] }
 rpc        = { version = "0.1.0", path = "../../generated/rpc", package = "gcp-sdk-rpc" }

--- a/src/generated/cloud/kms/v1/Cargo.toml
+++ b/src/generated/cloud/kms/v1/Cargo.toml
@@ -36,7 +36,7 @@ longrunning = { version = "0.1.0", path = "../../../../../src/generated/longrunn
 lro        = { version = "0.0.0", path = "../../../../../src/lro", package = "gcp-sdk-lro" }
 reqwest    = { version = "0.12.12", features = ["json"] }
 serde      = { version = "1.0.216", features = ["serde_derive"] }
-serde_json = { version = "1.0.134" }
+serde_json = { version = "1" }
 serde_with = { version = "3.12.0", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1.41" }
 wkt        = { version = "0.1.0", path = "../../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/cloud/location/Cargo.toml
+++ b/src/generated/cloud/location/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.1.0", path = "../../../../src/gax", package = "gcp-s
 lazy_static = { version = "1.5.0" }
 reqwest    = { version = "0.12.12", features = ["json"] }
 serde      = { version = "1.0.216", features = ["serde_derive"] }
-serde_json = { version = "1.0.134" }
+serde_json = { version = "1" }
 serde_with = { version = "3.12.0", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1.41" }
 wkt        = { version = "0.1.0", path = "../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/cloud/run/v2/Cargo.toml
+++ b/src/generated/cloud/run/v2/Cargo.toml
@@ -37,7 +37,7 @@ lro        = { version = "0.0.0", path = "../../../../../src/lro", package = "gc
 reqwest    = { version = "0.12.12", features = ["json"] }
 rpc        = { version = "0.1.0", path = "../../../../../src/generated/rpc", package = "gcp-sdk-rpc" }
 serde      = { version = "1.0.216", features = ["serde_derive"] }
-serde_json = { version = "1.0.134" }
+serde_json = { version = "1" }
 serde_with = { version = "3.12.0", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1.41" }
 wkt        = { version = "0.1.0", path = "../../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/cloud/secretmanager/v1/Cargo.toml
+++ b/src/generated/cloud/secretmanager/v1/Cargo.toml
@@ -34,7 +34,7 @@ lazy_static = { version = "1.5.0" }
 location   = { version = "0.1.0", path = "../../../../../src/generated/cloud/location", package = "gcp-sdk-location" }
 reqwest    = { version = "0.12.12", features = ["json"] }
 serde      = { version = "1.0.216", features = ["serde_derive"] }
-serde_json = { version = "1.0.134" }
+serde_json = { version = "1" }
 serde_with = { version = "3.12.0", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1.41" }
 wkt        = { version = "0.1.0", path = "../../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/cloud/sql/v1/Cargo.toml
+++ b/src/generated/cloud/sql/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.1.0", path = "../../../../../src/gax", package = "gc
 lazy_static = { version = "1.5.0" }
 reqwest    = { version = "0.12.12", features = ["json"] }
 serde      = { version = "1.0.216", features = ["serde_derive"] }
-serde_json = { version = "1.0.134" }
+serde_json = { version = "1" }
 serde_with = { version = "3.12.0", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1.41" }
 wkt        = { version = "0.1.0", path = "../../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/cloud/translate/v3/Cargo.toml
+++ b/src/generated/cloud/translate/v3/Cargo.toml
@@ -36,7 +36,7 @@ lro        = { version = "0.0.0", path = "../../../../../src/lro", package = "gc
 reqwest    = { version = "0.12.12", features = ["json"] }
 rpc        = { version = "0.1.0", path = "../../../../../src/generated/rpc", package = "gcp-sdk-rpc" }
 serde      = { version = "1.0.216", features = ["serde_derive"] }
-serde_json = { version = "1.0.134" }
+serde_json = { version = "1" }
 serde_with = { version = "3.12.0", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1.41" }
 wkt        = { version = "0.1.0", path = "../../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/cloud/webrisk/v1/Cargo.toml
+++ b/src/generated/cloud/webrisk/v1/Cargo.toml
@@ -34,7 +34,7 @@ longrunning = { version = "0.1.0", path = "../../../../../src/generated/longrunn
 lro        = { version = "0.0.0", path = "../../../../../src/lro", package = "gcp-sdk-lro" }
 reqwest    = { version = "0.12.12", features = ["json"] }
 serde      = { version = "1.0.216", features = ["serde_derive"] }
-serde_json = { version = "1.0.134" }
+serde_json = { version = "1" }
 serde_with = { version = "3.12.0", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1.41" }
 wkt        = { version = "0.1.0", path = "../../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/cloud/workflows/v1/Cargo.toml
+++ b/src/generated/cloud/workflows/v1/Cargo.toml
@@ -35,7 +35,7 @@ longrunning = { version = "0.1.0", path = "../../../../../src/generated/longrunn
 lro        = { version = "0.0.0", path = "../../../../../src/lro", package = "gcp-sdk-lro" }
 reqwest    = { version = "0.12.12", features = ["json"] }
 serde      = { version = "1.0.216", features = ["serde_derive"] }
-serde_json = { version = "1.0.134" }
+serde_json = { version = "1" }
 serde_with = { version = "3.12.0", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1.41" }
 wkt        = { version = "0.1.0", path = "../../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/devtools/cloudbuild/v2/Cargo.toml
+++ b/src/generated/devtools/cloudbuild/v2/Cargo.toml
@@ -37,7 +37,7 @@ lro        = { version = "0.0.0", path = "../../../../../src/lro", package = "gc
 reqwest    = { version = "0.12.12", features = ["json"] }
 rpc        = { version = "0.1.0", path = "../../../../../src/generated/rpc", package = "gcp-sdk-rpc" }
 serde      = { version = "1.0.216", features = ["serde_derive"] }
-serde_json = { version = "1.0.134" }
+serde_json = { version = "1" }
 serde_with = { version = "3.12.0", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1.41" }
 wkt        = { version = "0.1.0", path = "../../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/devtools/cloudtrace/v2/Cargo.toml
+++ b/src/generated/devtools/cloudtrace/v2/Cargo.toml
@@ -33,7 +33,7 @@ lazy_static = { version = "1.5.0" }
 reqwest    = { version = "0.12.12", features = ["json"] }
 rpc        = { version = "0.1.0", path = "../../../../../src/generated/rpc", package = "gcp-sdk-rpc" }
 serde      = { version = "1.0.216", features = ["serde_derive"] }
-serde_json = { version = "1.0.134" }
+serde_json = { version = "1" }
 serde_with = { version = "3.12.0", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1.41" }
 wkt        = { version = "0.1.0", path = "../../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/iam/v1/Cargo.toml
+++ b/src/generated/iam/v1/Cargo.toml
@@ -33,7 +33,7 @@ gtype      = { version = "0.1.0", path = "../../../../src/generated/type", packa
 lazy_static = { version = "1.5.0" }
 reqwest    = { version = "0.12.12", features = ["json"] }
 serde      = { version = "1.0.216", features = ["serde_derive"] }
-serde_json = { version = "1.0.134" }
+serde_json = { version = "1" }
 serde_with = { version = "3.12.0", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1.41" }
 wkt        = { version = "0.1.0", path = "../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/longrunning/Cargo.toml
+++ b/src/generated/longrunning/Cargo.toml
@@ -33,7 +33,7 @@ lazy_static = { version = "1.5.0" }
 reqwest    = { version = "0.12.12", features = ["json"] }
 rpc        = { version = "0.1.0", path = "../../../src/generated/rpc", package = "gcp-sdk-rpc" }
 serde      = { version = "1.0.216", features = ["serde_derive"] }
-serde_json = { version = "1.0.134" }
+serde_json = { version = "1" }
 serde_with = { version = "3.12.0", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1.41" }
 wkt        = { version = "0.1.0", path = "../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/openapi-validation/Cargo.toml
+++ b/src/generated/openapi-validation/Cargo.toml
@@ -33,7 +33,7 @@ gax        = { version = "0.1.0", path = "../../../src/gax", package = "gcp-sdk-
 lazy_static = { version = "1.5.0" }
 reqwest    = { version = "0.12.12", features = ["json"] }
 serde      = { version = "1.0.216", features = ["serde_derive"] }
-serde_json = { version = "1.0.134" }
+serde_json = { version = "1" }
 serde_with = { version = "3.12.0", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1.41" }
 wkt        = { version = "0.1.0", path = "../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/spanner/admin/database/v1/Cargo.toml
+++ b/src/generated/spanner/admin/database/v1/Cargo.toml
@@ -36,7 +36,7 @@ lro        = { version = "0.0.0", path = "../../../../../../src/lro", package = 
 reqwest    = { version = "0.12.12", features = ["json"] }
 rpc        = { version = "0.1.0", path = "../../../../../../src/generated/rpc", package = "gcp-sdk-rpc" }
 serde      = { version = "1.0.216", features = ["serde_derive"] }
-serde_json = { version = "1.0.134" }
+serde_json = { version = "1" }
 serde_with = { version = "3.12.0", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1.41" }
 wkt        = { version = "0.1.0", path = "../../../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/generated/spanner/admin/instance/v1/Cargo.toml
+++ b/src/generated/spanner/admin/instance/v1/Cargo.toml
@@ -35,7 +35,7 @@ longrunning = { version = "0.1.0", path = "../../../../../../src/generated/longr
 lro        = { version = "0.0.0", path = "../../../../../../src/lro", package = "gcp-sdk-lro" }
 reqwest    = { version = "0.12.12", features = ["json"] }
 serde      = { version = "1.0.216", features = ["serde_derive"] }
-serde_json = { version = "1.0.134" }
+serde_json = { version = "1" }
 serde_with = { version = "3.12.0", default-features = false, features = ["base64", "macros", "std"] }
 tracing    = { version = "0.1.41" }
 wkt        = { version = "0.1.0", path = "../../../../../../src/wkt", package = "gcp-sdk-wkt" }

--- a/src/integration-tests/Cargo.toml
+++ b/src/integration-tests/Cargo.toml
@@ -34,7 +34,7 @@ bytes              = "1.8.0"
 crc32c             = "0.6.8"
 futures            = "0.3.31"
 rand               = "0.8.5"
-serde_json         = "1.0.134"
+serde_json         = "1"
 tokio              = { version = "1.42", features = ["full", "macros"] }
 tracing            = "0.1.41"
 tracing-subscriber = "0.3.19"

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -41,5 +41,5 @@ auth       = { path = "../auth", package = "gcp-sdk-auth" }
 lro        = { path = ".", package = "gcp-sdk-lro", features = ["unstable-stream"] }
 axum       = "0.8.1"
 tokio      = { version = "1.42", features = ["test-util"] }
-serde_json = "1.0.134"
+serde_json = "1"
 reqwest    = "0.12.11"

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -30,7 +30,7 @@ time   = []
 [dependencies]
 serde      = { version = "1.0.217", features = ["serde_derive"] }
 serde_with = { version = "3.12.0", default-features = false, features = ["base64", "macros", "std"] }
-serde_json = "1.0.134"
+serde_json = "1"
 time       = { version = "0.3.36", features = ["formatting", "parsing"] }
 chrono     = { version = "0.4.39", optional = true }
 thiserror  = "2"


### PR DESCRIPTION
Change the `Cargo.toml` files to just requires version `1`. We are happy
to get updates, and I do not think we depend on specific features or
bugfixes beyond 1.0.0. In any case, a `cargo update` updates the lock
file to get the latest version.

I am hoping this will make the dependabot updates less toily.
