### PR TITLE
cleanup(ci): use tf variable where possible

### DIFF
--- a/.gcb/builds/backend.tf
+++ b/.gcb/builds/backend.tf
@@ -14,7 +14,7 @@
 
 terraform {
   backend "gcs" {
-    bucket = "rust-sdk-testing-terraform"
+    bucket = "${var.project}-terraform"
     prefix = "gcb"
   }
 }


### PR DESCRIPTION
Someone is copying the terraform configuration, but with a different project. They noticed the project name could be substituted here.

https://github.com/googleapis/google-cloud-rust/blob/b412e6cb9134fe3e7caeb989aec77a45a840ea0b/.gcb/builds/variables.tf#L15-L17