### PR TITLE
ci(auth): placeholder GCB integration test config

### DIFF
--- a/src/auth/.gcb/integration.yaml
+++ b/src/auth/.gcb/integration.yaml
@@ -1,0 +1,27 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+options:
+  dynamic_substitutions: true
+  substitutionOption: 'ALLOW_LOOSE'
+  logging: CLOUD_LOGGING_ONLY
+serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'
+steps:
+  - name: 'rust:1.84-bookworm'
+    script: |
+      #!/usr/bin/env bash
+      set -e
+      # TODO(806) - For now, we just build the code. Eventually we will run real
+      # integration tests.
+      cargo build -p gcp-sdk-auth


### PR DESCRIPTION
Part of the work for #806

Introduce a placeholder config for running auth integration tests on GCB.

Keep it separate than the top level `.gcb/`, because these things have different owners/maintainers and access different projects with different permissions.

Note that `rust-auth-testing` also has a SA named `integration-test-runner`.