### PR TITLE
Revert "cleanup(ci): use tf variable where possible"

### DIFF
--- a/.gcb/builds/backend.tf
+++ b/.gcb/builds/backend.tf
@@ -14,7 +14,7 @@
 
 terraform {
   backend "gcs" {
-    bucket = "${var.project}-terraform"
+    bucket = "rust-sdk-testing-terraform"
     prefix = "gcb"
   }
 }


### PR DESCRIPTION
Reverts googleapis/google-cloud-rust#805

https://developer.hashicorp.com/terraform/language/backend says

```
A backend block cannot refer to named values (like input variables, locals, or data source attributes).
```

It was not possible to use a variable here, I now realize. I shall claim the first recorded :monkey: of the Rust SDK.