### PR TITLE
feat(generator): automatic `longrunning` mixin

### DIFF
--- a/generator/internal/parser/mixin.go
+++ b/generator/internal/parser/mixin.go
@@ -76,6 +76,24 @@ func loadMixinMethods(serviceConfig *serviceconfig.Service) mixinMethods {
 	return enabledMixinMethods
 }
 
+// appendLongrunningMixin appends the longrunning mixin. Many services have
+// LROs, which need the mixin to be usable, but do not include the mixin in the
+// service config YAML file.
+func appendLongrunningMixin(methods mixinMethods, files []*descriptorpb.FileDescriptorProto) (mixinMethods, []*descriptorpb.FileDescriptorProto) {
+	desc := protodesc.ToFileDescriptorProto(longrunningpb.File_google_longrunning_operations_proto)
+	for _, f := range files {
+		if f.GetName() == desc.GetName() {
+			return methods, files
+		}
+	}
+	files = append(files, desc)
+	methods[".google.protobuf.Operations.ListOperations"] = true
+	methods[".google.protobuf.Operations.GetOperation"] = true
+	methods[".google.protobuf.Operations.DeleteOperation"] = true
+	methods[".google.protobuf.Operations.CancelOperation"] = true
+	return methods, files
+}
+
 // Apply `serviceConfig` overrides to `targetMethod`.
 //
 // The service config file may include overrides to mixin method definitions.

--- a/generator/internal/parser/mixin.go
+++ b/generator/internal/parser/mixin.go
@@ -44,10 +44,16 @@ func loadMixins(serviceConfig *serviceconfig.Service, withLongrunning bool) (mix
 	var files []*descriptorpb.FileDescriptorProto
 	var enabledMixinMethods mixinMethods = make(map[string]bool)
 	var apiNames []string
+	hasLongrunning := false
 	for _, api := range serviceConfig.GetApis() {
+		// Only insert the service if needed. We want to preserve the order
+		// to make the generated code reproducible, so we cannot use a map.
+		if api.GetName() == longrunningService {
+			hasLongrunning = true
+		}
 		apiNames = append(apiNames, api.GetName())
 	}
-	if withLongrunning {
+	if withLongrunning && !hasLongrunning {
 		apiNames = append(apiNames, longrunningService)
 	}
 	if len(apiNames) < 2 {


### PR DESCRIPTION
Some services need the `longrunning` mixin, but their service config YAML file
does not provide it. Automatically add it when needed.

Fixes #781
