### PR TITLE
ci(auth): bootstrap terraform resources

### DIFF
--- a/src/auth/.gcb/bootstrap/.terraform.lock.hcl
+++ b/src/auth/.gcb/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.44.2"
+  constraints = "~> 5.44.0"
+  hashes = [
+    "h1:gqtQa4oy2DGnwsGv2cYvvX0d4R6HYnMHEYMvTwYr8jI=",
+    "h1:ldYrjIeJlqK9UizqM4nuZnhyc+Bs3uA3TYPlmnkoXcI=",
+    "zh:2594d626d9148480688000b6c8e091d6bcc8f2a2dc28fe6e2ea27487f3c1726d",
+    "zh:2b0fafdb0ed7cbf4da5b4d7f3541ccd4402ee8cbdd66ebe26eaf9e904951da01",
+    "zh:310b1b0ac4f244a51abce22e41c7904e4bee50b5c1b66fd8646368f94ea6e563",
+    "zh:67c24e70b74e3d52f60e1b32d9c113f8d11e5db7265463e44a5b07474b79177c",
+    "zh:6d5069bf1e30570ef5189ad994a4b09c998b0f2630e169cc0b9cf68deafbb38d",
+    "zh:71bf6eb0d865082d736732cd48d9cb04a81500c55c48da91ac99816149cb3cb2",
+    "zh:970a29056d63a41bee915e634922cbb9caba7d34604f4884f001bfaf1e208b07",
+    "zh:a3b5ea6d67459a3237afcaaad4034998c8435b1d222f0c163d868a2863af5d24",
+    "zh:c049cb7edd8c797d7dd5b8f5a7a3a5b84cc08a1c60a50858fcdbec5d4db3f599",
+    "zh:c17c1133fce9ed5fea39da65f1c3024d5e04a5f0b94fd0d217c4988f6c1a3efd",
+    "zh:c657377f55a8a7abc16be34d26936d7879740d732136d40972013871c678db02",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/src/auth/.gcb/bootstrap/README.md
+++ b/src/auth/.gcb/bootstrap/README.md
@@ -1,0 +1,49 @@
+# Terraform for Auth Integration Tests
+
+This document assumes you are familiar with the
+[Terraform set up for `rust-sdk-testing`](/.gcb/bootstrap/README.md).
+
+The terraform configuration for auth is separate because:
+
+- the resources belong to a different project (`rust-auth-testing` vs. `rust-sdk-testing`)
+- accessing the different projects requires different permissions
+
+## Usage
+
+Change your working directory, for example:
+
+```shell
+cd $HOME/google-cloud-rust/src/auth/.gcb/bootstrap
+```
+
+Initialize terraform:
+
+```shell
+terraform init
+```
+
+Restore the current state. This may result in no action if you happen to have
+an up-to-date state in your local files.
+
+```shell
+terraform plan -out /tmp/bootstrap.tplan
+```
+
+Execute the plan:
+
+```shell
+terraform apply /tmp/bootstrap.tplan
+```
+
+Make any changes to the configuration and commit them to git:
+
+```shell
+git commit -m"Cool changes" .
+```
+
+Prepare and execute a plan to update the bucket:
+
+```shell
+terraform plan -out /tmp/update.tplan
+terraform apply /tmp/update.tplan
+```

--- a/src/auth/.gcb/bootstrap/main.tf
+++ b/src/auth/.gcb/bootstrap/main.tf
@@ -1,0 +1,70 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.44.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project
+  region  = var.region
+  zone    = var.zone
+}
+
+# Re-import the state of the bucket from GCP. Normally one would store
+# terraform's state in a global backend, such as Google Cloud Storage. But this
+# is the terraform configuration to bootstrap such a backend. While re-importing
+# the state of each resource would not scale as the number of resources grows,
+# re-importing a single bootstrap resource seems manageable.
+import {
+  to = google_storage_bucket.terraform
+  id = "${var.project}-terraform"
+}
+
+# Create a bucket to store the Terraform data.
+resource "google_storage_bucket" "terraform" {
+  name          = "${var.project}-terraform"
+  force_destroy = false
+  # This prevents Terraform from deleting the bucket. Any plan to do so is
+  # rejected. If we really need to delete the bucket we must take additional
+  # steps.
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  # The bucket configuration.
+  location                    = "US"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+  # Keep multiple versions of each object so we can recover if needed.
+  versioning {
+    enabled = true
+  }
+  # Tidy up archived objects after a year. They are small, so there is no need
+  # to rush.
+  lifecycle_rule {
+    condition {
+      days_since_noncurrent_time = 365
+      with_state                 = "ARCHIVED"
+    }
+    action {
+      type = "Delete"
+    }
+  }
+}

--- a/src/auth/.gcb/bootstrap/variables.tf
+++ b/src/auth/.gcb/bootstrap/variables.tf
@@ -1,0 +1,25 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project" {
+  default = "rust-auth-testing"
+}
+
+variable "region" {
+  default = "us-central1"
+}
+
+variable "zone" {
+  default = "us-central1-f"
+}


### PR DESCRIPTION
Part of the work for #806 

Introduce a (pre-existing) GCS bucket to hold the terraform state (for when we actually start introducing testing resources). And commit the terraform state for this bootstrap to version control.

This is the same design as is used in the top level `.gcb/` directory.

Also, we might just see a `gcb-pr-auth-integration` build running due to a local terraform plan I have not committed yet. :scream: 