### PR TITLE
cleanup(generator): use annotations for fields

### DIFF
--- a/generator/internal/language/rusttemplate.go
+++ b/generator/internal/language/rusttemplate.go
@@ -123,7 +123,7 @@ type RustOperationInfo struct {
 	PackageNamespace   string
 }
 
-type RustOneOfAnnotation struct {
+type rustOneOfAnnotation struct {
 	// In Rust, `oneof` fields are fields inside a struct. These must be
 	// `snake_case`. Possibly mangled with `r#` if the name is a Rust reserved
 	// word.
@@ -140,7 +140,7 @@ type RustOneOfAnnotation struct {
 	DocLines              []string
 }
 
-type RustFieldAnnotations struct {
+type rustFieldAnnotations struct {
 	// In Rust, message fields are fields inside a struct. These must be
 	// `snake_case`. Possibly mangled with `r#` if the name is a Rust reserved
 	// word.
@@ -306,7 +306,7 @@ func newRustMessage(m *api.Message, state *api.APIState, deserializeWithDefaults
 		}),
 		ExplicitOneOfs: mapSlice(m.OneOfs, func(s *api.OneOf) *api.OneOf {
 			messageName := rustMessageScopeName(m, "", modulePath, sourceSpecificationPackageName, packageMapping)
-			s.Codec = &RustOneOfAnnotation{
+			s.Codec = &rustOneOfAnnotation{
 				FieldName:  rustToSnake(s.Name),
 				SetterName: rustToSnakeNoMangling(s.Name),
 				EnumName:   rustToPascal(s.Name),
@@ -390,7 +390,7 @@ func newRustField(field *api.Field, state *api.APIState, modulePath, sourceSpeci
 	if field == nil {
 		return nil
 	}
-	field.Codec = &RustFieldAnnotations{
+	field.Codec = &rustFieldAnnotations{
 		FieldName:          rustToSnake(field.Name),
 		SetterName:         rustToSnakeNoMangling(field.Name),
 		BranchName:         rustToPascal(field.Name),

--- a/generator/internal/language/templates/go/client.go.mustache
+++ b/generator/internal/language/templates/go/client.go.mustache
@@ -97,24 +97,24 @@ func (c *Client) {{ServiceName}}() *{{ServiceName}}{
 {{/DocLines}}
 func (s *{{ServiceName}}) {{NameToCamel}}(ctx context.Context, req *{{InputTypeName}}) (*{{OutputTypeName}}, error) {
     out := new({{OutputTypeName}})
-    {{#HasBody}}
+    {{#PathInfo.Codec.HasBody}}
     reqBody, err := json.Marshal(req{{BodyAccessor}})
     if err != nil {
         return nil, err
     }
-    {{/HasBody}}
+    {{/PathInfo.Codec.HasBody}}
     baseURL, err := url.Parse(s.baseURL)
     if err != nil {
 		return nil, err
 	}
-    baseURL.Path += fmt.Sprintf("{{HTTPPathFmt}}"{{#HTTPPathArgs}}{{.}}{{/HTTPPathArgs}})
+    baseURL.Path += fmt.Sprintf("{{PathInfo.Codec.PathFmt}}"{{#PathInfo.Codec.PathArgs}}{{.}}{{/PathInfo.Codec.PathArgs}})
     params := url.Values{}
     params.Add("$alt", "json")
     {{#QueryParams}}
-    params.Add("{{JSONName}}", fmt.Sprintf("%v", {{AsQueryParameter}}))
+    params.Add("{{JSONName}}", fmt.Sprintf("%v", {{Codec.AsQueryParameter}}))
     {{/QueryParams}}
     baseURL.RawQuery = params.Encode()
-    httpReq, err := http.NewRequestWithContext(ctx, "{{HTTPMethod}}", baseURL.String(), {{#HasBody}}bytes.NewReader(reqBody){{/HasBody}}{{^HasBody}}nil{{/HasBody}})
+    httpReq, err := http.NewRequestWithContext(ctx, "{{PathInfo.Codec.Method}}", baseURL.String(), {{#PathInfo.Codec.HasBody}}bytes.NewReader(reqBody){{/PathInfo.Codec.HasBody}}{{^PathInfo.Codec.HasBody}}nil{{/PathInfo.Codec.HasBody}})
     if err != nil {
         return nil, err
     }

--- a/generator/internal/language/templates/go/message.mustache
+++ b/generator/internal/language/templates/go/message.mustache
@@ -21,10 +21,10 @@ limitations under the License.
 type {{Name}} struct {
     {{#Fields}}
 
-    {{#DocLines}}
+    {{#Codec.DocLines}}
     // {{{.}}}
-    {{/DocLines}}
-    {{NameToPascal}} {{FieldType}} `json:"{{JSONName}},omitempty"`
+    {{/Codec.DocLines}}
+    {{Codec.Name}} {{Codec.FieldType}} `json:"{{JSONName}},omitempty"`
     {{/Fields}}
 }
 {{#NestedMessages}}


### PR DESCRIPTION
Use annotations instead of duplicating the api.* data structures. This
brings the golang Codec to parity with the Rust Codec.

Part of the work for #653 