### PR TITLE
ci(auth): terraform for GCB

### DIFF
--- a/src/auth/.gcb/builds/.terraform.lock.hcl
+++ b/src/auth/.gcb/builds/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.44.2"
+  constraints = "~> 5.44.0"
+  hashes = [
+    "h1:gqtQa4oy2DGnwsGv2cYvvX0d4R6HYnMHEYMvTwYr8jI=",
+    "h1:ldYrjIeJlqK9UizqM4nuZnhyc+Bs3uA3TYPlmnkoXcI=",
+    "zh:2594d626d9148480688000b6c8e091d6bcc8f2a2dc28fe6e2ea27487f3c1726d",
+    "zh:2b0fafdb0ed7cbf4da5b4d7f3541ccd4402ee8cbdd66ebe26eaf9e904951da01",
+    "zh:310b1b0ac4f244a51abce22e41c7904e4bee50b5c1b66fd8646368f94ea6e563",
+    "zh:67c24e70b74e3d52f60e1b32d9c113f8d11e5db7265463e44a5b07474b79177c",
+    "zh:6d5069bf1e30570ef5189ad994a4b09c998b0f2630e169cc0b9cf68deafbb38d",
+    "zh:71bf6eb0d865082d736732cd48d9cb04a81500c55c48da91ac99816149cb3cb2",
+    "zh:970a29056d63a41bee915e634922cbb9caba7d34604f4884f001bfaf1e208b07",
+    "zh:a3b5ea6d67459a3237afcaaad4034998c8435b1d222f0c163d868a2863af5d24",
+    "zh:c049cb7edd8c797d7dd5b8f5a7a3a5b84cc08a1c60a50858fcdbec5d4db3f599",
+    "zh:c17c1133fce9ed5fea39da65f1c3024d5e04a5f0b94fd0d217c4988f6c1a3efd",
+    "zh:c657377f55a8a7abc16be34d26936d7879740d732136d40972013871c678db02",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/src/auth/.gcb/builds/backend.tf
+++ b/src/auth/.gcb/builds/backend.tf
@@ -1,0 +1,20 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  backend "gcs" {
+    bucket = "rust-auth-testing-terraform"
+    prefix = "gcb"
+  }
+}

--- a/src/auth/.gcb/builds/grants/main.tf
+++ b/src/auth/.gcb/builds/grants/main.tf
@@ -1,0 +1,36 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project" {
+  type = string
+}
+
+data "google_project" "project" {
+}
+
+# This service account is created externally. It is used for all the builds.
+data "google_service_account" "integration-test-runner" {
+  account_id = "integration-test-runner"
+}
+
+# The service account will need to read tarballs uploaded by `gcloud submit`.
+resource "google_storage_bucket_iam_member" "sa-can-read-build-tarballs" {
+  bucket = "${var.project}_cloudbuild"
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${data.google_service_account.integration-test-runner.email}"
+}
+
+output "runner" {
+  value = data.google_service_account.integration-test-runner.id
+}

--- a/src/auth/.gcb/builds/main.tf
+++ b/src/auth/.gcb/builds/main.tf
@@ -1,0 +1,56 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.44.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project
+  region  = var.region
+  zone    = var.zone
+}
+
+# Enable Cloud Build
+module "services" {
+  source  = "./services"
+  project = var.project
+}
+
+# Create the resources we will need to run integration tests on.
+module "resources" {
+  source  = "./resources"
+  project = var.project
+}
+
+# Create the service account needed for GCB and grant it the necessary
+# permissions.
+module "grants" {
+  source      = "./grants"
+  project     = var.project
+}
+
+# Create the GCB triggers.
+module "triggers" {
+  depends_on      = [module.services, module.resources, module.grants]
+  source          = "./triggers"
+  project         = var.project
+  region          = var.region
+  service_account = module.grants.runner
+}

--- a/src/auth/.gcb/builds/resources/main.tf
+++ b/src/auth/.gcb/builds/resources/main.tf
@@ -1,0 +1,37 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project" {
+  type = string
+}
+
+# Create a bucket used by Cloud Build.
+resource "google_storage_bucket" "cloudbuild" {
+  name          = "${var.project}_cloudbuild"
+  uniform_bucket_level_access = true
+  force_destroy = false
+  # This prevents Terraform from deleting the bucket. Any plan to do so is
+  # rejected. If we really need to delete the bucket we must take additional
+  # steps.
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  # The bucket configuration.
+  location                    = "US-CENTRAL1"
+  storage_class               = "STANDARD"
+  versioning {
+    enabled = false
+  }
+}

--- a/src/auth/.gcb/builds/services/main.tf
+++ b/src/auth/.gcb/builds/services/main.tf
@@ -1,0 +1,27 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project" {}
+
+resource "google_project_service" "cloudbuild" {
+  project = var.project
+  service = "cloudbuild.googleapis.com"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+
+  disable_dependent_services = true
+}

--- a/src/auth/.gcb/builds/triggers/main.tf
+++ b/src/auth/.gcb/builds/triggers/main.tf
@@ -1,0 +1,119 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project" {}
+variable "region" {}
+variable "service_account" {}
+
+locals {
+  # Google Cloud Build installs an application on the GitHub organization or
+  # repository. This id is hard-coded here because there is no easy way [^1] to
+  # manage that installation via terraform.
+  #
+  # [^1]: there is a way, described in [Connecting a Gitub host programmatically]
+  #     but I would not call that "easy". It requires (for example) manually
+  #     creating a personally access token (PAT) on GitHub, and storing that
+  #     in the Terraform file.
+  # [Connecting a Gitub host programmatically]: https://cloud.google.com/build/docs/automating-builds/github/connect-repo-github?generation=2nd-gen#terraform
+  #
+  # There is one GCB App installation shared between `rust-auth-testing` and
+  # `rust-sdk-testing`.
+  #
+  gcb_app_installation_id = 1168573
+
+  # Google Cloud uses Secret Manager to save the Github access token. Similar to
+  # the previous problem. It is much easier to use the UI to create the
+  # connection and just record it here.
+  #
+  # This secret is shared between `rust-auth-testing` and `rust-sdk-testing`.
+  # It was manually copied from one test project to the other.
+  #
+  # ```
+  # SECRET=github-github-oauthtoken-319d75
+  # gcloud --project=rust-sdk-testing secrets versions access latest --secret=${SECRET} | \
+  #     gcloud --project=rust-auth-testing secrets create ${SECRET} --data-file=-
+  # ```
+  #
+  gcb_secret_name = "projects/${var.project}/secrets/github-github-oauthtoken-319d75/versions/latest"
+
+  # Add to this list of you want to have more triggers.
+  builds = {
+    integration = {}
+  }
+}
+
+# This is used to retrieve the project number. The project number is embedded in
+# certain P4 (Per-product per-project) service accounts.
+data "google_project" "project" {
+}
+
+resource "google_cloudbuildv2_connection" "github" {
+  project  = var.project
+  location = var.region
+  name     = "github"
+
+  github_config {
+    app_installation_id = local.gcb_app_installation_id
+    authorizer_credential {
+      oauth_token_secret_version = local.gcb_secret_name
+    }
+  }
+}
+
+resource "google_cloudbuildv2_repository" "main" {
+  project           = var.project
+  location          = var.region
+  name              = "googleapis-google-cloud-rust"
+  parent_connection = google_cloudbuildv2_connection.github.name
+  remote_uri        = "https://github.com/googleapis/google-cloud-rust.git"
+}
+
+resource "google_cloudbuild_trigger" "pull-request" {
+  for_each = tomap(local.builds)
+  location = var.region
+  name     = "gcb-pr-auth-${each.key}"
+  filename = "src/auth/.gcb/${each.key}.yaml"
+  tags     = ["pull-request", "name:${each.key}"]
+
+  service_account = var.service_account
+
+  repository_event_config {
+    repository = google_cloudbuildv2_repository.main.id
+    pull_request {
+      branch          = "^main$"
+      comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"
+    }
+  }
+
+  include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
+}
+
+resource "google_cloudbuild_trigger" "post-merge" {
+  for_each = tomap(local.builds)
+  location = var.region
+  name     = "gcb-pm-auth-${each.key}"
+  filename = "src/auth/.gcb/${each.key}.yaml"
+  tags     = ["post-merge", "push", "name:${each.key}"]
+
+  service_account = var.service_account
+
+  repository_event_config {
+    repository = google_cloudbuildv2_repository.main.id
+    push {
+      branch = "^main$"
+    }
+  }
+
+  include_build_logs = "INCLUDE_BUILD_LOGS_WITH_STATUS"
+}

--- a/src/auth/.gcb/builds/variables.tf
+++ b/src/auth/.gcb/builds/variables.tf
@@ -1,0 +1,25 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project" {
+  default = "rust-auth-testing"
+}
+
+variable "region" {
+  default = "us-central1"
+}
+
+variable "zone" {
+  default = "us-central1-f"
+}


### PR DESCRIPTION
Part of the work for #806 

Manage the auth GCB configuration (test runner SA, triggers, GH link) via terraform.

This is very similar to `.gcb/builds`, but with some name changes.

This configuration is live.