### PR TITLE
fix(generator/rust): service and methods links

### DIFF
--- a/generator/internal/language/rust.go
+++ b/generator/internal/language/rust.go
@@ -1203,9 +1203,9 @@ func rustMethodRustdocLink(m *api.Method, state *api.APIState, packageMapping ma
 func rustServiceRustdocLink(s *api.Service, packageMapping map[string]*rustPackage) string {
 	mapped, ok := rustMapPackage(s.Package, packageMapping)
 	if ok {
-		return fmt.Sprintf("%s::traits::%s", mapped.name, s.Name)
+		return fmt.Sprintf("%s::client::%s", mapped.name, rustToPascal(s.Name))
 	}
-	return fmt.Sprintf("crate::traits::%s", s.Name)
+	return fmt.Sprintf("crate::client::%s", rustToPascal(s.Name))
 }
 
 func rustProjectRoot(outdir string) string {

--- a/generator/internal/language/rust_test.go
+++ b/generator/internal/language/rust_test.go
@@ -1531,6 +1531,8 @@ func TestRust_FormatDocCommentsCrossLinks(t *testing.T) {
 [ENUM_VALUE][test.v1.SomeMessage.SomeEnum.ENUM_VALUE]
 [SomeService.CreateFoo][test.v1.SomeService.CreateFoo]
 [SomeService.CreateBar][test.v1.SomeService.CreateBar]
+[a method][test.v1.YELL.CreateThing]
+[the service name][test.v1.YELL]
 `
 	want := []string{
 		"/// [Any][google.protobuf.Any]",
@@ -1544,8 +1546,10 @@ func TestRust_FormatDocCommentsCrossLinks(t *testing.T) {
 		"/// [ENUM_VALUE][test.v1.SomeMessage.SomeEnum.ENUM_VALUE]",
 		"/// [SomeService.CreateFoo][test.v1.SomeService.CreateFoo]",
 		"/// [SomeService.CreateBar][test.v1.SomeService.CreateBar]",
+		"/// [a method][test.v1.YELL.CreateThing]",
+		"/// [the service name][test.v1.YELL]",
 		"///",
-		"/// [google.iam.v1.Iampolicy]: iam_v1::traits::Iampolicy",
+		"/// [google.iam.v1.Iampolicy]: iam_v1::client::Iampolicy",
 		"/// [google.iam.v1.SetIamPolicyRequest]: iam_v1::model::SetIamPolicyRequest",
 		"/// [google.protobuf.Any]: wkt::Any",
 		"/// [test.v1.SomeMessage]: crate::model::SomeMessage",
@@ -1553,10 +1557,13 @@ func TestRust_FormatDocCommentsCrossLinks(t *testing.T) {
 		"/// [test.v1.SomeMessage.SomeEnum.ENUM_VALUE]: crate::model::some_message::some_enum::ENUM_VALUE",
 		"/// [test.v1.SomeMessage.error]: crate::model::SomeMessage::result",
 		"/// [test.v1.SomeMessage.field]: crate::model::SomeMessage::field",
-		"/// [test.v1.SomeService]: crate::traits::SomeService",
+		"/// [test.v1.SomeService]: crate::client::SomeService",
 		// Skipped because the method is skipped
-		// "/// [test.v1.SomeService.CreateBar]: crate::traits::SomeService::create_bar",
-		"/// [test.v1.SomeService.CreateFoo]: crate::traits::SomeService::create_foo",
+		// "/// [test.v1.SomeService.CreateBar]: crate::client::SomeService::create_bar",
+		"/// [test.v1.SomeService.CreateFoo]: crate::client::SomeService::create_foo",
+		// Services named with all uppercase have a different mapping.
+		"/// [test.v1.YELL]: crate::client::Yell",
+		"/// [test.v1.YELL.CreateThing]: crate::client::Yell::create_thing",
 	}
 
 	wkt := &rustPackage{
@@ -1667,10 +1674,26 @@ func makeApiForRustFormatDocCommentsCrossLinks() *api.API {
 			{Name: "CreateBar", ID: ".test.v1.SomeService.CreateBar"},
 		},
 	}
+	yellyService := &api.Service{
+		Name: "YELL",
+		ID:   ".test.v1.YELL",
+		Methods: []*api.Method{
+			{
+				Name: "CreateThing",
+				ID:   ".test.v1.YELL.CreateThing",
+				PathInfo: &api.PathInfo{
+					Verb: "GET",
+					PathTemplate: []api.PathSegment{
+						api.NewLiteralPathSegment("/v1/thing"),
+					},
+				},
+			},
+		},
+	}
 	a := api.NewTestAPI(
 		[]*api.Message{someMessage},
 		[]*api.Enum{someEnum},
-		[]*api.Service{someService})
+		[]*api.Service{someService, yellyService})
 	a.PackageName = "test.v1"
 	a.State.MessageByID[".google.iam.v1.SetIamPolicyRequest"] = &api.Message{
 		Name:    "SetIamPolicyRequest",

--- a/generator/testdata/rust/protobuf/golden/location/src/model.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/model.rs
@@ -23,7 +23,7 @@ extern crate wkt;
 
 /// The request message for [Locations.ListLocations][google.cloud.location.Locations.ListLocations].
 ///
-/// [google.cloud.location.Locations.ListLocations]: crate::traits::Locations::list_locations
+/// [google.cloud.location.Locations.ListLocations]: crate::client::Locations::list_locations
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -81,7 +81,7 @@ impl wkt::message::Message for ListLocationsRequest {
 
 /// The response message for [Locations.ListLocations][google.cloud.location.Locations.ListLocations].
 ///
-/// [google.cloud.location.Locations.ListLocations]: crate::traits::Locations::list_locations
+/// [google.cloud.location.Locations.ListLocations]: crate::client::Locations::list_locations
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -133,7 +133,7 @@ impl gax::paginator::PageableResponse for ListLocationsResponse {
 
 /// The request message for [Locations.GetLocation][google.cloud.location.Locations.GetLocation].
 ///
-/// [google.cloud.location.Locations.GetLocation]: crate::traits::Locations::get_location
+/// [google.cloud.location.Locations.GetLocation]: crate::client::Locations::get_location
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/model.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/model.rs
@@ -353,8 +353,8 @@ pub struct SecretVersion {
     /// on
     /// [SecretManagerService.AddSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion].
     ///
-    /// [google.cloud.secretmanager.v1.SecretManagerService]: crate::traits::SecretManagerService
-    /// [google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion]: crate::traits::SecretManagerService::add_secret_version
+    /// [google.cloud.secretmanager.v1.SecretManagerService]: crate::client::SecretManagerService
+    /// [google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion]: crate::client::SecretManagerService::add_secret_version
     /// [google.cloud.secretmanager.v1.SecretPayload]: crate::model::SecretPayload
     pub client_specified_payload_checksum: bool,
 
@@ -1094,9 +1094,9 @@ pub struct SecretPayload {
     /// safely downconverted to uint32 in languages that support this type.
     /// <https://cloud.google.com/apis/design/design_patterns#integer_types>
     ///
-    /// [google.cloud.secretmanager.v1.SecretManagerService]: crate::traits::SecretManagerService
-    /// [google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion]: crate::traits::SecretManagerService::access_secret_version
-    /// [google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion]: crate::traits::SecretManagerService::add_secret_version
+    /// [google.cloud.secretmanager.v1.SecretManagerService]: crate::client::SecretManagerService
+    /// [google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion]: crate::client::SecretManagerService::access_secret_version
+    /// [google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion]: crate::client::SecretManagerService::add_secret_version
     /// [google.cloud.secretmanager.v1.SecretPayload.data]: crate::model::SecretPayload::data
     #[serde(rename = "dataCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
@@ -1128,7 +1128,7 @@ impl wkt::message::Message for SecretPayload {
 /// Request message for
 /// [SecretManagerService.ListSecrets][google.cloud.secretmanager.v1.SecretManagerService.ListSecrets].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.ListSecrets]: crate::traits::SecretManagerService::list_secrets
+/// [google.cloud.secretmanager.v1.SecretManagerService.ListSecrets]: crate::client::SecretManagerService::list_secrets
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1200,7 +1200,7 @@ impl wkt::message::Message for ListSecretsRequest {
 /// Response message for
 /// [SecretManagerService.ListSecrets][google.cloud.secretmanager.v1.SecretManagerService.ListSecrets].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.ListSecrets]: crate::traits::SecretManagerService::list_secrets
+/// [google.cloud.secretmanager.v1.SecretManagerService.ListSecrets]: crate::client::SecretManagerService::list_secrets
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1275,7 +1275,7 @@ impl gax::paginator::PageableResponse for ListSecretsResponse {
 /// Request message for
 /// [SecretManagerService.CreateSecret][google.cloud.secretmanager.v1.SecretManagerService.CreateSecret].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.CreateSecret]: crate::traits::SecretManagerService::create_secret
+/// [google.cloud.secretmanager.v1.SecretManagerService.CreateSecret]: crate::client::SecretManagerService::create_secret
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1336,7 +1336,7 @@ impl wkt::message::Message for CreateSecretRequest {
 /// Request message for
 /// [SecretManagerService.AddSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion]: crate::traits::SecretManagerService::add_secret_version
+/// [google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion]: crate::client::SecretManagerService::add_secret_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1385,7 +1385,7 @@ impl wkt::message::Message for AddSecretVersionRequest {
 /// Request message for
 /// [SecretManagerService.GetSecret][google.cloud.secretmanager.v1.SecretManagerService.GetSecret].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.GetSecret]: crate::traits::SecretManagerService::get_secret
+/// [google.cloud.secretmanager.v1.SecretManagerService.GetSecret]: crate::client::SecretManagerService::get_secret
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1419,7 +1419,7 @@ impl wkt::message::Message for GetSecretRequest {
 /// Request message for
 /// [SecretManagerService.ListSecretVersions][google.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions]: crate::traits::SecretManagerService::list_secret_versions
+/// [google.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions]: crate::client::SecretManagerService::list_secret_versions
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1491,7 +1491,7 @@ impl wkt::message::Message for ListSecretVersionsRequest {
 /// Response message for
 /// [SecretManagerService.ListSecretVersions][google.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions]: crate::traits::SecretManagerService::list_secret_versions
+/// [google.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions]: crate::client::SecretManagerService::list_secret_versions
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1567,7 +1567,7 @@ impl gax::paginator::PageableResponse for ListSecretVersionsResponse {
 /// Request message for
 /// [SecretManagerService.GetSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.GetSecretVersion].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.GetSecretVersion]: crate::traits::SecretManagerService::get_secret_version
+/// [google.cloud.secretmanager.v1.SecretManagerService.GetSecretVersion]: crate::client::SecretManagerService::get_secret_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1607,7 +1607,7 @@ impl wkt::message::Message for GetSecretVersionRequest {
 /// Request message for
 /// [SecretManagerService.UpdateSecret][google.cloud.secretmanager.v1.SecretManagerService.UpdateSecret].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.UpdateSecret]: crate::traits::SecretManagerService::update_secret
+/// [google.cloud.secretmanager.v1.SecretManagerService.UpdateSecret]: crate::client::SecretManagerService::update_secret
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1650,7 +1650,7 @@ impl wkt::message::Message for UpdateSecretRequest {
 /// Request message for
 /// [SecretManagerService.AccessSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion]: crate::traits::SecretManagerService::access_secret_version
+/// [google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion]: crate::client::SecretManagerService::access_secret_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1690,7 +1690,7 @@ impl wkt::message::Message for AccessSecretVersionRequest {
 /// Response message for
 /// [SecretManagerService.AccessSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion]: crate::traits::SecretManagerService::access_secret_version
+/// [google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion]: crate::client::SecretManagerService::access_secret_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1735,7 +1735,7 @@ impl wkt::message::Message for AccessSecretVersionResponse {
 /// Request message for
 /// [SecretManagerService.DeleteSecret][google.cloud.secretmanager.v1.SecretManagerService.DeleteSecret].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.DeleteSecret]: crate::traits::SecretManagerService::delete_secret
+/// [google.cloud.secretmanager.v1.SecretManagerService.DeleteSecret]: crate::client::SecretManagerService::delete_secret
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1783,7 +1783,7 @@ impl wkt::message::Message for DeleteSecretRequest {
 /// Request message for
 /// [SecretManagerService.DisableSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.DisableSecretVersion].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.DisableSecretVersion]: crate::traits::SecretManagerService::disable_secret_version
+/// [google.cloud.secretmanager.v1.SecretManagerService.DisableSecretVersion]: crate::client::SecretManagerService::disable_secret_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1833,7 +1833,7 @@ impl wkt::message::Message for DisableSecretVersionRequest {
 /// Request message for
 /// [SecretManagerService.EnableSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.EnableSecretVersion].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.EnableSecretVersion]: crate::traits::SecretManagerService::enable_secret_version
+/// [google.cloud.secretmanager.v1.SecretManagerService.EnableSecretVersion]: crate::client::SecretManagerService::enable_secret_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1883,7 +1883,7 @@ impl wkt::message::Message for EnableSecretVersionRequest {
 /// Request message for
 /// [SecretManagerService.DestroySecretVersion][google.cloud.secretmanager.v1.SecretManagerService.DestroySecretVersion].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.DestroySecretVersion]: crate::traits::SecretManagerService::destroy_secret_version
+/// [google.cloud.secretmanager.v1.SecretManagerService.DestroySecretVersion]: crate::client::SecretManagerService::destroy_secret_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]

--- a/src/generated/bigtable/admin/v2/src/client.rs
+++ b/src/generated/bigtable/admin/v2/src/client.rs
@@ -841,7 +841,7 @@ impl BigtableInstanceAdmin {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
         name: impl Into<std::string::String>,
@@ -852,7 +852,7 @@ impl BigtableInstanceAdmin {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -863,7 +863,7 @@ impl BigtableInstanceAdmin {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -874,7 +874,7 @@ impl BigtableInstanceAdmin {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn cancel_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -2099,7 +2099,7 @@ impl BigtableTableAdmin {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
         name: impl Into<std::string::String>,
@@ -2110,7 +2110,7 @@ impl BigtableTableAdmin {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -2121,7 +2121,7 @@ impl BigtableTableAdmin {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -2132,7 +2132,7 @@ impl BigtableTableAdmin {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn cancel_operation(
         &self,
         name: impl Into<std::string::String>,

--- a/src/generated/bigtable/admin/v2/src/model.rs
+++ b/src/generated/bigtable/admin/v2/src/model.rs
@@ -1398,7 +1398,7 @@ impl gax::paginator::PageableResponse for ListHotTabletsResponse {
 /// The request for
 /// [RestoreTable][google.bigtable.admin.v2.BigtableTableAdmin.RestoreTable].
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.RestoreTable]: crate::traits::BigtableTableAdmin::restore_table
+/// [google.bigtable.admin.v2.BigtableTableAdmin.RestoreTable]: crate::client::BigtableTableAdmin::restore_table
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1471,7 +1471,7 @@ pub mod restore_table_request {
 /// Metadata type for the long-running operation returned by
 /// [RestoreTable][google.bigtable.admin.v2.BigtableTableAdmin.RestoreTable].
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.RestoreTable]: crate::traits::BigtableTableAdmin::restore_table
+/// [google.bigtable.admin.v2.BigtableTableAdmin.RestoreTable]: crate::client::BigtableTableAdmin::restore_table
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1502,7 +1502,7 @@ pub struct RestoreTableMetadata {
     /// [RestoreTable][google.bigtable.admin.v2.BigtableTableAdmin.RestoreTable]
     /// operation.
     ///
-    /// [google.bigtable.admin.v2.BigtableTableAdmin.RestoreTable]: crate::traits::BigtableTableAdmin::restore_table
+    /// [google.bigtable.admin.v2.BigtableTableAdmin.RestoreTable]: crate::client::BigtableTableAdmin::restore_table
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub progress: std::option::Option<crate::model::OperationProgress>,
 
@@ -1633,7 +1633,7 @@ impl wkt::message::Message for OptimizeRestoredTableMetadata {
 /// Request message for
 /// [google.bigtable.admin.v2.BigtableTableAdmin.CreateTable][google.bigtable.admin.v2.BigtableTableAdmin.CreateTable]
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.CreateTable]: crate::traits::BigtableTableAdmin::create_table
+/// [google.bigtable.admin.v2.BigtableTableAdmin.CreateTable]: crate::client::BigtableTableAdmin::create_table
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1754,7 +1754,7 @@ pub mod create_table_request {
 /// feature might be changed in backward-incompatible ways and is not recommended
 /// for production use. It is not subject to any SLA or deprecation policy.
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.CreateTableFromSnapshot]: crate::traits::BigtableTableAdmin::create_table_from_snapshot
+/// [google.bigtable.admin.v2.BigtableTableAdmin.CreateTableFromSnapshot]: crate::client::BigtableTableAdmin::create_table_from_snapshot
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1807,7 +1807,7 @@ impl wkt::message::Message for CreateTableFromSnapshotRequest {
 /// Request message for
 /// [google.bigtable.admin.v2.BigtableTableAdmin.DropRowRange][google.bigtable.admin.v2.BigtableTableAdmin.DropRowRange]
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.DropRowRange]: crate::traits::BigtableTableAdmin::drop_row_range
+/// [google.bigtable.admin.v2.BigtableTableAdmin.DropRowRange]: crate::client::BigtableTableAdmin::drop_row_range
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1870,7 +1870,7 @@ pub mod drop_row_range_request {
 /// Request message for
 /// [google.bigtable.admin.v2.BigtableTableAdmin.ListTables][google.bigtable.admin.v2.BigtableTableAdmin.ListTables]
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.ListTables]: crate::traits::BigtableTableAdmin::list_tables
+/// [google.bigtable.admin.v2.BigtableTableAdmin.ListTables]: crate::client::BigtableTableAdmin::list_tables
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1936,7 +1936,7 @@ impl wkt::message::Message for ListTablesRequest {
 /// Response message for
 /// [google.bigtable.admin.v2.BigtableTableAdmin.ListTables][google.bigtable.admin.v2.BigtableTableAdmin.ListTables]
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.ListTables]: crate::traits::BigtableTableAdmin::list_tables
+/// [google.bigtable.admin.v2.BigtableTableAdmin.ListTables]: crate::client::BigtableTableAdmin::list_tables
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1992,7 +1992,7 @@ impl gax::paginator::PageableResponse for ListTablesResponse {
 /// Request message for
 /// [google.bigtable.admin.v2.BigtableTableAdmin.GetTable][google.bigtable.admin.v2.BigtableTableAdmin.GetTable]
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.GetTable]: crate::traits::BigtableTableAdmin::get_table
+/// [google.bigtable.admin.v2.BigtableTableAdmin.GetTable]: crate::client::BigtableTableAdmin::get_table
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2032,7 +2032,7 @@ impl wkt::message::Message for GetTableRequest {
 /// The request for
 /// [UpdateTable][google.bigtable.admin.v2.BigtableTableAdmin.UpdateTable].
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.UpdateTable]: crate::traits::BigtableTableAdmin::update_table
+/// [google.bigtable.admin.v2.BigtableTableAdmin.UpdateTable]: crate::client::BigtableTableAdmin::update_table
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2088,7 +2088,7 @@ impl wkt::message::Message for UpdateTableRequest {
 /// Metadata type for the operation returned by
 /// [UpdateTable][google.bigtable.admin.v2.BigtableTableAdmin.UpdateTable].
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.UpdateTable]: crate::traits::BigtableTableAdmin::update_table
+/// [google.bigtable.admin.v2.BigtableTableAdmin.UpdateTable]: crate::client::BigtableTableAdmin::update_table
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2142,7 +2142,7 @@ impl wkt::message::Message for UpdateTableMetadata {
 /// Request message for
 /// [google.bigtable.admin.v2.BigtableTableAdmin.DeleteTable][google.bigtable.admin.v2.BigtableTableAdmin.DeleteTable]
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.DeleteTable]: crate::traits::BigtableTableAdmin::delete_table
+/// [google.bigtable.admin.v2.BigtableTableAdmin.DeleteTable]: crate::client::BigtableTableAdmin::delete_table
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2172,7 +2172,7 @@ impl wkt::message::Message for DeleteTableRequest {
 /// Request message for
 /// [google.bigtable.admin.v2.BigtableTableAdmin.UndeleteTable][google.bigtable.admin.v2.BigtableTableAdmin.UndeleteTable]
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.UndeleteTable]: crate::traits::BigtableTableAdmin::undelete_table
+/// [google.bigtable.admin.v2.BigtableTableAdmin.UndeleteTable]: crate::client::BigtableTableAdmin::undelete_table
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2202,7 +2202,7 @@ impl wkt::message::Message for UndeleteTableRequest {
 /// Metadata type for the operation returned by
 /// [google.bigtable.admin.v2.BigtableTableAdmin.UndeleteTable][google.bigtable.admin.v2.BigtableTableAdmin.UndeleteTable].
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.UndeleteTable]: crate::traits::BigtableTableAdmin::undelete_table
+/// [google.bigtable.admin.v2.BigtableTableAdmin.UndeleteTable]: crate::client::BigtableTableAdmin::undelete_table
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2256,7 +2256,7 @@ impl wkt::message::Message for UndeleteTableMetadata {
 /// Request message for
 /// [google.bigtable.admin.v2.BigtableTableAdmin.ModifyColumnFamilies][google.bigtable.admin.v2.BigtableTableAdmin.ModifyColumnFamilies]
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.ModifyColumnFamilies]: crate::traits::BigtableTableAdmin::modify_column_families
+/// [google.bigtable.admin.v2.BigtableTableAdmin.ModifyColumnFamilies]: crate::client::BigtableTableAdmin::modify_column_families
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2403,7 +2403,7 @@ pub mod modify_column_families_request {
 /// Request message for
 /// [google.bigtable.admin.v2.BigtableTableAdmin.GenerateConsistencyToken][google.bigtable.admin.v2.BigtableTableAdmin.GenerateConsistencyToken]
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.GenerateConsistencyToken]: crate::traits::BigtableTableAdmin::generate_consistency_token
+/// [google.bigtable.admin.v2.BigtableTableAdmin.GenerateConsistencyToken]: crate::client::BigtableTableAdmin::generate_consistency_token
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2433,7 +2433,7 @@ impl wkt::message::Message for GenerateConsistencyTokenRequest {
 /// Response message for
 /// [google.bigtable.admin.v2.BigtableTableAdmin.GenerateConsistencyToken][google.bigtable.admin.v2.BigtableTableAdmin.GenerateConsistencyToken]
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.GenerateConsistencyToken]: crate::traits::BigtableTableAdmin::generate_consistency_token
+/// [google.bigtable.admin.v2.BigtableTableAdmin.GenerateConsistencyToken]: crate::client::BigtableTableAdmin::generate_consistency_token
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2464,7 +2464,7 @@ impl wkt::message::Message for GenerateConsistencyTokenResponse {
 /// Request message for
 /// [google.bigtable.admin.v2.BigtableTableAdmin.CheckConsistency][google.bigtable.admin.v2.BigtableTableAdmin.CheckConsistency]
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.CheckConsistency]: crate::traits::BigtableTableAdmin::check_consistency
+/// [google.bigtable.admin.v2.BigtableTableAdmin.CheckConsistency]: crate::client::BigtableTableAdmin::check_consistency
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2577,7 +2577,7 @@ impl wkt::message::Message for DataBoostReadLocalWrites {
 /// Response message for
 /// [google.bigtable.admin.v2.BigtableTableAdmin.CheckConsistency][google.bigtable.admin.v2.BigtableTableAdmin.CheckConsistency]
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.CheckConsistency]: crate::traits::BigtableTableAdmin::check_consistency
+/// [google.bigtable.admin.v2.BigtableTableAdmin.CheckConsistency]: crate::client::BigtableTableAdmin::check_consistency
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2610,7 +2610,7 @@ impl wkt::message::Message for CheckConsistencyResponse {
 /// feature might be changed in backward-incompatible ways and is not recommended
 /// for production use. It is not subject to any SLA or deprecation policy.
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.SnapshotTable]: crate::traits::BigtableTableAdmin::snapshot_table
+/// [google.bigtable.admin.v2.BigtableTableAdmin.SnapshotTable]: crate::client::BigtableTableAdmin::snapshot_table
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2696,7 +2696,7 @@ impl wkt::message::Message for SnapshotTableRequest {
 /// feature might be changed in backward-incompatible ways and is not recommended
 /// for production use. It is not subject to any SLA or deprecation policy.
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.GetSnapshot]: crate::traits::BigtableTableAdmin::get_snapshot
+/// [google.bigtable.admin.v2.BigtableTableAdmin.GetSnapshot]: crate::client::BigtableTableAdmin::get_snapshot
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2731,7 +2731,7 @@ impl wkt::message::Message for GetSnapshotRequest {
 /// feature might be changed in backward-incompatible ways and is not recommended
 /// for production use. It is not subject to any SLA or deprecation policy.
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.ListSnapshots]: crate::traits::BigtableTableAdmin::list_snapshots
+/// [google.bigtable.admin.v2.BigtableTableAdmin.ListSnapshots]: crate::client::BigtableTableAdmin::list_snapshots
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2788,7 +2788,7 @@ impl wkt::message::Message for ListSnapshotsRequest {
 /// feature might be changed in backward-incompatible ways and is not recommended
 /// for production use. It is not subject to any SLA or deprecation policy.
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.ListSnapshots]: crate::traits::BigtableTableAdmin::list_snapshots
+/// [google.bigtable.admin.v2.BigtableTableAdmin.ListSnapshots]: crate::client::BigtableTableAdmin::list_snapshots
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2849,7 +2849,7 @@ impl gax::paginator::PageableResponse for ListSnapshotsResponse {
 /// feature might be changed in backward-incompatible ways and is not recommended
 /// for production use. It is not subject to any SLA or deprecation policy.
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.DeleteSnapshot]: crate::traits::BigtableTableAdmin::delete_snapshot
+/// [google.bigtable.admin.v2.BigtableTableAdmin.DeleteSnapshot]: crate::client::BigtableTableAdmin::delete_snapshot
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3002,7 +3002,7 @@ impl wkt::message::Message for CreateTableFromSnapshotMetadata {
 /// The request for
 /// [CreateBackup][google.bigtable.admin.v2.BigtableTableAdmin.CreateBackup].
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.CreateBackup]: crate::traits::BigtableTableAdmin::create_backup
+/// [google.bigtable.admin.v2.BigtableTableAdmin.CreateBackup]: crate::client::BigtableTableAdmin::create_backup
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3060,7 +3060,7 @@ impl wkt::message::Message for CreateBackupRequest {
 /// Metadata type for the operation returned by
 /// [CreateBackup][google.bigtable.admin.v2.BigtableTableAdmin.CreateBackup].
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.CreateBackup]: crate::traits::BigtableTableAdmin::create_backup
+/// [google.bigtable.admin.v2.BigtableTableAdmin.CreateBackup]: crate::client::BigtableTableAdmin::create_backup
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3124,7 +3124,7 @@ impl wkt::message::Message for CreateBackupMetadata {
 /// The request for
 /// [UpdateBackup][google.bigtable.admin.v2.BigtableTableAdmin.UpdateBackup].
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.UpdateBackup]: crate::traits::BigtableTableAdmin::update_backup
+/// [google.bigtable.admin.v2.BigtableTableAdmin.UpdateBackup]: crate::client::BigtableTableAdmin::update_backup
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3176,7 +3176,7 @@ impl wkt::message::Message for UpdateBackupRequest {
 /// The request for
 /// [GetBackup][google.bigtable.admin.v2.BigtableTableAdmin.GetBackup].
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.GetBackup]: crate::traits::BigtableTableAdmin::get_backup
+/// [google.bigtable.admin.v2.BigtableTableAdmin.GetBackup]: crate::client::BigtableTableAdmin::get_backup
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3206,7 +3206,7 @@ impl wkt::message::Message for GetBackupRequest {
 /// The request for
 /// [DeleteBackup][google.bigtable.admin.v2.BigtableTableAdmin.DeleteBackup].
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.DeleteBackup]: crate::traits::BigtableTableAdmin::delete_backup
+/// [google.bigtable.admin.v2.BigtableTableAdmin.DeleteBackup]: crate::client::BigtableTableAdmin::delete_backup
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3236,7 +3236,7 @@ impl wkt::message::Message for DeleteBackupRequest {
 /// The request for
 /// [ListBackups][google.bigtable.admin.v2.BigtableTableAdmin.ListBackups].
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.ListBackups]: crate::traits::BigtableTableAdmin::list_backups
+/// [google.bigtable.admin.v2.BigtableTableAdmin.ListBackups]: crate::client::BigtableTableAdmin::list_backups
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3369,7 +3369,7 @@ impl wkt::message::Message for ListBackupsRequest {
 /// The response for
 /// [ListBackups][google.bigtable.admin.v2.BigtableTableAdmin.ListBackups].
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.ListBackups]: crate::traits::BigtableTableAdmin::list_backups
+/// [google.bigtable.admin.v2.BigtableTableAdmin.ListBackups]: crate::client::BigtableTableAdmin::list_backups
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3383,7 +3383,7 @@ pub struct ListBackupsResponse {
     /// [ListBackups][google.bigtable.admin.v2.BigtableTableAdmin.ListBackups] call
     /// to fetch more of the matching backups.
     ///
-    /// [google.bigtable.admin.v2.BigtableTableAdmin.ListBackups]: crate::traits::BigtableTableAdmin::list_backups
+    /// [google.bigtable.admin.v2.BigtableTableAdmin.ListBackups]: crate::client::BigtableTableAdmin::list_backups
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub next_page_token: std::string::String,
 }
@@ -3427,7 +3427,7 @@ impl gax::paginator::PageableResponse for ListBackupsResponse {
 /// The request for
 /// [CopyBackup][google.bigtable.admin.v2.BigtableTableAdmin.CopyBackup].
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.CopyBackup]: crate::traits::BigtableTableAdmin::copy_backup
+/// [google.bigtable.admin.v2.BigtableTableAdmin.CopyBackup]: crate::client::BigtableTableAdmin::copy_backup
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3505,7 +3505,7 @@ impl wkt::message::Message for CopyBackupRequest {
 /// Metadata type for the google.longrunning.Operation returned by
 /// [CopyBackup][google.bigtable.admin.v2.BigtableTableAdmin.CopyBackup].
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.CopyBackup]: crate::traits::BigtableTableAdmin::copy_backup
+/// [google.bigtable.admin.v2.BigtableTableAdmin.CopyBackup]: crate::client::BigtableTableAdmin::copy_backup
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3525,7 +3525,7 @@ pub struct CopyBackupMetadata {
     /// [CopyBackup][google.bigtable.admin.v2.BigtableTableAdmin.CopyBackup]
     /// operation.
     ///
-    /// [google.bigtable.admin.v2.BigtableTableAdmin.CopyBackup]: crate::traits::BigtableTableAdmin::copy_backup
+    /// [google.bigtable.admin.v2.BigtableTableAdmin.CopyBackup]: crate::client::BigtableTableAdmin::copy_backup
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub progress: std::option::Option<crate::model::OperationProgress>,
 }
@@ -3569,7 +3569,7 @@ impl wkt::message::Message for CopyBackupMetadata {
 /// The request for
 /// [CreateAuthorizedView][google.bigtable.admin.v2.BigtableTableAdmin.CreateAuthorizedView]
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.CreateAuthorizedView]: crate::traits::BigtableTableAdmin::create_authorized_view
+/// [google.bigtable.admin.v2.BigtableTableAdmin.CreateAuthorizedView]: crate::client::BigtableTableAdmin::create_authorized_view
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3686,7 +3686,7 @@ impl wkt::message::Message for CreateAuthorizedViewMetadata {
 /// Request message for
 /// [google.bigtable.admin.v2.BigtableTableAdmin.ListAuthorizedViews][google.bigtable.admin.v2.BigtableTableAdmin.ListAuthorizedViews]
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.ListAuthorizedViews]: crate::traits::BigtableTableAdmin::list_authorized_views
+/// [google.bigtable.admin.v2.BigtableTableAdmin.ListAuthorizedViews]: crate::client::BigtableTableAdmin::list_authorized_views
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3756,7 +3756,7 @@ impl wkt::message::Message for ListAuthorizedViewsRequest {
 /// Response message for
 /// [google.bigtable.admin.v2.BigtableTableAdmin.ListAuthorizedViews][google.bigtable.admin.v2.BigtableTableAdmin.ListAuthorizedViews]
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.ListAuthorizedViews]: crate::traits::BigtableTableAdmin::list_authorized_views
+/// [google.bigtable.admin.v2.BigtableTableAdmin.ListAuthorizedViews]: crate::client::BigtableTableAdmin::list_authorized_views
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3814,7 +3814,7 @@ impl gax::paginator::PageableResponse for ListAuthorizedViewsResponse {
 /// Request message for
 /// [google.bigtable.admin.v2.BigtableTableAdmin.GetAuthorizedView][google.bigtable.admin.v2.BigtableTableAdmin.GetAuthorizedView]
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.GetAuthorizedView]: crate::traits::BigtableTableAdmin::get_authorized_view
+/// [google.bigtable.admin.v2.BigtableTableAdmin.GetAuthorizedView]: crate::client::BigtableTableAdmin::get_authorized_view
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3857,7 +3857,7 @@ impl wkt::message::Message for GetAuthorizedViewRequest {
 /// The request for
 /// [UpdateAuthorizedView][google.bigtable.admin.v2.BigtableTableAdmin.UpdateAuthorizedView].
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.UpdateAuthorizedView]: crate::traits::BigtableTableAdmin::update_authorized_view
+/// [google.bigtable.admin.v2.BigtableTableAdmin.UpdateAuthorizedView]: crate::client::BigtableTableAdmin::update_authorized_view
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3922,7 +3922,7 @@ impl wkt::message::Message for UpdateAuthorizedViewRequest {
 /// Metadata for the google.longrunning.Operation returned by
 /// [UpdateAuthorizedView][google.bigtable.admin.v2.BigtableTableAdmin.UpdateAuthorizedView].
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.UpdateAuthorizedView]: crate::traits::BigtableTableAdmin::update_authorized_view
+/// [google.bigtable.admin.v2.BigtableTableAdmin.UpdateAuthorizedView]: crate::client::BigtableTableAdmin::update_authorized_view
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3982,7 +3982,7 @@ impl wkt::message::Message for UpdateAuthorizedViewMetadata {
 /// Request message for
 /// [google.bigtable.admin.v2.BigtableTableAdmin.DeleteAuthorizedView][google.bigtable.admin.v2.BigtableTableAdmin.DeleteAuthorizedView]
 ///
-/// [google.bigtable.admin.v2.BigtableTableAdmin.DeleteAuthorizedView]: crate::traits::BigtableTableAdmin::delete_authorized_view
+/// [google.bigtable.admin.v2.BigtableTableAdmin.DeleteAuthorizedView]: crate::client::BigtableTableAdmin::delete_authorized_view
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -6310,7 +6310,7 @@ pub struct Backup {
     /// request is received).  The row data in this backup will be no older than
     /// this timestamp.
     ///
-    /// [google.bigtable.admin.v2.BigtableTableAdmin.CreateBackup]: crate::traits::BigtableTableAdmin::create_backup
+    /// [google.bigtable.admin.v2.BigtableTableAdmin.CreateBackup]: crate::client::BigtableTableAdmin::create_backup
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub start_time: std::option::Option<wkt::Timestamp>,
 

--- a/src/generated/bigtable/admin/v2/src/traits/mod.rs
+++ b/src/generated/bigtable/admin/v2/src/traits/mod.rs
@@ -301,7 +301,7 @@ pub trait BigtableInstanceAdmin: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn list_operations(
         &self,
         _req: longrunning::model::ListOperationsRequest,
@@ -315,7 +315,7 @@ pub trait BigtableInstanceAdmin: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn get_operation(
         &self,
         _req: longrunning::model::GetOperationRequest,
@@ -329,7 +329,7 @@ pub trait BigtableInstanceAdmin: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn delete_operation(
         &self,
         _req: longrunning::model::DeleteOperationRequest,
@@ -340,7 +340,7 @@ pub trait BigtableInstanceAdmin: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn cancel_operation(
         &self,
         _req: longrunning::model::CancelOperationRequest,
@@ -783,7 +783,7 @@ pub trait BigtableTableAdmin: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn list_operations(
         &self,
         _req: longrunning::model::ListOperationsRequest,
@@ -797,7 +797,7 @@ pub trait BigtableTableAdmin: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn get_operation(
         &self,
         _req: longrunning::model::GetOperationRequest,
@@ -811,7 +811,7 @@ pub trait BigtableTableAdmin: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn delete_operation(
         &self,
         _req: longrunning::model::DeleteOperationRequest,
@@ -822,7 +822,7 @@ pub trait BigtableTableAdmin: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn cancel_operation(
         &self,
         _req: longrunning::model::CancelOperationRequest,

--- a/src/generated/cloud/functions/v2/src/client.rs
+++ b/src/generated/cloud/functions/v2/src/client.rs
@@ -504,7 +504,7 @@ impl FunctionService {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
         name: impl Into<std::string::String>,
@@ -515,7 +515,7 @@ impl FunctionService {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
         name: impl Into<std::string::String>,

--- a/src/generated/cloud/functions/v2/src/traits/mod.rs
+++ b/src/generated/cloud/functions/v2/src/traits/mod.rs
@@ -217,7 +217,7 @@ pub trait FunctionService: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn list_operations(
         &self,
         _req: longrunning::model::ListOperationsRequest,
@@ -231,7 +231,7 @@ pub trait FunctionService: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn get_operation(
         &self,
         _req: longrunning::model::GetOperationRequest,

--- a/src/generated/cloud/kms/v1/src/client.rs
+++ b/src/generated/cloud/kms/v1/src/client.rs
@@ -46,8 +46,8 @@ use std::sync::Arc;
 /// a resource project's ancestor folder, see
 /// [ShowEffectiveAutokeyConfig][google.cloud.kms.v1.AutokeyAdmin.ShowEffectiveAutokeyConfig].
 ///
-/// [google.cloud.kms.v1.AutokeyAdmin.ShowEffectiveAutokeyConfig]: crate::traits::AutokeyAdmin::show_effective_autokey_config
-/// [google.cloud.kms.v1.AutokeyAdmin.UpdateAutokeyConfig]: crate::traits::AutokeyAdmin::update_autokey_config
+/// [google.cloud.kms.v1.AutokeyAdmin.ShowEffectiveAutokeyConfig]: crate::client::AutokeyAdmin::show_effective_autokey_config
+/// [google.cloud.kms.v1.AutokeyAdmin.UpdateAutokeyConfig]: crate::client::AutokeyAdmin::update_autokey_config
 /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
 /// [google.cloud.kms.v1.KeyHandle]: crate::model::KeyHandle
 #[derive(Clone, Debug)]
@@ -285,7 +285,7 @@ impl Autokey {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -463,7 +463,7 @@ impl AutokeyAdmin {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -683,7 +683,7 @@ impl EkmService {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -998,8 +998,8 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED]: crate::model::crypto_key_version::crypto_key_version_state::DISABLED
     /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::crypto_key_version_state::ENABLED
     /// [google.cloud.kms.v1.CryptoKeyVersion.state]: crate::model::CryptoKeyVersion::state
-    /// [google.cloud.kms.v1.KeyManagementService.DestroyCryptoKeyVersion]: crate::traits::KeyManagementService::destroy_crypto_key_version
-    /// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: crate::traits::KeyManagementService::restore_crypto_key_version
+    /// [google.cloud.kms.v1.KeyManagementService.DestroyCryptoKeyVersion]: crate::client::KeyManagementService::destroy_crypto_key_version
+    /// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: crate::client::KeyManagementService::restore_crypto_key_version
     pub fn update_crypto_key_version(
         &self,
         crypto_key_version: impl Into<crate::model::CryptoKeyVersion>,
@@ -1017,7 +1017,7 @@ impl KeyManagementService {
     ///
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
     /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::crypto_key_purpose::ENCRYPT_DECRYPT
-    /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::traits::KeyManagementService::encrypt
+    /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::client::KeyManagementService::encrypt
     pub fn update_crypto_key_primary_version(
         &self,
         name: impl Into<std::string::String>,
@@ -1056,7 +1056,7 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED]: crate::model::crypto_key_version::crypto_key_version_state::DESTROY_SCHEDULED
     /// [google.cloud.kms.v1.CryptoKeyVersion.destroy_time]: crate::model::CryptoKeyVersion::destroy_time
     /// [google.cloud.kms.v1.CryptoKeyVersion.state]: crate::model::CryptoKeyVersion::state
-    /// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: crate::traits::KeyManagementService::restore_crypto_key_version
+    /// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: crate::client::KeyManagementService::restore_crypto_key_version
     pub fn destroy_crypto_key_version(
         &self,
         name: impl Into<std::string::String>,
@@ -1095,7 +1095,7 @@ impl KeyManagementService {
     ///
     /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::crypto_key_purpose::ENCRYPT_DECRYPT
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
-    /// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::traits::KeyManagementService::decrypt
+    /// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::client::KeyManagementService::decrypt
     pub fn encrypt(
         &self,
         name: impl Into<std::string::String>,
@@ -1111,7 +1111,7 @@ impl KeyManagementService {
     ///
     /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::crypto_key_purpose::ENCRYPT_DECRYPT
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
-    /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::traits::KeyManagementService::encrypt
+    /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::client::KeyManagementService::encrypt
     pub fn decrypt(
         &self,
         name: impl Into<std::string::String>,
@@ -1129,8 +1129,8 @@ impl KeyManagementService {
     ///
     /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.RAW_ENCRYPT_DECRYPT]: crate::model::crypto_key::crypto_key_purpose::RAW_ENCRYPT_DECRYPT
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
-    /// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::traits::KeyManagementService::decrypt
-    /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::traits::KeyManagementService::encrypt
+    /// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::client::KeyManagementService::decrypt
+    /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::client::KeyManagementService::encrypt
     pub fn raw_encrypt(
         &self,
         name: impl Into<std::string::String>,
@@ -1162,7 +1162,7 @@ impl KeyManagementService {
     ///
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-    /// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::traits::KeyManagementService::get_public_key
+    /// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::client::KeyManagementService::get_public_key
     pub fn asymmetric_sign(
         &self,
         name: impl Into<std::string::String>,
@@ -1179,7 +1179,7 @@ impl KeyManagementService {
     ///
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-    /// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::traits::KeyManagementService::get_public_key
+    /// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::client::KeyManagementService::get_public_key
     pub fn asymmetric_decrypt(
         &self,
         name: impl Into<std::string::String>,
@@ -1285,7 +1285,7 @@ impl KeyManagementService {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
         name: impl Into<std::string::String>,

--- a/src/generated/cloud/kms/v1/src/model.rs
+++ b/src/generated/cloud/kms/v1/src/model.rs
@@ -37,7 +37,7 @@ extern crate wkt;
 /// Request message for
 /// [Autokey.CreateKeyHandle][google.cloud.kms.v1.Autokey.CreateKeyHandle].
 ///
-/// [google.cloud.kms.v1.Autokey.CreateKeyHandle]: crate::traits::Autokey::create_key_handle
+/// [google.cloud.kms.v1.Autokey.CreateKeyHandle]: crate::client::Autokey::create_key_handle
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -97,7 +97,7 @@ impl wkt::message::Message for CreateKeyHandleRequest {
 
 /// Request message for [GetKeyHandle][google.cloud.kms.v1.Autokey.GetKeyHandle].
 ///
-/// [google.cloud.kms.v1.Autokey.GetKeyHandle]: crate::traits::Autokey::get_key_handle
+/// [google.cloud.kms.v1.Autokey.GetKeyHandle]: crate::client::Autokey::get_key_handle
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -204,7 +204,7 @@ impl wkt::message::Message for KeyHandle {
 /// [CreateKeyHandle][google.cloud.kms.v1.Autokey.CreateKeyHandle] long-running
 /// operation response.
 ///
-/// [google.cloud.kms.v1.Autokey.CreateKeyHandle]: crate::traits::Autokey::create_key_handle
+/// [google.cloud.kms.v1.Autokey.CreateKeyHandle]: crate::client::Autokey::create_key_handle
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -222,7 +222,7 @@ impl wkt::message::Message for CreateKeyHandleMetadata {
 /// Request message for
 /// [Autokey.ListKeyHandles][google.cloud.kms.v1.Autokey.ListKeyHandles].
 ///
-/// [google.cloud.kms.v1.Autokey.ListKeyHandles]: crate::traits::Autokey::list_key_handles
+/// [google.cloud.kms.v1.Autokey.ListKeyHandles]: crate::client::Autokey::list_key_handles
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -300,7 +300,7 @@ impl wkt::message::Message for ListKeyHandlesRequest {
 /// Response message for
 /// [Autokey.ListKeyHandles][google.cloud.kms.v1.Autokey.ListKeyHandles].
 ///
-/// [google.cloud.kms.v1.Autokey.ListKeyHandles]: crate::traits::Autokey::list_key_handles
+/// [google.cloud.kms.v1.Autokey.ListKeyHandles]: crate::client::Autokey::list_key_handles
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -360,7 +360,7 @@ impl gax::paginator::PageableResponse for ListKeyHandlesResponse {
 /// Request message for
 /// [UpdateAutokeyConfig][google.cloud.kms.v1.AutokeyAdmin.UpdateAutokeyConfig].
 ///
-/// [google.cloud.kms.v1.AutokeyAdmin.UpdateAutokeyConfig]: crate::traits::AutokeyAdmin::update_autokey_config
+/// [google.cloud.kms.v1.AutokeyAdmin.UpdateAutokeyConfig]: crate::client::AutokeyAdmin::update_autokey_config
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -413,7 +413,7 @@ impl wkt::message::Message for UpdateAutokeyConfigRequest {
 /// Request message for
 /// [GetAutokeyConfig][google.cloud.kms.v1.AutokeyAdmin.GetAutokeyConfig].
 ///
-/// [google.cloud.kms.v1.AutokeyAdmin.GetAutokeyConfig]: crate::traits::AutokeyAdmin::get_autokey_config
+/// [google.cloud.kms.v1.AutokeyAdmin.GetAutokeyConfig]: crate::client::AutokeyAdmin::get_autokey_config
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -466,7 +466,7 @@ pub struct AutokeyConfig {
     /// `cloudkms.admin` role (or pertinent permissions). A request with an empty
     /// key project field will clear the configuration.
     ///
-    /// [google.cloud.kms.v1.AutokeyAdmin.UpdateAutokeyConfig]: crate::traits::AutokeyAdmin::update_autokey_config
+    /// [google.cloud.kms.v1.AutokeyAdmin.UpdateAutokeyConfig]: crate::client::AutokeyAdmin::update_autokey_config
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
     /// [google.cloud.kms.v1.KeyHandle]: crate::model::KeyHandle
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
@@ -549,7 +549,7 @@ pub mod autokey_config {
 /// Request message for
 /// [ShowEffectiveAutokeyConfig][google.cloud.kms.v1.AutokeyAdmin.ShowEffectiveAutokeyConfig].
 ///
-/// [google.cloud.kms.v1.AutokeyAdmin.ShowEffectiveAutokeyConfig]: crate::traits::AutokeyAdmin::show_effective_autokey_config
+/// [google.cloud.kms.v1.AutokeyAdmin.ShowEffectiveAutokeyConfig]: crate::client::AutokeyAdmin::show_effective_autokey_config
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -579,7 +579,7 @@ impl wkt::message::Message for ShowEffectiveAutokeyConfigRequest {
 /// Response message for
 /// [ShowEffectiveAutokeyConfig][google.cloud.kms.v1.AutokeyAdmin.ShowEffectiveAutokeyConfig].
 ///
-/// [google.cloud.kms.v1.AutokeyAdmin.ShowEffectiveAutokeyConfig]: crate::traits::AutokeyAdmin::show_effective_autokey_config
+/// [google.cloud.kms.v1.AutokeyAdmin.ShowEffectiveAutokeyConfig]: crate::client::AutokeyAdmin::show_effective_autokey_config
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -608,7 +608,7 @@ impl wkt::message::Message for ShowEffectiveAutokeyConfigResponse {
 /// Request message for
 /// [EkmService.ListEkmConnections][google.cloud.kms.v1.EkmService.ListEkmConnections].
 ///
-/// [google.cloud.kms.v1.EkmService.ListEkmConnections]: crate::traits::EkmService::list_ekm_connections
+/// [google.cloud.kms.v1.EkmService.ListEkmConnections]: crate::client::EkmService::list_ekm_connections
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -697,7 +697,7 @@ impl wkt::message::Message for ListEkmConnectionsRequest {
 /// Response message for
 /// [EkmService.ListEkmConnections][google.cloud.kms.v1.EkmService.ListEkmConnections].
 ///
-/// [google.cloud.kms.v1.EkmService.ListEkmConnections]: crate::traits::EkmService::list_ekm_connections
+/// [google.cloud.kms.v1.EkmService.ListEkmConnections]: crate::client::EkmService::list_ekm_connections
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -771,7 +771,7 @@ impl gax::paginator::PageableResponse for ListEkmConnectionsResponse {
 /// Request message for
 /// [EkmService.GetEkmConnection][google.cloud.kms.v1.EkmService.GetEkmConnection].
 ///
-/// [google.cloud.kms.v1.EkmService.GetEkmConnection]: crate::traits::EkmService::get_ekm_connection
+/// [google.cloud.kms.v1.EkmService.GetEkmConnection]: crate::client::EkmService::get_ekm_connection
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -803,7 +803,7 @@ impl wkt::message::Message for GetEkmConnectionRequest {
 /// Request message for
 /// [EkmService.CreateEkmConnection][google.cloud.kms.v1.EkmService.CreateEkmConnection].
 ///
-/// [google.cloud.kms.v1.EkmService.CreateEkmConnection]: crate::traits::EkmService::create_ekm_connection
+/// [google.cloud.kms.v1.EkmService.CreateEkmConnection]: crate::client::EkmService::create_ekm_connection
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -867,7 +867,7 @@ impl wkt::message::Message for CreateEkmConnectionRequest {
 /// Request message for
 /// [EkmService.UpdateEkmConnection][google.cloud.kms.v1.EkmService.UpdateEkmConnection].
 ///
-/// [google.cloud.kms.v1.EkmService.UpdateEkmConnection]: crate::traits::EkmService::update_ekm_connection
+/// [google.cloud.kms.v1.EkmService.UpdateEkmConnection]: crate::client::EkmService::update_ekm_connection
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -916,7 +916,7 @@ impl wkt::message::Message for UpdateEkmConnectionRequest {
 /// Request message for
 /// [EkmService.GetEkmConfig][google.cloud.kms.v1.EkmService.GetEkmConfig].
 ///
-/// [google.cloud.kms.v1.EkmService.GetEkmConfig]: crate::traits::EkmService::get_ekm_config
+/// [google.cloud.kms.v1.EkmService.GetEkmConfig]: crate::client::EkmService::get_ekm_config
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -948,7 +948,7 @@ impl wkt::message::Message for GetEkmConfigRequest {
 /// Request message for
 /// [EkmService.UpdateEkmConfig][google.cloud.kms.v1.EkmService.UpdateEkmConfig].
 ///
-/// [google.cloud.kms.v1.EkmService.UpdateEkmConfig]: crate::traits::EkmService::update_ekm_config
+/// [google.cloud.kms.v1.EkmService.UpdateEkmConfig]: crate::client::EkmService::update_ekm_config
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1420,7 +1420,7 @@ pub mod ekm_connection {
         /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
         /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
         /// [google.cloud.kms.v1.EkmConnection]: crate::model::EkmConnection
-        /// [google.cloud.kms.v1.KeyManagementService.DestroyCryptoKeyVersion]: crate::traits::KeyManagementService::destroy_crypto_key_version
+        /// [google.cloud.kms.v1.KeyManagementService.DestroyCryptoKeyVersion]: crate::client::KeyManagementService::destroy_crypto_key_version
         pub const CLOUD_KMS: &str = "CLOUD_KMS";
     }
 }
@@ -1486,7 +1486,7 @@ impl wkt::message::Message for EkmConfig {
 /// Request message for
 /// [EkmService.VerifyConnectivity][google.cloud.kms.v1.EkmService.VerifyConnectivity].
 ///
-/// [google.cloud.kms.v1.EkmService.VerifyConnectivity]: crate::traits::EkmService::verify_connectivity
+/// [google.cloud.kms.v1.EkmService.VerifyConnectivity]: crate::client::EkmService::verify_connectivity
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1518,7 +1518,7 @@ impl wkt::message::Message for VerifyConnectivityRequest {
 /// Response message for
 /// [EkmService.VerifyConnectivity][google.cloud.kms.v1.EkmService.VerifyConnectivity].
 ///
-/// [google.cloud.kms.v1.EkmService.VerifyConnectivity]: crate::traits::EkmService::verify_connectivity
+/// [google.cloud.kms.v1.EkmService.VerifyConnectivity]: crate::client::EkmService::verify_connectivity
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1623,8 +1623,8 @@ pub struct CryptoKey {
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
     /// [google.cloud.kms.v1.EncryptRequest.name]: crate::model::EncryptRequest::name
-    /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::traits::KeyManagementService::encrypt
-    /// [google.cloud.kms.v1.KeyManagementService.UpdateCryptoKeyPrimaryVersion]: crate::traits::KeyManagementService::update_crypto_key_primary_version
+    /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::client::KeyManagementService::encrypt
+    /// [google.cloud.kms.v1.KeyManagementService.UpdateCryptoKeyPrimaryVersion]: crate::client::KeyManagementService::update_crypto_key_primary_version
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub primary: std::option::Option<crate::model::CryptoKeyVersion>,
 
@@ -1662,8 +1662,8 @@ pub struct CryptoKey {
     /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::crypto_key_purpose::ENCRYPT_DECRYPT
     /// [google.cloud.kms.v1.CryptoKey.next_rotation_time]: crate::model::CryptoKey::next_rotation_time
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
-    /// [google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion]: crate::traits::KeyManagementService::create_crypto_key_version
-    /// [google.cloud.kms.v1.KeyManagementService.UpdateCryptoKeyPrimaryVersion]: crate::traits::KeyManagementService::update_crypto_key_primary_version
+    /// [google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion]: crate::client::KeyManagementService::create_crypto_key_version
+    /// [google.cloud.kms.v1.KeyManagementService.UpdateCryptoKeyPrimaryVersion]: crate::client::KeyManagementService::update_crypto_key_primary_version
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub next_rotation_time: std::option::Option<wkt::Timestamp>,
 
@@ -1675,7 +1675,7 @@ pub struct CryptoKey {
     /// or auto-rotation are controlled by this template.
     ///
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-    /// [google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion]: crate::traits::KeyManagementService::create_crypto_key_version
+    /// [google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion]: crate::client::KeyManagementService::create_crypto_key_version
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub version_template: std::option::Option<crate::model::CryptoKeyVersionTemplate>,
 
@@ -1895,8 +1895,8 @@ pub mod crypto_key {
         /// [Decrypt][google.cloud.kms.v1.KeyManagementService.Decrypt].
         ///
         /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
-        /// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::traits::KeyManagementService::decrypt
-        /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::traits::KeyManagementService::encrypt
+        /// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::client::KeyManagementService::decrypt
+        /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::client::KeyManagementService::encrypt
         pub const ENCRYPT_DECRYPT: &str = "ENCRYPT_DECRYPT";
 
         /// [CryptoKeys][google.cloud.kms.v1.CryptoKey] with this purpose may be used
@@ -1906,8 +1906,8 @@ pub mod crypto_key {
         /// [GetPublicKey][google.cloud.kms.v1.KeyManagementService.GetPublicKey].
         ///
         /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
-        /// [google.cloud.kms.v1.KeyManagementService.AsymmetricSign]: crate::traits::KeyManagementService::asymmetric_sign
-        /// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::traits::KeyManagementService::get_public_key
+        /// [google.cloud.kms.v1.KeyManagementService.AsymmetricSign]: crate::client::KeyManagementService::asymmetric_sign
+        /// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::client::KeyManagementService::get_public_key
         pub const ASYMMETRIC_SIGN: &str = "ASYMMETRIC_SIGN";
 
         /// [CryptoKeys][google.cloud.kms.v1.CryptoKey] with this purpose may be used
@@ -1917,8 +1917,8 @@ pub mod crypto_key {
         /// [GetPublicKey][google.cloud.kms.v1.KeyManagementService.GetPublicKey].
         ///
         /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
-        /// [google.cloud.kms.v1.KeyManagementService.AsymmetricDecrypt]: crate::traits::KeyManagementService::asymmetric_decrypt
-        /// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::traits::KeyManagementService::get_public_key
+        /// [google.cloud.kms.v1.KeyManagementService.AsymmetricDecrypt]: crate::client::KeyManagementService::asymmetric_decrypt
+        /// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::client::KeyManagementService::get_public_key
         pub const ASYMMETRIC_DECRYPT: &str = "ASYMMETRIC_DECRYPT";
 
         /// [CryptoKeys][google.cloud.kms.v1.CryptoKey] with this purpose may be used
@@ -1928,15 +1928,15 @@ pub mod crypto_key {
         /// encryption and does not support automatic CryptoKey rotation.
         ///
         /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
-        /// [google.cloud.kms.v1.KeyManagementService.RawDecrypt]: crate::traits::KeyManagementService::raw_decrypt
-        /// [google.cloud.kms.v1.KeyManagementService.RawEncrypt]: crate::traits::KeyManagementService::raw_encrypt
+        /// [google.cloud.kms.v1.KeyManagementService.RawDecrypt]: crate::client::KeyManagementService::raw_decrypt
+        /// [google.cloud.kms.v1.KeyManagementService.RawEncrypt]: crate::client::KeyManagementService::raw_encrypt
         pub const RAW_ENCRYPT_DECRYPT: &str = "RAW_ENCRYPT_DECRYPT";
 
         /// [CryptoKeys][google.cloud.kms.v1.CryptoKey] with this purpose may be used
         /// with [MacSign][google.cloud.kms.v1.KeyManagementService.MacSign].
         ///
         /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
-        /// [google.cloud.kms.v1.KeyManagementService.MacSign]: crate::traits::KeyManagementService::mac_sign
+        /// [google.cloud.kms.v1.KeyManagementService.MacSign]: crate::client::KeyManagementService::mac_sign
         pub const MAC: &str = "MAC";
     }
 
@@ -1975,7 +1975,7 @@ pub mod crypto_key {
 ///
 /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
 /// [google.cloud.kms.v1.CryptoKeyVersionTemplate]: crate::model::CryptoKeyVersionTemplate
-/// [google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion]: crate::traits::KeyManagementService::create_crypto_key_version
+/// [google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion]: crate::client::KeyManagementService::create_crypto_key_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2766,7 +2766,7 @@ pub mod crypto_key_version {
         ///
         /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::crypto_key_version_state::ENABLED
         /// [google.cloud.kms.v1.CryptoKeyVersion.reimport_eligible]: crate::model::CryptoKeyVersion::reimport_eligible
-        /// [google.cloud.kms.v1.KeyManagementService.ImportCryptoKeyVersion]: crate::traits::KeyManagementService::import_crypto_key_version
+        /// [google.cloud.kms.v1.KeyManagementService.ImportCryptoKeyVersion]: crate::client::KeyManagementService::import_crypto_key_version
         pub const DESTROYED: &str = "DESTROYED";
 
         /// This version is scheduled for destruction, and will be destroyed soon.
@@ -2777,7 +2777,7 @@ pub mod crypto_key_version {
         /// state.
         ///
         /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED]: crate::model::crypto_key_version::crypto_key_version_state::DISABLED
-        /// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: crate::traits::KeyManagementService::restore_crypto_key_version
+        /// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: crate::client::KeyManagementService::restore_crypto_key_version
         pub const DESTROY_SCHEDULED: &str = "DESTROY_SCHEDULED";
 
         /// This version is still being imported. It may not be used, enabled,
@@ -2827,8 +2827,8 @@ pub mod crypto_key_version {
     /// [KeyManagementService.ListCryptoKeys][google.cloud.kms.v1.KeyManagementService.ListCryptoKeys].
     ///
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-    /// [google.cloud.kms.v1.KeyManagementService.ListCryptoKeyVersions]: crate::traits::KeyManagementService::list_crypto_key_versions
-    /// [google.cloud.kms.v1.KeyManagementService.ListCryptoKeys]: crate::traits::KeyManagementService::list_crypto_keys
+    /// [google.cloud.kms.v1.KeyManagementService.ListCryptoKeyVersions]: crate::client::KeyManagementService::list_crypto_key_versions
+    /// [google.cloud.kms.v1.KeyManagementService.ListCryptoKeys]: crate::client::KeyManagementService::list_crypto_keys
     #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CryptoKeyVersionView(std::string::String);
 
@@ -2872,7 +2872,7 @@ pub mod crypto_key_version {
 /// [GetPublicKey][google.cloud.kms.v1.KeyManagementService.GetPublicKey].
 ///
 /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-/// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::traits::KeyManagementService::get_public_key
+/// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::client::KeyManagementService::get_public_key
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3023,7 +3023,7 @@ impl wkt::message::Message for PublicKey {
 /// [google.cloud.kms.v1.ImportJob.import_method]: crate::model::ImportJob::import_method
 /// [google.cloud.kms.v1.ImportJob.public_key]: crate::model::ImportJob::public_key
 /// [google.cloud.kms.v1.ImportJob.state]: crate::model::ImportJob::state
-/// [google.cloud.kms.v1.KeyManagementService.ImportCryptoKeyVersion]: crate::traits::KeyManagementService::import_crypto_key_version
+/// [google.cloud.kms.v1.KeyManagementService.ImportCryptoKeyVersion]: crate::client::KeyManagementService::import_crypto_key_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3364,8 +3364,8 @@ pub mod import_job {
         /// [CreateCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion]
         /// requests.
         ///
-        /// [google.cloud.kms.v1.KeyManagementService.CreateCryptoKey]: crate::traits::KeyManagementService::create_crypto_key
-        /// [google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion]: crate::traits::KeyManagementService::create_crypto_key_version
+        /// [google.cloud.kms.v1.KeyManagementService.CreateCryptoKey]: crate::client::KeyManagementService::create_crypto_key
+        /// [google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion]: crate::client::KeyManagementService::create_crypto_key_version
         pub const ACTIVE: &str = "ACTIVE";
 
         /// This job can no longer be used and may not leave this state once entered.
@@ -3478,7 +3478,7 @@ impl wkt::message::Message for KeyAccessJustificationsPolicy {
 /// Request message for
 /// [KeyManagementService.ListKeyRings][google.cloud.kms.v1.KeyManagementService.ListKeyRings].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.ListKeyRings]: crate::traits::KeyManagementService::list_key_rings
+/// [google.cloud.kms.v1.KeyManagementService.ListKeyRings]: crate::client::KeyManagementService::list_key_rings
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3567,7 +3567,7 @@ impl wkt::message::Message for ListKeyRingsRequest {
 /// Request message for
 /// [KeyManagementService.ListCryptoKeys][google.cloud.kms.v1.KeyManagementService.ListCryptoKeys].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.ListCryptoKeys]: crate::traits::KeyManagementService::list_crypto_keys
+/// [google.cloud.kms.v1.KeyManagementService.ListCryptoKeys]: crate::client::KeyManagementService::list_crypto_keys
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3669,7 +3669,7 @@ impl wkt::message::Message for ListCryptoKeysRequest {
 /// Request message for
 /// [KeyManagementService.ListCryptoKeyVersions][google.cloud.kms.v1.KeyManagementService.ListCryptoKeyVersions].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.ListCryptoKeyVersions]: crate::traits::KeyManagementService::list_crypto_key_versions
+/// [google.cloud.kms.v1.KeyManagementService.ListCryptoKeyVersions]: crate::client::KeyManagementService::list_crypto_key_versions
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3772,7 +3772,7 @@ impl wkt::message::Message for ListCryptoKeyVersionsRequest {
 /// Request message for
 /// [KeyManagementService.ListImportJobs][google.cloud.kms.v1.KeyManagementService.ListImportJobs].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.ListImportJobs]: crate::traits::KeyManagementService::list_import_jobs
+/// [google.cloud.kms.v1.KeyManagementService.ListImportJobs]: crate::client::KeyManagementService::list_import_jobs
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3860,7 +3860,7 @@ impl wkt::message::Message for ListImportJobsRequest {
 /// Response message for
 /// [KeyManagementService.ListKeyRings][google.cloud.kms.v1.KeyManagementService.ListKeyRings].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.ListKeyRings]: crate::traits::KeyManagementService::list_key_rings
+/// [google.cloud.kms.v1.KeyManagementService.ListKeyRings]: crate::client::KeyManagementService::list_key_rings
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3932,7 +3932,7 @@ impl gax::paginator::PageableResponse for ListKeyRingsResponse {
 /// Response message for
 /// [KeyManagementService.ListCryptoKeys][google.cloud.kms.v1.KeyManagementService.ListCryptoKeys].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.ListCryptoKeys]: crate::traits::KeyManagementService::list_crypto_keys
+/// [google.cloud.kms.v1.KeyManagementService.ListCryptoKeys]: crate::client::KeyManagementService::list_crypto_keys
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -4004,7 +4004,7 @@ impl gax::paginator::PageableResponse for ListCryptoKeysResponse {
 /// Response message for
 /// [KeyManagementService.ListCryptoKeyVersions][google.cloud.kms.v1.KeyManagementService.ListCryptoKeyVersions].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.ListCryptoKeyVersions]: crate::traits::KeyManagementService::list_crypto_key_versions
+/// [google.cloud.kms.v1.KeyManagementService.ListCryptoKeyVersions]: crate::client::KeyManagementService::list_crypto_key_versions
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -4079,7 +4079,7 @@ impl gax::paginator::PageableResponse for ListCryptoKeyVersionsResponse {
 /// Response message for
 /// [KeyManagementService.ListImportJobs][google.cloud.kms.v1.KeyManagementService.ListImportJobs].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.ListImportJobs]: crate::traits::KeyManagementService::list_import_jobs
+/// [google.cloud.kms.v1.KeyManagementService.ListImportJobs]: crate::client::KeyManagementService::list_import_jobs
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -4151,7 +4151,7 @@ impl gax::paginator::PageableResponse for ListImportJobsResponse {
 /// Request message for
 /// [KeyManagementService.GetKeyRing][google.cloud.kms.v1.KeyManagementService.GetKeyRing].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.GetKeyRing]: crate::traits::KeyManagementService::get_key_ring
+/// [google.cloud.kms.v1.KeyManagementService.GetKeyRing]: crate::client::KeyManagementService::get_key_ring
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -4183,7 +4183,7 @@ impl wkt::message::Message for GetKeyRingRequest {
 /// Request message for
 /// [KeyManagementService.GetCryptoKey][google.cloud.kms.v1.KeyManagementService.GetCryptoKey].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.GetCryptoKey]: crate::traits::KeyManagementService::get_crypto_key
+/// [google.cloud.kms.v1.KeyManagementService.GetCryptoKey]: crate::client::KeyManagementService::get_crypto_key
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -4215,7 +4215,7 @@ impl wkt::message::Message for GetCryptoKeyRequest {
 /// Request message for
 /// [KeyManagementService.GetCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.GetCryptoKeyVersion].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.GetCryptoKeyVersion]: crate::traits::KeyManagementService::get_crypto_key_version
+/// [google.cloud.kms.v1.KeyManagementService.GetCryptoKeyVersion]: crate::client::KeyManagementService::get_crypto_key_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -4247,7 +4247,7 @@ impl wkt::message::Message for GetCryptoKeyVersionRequest {
 /// Request message for
 /// [KeyManagementService.GetPublicKey][google.cloud.kms.v1.KeyManagementService.GetPublicKey].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::traits::KeyManagementService::get_public_key
+/// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::client::KeyManagementService::get_public_key
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -4279,7 +4279,7 @@ impl wkt::message::Message for GetPublicKeyRequest {
 /// Request message for
 /// [KeyManagementService.GetImportJob][google.cloud.kms.v1.KeyManagementService.GetImportJob].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.GetImportJob]: crate::traits::KeyManagementService::get_import_job
+/// [google.cloud.kms.v1.KeyManagementService.GetImportJob]: crate::client::KeyManagementService::get_import_job
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -4311,7 +4311,7 @@ impl wkt::message::Message for GetImportJobRequest {
 /// Request message for
 /// [KeyManagementService.CreateKeyRing][google.cloud.kms.v1.KeyManagementService.CreateKeyRing].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.CreateKeyRing]: crate::traits::KeyManagementService::create_key_ring
+/// [google.cloud.kms.v1.KeyManagementService.CreateKeyRing]: crate::client::KeyManagementService::create_key_ring
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -4370,7 +4370,7 @@ impl wkt::message::Message for CreateKeyRingRequest {
 /// Request message for
 /// [KeyManagementService.CreateCryptoKey][google.cloud.kms.v1.KeyManagementService.CreateCryptoKey].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.CreateCryptoKey]: crate::traits::KeyManagementService::create_crypto_key
+/// [google.cloud.kms.v1.KeyManagementService.CreateCryptoKey]: crate::client::KeyManagementService::create_crypto_key
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -4407,8 +4407,8 @@ pub struct CreateCryptoKeyRequest {
     ///
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-    /// [google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion]: crate::traits::KeyManagementService::create_crypto_key_version
-    /// [google.cloud.kms.v1.KeyManagementService.ImportCryptoKeyVersion]: crate::traits::KeyManagementService::import_crypto_key_version
+    /// [google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion]: crate::client::KeyManagementService::create_crypto_key_version
+    /// [google.cloud.kms.v1.KeyManagementService.ImportCryptoKeyVersion]: crate::client::KeyManagementService::import_crypto_key_version
     pub skip_initial_version_creation: bool,
 }
 
@@ -4450,7 +4450,7 @@ impl wkt::message::Message for CreateCryptoKeyRequest {
 /// Request message for
 /// [KeyManagementService.CreateCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion]: crate::traits::KeyManagementService::create_crypto_key_version
+/// [google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion]: crate::client::KeyManagementService::create_crypto_key_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -4502,7 +4502,7 @@ impl wkt::message::Message for CreateCryptoKeyVersionRequest {
 /// Request message for
 /// [KeyManagementService.ImportCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.ImportCryptoKeyVersion].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.ImportCryptoKeyVersion]: crate::traits::KeyManagementService::import_crypto_key_version
+/// [google.cloud.kms.v1.KeyManagementService.ImportCryptoKeyVersion]: crate::client::KeyManagementService::import_crypto_key_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -4548,7 +4548,7 @@ pub struct ImportCryptoKeyVersionRequest {
     /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.IMPORT_FAILED]: crate::model::crypto_key_version::crypto_key_version_state::IMPORT_FAILED
     /// [google.cloud.kms.v1.CryptoKeyVersion.name]: crate::model::CryptoKeyVersion::name
     /// [google.cloud.kms.v1.ImportCryptoKeyVersionRequest.parent]: crate::model::ImportCryptoKeyVersionRequest::parent
-    /// [google.cloud.kms.v1.KeyManagementService.ImportCryptoKeyVersion]: crate::traits::KeyManagementService::import_crypto_key_version
+    /// [google.cloud.kms.v1.KeyManagementService.ImportCryptoKeyVersion]: crate::client::KeyManagementService::import_crypto_key_version
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub crypto_key_version: std::string::String,
 
@@ -4711,7 +4711,7 @@ pub mod import_crypto_key_version_request {
 /// Request message for
 /// [KeyManagementService.CreateImportJob][google.cloud.kms.v1.KeyManagementService.CreateImportJob].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.CreateImportJob]: crate::traits::KeyManagementService::create_import_job
+/// [google.cloud.kms.v1.KeyManagementService.CreateImportJob]: crate::client::KeyManagementService::create_import_job
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -4772,7 +4772,7 @@ impl wkt::message::Message for CreateImportJobRequest {
 /// Request message for
 /// [KeyManagementService.UpdateCryptoKey][google.cloud.kms.v1.KeyManagementService.UpdateCryptoKey].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.UpdateCryptoKey]: crate::traits::KeyManagementService::update_crypto_key
+/// [google.cloud.kms.v1.KeyManagementService.UpdateCryptoKey]: crate::client::KeyManagementService::update_crypto_key
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -4818,7 +4818,7 @@ impl wkt::message::Message for UpdateCryptoKeyRequest {
 /// Request message for
 /// [KeyManagementService.UpdateCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.UpdateCryptoKeyVersion].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.UpdateCryptoKeyVersion]: crate::traits::KeyManagementService::update_crypto_key_version
+/// [google.cloud.kms.v1.KeyManagementService.UpdateCryptoKeyVersion]: crate::client::KeyManagementService::update_crypto_key_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -4867,7 +4867,7 @@ impl wkt::message::Message for UpdateCryptoKeyVersionRequest {
 /// Request message for
 /// [KeyManagementService.UpdateCryptoKeyPrimaryVersion][google.cloud.kms.v1.KeyManagementService.UpdateCryptoKeyPrimaryVersion].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.UpdateCryptoKeyPrimaryVersion]: crate::traits::KeyManagementService::update_crypto_key_primary_version
+/// [google.cloud.kms.v1.KeyManagementService.UpdateCryptoKeyPrimaryVersion]: crate::client::KeyManagementService::update_crypto_key_primary_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -4914,7 +4914,7 @@ impl wkt::message::Message for UpdateCryptoKeyPrimaryVersionRequest {
 /// Request message for
 /// [KeyManagementService.DestroyCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.DestroyCryptoKeyVersion].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.DestroyCryptoKeyVersion]: crate::traits::KeyManagementService::destroy_crypto_key_version
+/// [google.cloud.kms.v1.KeyManagementService.DestroyCryptoKeyVersion]: crate::client::KeyManagementService::destroy_crypto_key_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -4945,7 +4945,7 @@ impl wkt::message::Message for DestroyCryptoKeyVersionRequest {
 /// Request message for
 /// [KeyManagementService.RestoreCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: crate::traits::KeyManagementService::restore_crypto_key_version
+/// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: crate::client::KeyManagementService::restore_crypto_key_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -4976,7 +4976,7 @@ impl wkt::message::Message for RestoreCryptoKeyVersionRequest {
 /// Request message for
 /// [KeyManagementService.Encrypt][google.cloud.kms.v1.KeyManagementService.Encrypt].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::traits::KeyManagementService::encrypt
+/// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::client::KeyManagementService::encrypt
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -5063,7 +5063,7 @@ pub struct EncryptRequest {
     ///
     /// [google.cloud.kms.v1.EncryptRequest.plaintext]: crate::model::EncryptRequest::plaintext
     /// [google.cloud.kms.v1.EncryptRequest.plaintext_crc32c]: crate::model::EncryptRequest::plaintext_crc32c
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     #[serde(rename = "plaintextCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
@@ -5091,7 +5091,7 @@ pub struct EncryptRequest {
     ///
     /// [google.cloud.kms.v1.EncryptRequest.additional_authenticated_data]: crate::model::EncryptRequest::additional_authenticated_data
     /// [google.cloud.kms.v1.EncryptRequest.additional_authenticated_data_crc32c]: crate::model::EncryptRequest::additional_authenticated_data_crc32c
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     #[serde(rename = "additionalAuthenticatedDataCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
@@ -5150,7 +5150,7 @@ impl wkt::message::Message for EncryptRequest {
 /// Request message for
 /// [KeyManagementService.Decrypt][google.cloud.kms.v1.KeyManagementService.Decrypt].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::traits::KeyManagementService::decrypt
+/// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::client::KeyManagementService::decrypt
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -5202,7 +5202,7 @@ pub struct DecryptRequest {
     ///
     /// [google.cloud.kms.v1.DecryptRequest.ciphertext]: crate::model::DecryptRequest::ciphertext
     /// [google.cloud.kms.v1.DecryptRequest.ciphertext_crc32c]: crate::model::DecryptRequest::ciphertext_crc32c
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     #[serde(rename = "ciphertextCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
@@ -5230,7 +5230,7 @@ pub struct DecryptRequest {
     ///
     /// [google.cloud.kms.v1.DecryptRequest.additional_authenticated_data]: crate::model::DecryptRequest::additional_authenticated_data
     /// [google.cloud.kms.v1.DecryptRequest.additional_authenticated_data_crc32c]: crate::model::DecryptRequest::additional_authenticated_data_crc32c
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     #[serde(rename = "additionalAuthenticatedDataCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
@@ -5289,7 +5289,7 @@ impl wkt::message::Message for DecryptRequest {
 /// Request message for
 /// [KeyManagementService.RawEncrypt][google.cloud.kms.v1.KeyManagementService.RawEncrypt].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.RawEncrypt]: crate::traits::KeyManagementService::raw_encrypt
+/// [google.cloud.kms.v1.KeyManagementService.RawEncrypt]: crate::client::KeyManagementService::raw_encrypt
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -5360,7 +5360,7 @@ pub struct RawEncryptRequest {
     /// will never exceed 2^32-1, and can be safely downconverted to uint32 in
     /// languages that support this type.
     ///
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     /// [google.cloud.kms.v1.RawEncryptRequest.plaintext]: crate::model::RawEncryptRequest::plaintext
     #[serde(rename = "plaintextCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
@@ -5385,7 +5385,7 @@ pub struct RawEncryptRequest {
     /// never exceed 2^32-1, and can be safely downconverted to uint32 in languages
     /// that support this type.
     ///
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     /// [google.cloud.kms.v1.RawEncryptRequest.additional_authenticated_data]: crate::model::RawEncryptRequest::additional_authenticated_data
     #[serde(rename = "additionalAuthenticatedDataCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
@@ -5419,7 +5419,7 @@ pub struct RawEncryptRequest {
     /// never exceed 2^32-1, and can be safely downconverted to uint32 in languages
     /// that support this type.
     ///
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     /// [google.cloud.kms.v1.RawEncryptRequest.initialization_vector]: crate::model::RawEncryptRequest::initialization_vector
     #[serde(rename = "initializationVectorCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
@@ -5496,7 +5496,7 @@ impl wkt::message::Message for RawEncryptRequest {
 /// Request message for
 /// [KeyManagementService.RawDecrypt][google.cloud.kms.v1.KeyManagementService.RawDecrypt].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.RawDecrypt]: crate::traits::KeyManagementService::raw_decrypt
+/// [google.cloud.kms.v1.KeyManagementService.RawDecrypt]: crate::client::KeyManagementService::raw_decrypt
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -5555,7 +5555,7 @@ pub struct RawDecryptRequest {
     /// will never exceed 2^32-1, and can be safely downconverted to uint32 in
     /// languages that support this type.
     ///
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     /// [google.cloud.kms.v1.RawDecryptRequest.ciphertext]: crate::model::RawDecryptRequest::ciphertext
     #[serde(rename = "ciphertextCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
@@ -5580,7 +5580,7 @@ pub struct RawDecryptRequest {
     /// never exceed 2^32-1, and can be safely downconverted to uint32 in languages
     /// that support this type.
     ///
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     /// [google.cloud.kms.v1.RawDecryptRequest.additional_authenticated_data]: crate::model::RawDecryptRequest::additional_authenticated_data
     #[serde(rename = "additionalAuthenticatedDataCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
@@ -5603,7 +5603,7 @@ pub struct RawDecryptRequest {
     /// never exceed 2^32-1, and can be safely downconverted to uint32 in languages
     /// that support this type.
     ///
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     /// [google.cloud.kms.v1.RawDecryptRequest.initialization_vector]: crate::model::RawDecryptRequest::initialization_vector
     #[serde(rename = "initializationVectorCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
@@ -5686,7 +5686,7 @@ impl wkt::message::Message for RawDecryptRequest {
 /// Request message for
 /// [KeyManagementService.AsymmetricSign][google.cloud.kms.v1.KeyManagementService.AsymmetricSign].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.AsymmetricSign]: crate::traits::KeyManagementService::asymmetric_sign
+/// [google.cloud.kms.v1.KeyManagementService.AsymmetricSign]: crate::client::KeyManagementService::asymmetric_sign
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -5735,7 +5735,7 @@ pub struct AsymmetricSignRequest {
     ///
     /// [google.cloud.kms.v1.AsymmetricSignRequest.digest]: crate::model::AsymmetricSignRequest::digest
     /// [google.cloud.kms.v1.AsymmetricSignRequest.digest_crc32c]: crate::model::AsymmetricSignRequest::digest_crc32c
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     #[serde(rename = "digestCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
@@ -5773,7 +5773,7 @@ pub struct AsymmetricSignRequest {
     ///
     /// [google.cloud.kms.v1.AsymmetricSignRequest.data]: crate::model::AsymmetricSignRequest::data
     /// [google.cloud.kms.v1.AsymmetricSignRequest.data_crc32c]: crate::model::AsymmetricSignRequest::data_crc32c
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     #[serde(rename = "dataCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
@@ -5830,7 +5830,7 @@ impl wkt::message::Message for AsymmetricSignRequest {
 /// Request message for
 /// [KeyManagementService.AsymmetricDecrypt][google.cloud.kms.v1.KeyManagementService.AsymmetricDecrypt].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.AsymmetricDecrypt]: crate::traits::KeyManagementService::asymmetric_decrypt
+/// [google.cloud.kms.v1.KeyManagementService.AsymmetricDecrypt]: crate::client::KeyManagementService::asymmetric_decrypt
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -5875,7 +5875,7 @@ pub struct AsymmetricDecryptRequest {
     ///
     /// [google.cloud.kms.v1.AsymmetricDecryptRequest.ciphertext]: crate::model::AsymmetricDecryptRequest::ciphertext
     /// [google.cloud.kms.v1.AsymmetricDecryptRequest.ciphertext_crc32c]: crate::model::AsymmetricDecryptRequest::ciphertext_crc32c
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     #[serde(rename = "ciphertextCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
@@ -5914,7 +5914,7 @@ impl wkt::message::Message for AsymmetricDecryptRequest {
 /// Request message for
 /// [KeyManagementService.MacSign][google.cloud.kms.v1.KeyManagementService.MacSign].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.MacSign]: crate::traits::KeyManagementService::mac_sign
+/// [google.cloud.kms.v1.KeyManagementService.MacSign]: crate::client::KeyManagementService::mac_sign
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -5952,7 +5952,7 @@ pub struct MacSignRequest {
     /// 2^32-1, and can be safely downconverted to uint32 in languages that support
     /// this type.
     ///
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     /// [google.cloud.kms.v1.MacSignRequest.data]: crate::model::MacSignRequest::data
     /// [google.cloud.kms.v1.MacSignRequest.data_crc32c]: crate::model::MacSignRequest::data_crc32c
     #[serde(rename = "dataCrc32c")]
@@ -5993,7 +5993,7 @@ impl wkt::message::Message for MacSignRequest {
 /// Request message for
 /// [KeyManagementService.MacVerify][google.cloud.kms.v1.KeyManagementService.MacVerify].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.MacVerify]: crate::traits::KeyManagementService::mac_verify
+/// [google.cloud.kms.v1.KeyManagementService.MacVerify]: crate::client::KeyManagementService::mac_verify
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -6035,7 +6035,7 @@ pub struct MacVerifyRequest {
     /// 2^32-1, and can be safely downconverted to uint32 in languages that support
     /// this type.
     ///
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     /// [google.cloud.kms.v1.MacVerifyRequest.data]: crate::model::MacVerifyRequest::data
     /// [google.cloud.kms.v1.MacVerifyRequest.data_crc32c]: crate::model::MacVerifyRequest::data_crc32c
     #[serde(rename = "dataCrc32c")]
@@ -6066,7 +6066,7 @@ pub struct MacVerifyRequest {
     /// 2^32-1, and can be safely downconverted to uint32 in languages that support
     /// this type.
     ///
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     /// [google.cloud.kms.v1.MacVerifyRequest.mac]: crate::model::MacVerifyRequest::mac
     /// [google.cloud.kms.v1.MacVerifyRequest.mac_crc32c]: crate::model::MacVerifyRequest::mac_crc32c
     #[serde(rename = "macCrc32c")]
@@ -6122,7 +6122,7 @@ impl wkt::message::Message for MacVerifyRequest {
 /// Request message for
 /// [KeyManagementService.GenerateRandomBytes][google.cloud.kms.v1.KeyManagementService.GenerateRandomBytes].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.GenerateRandomBytes]: crate::traits::KeyManagementService::generate_random_bytes
+/// [google.cloud.kms.v1.KeyManagementService.GenerateRandomBytes]: crate::client::KeyManagementService::generate_random_bytes
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -6179,7 +6179,7 @@ impl wkt::message::Message for GenerateRandomBytesRequest {
 /// Response message for
 /// [KeyManagementService.Encrypt][google.cloud.kms.v1.KeyManagementService.Encrypt].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::traits::KeyManagementService::encrypt
+/// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::client::KeyManagementService::encrypt
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -6236,7 +6236,7 @@ pub struct EncryptResponse {
     ///
     /// [google.cloud.kms.v1.EncryptRequest.plaintext]: crate::model::EncryptRequest::plaintext
     /// [google.cloud.kms.v1.EncryptRequest.plaintext_crc32c]: crate::model::EncryptRequest::plaintext_crc32c
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     #[serde(rename = "verifiedPlaintextCrc32c")]
     pub verified_plaintext_crc32c: bool,
 
@@ -6257,7 +6257,7 @@ pub struct EncryptResponse {
     ///
     /// [google.cloud.kms.v1.EncryptRequest.additional_authenticated_data]: crate::model::EncryptRequest::additional_authenticated_data
     /// [google.cloud.kms.v1.EncryptRequest.additional_authenticated_data_crc32c]: crate::model::EncryptRequest::additional_authenticated_data_crc32c
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     #[serde(rename = "verifiedAdditionalAuthenticatedDataCrc32c")]
     pub verified_additional_authenticated_data_crc32c: bool,
 
@@ -6326,7 +6326,7 @@ impl wkt::message::Message for EncryptResponse {
 /// Response message for
 /// [KeyManagementService.Decrypt][google.cloud.kms.v1.KeyManagementService.Decrypt].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::traits::KeyManagementService::decrypt
+/// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::client::KeyManagementService::decrypt
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -6360,7 +6360,7 @@ pub struct DecryptResponse {
     ///
     /// [google.cloud.kms.v1.DecryptRequest.ciphertext]: crate::model::DecryptRequest::ciphertext
     /// [google.cloud.kms.v1.DecryptResponse.plaintext]: crate::model::DecryptResponse::plaintext
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     #[serde(rename = "plaintextCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
@@ -6419,7 +6419,7 @@ impl wkt::message::Message for DecryptResponse {
 /// Response message for
 /// [KeyManagementService.RawEncrypt][google.cloud.kms.v1.KeyManagementService.RawEncrypt].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.RawEncrypt]: crate::traits::KeyManagementService::raw_encrypt
+/// [google.cloud.kms.v1.KeyManagementService.RawEncrypt]: crate::client::KeyManagementService::raw_encrypt
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -6496,7 +6496,7 @@ pub struct RawEncryptResponse {
     /// but this field is still false, discard the response and perform a limited
     /// number of retries.
     ///
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     /// [google.cloud.kms.v1.RawEncryptRequest.plaintext_crc32c]: crate::model::RawEncryptRequest::plaintext_crc32c
     #[serde(rename = "verifiedPlaintextCrc32c")]
     pub verified_plaintext_crc32c: bool,
@@ -6515,7 +6515,7 @@ pub struct RawEncryptResponse {
     /// but this field is still false, discard the response and perform a limited
     /// number of retries.
     ///
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     /// [google.cloud.kms.v1.RawEncryptRequest.additional_authenticated_data_crc32c]: crate::model::RawEncryptRequest::additional_authenticated_data_crc32c
     #[serde(rename = "verifiedAdditionalAuthenticatedDataCrc32c")]
     pub verified_additional_authenticated_data_crc32c: bool,
@@ -6534,7 +6534,7 @@ pub struct RawEncryptResponse {
     /// but this field is still false, discard the response and perform a limited
     /// number of retries.
     ///
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     /// [google.cloud.kms.v1.RawEncryptRequest.initialization_vector_crc32c]: crate::model::RawEncryptRequest::initialization_vector_crc32c
     #[serde(rename = "verifiedInitializationVectorCrc32c")]
     pub verified_initialization_vector_crc32c: bool,
@@ -6645,7 +6645,7 @@ impl wkt::message::Message for RawEncryptResponse {
 /// Response message for
 /// [KeyManagementService.RawDecrypt][google.cloud.kms.v1.KeyManagementService.RawDecrypt].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.RawDecrypt]: crate::traits::KeyManagementService::raw_decrypt
+/// [google.cloud.kms.v1.KeyManagementService.RawDecrypt]: crate::client::KeyManagementService::raw_decrypt
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -6672,7 +6672,7 @@ pub struct RawDecryptResponse {
     /// never exceed 2^32-1, and can be safely downconverted to uint32 in languages
     /// that support this type.
     ///
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     /// [google.cloud.kms.v1.RawDecryptRequest.ciphertext]: crate::model::RawDecryptRequest::ciphertext
     /// [google.cloud.kms.v1.RawDecryptResponse.plaintext]: crate::model::RawDecryptResponse::plaintext
     #[serde(rename = "plaintextCrc32c")]
@@ -6702,7 +6702,7 @@ pub struct RawDecryptResponse {
     /// but this field is still false, discard the response and perform a limited
     /// number of retries.
     ///
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     /// [google.cloud.kms.v1.RawDecryptRequest.ciphertext_crc32c]: crate::model::RawDecryptRequest::ciphertext_crc32c
     #[serde(rename = "verifiedCiphertextCrc32c")]
     pub verified_ciphertext_crc32c: bool,
@@ -6721,7 +6721,7 @@ pub struct RawDecryptResponse {
     /// but this field is still false, discard the response and perform a limited
     /// number of retries.
     ///
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     /// [google.cloud.kms.v1.RawDecryptRequest.additional_authenticated_data_crc32c]: crate::model::RawDecryptRequest::additional_authenticated_data_crc32c
     #[serde(rename = "verifiedAdditionalAuthenticatedDataCrc32c")]
     pub verified_additional_authenticated_data_crc32c: bool,
@@ -6740,7 +6740,7 @@ pub struct RawDecryptResponse {
     /// but this field is still false, discard the response and perform a limited
     /// number of retries.
     ///
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     /// [google.cloud.kms.v1.RawDecryptRequest.initialization_vector_crc32c]: crate::model::RawDecryptRequest::initialization_vector_crc32c
     #[serde(rename = "verifiedInitializationVectorCrc32c")]
     pub verified_initialization_vector_crc32c: bool,
@@ -6805,7 +6805,7 @@ impl wkt::message::Message for RawDecryptResponse {
 /// Response message for
 /// [KeyManagementService.AsymmetricSign][google.cloud.kms.v1.KeyManagementService.AsymmetricSign].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.AsymmetricSign]: crate::traits::KeyManagementService::asymmetric_sign
+/// [google.cloud.kms.v1.KeyManagementService.AsymmetricSign]: crate::client::KeyManagementService::asymmetric_sign
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -6853,7 +6853,7 @@ pub struct AsymmetricSignResponse {
     ///
     /// [google.cloud.kms.v1.AsymmetricSignRequest.digest]: crate::model::AsymmetricSignRequest::digest
     /// [google.cloud.kms.v1.AsymmetricSignRequest.digest_crc32c]: crate::model::AsymmetricSignRequest::digest_crc32c
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     #[serde(rename = "verifiedDigestCrc32c")]
     pub verified_digest_crc32c: bool,
 
@@ -6882,7 +6882,7 @@ pub struct AsymmetricSignResponse {
     ///
     /// [google.cloud.kms.v1.AsymmetricSignRequest.data]: crate::model::AsymmetricSignRequest::data
     /// [google.cloud.kms.v1.AsymmetricSignRequest.data_crc32c]: crate::model::AsymmetricSignRequest::data_crc32c
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     #[serde(rename = "verifiedDataCrc32c")]
     pub verified_data_crc32c: bool,
 
@@ -6947,7 +6947,7 @@ impl wkt::message::Message for AsymmetricSignResponse {
 /// Response message for
 /// [KeyManagementService.AsymmetricDecrypt][google.cloud.kms.v1.KeyManagementService.AsymmetricDecrypt].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.AsymmetricDecrypt]: crate::traits::KeyManagementService::asymmetric_decrypt
+/// [google.cloud.kms.v1.KeyManagementService.AsymmetricDecrypt]: crate::client::KeyManagementService::asymmetric_decrypt
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -6995,7 +6995,7 @@ pub struct AsymmetricDecryptResponse {
     ///
     /// [google.cloud.kms.v1.AsymmetricDecryptRequest.ciphertext]: crate::model::AsymmetricDecryptRequest::ciphertext
     /// [google.cloud.kms.v1.AsymmetricDecryptRequest.ciphertext_crc32c]: crate::model::AsymmetricDecryptRequest::ciphertext_crc32c
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     #[serde(rename = "verifiedCiphertextCrc32c")]
     pub verified_ciphertext_crc32c: bool,
 
@@ -7049,7 +7049,7 @@ impl wkt::message::Message for AsymmetricDecryptResponse {
 /// Response message for
 /// [KeyManagementService.MacSign][google.cloud.kms.v1.KeyManagementService.MacSign].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.MacSign]: crate::traits::KeyManagementService::mac_sign
+/// [google.cloud.kms.v1.KeyManagementService.MacSign]: crate::client::KeyManagementService::mac_sign
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -7103,7 +7103,7 @@ pub struct MacSignResponse {
     /// but this field is still false, discard the response and perform a limited
     /// number of retries.
     ///
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     /// [google.cloud.kms.v1.MacSignRequest.data]: crate::model::MacSignRequest::data
     /// [google.cloud.kms.v1.MacSignRequest.data_crc32c]: crate::model::MacSignRequest::data_crc32c
     #[serde(rename = "verifiedDataCrc32c")]
@@ -7164,7 +7164,7 @@ impl wkt::message::Message for MacSignResponse {
 /// Response message for
 /// [KeyManagementService.MacVerify][google.cloud.kms.v1.KeyManagementService.MacVerify].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.MacVerify]: crate::traits::KeyManagementService::mac_verify
+/// [google.cloud.kms.v1.KeyManagementService.MacVerify]: crate::client::KeyManagementService::mac_verify
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -7203,7 +7203,7 @@ pub struct MacVerifyResponse {
     /// but this field is still false, discard the response and perform a limited
     /// number of retries.
     ///
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     /// [google.cloud.kms.v1.MacVerifyRequest.data]: crate::model::MacVerifyRequest::data
     /// [google.cloud.kms.v1.MacVerifyRequest.data_crc32c]: crate::model::MacVerifyRequest::data_crc32c
     #[serde(rename = "verifiedDataCrc32c")]
@@ -7224,7 +7224,7 @@ pub struct MacVerifyResponse {
     /// but this field is still false, discard the response and perform a limited
     /// number of retries.
     ///
-    /// [google.cloud.kms.v1.KeyManagementService]: crate::traits::KeyManagementService
+    /// [google.cloud.kms.v1.KeyManagementService]: crate::client::KeyManagementService
     /// [google.cloud.kms.v1.MacVerifyRequest.mac]: crate::model::MacVerifyRequest::mac
     /// [google.cloud.kms.v1.MacVerifyRequest.mac_crc32c]: crate::model::MacVerifyRequest::mac_crc32c
     #[serde(rename = "verifiedMacCrc32c")]
@@ -7295,7 +7295,7 @@ impl wkt::message::Message for MacVerifyResponse {
 /// Response message for
 /// [KeyManagementService.GenerateRandomBytes][google.cloud.kms.v1.KeyManagementService.GenerateRandomBytes].
 ///
-/// [google.cloud.kms.v1.KeyManagementService.GenerateRandomBytes]: crate::traits::KeyManagementService::generate_random_bytes
+/// [google.cloud.kms.v1.KeyManagementService.GenerateRandomBytes]: crate::client::KeyManagementService::generate_random_bytes
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]

--- a/src/generated/cloud/kms/v1/src/traits/mod.rs
+++ b/src/generated/cloud/kms/v1/src/traits/mod.rs
@@ -37,8 +37,8 @@ pub(crate) mod dyntraits;
 /// a resource project's ancestor folder, see
 /// [ShowEffectiveAutokeyConfig][google.cloud.kms.v1.AutokeyAdmin.ShowEffectiveAutokeyConfig].
 ///
-/// [google.cloud.kms.v1.AutokeyAdmin.ShowEffectiveAutokeyConfig]: crate::traits::AutokeyAdmin::show_effective_autokey_config
-/// [google.cloud.kms.v1.AutokeyAdmin.UpdateAutokeyConfig]: crate::traits::AutokeyAdmin::update_autokey_config
+/// [google.cloud.kms.v1.AutokeyAdmin.ShowEffectiveAutokeyConfig]: crate::client::AutokeyAdmin::show_effective_autokey_config
+/// [google.cloud.kms.v1.AutokeyAdmin.UpdateAutokeyConfig]: crate::client::AutokeyAdmin::update_autokey_config
 /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
 /// [google.cloud.kms.v1.KeyHandle]: crate::model::KeyHandle
 ///
@@ -168,7 +168,7 @@ pub trait Autokey: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn get_operation(
         &self,
         _req: longrunning::model::GetOperationRequest,
@@ -330,7 +330,7 @@ pub trait AutokeyAdmin: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn get_operation(
         &self,
         _req: longrunning::model::GetOperationRequest,
@@ -531,7 +531,7 @@ pub trait EkmService: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn get_operation(
         &self,
         _req: longrunning::model::GetOperationRequest,
@@ -833,8 +833,8 @@ pub trait KeyManagementService: std::fmt::Debug + Send + Sync {
     /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED]: crate::model::crypto_key_version::crypto_key_version_state::DISABLED
     /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::crypto_key_version_state::ENABLED
     /// [google.cloud.kms.v1.CryptoKeyVersion.state]: crate::model::CryptoKeyVersion::state
-    /// [google.cloud.kms.v1.KeyManagementService.DestroyCryptoKeyVersion]: crate::traits::KeyManagementService::destroy_crypto_key_version
-    /// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: crate::traits::KeyManagementService::restore_crypto_key_version
+    /// [google.cloud.kms.v1.KeyManagementService.DestroyCryptoKeyVersion]: crate::client::KeyManagementService::destroy_crypto_key_version
+    /// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: crate::client::KeyManagementService::restore_crypto_key_version
     fn update_crypto_key_version(
         &self,
         _req: crate::model::UpdateCryptoKeyVersionRequest,
@@ -855,7 +855,7 @@ pub trait KeyManagementService: std::fmt::Debug + Send + Sync {
     ///
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
     /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::crypto_key_purpose::ENCRYPT_DECRYPT
-    /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::traits::KeyManagementService::encrypt
+    /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::client::KeyManagementService::encrypt
     fn update_crypto_key_primary_version(
         &self,
         _req: crate::model::UpdateCryptoKeyPrimaryVersionRequest,
@@ -894,7 +894,7 @@ pub trait KeyManagementService: std::fmt::Debug + Send + Sync {
     /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED]: crate::model::crypto_key_version::crypto_key_version_state::DESTROY_SCHEDULED
     /// [google.cloud.kms.v1.CryptoKeyVersion.destroy_time]: crate::model::CryptoKeyVersion::destroy_time
     /// [google.cloud.kms.v1.CryptoKeyVersion.state]: crate::model::CryptoKeyVersion::state
-    /// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: crate::traits::KeyManagementService::restore_crypto_key_version
+    /// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: crate::client::KeyManagementService::restore_crypto_key_version
     fn destroy_crypto_key_version(
         &self,
         _req: crate::model::DestroyCryptoKeyVersionRequest,
@@ -939,7 +939,7 @@ pub trait KeyManagementService: std::fmt::Debug + Send + Sync {
     ///
     /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::crypto_key_purpose::ENCRYPT_DECRYPT
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
-    /// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::traits::KeyManagementService::decrypt
+    /// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::client::KeyManagementService::decrypt
     fn encrypt(
         &self,
         _req: crate::model::EncryptRequest,
@@ -958,7 +958,7 @@ pub trait KeyManagementService: std::fmt::Debug + Send + Sync {
     ///
     /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::crypto_key_purpose::ENCRYPT_DECRYPT
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
-    /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::traits::KeyManagementService::encrypt
+    /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::client::KeyManagementService::encrypt
     fn decrypt(
         &self,
         _req: crate::model::DecryptRequest,
@@ -979,8 +979,8 @@ pub trait KeyManagementService: std::fmt::Debug + Send + Sync {
     ///
     /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.RAW_ENCRYPT_DECRYPT]: crate::model::crypto_key::crypto_key_purpose::RAW_ENCRYPT_DECRYPT
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
-    /// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::traits::KeyManagementService::decrypt
-    /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::traits::KeyManagementService::encrypt
+    /// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::client::KeyManagementService::decrypt
+    /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::client::KeyManagementService::encrypt
     fn raw_encrypt(
         &self,
         _req: crate::model::RawEncryptRequest,
@@ -1018,7 +1018,7 @@ pub trait KeyManagementService: std::fmt::Debug + Send + Sync {
     ///
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-    /// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::traits::KeyManagementService::get_public_key
+    /// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::client::KeyManagementService::get_public_key
     fn asymmetric_sign(
         &self,
         _req: crate::model::AsymmetricSignRequest,
@@ -1038,7 +1038,7 @@ pub trait KeyManagementService: std::fmt::Debug + Send + Sync {
     ///
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-    /// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::traits::KeyManagementService::get_public_key
+    /// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::client::KeyManagementService::get_public_key
     fn asymmetric_decrypt(
         &self,
         _req: crate::model::AsymmetricDecryptRequest,
@@ -1168,7 +1168,7 @@ pub trait KeyManagementService: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn get_operation(
         &self,
         _req: longrunning::model::GetOperationRequest,

--- a/src/generated/cloud/location/src/model.rs
+++ b/src/generated/cloud/location/src/model.rs
@@ -32,7 +32,7 @@ extern crate wkt;
 
 /// The request message for [Locations.ListLocations][google.cloud.location.Locations.ListLocations].
 ///
-/// [google.cloud.location.Locations.ListLocations]: crate::traits::Locations::list_locations
+/// [google.cloud.location.Locations.ListLocations]: crate::client::Locations::list_locations
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -88,7 +88,7 @@ impl wkt::message::Message for ListLocationsRequest {
 
 /// The response message for [Locations.ListLocations][google.cloud.location.Locations.ListLocations].
 ///
-/// [google.cloud.location.Locations.ListLocations]: crate::traits::Locations::list_locations
+/// [google.cloud.location.Locations.ListLocations]: crate::client::Locations::list_locations
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -141,7 +141,7 @@ impl gax::paginator::PageableResponse for ListLocationsResponse {
 
 /// The request message for [Locations.GetLocation][google.cloud.location.Locations.GetLocation].
 ///
-/// [google.cloud.location.Locations.GetLocation]: crate::traits::Locations::get_location
+/// [google.cloud.location.Locations.GetLocation]: crate::client::Locations::get_location
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]

--- a/src/generated/cloud/run/v2/src/client.rs
+++ b/src/generated/cloud/run/v2/src/client.rs
@@ -91,7 +91,7 @@ impl Builds {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
         name: impl Into<std::string::String>,
@@ -101,7 +101,7 @@ impl Builds {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -111,7 +111,7 @@ impl Builds {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -121,7 +121,7 @@ impl Builds {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn wait_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -408,7 +408,7 @@ impl Executions {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
         name: impl Into<std::string::String>,
@@ -418,7 +418,7 @@ impl Executions {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -428,7 +428,7 @@ impl Executions {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -438,7 +438,7 @@ impl Executions {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn wait_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -938,7 +938,7 @@ impl Jobs {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
         name: impl Into<std::string::String>,
@@ -948,7 +948,7 @@ impl Jobs {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -958,7 +958,7 @@ impl Jobs {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -968,7 +968,7 @@ impl Jobs {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn wait_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -1157,7 +1157,7 @@ impl Revisions {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
         name: impl Into<std::string::String>,
@@ -1167,7 +1167,7 @@ impl Revisions {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -1177,7 +1177,7 @@ impl Revisions {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -1187,7 +1187,7 @@ impl Revisions {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn wait_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -1603,7 +1603,7 @@ impl Services {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
         name: impl Into<std::string::String>,
@@ -1613,7 +1613,7 @@ impl Services {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -1623,7 +1623,7 @@ impl Services {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -1633,7 +1633,7 @@ impl Services {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn wait_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -1724,7 +1724,7 @@ impl Tasks {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
         name: impl Into<std::string::String>,
@@ -1734,7 +1734,7 @@ impl Tasks {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -1744,7 +1744,7 @@ impl Tasks {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -1754,7 +1754,7 @@ impl Tasks {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn wait_operation(
         &self,
         name: impl Into<std::string::String>,

--- a/src/generated/cloud/run/v2/src/traits/mod.rs
+++ b/src/generated/cloud/run/v2/src/traits/mod.rs
@@ -42,7 +42,7 @@ pub trait Builds: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn list_operations(
         &self,
         _req: longrunning::model::ListOperationsRequest,
@@ -56,7 +56,7 @@ pub trait Builds: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn get_operation(
         &self,
         _req: longrunning::model::GetOperationRequest,
@@ -70,7 +70,7 @@ pub trait Builds: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn delete_operation(
         &self,
         _req: longrunning::model::DeleteOperationRequest,
@@ -81,7 +81,7 @@ pub trait Builds: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn wait_operation(
         &self,
         _req: longrunning::model::WaitOperationRequest,
@@ -154,7 +154,7 @@ pub trait Executions: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn list_operations(
         &self,
         _req: longrunning::model::ListOperationsRequest,
@@ -168,7 +168,7 @@ pub trait Executions: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn get_operation(
         &self,
         _req: longrunning::model::GetOperationRequest,
@@ -182,7 +182,7 @@ pub trait Executions: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn delete_operation(
         &self,
         _req: longrunning::model::DeleteOperationRequest,
@@ -193,7 +193,7 @@ pub trait Executions: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn wait_operation(
         &self,
         _req: longrunning::model::WaitOperationRequest,
@@ -337,7 +337,7 @@ pub trait Jobs: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn list_operations(
         &self,
         _req: longrunning::model::ListOperationsRequest,
@@ -351,7 +351,7 @@ pub trait Jobs: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn get_operation(
         &self,
         _req: longrunning::model::GetOperationRequest,
@@ -365,7 +365,7 @@ pub trait Jobs: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn delete_operation(
         &self,
         _req: longrunning::model::DeleteOperationRequest,
@@ -376,7 +376,7 @@ pub trait Jobs: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn wait_operation(
         &self,
         _req: longrunning::model::WaitOperationRequest,
@@ -449,7 +449,7 @@ pub trait Revisions: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn list_operations(
         &self,
         _req: longrunning::model::ListOperationsRequest,
@@ -463,7 +463,7 @@ pub trait Revisions: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn get_operation(
         &self,
         _req: longrunning::model::GetOperationRequest,
@@ -477,7 +477,7 @@ pub trait Revisions: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn delete_operation(
         &self,
         _req: longrunning::model::DeleteOperationRequest,
@@ -488,7 +488,7 @@ pub trait Revisions: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn wait_operation(
         &self,
         _req: longrunning::model::WaitOperationRequest,
@@ -624,7 +624,7 @@ pub trait Services: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn list_operations(
         &self,
         _req: longrunning::model::ListOperationsRequest,
@@ -638,7 +638,7 @@ pub trait Services: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn get_operation(
         &self,
         _req: longrunning::model::GetOperationRequest,
@@ -652,7 +652,7 @@ pub trait Services: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn delete_operation(
         &self,
         _req: longrunning::model::DeleteOperationRequest,
@@ -663,7 +663,7 @@ pub trait Services: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn wait_operation(
         &self,
         _req: longrunning::model::WaitOperationRequest,
@@ -721,7 +721,7 @@ pub trait Tasks: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn list_operations(
         &self,
         _req: longrunning::model::ListOperationsRequest,
@@ -735,7 +735,7 @@ pub trait Tasks: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn get_operation(
         &self,
         _req: longrunning::model::GetOperationRequest,
@@ -749,7 +749,7 @@ pub trait Tasks: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn delete_operation(
         &self,
         _req: longrunning::model::DeleteOperationRequest,
@@ -760,7 +760,7 @@ pub trait Tasks: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn wait_operation(
         &self,
         _req: longrunning::model::WaitOperationRequest,

--- a/src/generated/cloud/secretmanager/v1/src/model.rs
+++ b/src/generated/cloud/secretmanager/v1/src/model.rs
@@ -400,8 +400,8 @@ pub struct SecretVersion {
     /// on
     /// [SecretManagerService.AddSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion].
     ///
-    /// [google.cloud.secretmanager.v1.SecretManagerService]: crate::traits::SecretManagerService
-    /// [google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion]: crate::traits::SecretManagerService::add_secret_version
+    /// [google.cloud.secretmanager.v1.SecretManagerService]: crate::client::SecretManagerService
+    /// [google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion]: crate::client::SecretManagerService::add_secret_version
     /// [google.cloud.secretmanager.v1.SecretPayload]: crate::model::SecretPayload
     pub client_specified_payload_checksum: bool,
 
@@ -1206,9 +1206,9 @@ pub struct SecretPayload {
     /// safely downconverted to uint32 in languages that support this type.
     /// <https://cloud.google.com/apis/design/design_patterns#integer_types>
     ///
-    /// [google.cloud.secretmanager.v1.SecretManagerService]: crate::traits::SecretManagerService
-    /// [google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion]: crate::traits::SecretManagerService::access_secret_version
-    /// [google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion]: crate::traits::SecretManagerService::add_secret_version
+    /// [google.cloud.secretmanager.v1.SecretManagerService]: crate::client::SecretManagerService
+    /// [google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion]: crate::client::SecretManagerService::access_secret_version
+    /// [google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion]: crate::client::SecretManagerService::add_secret_version
     /// [google.cloud.secretmanager.v1.SecretPayload.data]: crate::model::SecretPayload::data
     #[serde(rename = "dataCrc32c")]
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
@@ -1242,7 +1242,7 @@ impl wkt::message::Message for SecretPayload {
 /// Request message for
 /// [SecretManagerService.ListSecrets][google.cloud.secretmanager.v1.SecretManagerService.ListSecrets].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.ListSecrets]: crate::traits::SecretManagerService::list_secrets
+/// [google.cloud.secretmanager.v1.SecretManagerService.ListSecrets]: crate::client::SecretManagerService::list_secrets
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1312,7 +1312,7 @@ impl wkt::message::Message for ListSecretsRequest {
 /// Response message for
 /// [SecretManagerService.ListSecrets][google.cloud.secretmanager.v1.SecretManagerService.ListSecrets].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.ListSecrets]: crate::traits::SecretManagerService::list_secrets
+/// [google.cloud.secretmanager.v1.SecretManagerService.ListSecrets]: crate::client::SecretManagerService::list_secrets
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1388,7 +1388,7 @@ impl gax::paginator::PageableResponse for ListSecretsResponse {
 /// Request message for
 /// [SecretManagerService.CreateSecret][google.cloud.secretmanager.v1.SecretManagerService.CreateSecret].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.CreateSecret]: crate::traits::SecretManagerService::create_secret
+/// [google.cloud.secretmanager.v1.SecretManagerService.CreateSecret]: crate::client::SecretManagerService::create_secret
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1450,7 +1450,7 @@ impl wkt::message::Message for CreateSecretRequest {
 /// Request message for
 /// [SecretManagerService.AddSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion]: crate::traits::SecretManagerService::add_secret_version
+/// [google.cloud.secretmanager.v1.SecretManagerService.AddSecretVersion]: crate::client::SecretManagerService::add_secret_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1500,7 +1500,7 @@ impl wkt::message::Message for AddSecretVersionRequest {
 /// Request message for
 /// [SecretManagerService.GetSecret][google.cloud.secretmanager.v1.SecretManagerService.GetSecret].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.GetSecret]: crate::traits::SecretManagerService::get_secret
+/// [google.cloud.secretmanager.v1.SecretManagerService.GetSecret]: crate::client::SecretManagerService::get_secret
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1532,7 +1532,7 @@ impl wkt::message::Message for GetSecretRequest {
 /// Request message for
 /// [SecretManagerService.ListSecretVersions][google.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions]: crate::traits::SecretManagerService::list_secret_versions
+/// [google.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions]: crate::client::SecretManagerService::list_secret_versions
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1602,7 +1602,7 @@ impl wkt::message::Message for ListSecretVersionsRequest {
 /// Response message for
 /// [SecretManagerService.ListSecretVersions][google.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions]: crate::traits::SecretManagerService::list_secret_versions
+/// [google.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions]: crate::client::SecretManagerService::list_secret_versions
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1679,7 +1679,7 @@ impl gax::paginator::PageableResponse for ListSecretVersionsResponse {
 /// Request message for
 /// [SecretManagerService.GetSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.GetSecretVersion].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.GetSecretVersion]: crate::traits::SecretManagerService::get_secret_version
+/// [google.cloud.secretmanager.v1.SecretManagerService.GetSecretVersion]: crate::client::SecretManagerService::get_secret_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1717,7 +1717,7 @@ impl wkt::message::Message for GetSecretVersionRequest {
 /// Request message for
 /// [SecretManagerService.UpdateSecret][google.cloud.secretmanager.v1.SecretManagerService.UpdateSecret].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.UpdateSecret]: crate::traits::SecretManagerService::update_secret
+/// [google.cloud.secretmanager.v1.SecretManagerService.UpdateSecret]: crate::client::SecretManagerService::update_secret
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1764,7 +1764,7 @@ impl wkt::message::Message for UpdateSecretRequest {
 /// Request message for
 /// [SecretManagerService.AccessSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion]: crate::traits::SecretManagerService::access_secret_version
+/// [google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion]: crate::client::SecretManagerService::access_secret_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1802,7 +1802,7 @@ impl wkt::message::Message for AccessSecretVersionRequest {
 /// Response message for
 /// [SecretManagerService.AccessSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion]: crate::traits::SecretManagerService::access_secret_version
+/// [google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion]: crate::client::SecretManagerService::access_secret_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1848,7 +1848,7 @@ impl wkt::message::Message for AccessSecretVersionResponse {
 /// Request message for
 /// [SecretManagerService.DeleteSecret][google.cloud.secretmanager.v1.SecretManagerService.DeleteSecret].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.DeleteSecret]: crate::traits::SecretManagerService::delete_secret
+/// [google.cloud.secretmanager.v1.SecretManagerService.DeleteSecret]: crate::client::SecretManagerService::delete_secret
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1894,7 +1894,7 @@ impl wkt::message::Message for DeleteSecretRequest {
 /// Request message for
 /// [SecretManagerService.DisableSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.DisableSecretVersion].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.DisableSecretVersion]: crate::traits::SecretManagerService::disable_secret_version
+/// [google.cloud.secretmanager.v1.SecretManagerService.DisableSecretVersion]: crate::client::SecretManagerService::disable_secret_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1942,7 +1942,7 @@ impl wkt::message::Message for DisableSecretVersionRequest {
 /// Request message for
 /// [SecretManagerService.EnableSecretVersion][google.cloud.secretmanager.v1.SecretManagerService.EnableSecretVersion].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.EnableSecretVersion]: crate::traits::SecretManagerService::enable_secret_version
+/// [google.cloud.secretmanager.v1.SecretManagerService.EnableSecretVersion]: crate::client::SecretManagerService::enable_secret_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1990,7 +1990,7 @@ impl wkt::message::Message for EnableSecretVersionRequest {
 /// Request message for
 /// [SecretManagerService.DestroySecretVersion][google.cloud.secretmanager.v1.SecretManagerService.DestroySecretVersion].
 ///
-/// [google.cloud.secretmanager.v1.SecretManagerService.DestroySecretVersion]: crate::traits::SecretManagerService::destroy_secret_version
+/// [google.cloud.secretmanager.v1.SecretManagerService.DestroySecretVersion]: crate::client::SecretManagerService::destroy_secret_version
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]

--- a/src/generated/cloud/translate/v3/src/client.rs
+++ b/src/generated/cloud/translate/v3/src/client.rs
@@ -1442,7 +1442,7 @@ impl TranslationService {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
         name: impl Into<std::string::String>,
@@ -1453,7 +1453,7 @@ impl TranslationService {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -1464,7 +1464,7 @@ impl TranslationService {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -1475,7 +1475,7 @@ impl TranslationService {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn cancel_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -1486,7 +1486,7 @@ impl TranslationService {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn wait_operation(
         &self,
         name: impl Into<std::string::String>,

--- a/src/generated/cloud/translate/v3/src/traits/mod.rs
+++ b/src/generated/cloud/translate/v3/src/traits/mod.rs
@@ -512,7 +512,7 @@ pub trait TranslationService: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn list_operations(
         &self,
         _req: longrunning::model::ListOperationsRequest,
@@ -526,7 +526,7 @@ pub trait TranslationService: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn get_operation(
         &self,
         _req: longrunning::model::GetOperationRequest,
@@ -540,7 +540,7 @@ pub trait TranslationService: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn delete_operation(
         &self,
         _req: longrunning::model::DeleteOperationRequest,
@@ -551,7 +551,7 @@ pub trait TranslationService: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn cancel_operation(
         &self,
         _req: longrunning::model::CancelOperationRequest,
@@ -562,7 +562,7 @@ pub trait TranslationService: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn wait_operation(
         &self,
         _req: longrunning::model::WaitOperationRequest,

--- a/src/generated/cloud/webrisk/v1/src/client.rs
+++ b/src/generated/cloud/webrisk/v1/src/client.rs
@@ -236,7 +236,7 @@ impl WebRiskService {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
         name: impl Into<std::string::String>,
@@ -247,7 +247,7 @@ impl WebRiskService {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -258,7 +258,7 @@ impl WebRiskService {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -269,7 +269,7 @@ impl WebRiskService {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn cancel_operation(
         &self,
         name: impl Into<std::string::String>,

--- a/src/generated/cloud/webrisk/v1/src/traits/mod.rs
+++ b/src/generated/cloud/webrisk/v1/src/traits/mod.rs
@@ -118,7 +118,7 @@ pub trait WebRiskService: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn list_operations(
         &self,
         _req: longrunning::model::ListOperationsRequest,
@@ -132,7 +132,7 @@ pub trait WebRiskService: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn get_operation(
         &self,
         _req: longrunning::model::GetOperationRequest,
@@ -146,7 +146,7 @@ pub trait WebRiskService: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn delete_operation(
         &self,
         _req: longrunning::model::DeleteOperationRequest,
@@ -157,7 +157,7 @@ pub trait WebRiskService: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn cancel_operation(
         &self,
         _req: longrunning::model::CancelOperationRequest,

--- a/src/generated/cloud/workflows/v1/src/client.rs
+++ b/src/generated/cloud/workflows/v1/src/client.rs
@@ -419,7 +419,7 @@ impl Workflows {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
         name: impl Into<std::string::String>,
@@ -429,7 +429,7 @@ impl Workflows {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -439,7 +439,7 @@ impl Workflows {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
         name: impl Into<std::string::String>,

--- a/src/generated/cloud/workflows/v1/src/model.rs
+++ b/src/generated/cloud/workflows/v1/src/model.rs
@@ -426,7 +426,7 @@ pub mod workflow {
 /// [ListWorkflows][google.cloud.workflows.v1.Workflows.ListWorkflows]
 /// method.
 ///
-/// [google.cloud.workflows.v1.Workflows.ListWorkflows]: crate::traits::Workflows::list_workflows
+/// [google.cloud.workflows.v1.Workflows.ListWorkflows]: crate::client::Workflows::list_workflows
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -505,7 +505,7 @@ impl wkt::message::Message for ListWorkflowsRequest {
 /// [ListWorkflows][google.cloud.workflows.v1.Workflows.ListWorkflows]
 /// method.
 ///
-/// [google.cloud.workflows.v1.Workflows.ListWorkflows]: crate::traits::Workflows::list_workflows
+/// [google.cloud.workflows.v1.Workflows.ListWorkflows]: crate::client::Workflows::list_workflows
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -573,7 +573,7 @@ impl gax::paginator::PageableResponse for ListWorkflowsResponse {
 /// Request for the
 /// [GetWorkflow][google.cloud.workflows.v1.Workflows.GetWorkflow] method.
 ///
-/// [google.cloud.workflows.v1.Workflows.GetWorkflow]: crate::traits::Workflows::get_workflow
+/// [google.cloud.workflows.v1.Workflows.GetWorkflow]: crate::client::Workflows::get_workflow
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -617,7 +617,7 @@ impl wkt::message::Message for GetWorkflowRequest {
 /// [CreateWorkflow][google.cloud.workflows.v1.Workflows.CreateWorkflow]
 /// method.
 ///
-/// [google.cloud.workflows.v1.Workflows.CreateWorkflow]: crate::traits::Workflows::create_workflow
+/// [google.cloud.workflows.v1.Workflows.CreateWorkflow]: crate::client::Workflows::create_workflow
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -677,7 +677,7 @@ impl wkt::message::Message for CreateWorkflowRequest {
 /// [DeleteWorkflow][google.cloud.workflows.v1.Workflows.DeleteWorkflow]
 /// method.
 ///
-/// [google.cloud.workflows.v1.Workflows.DeleteWorkflow]: crate::traits::Workflows::delete_workflow
+/// [google.cloud.workflows.v1.Workflows.DeleteWorkflow]: crate::client::Workflows::delete_workflow
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -707,7 +707,7 @@ impl wkt::message::Message for DeleteWorkflowRequest {
 /// [UpdateWorkflow][google.cloud.workflows.v1.Workflows.UpdateWorkflow]
 /// method.
 ///
-/// [google.cloud.workflows.v1.Workflows.UpdateWorkflow]: crate::traits::Workflows::update_workflow
+/// [google.cloud.workflows.v1.Workflows.UpdateWorkflow]: crate::client::Workflows::update_workflow
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]

--- a/src/generated/cloud/workflows/v1/src/traits/mod.rs
+++ b/src/generated/cloud/workflows/v1/src/traits/mod.rs
@@ -123,7 +123,7 @@ pub trait Workflows: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn list_operations(
         &self,
         _req: longrunning::model::ListOperationsRequest,
@@ -137,7 +137,7 @@ pub trait Workflows: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn get_operation(
         &self,
         _req: longrunning::model::GetOperationRequest,
@@ -151,7 +151,7 @@ pub trait Workflows: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn delete_operation(
         &self,
         _req: longrunning::model::DeleteOperationRequest,

--- a/src/generated/devtools/cloudbuild/v2/src/client.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/client.rs
@@ -782,7 +782,7 @@ impl RepositoryManager {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -793,7 +793,7 @@ impl RepositoryManager {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn cancel_operation(
         &self,
         name: impl Into<std::string::String>,

--- a/src/generated/devtools/cloudbuild/v2/src/traits/mod.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/traits/mod.rs
@@ -243,7 +243,7 @@ pub trait RepositoryManager: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn get_operation(
         &self,
         _req: longrunning::model::GetOperationRequest,
@@ -257,7 +257,7 @@ pub trait RepositoryManager: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn cancel_operation(
         &self,
         _req: longrunning::model::CancelOperationRequest,

--- a/src/generated/iam/v2/src/client.rs
+++ b/src/generated/iam/v2/src/client.rs
@@ -210,7 +210,7 @@ impl Policies {
     ///
     /// This pattern helps prevent conflicts between concurrent updates.
     ///
-    /// [google.iam.v2.Policies.GetPolicy]: crate::traits::Policies::get_policy
+    /// [google.iam.v2.Policies.GetPolicy]: crate::client::Policies::get_policy
     ///
     /// # Long running operations
     ///
@@ -406,7 +406,7 @@ impl Policies {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
         name: impl Into<std::string::String>,

--- a/src/generated/iam/v2/src/traits/mod.rs
+++ b/src/generated/iam/v2/src/traits/mod.rs
@@ -79,7 +79,7 @@ pub trait Policies: std::fmt::Debug + Send + Sync {
     ///
     /// This pattern helps prevent conflicts between concurrent updates.
     ///
-    /// [google.iam.v2.Policies.GetPolicy]: crate::traits::Policies::get_policy
+    /// [google.iam.v2.Policies.GetPolicy]: crate::client::Policies::get_policy
     fn update_policy(
         &self,
         _req: crate::model::UpdatePolicyRequest,
@@ -105,7 +105,7 @@ pub trait Policies: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn get_operation(
         &self,
         _req: longrunning::model::GetOperationRequest,

--- a/src/generated/longrunning/src/client.rs
+++ b/src/generated/longrunning/src/client.rs
@@ -134,7 +134,7 @@ impl Operations {
     /// `Code.CANCELLED`.
     ///
     /// [google.longrunning.Operation.error]: crate::model::Operation::result
-    /// [google.longrunning.Operations.GetOperation]: crate::traits::Operations::get_operation
+    /// [google.longrunning.Operations.GetOperation]: crate::client::Operations::get_operation
     /// [google.rpc.Status.code]: rpc::model::Status::code
     pub fn cancel_operation(
         &self,

--- a/src/generated/longrunning/src/model.rs
+++ b/src/generated/longrunning/src/model.rs
@@ -134,7 +134,7 @@ pub mod operation {
 /// The request message for
 /// [Operations.GetOperation][google.longrunning.Operations.GetOperation].
 ///
-/// [google.longrunning.Operations.GetOperation]: crate::traits::Operations::get_operation
+/// [google.longrunning.Operations.GetOperation]: crate::client::Operations::get_operation
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -162,7 +162,7 @@ impl wkt::message::Message for GetOperationRequest {
 /// The request message for
 /// [Operations.ListOperations][google.longrunning.Operations.ListOperations].
 ///
-/// [google.longrunning.Operations.ListOperations]: crate::traits::Operations::list_operations
+/// [google.longrunning.Operations.ListOperations]: crate::client::Operations::list_operations
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -219,7 +219,7 @@ impl wkt::message::Message for ListOperationsRequest {
 /// The response message for
 /// [Operations.ListOperations][google.longrunning.Operations.ListOperations].
 ///
-/// [google.longrunning.Operations.ListOperations]: crate::traits::Operations::list_operations
+/// [google.longrunning.Operations.ListOperations]: crate::client::Operations::list_operations
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -273,7 +273,7 @@ impl gax::paginator::PageableResponse for ListOperationsResponse {
 /// The request message for
 /// [Operations.CancelOperation][google.longrunning.Operations.CancelOperation].
 ///
-/// [google.longrunning.Operations.CancelOperation]: crate::traits::Operations::cancel_operation
+/// [google.longrunning.Operations.CancelOperation]: crate::client::Operations::cancel_operation
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -301,7 +301,7 @@ impl wkt::message::Message for CancelOperationRequest {
 /// The request message for
 /// [Operations.DeleteOperation][google.longrunning.Operations.DeleteOperation].
 ///
-/// [google.longrunning.Operations.DeleteOperation]: crate::traits::Operations::delete_operation
+/// [google.longrunning.Operations.DeleteOperation]: crate::client::Operations::delete_operation
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]

--- a/src/generated/longrunning/src/traits/mod.rs
+++ b/src/generated/longrunning/src/traits/mod.rs
@@ -89,7 +89,7 @@ pub trait Operations: std::fmt::Debug + Send + Sync {
     /// `Code.CANCELLED`.
     ///
     /// [google.longrunning.Operation.error]: crate::model::Operation::result
-    /// [google.longrunning.Operations.GetOperation]: crate::traits::Operations::get_operation
+    /// [google.longrunning.Operations.GetOperation]: crate::client::Operations::get_operation
     /// [google.rpc.Status.code]: rpc::model::Status::code
     fn cancel_operation(
         &self,

--- a/src/generated/spanner/admin/database/v1/src/client.rs
+++ b/src/generated/spanner/admin/database/v1/src/client.rs
@@ -483,7 +483,7 @@ impl DatabaseAdmin {
     /// DDL statements. This method does not show pending schema updates, those may
     /// be queried using the [Operations][google.longrunning.Operations] API.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_database_ddl(
         &self,
         database: impl Into<std::string::String>,
@@ -1037,7 +1037,7 @@ impl DatabaseAdmin {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
         name: impl Into<std::string::String>,
@@ -1048,7 +1048,7 @@ impl DatabaseAdmin {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -1058,7 +1058,7 @@ impl DatabaseAdmin {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -1069,7 +1069,7 @@ impl DatabaseAdmin {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn cancel_operation(
         &self,
         name: impl Into<std::string::String>,

--- a/src/generated/spanner/admin/database/v1/src/model.rs
+++ b/src/generated/spanner/admin/database/v1/src/model.rs
@@ -46,7 +46,7 @@ pub struct Backup {
     /// needs to be in the same instance as the backup. Values are of the form
     /// `projects/<project>/instances/<instance>/databases/<database>`.
     ///
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup]: crate::traits::DatabaseAdmin::create_backup
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup]: crate::client::DatabaseAdmin::create_backup
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub database: std::string::String,
 
@@ -65,7 +65,7 @@ pub struct Backup {
     /// has passed, the backup is eligible to be automatically deleted by Cloud
     /// Spanner to free the resources used by the backup.
     ///
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup]: crate::traits::DatabaseAdmin::create_backup
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup]: crate::client::DatabaseAdmin::create_backup
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub expire_time: std::option::Option<wkt::Timestamp>,
 
@@ -86,8 +86,8 @@ pub struct Backup {
     /// by the prefix of the backup name of the form
     /// `projects/<project>/instances/<instance>`.
     ///
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup]: crate::traits::DatabaseAdmin::create_backup
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateBackup]: crate::traits::DatabaseAdmin::update_backup
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup]: crate::client::DatabaseAdmin::create_backup
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateBackup]: crate::client::DatabaseAdmin::update_backup
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub name: std::string::String,
 
@@ -96,7 +96,7 @@ pub struct Backup {
     /// request is received. If the request does not specify `version_time`, the
     /// `version_time` of the backup will be equivalent to the `create_time`.
     ///
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup]: crate::traits::DatabaseAdmin::create_backup
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup]: crate::client::DatabaseAdmin::create_backup
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub create_time: std::option::Option<wkt::Timestamp>,
 
@@ -397,7 +397,7 @@ pub mod backup {
 /// The request for
 /// [CreateBackup][google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup]: crate::traits::DatabaseAdmin::create_backup
+/// [google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup]: crate::client::DatabaseAdmin::create_backup
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -476,7 +476,7 @@ impl wkt::message::Message for CreateBackupRequest {
 /// Metadata type for the operation returned by
 /// [CreateBackup][google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup]: crate::traits::DatabaseAdmin::create_backup
+/// [google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup]: crate::client::DatabaseAdmin::create_backup
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -494,7 +494,7 @@ pub struct CreateBackupMetadata {
     /// [CreateBackup][google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup]
     /// operation.
     ///
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup]: crate::traits::DatabaseAdmin::create_backup
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup]: crate::client::DatabaseAdmin::create_backup
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub progress: std::option::Option<crate::model::OperationProgress>,
 
@@ -560,7 +560,7 @@ impl wkt::message::Message for CreateBackupMetadata {
 /// The request for
 /// [CopyBackup][google.spanner.admin.database.v1.DatabaseAdmin.CopyBackup].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.CopyBackup]: crate::traits::DatabaseAdmin::copy_backup
+/// [google.spanner.admin.database.v1.DatabaseAdmin.CopyBackup]: crate::client::DatabaseAdmin::copy_backup
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -654,7 +654,7 @@ impl wkt::message::Message for CopyBackupRequest {
 /// Metadata type for the operation returned by
 /// [CopyBackup][google.spanner.admin.database.v1.DatabaseAdmin.CopyBackup].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.CopyBackup]: crate::traits::DatabaseAdmin::copy_backup
+/// [google.spanner.admin.database.v1.DatabaseAdmin.CopyBackup]: crate::client::DatabaseAdmin::copy_backup
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -676,7 +676,7 @@ pub struct CopyBackupMetadata {
     /// [CopyBackup][google.spanner.admin.database.v1.DatabaseAdmin.CopyBackup]
     /// operation.
     ///
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.CopyBackup]: crate::traits::DatabaseAdmin::copy_backup
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.CopyBackup]: crate::client::DatabaseAdmin::copy_backup
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub progress: std::option::Option<crate::model::OperationProgress>,
 
@@ -742,7 +742,7 @@ impl wkt::message::Message for CopyBackupMetadata {
 /// The request for
 /// [UpdateBackup][google.spanner.admin.database.v1.DatabaseAdmin.UpdateBackup].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateBackup]: crate::traits::DatabaseAdmin::update_backup
+/// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateBackup]: crate::client::DatabaseAdmin::update_backup
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -794,7 +794,7 @@ impl wkt::message::Message for UpdateBackupRequest {
 /// The request for
 /// [GetBackup][google.spanner.admin.database.v1.DatabaseAdmin.GetBackup].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.GetBackup]: crate::traits::DatabaseAdmin::get_backup
+/// [google.spanner.admin.database.v1.DatabaseAdmin.GetBackup]: crate::client::DatabaseAdmin::get_backup
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -824,7 +824,7 @@ impl wkt::message::Message for GetBackupRequest {
 /// The request for
 /// [DeleteBackup][google.spanner.admin.database.v1.DatabaseAdmin.DeleteBackup].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.DeleteBackup]: crate::traits::DatabaseAdmin::delete_backup
+/// [google.spanner.admin.database.v1.DatabaseAdmin.DeleteBackup]: crate::client::DatabaseAdmin::delete_backup
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -854,7 +854,7 @@ impl wkt::message::Message for DeleteBackupRequest {
 /// The request for
 /// [ListBackups][google.spanner.admin.database.v1.DatabaseAdmin.ListBackups].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.ListBackups]: crate::traits::DatabaseAdmin::list_backups
+/// [google.spanner.admin.database.v1.DatabaseAdmin.ListBackups]: crate::client::DatabaseAdmin::list_backups
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -961,7 +961,7 @@ impl wkt::message::Message for ListBackupsRequest {
 /// The response for
 /// [ListBackups][google.spanner.admin.database.v1.DatabaseAdmin.ListBackups].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.ListBackups]: crate::traits::DatabaseAdmin::list_backups
+/// [google.spanner.admin.database.v1.DatabaseAdmin.ListBackups]: crate::client::DatabaseAdmin::list_backups
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -976,7 +976,7 @@ pub struct ListBackupsResponse {
     /// [ListBackups][google.spanner.admin.database.v1.DatabaseAdmin.ListBackups]
     /// call to fetch more of the matching backups.
     ///
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.ListBackups]: crate::traits::DatabaseAdmin::list_backups
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.ListBackups]: crate::client::DatabaseAdmin::list_backups
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub next_page_token: std::string::String,
 }
@@ -1020,7 +1020,7 @@ impl gax::paginator::PageableResponse for ListBackupsResponse {
 /// The request for
 /// [ListBackupOperations][google.spanner.admin.database.v1.DatabaseAdmin.ListBackupOperations].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.ListBackupOperations]: crate::traits::DatabaseAdmin::list_backup_operations
+/// [google.spanner.admin.database.v1.DatabaseAdmin.ListBackupOperations]: crate::client::DatabaseAdmin::list_backup_operations
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1159,7 +1159,7 @@ impl wkt::message::Message for ListBackupOperationsRequest {
 /// The response for
 /// [ListBackupOperations][google.spanner.admin.database.v1.DatabaseAdmin.ListBackupOperations].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.ListBackupOperations]: crate::traits::DatabaseAdmin::list_backup_operations
+/// [google.spanner.admin.database.v1.DatabaseAdmin.ListBackupOperations]: crate::client::DatabaseAdmin::list_backup_operations
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1184,7 +1184,7 @@ pub struct ListBackupOperationsResponse {
     /// [ListBackupOperations][google.spanner.admin.database.v1.DatabaseAdmin.ListBackupOperations]
     /// call to fetch more of the matching metadata.
     ///
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.ListBackupOperations]: crate::traits::DatabaseAdmin::list_backup_operations
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.ListBackupOperations]: crate::client::DatabaseAdmin::list_backup_operations
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub next_page_token: std::string::String,
 }
@@ -1241,7 +1241,7 @@ pub struct BackupInfo {
     /// request did not specify `version_time`, the `version_time` of the backup is
     /// equivalent to the `create_time`.
     ///
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup]: crate::traits::DatabaseAdmin::create_backup
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup]: crate::client::DatabaseAdmin::create_backup
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub version_time: std::option::Option<wkt::Timestamp>,
 
@@ -1249,7 +1249,7 @@ pub struct BackupInfo {
     /// [CreateBackup][google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup]
     /// request was received.
     ///
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup]: crate::traits::DatabaseAdmin::create_backup
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup]: crate::client::DatabaseAdmin::create_backup
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub create_time: std::option::Option<wkt::Timestamp>,
 
@@ -1527,7 +1527,7 @@ pub mod copy_backup_encryption_config {
         /// KMS key as the source backup.
         ///
         /// [google.spanner.admin.database.v1.CopyBackupEncryptionConfig]: crate::model::CopyBackupEncryptionConfig
-        /// [google.spanner.admin.database.v1.DatabaseAdmin.CopyBackup]: crate::traits::DatabaseAdmin::copy_backup
+        /// [google.spanner.admin.database.v1.DatabaseAdmin.CopyBackup]: crate::client::DatabaseAdmin::copy_backup
         pub const USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION: &str =
             "USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION";
 
@@ -1640,7 +1640,7 @@ pub struct BackupSchedule {
     /// The final segment of the name must be between 2 and 60 characters in
     /// length.
     ///
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateBackupSchedule]: crate::traits::DatabaseAdmin::update_backup_schedule
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateBackupSchedule]: crate::client::DatabaseAdmin::update_backup_schedule
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub name: std::string::String,
 
@@ -1827,7 +1827,7 @@ impl wkt::message::Message for CrontabSpec {
 /// The request for
 /// [CreateBackupSchedule][google.spanner.admin.database.v1.DatabaseAdmin.CreateBackupSchedule].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.CreateBackupSchedule]: crate::traits::DatabaseAdmin::create_backup_schedule
+/// [google.spanner.admin.database.v1.DatabaseAdmin.CreateBackupSchedule]: crate::client::DatabaseAdmin::create_backup_schedule
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1885,7 +1885,7 @@ impl wkt::message::Message for CreateBackupScheduleRequest {
 /// The request for
 /// [GetBackupSchedule][google.spanner.admin.database.v1.DatabaseAdmin.GetBackupSchedule].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.GetBackupSchedule]: crate::traits::DatabaseAdmin::get_backup_schedule
+/// [google.spanner.admin.database.v1.DatabaseAdmin.GetBackupSchedule]: crate::client::DatabaseAdmin::get_backup_schedule
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1915,7 +1915,7 @@ impl wkt::message::Message for GetBackupScheduleRequest {
 /// The request for
 /// [DeleteBackupSchedule][google.spanner.admin.database.v1.DatabaseAdmin.DeleteBackupSchedule].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.DeleteBackupSchedule]: crate::traits::DatabaseAdmin::delete_backup_schedule
+/// [google.spanner.admin.database.v1.DatabaseAdmin.DeleteBackupSchedule]: crate::client::DatabaseAdmin::delete_backup_schedule
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1945,7 +1945,7 @@ impl wkt::message::Message for DeleteBackupScheduleRequest {
 /// The request for
 /// [ListBackupSchedules][google.spanner.admin.database.v1.DatabaseAdmin.ListBackupSchedules].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.ListBackupSchedules]: crate::traits::DatabaseAdmin::list_backup_schedules
+/// [google.spanner.admin.database.v1.DatabaseAdmin.ListBackupSchedules]: crate::client::DatabaseAdmin::list_backup_schedules
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2002,7 +2002,7 @@ impl wkt::message::Message for ListBackupSchedulesRequest {
 /// The response for
 /// [ListBackupSchedules][google.spanner.admin.database.v1.DatabaseAdmin.ListBackupSchedules].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.ListBackupSchedules]: crate::traits::DatabaseAdmin::list_backup_schedules
+/// [google.spanner.admin.database.v1.DatabaseAdmin.ListBackupSchedules]: crate::client::DatabaseAdmin::list_backup_schedules
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2016,7 +2016,7 @@ pub struct ListBackupSchedulesResponse {
     /// [ListBackupSchedules][google.spanner.admin.database.v1.DatabaseAdmin.ListBackupSchedules]
     /// call to fetch more of the schedules.
     ///
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.ListBackupSchedules]: crate::traits::DatabaseAdmin::list_backup_schedules
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.ListBackupSchedules]: crate::client::DatabaseAdmin::list_backup_schedules
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub next_page_token: std::string::String,
 }
@@ -2062,7 +2062,7 @@ impl gax::paginator::PageableResponse for ListBackupSchedulesResponse {
 /// The request for
 /// [UpdateBackupScheduleRequest][google.spanner.admin.database.v1.DatabaseAdmin.UpdateBackupSchedule].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateBackupSchedule]: crate::traits::DatabaseAdmin::update_backup_schedule
+/// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateBackupSchedule]: crate::client::DatabaseAdmin::update_backup_schedule
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2422,7 +2422,7 @@ pub struct Database {
     /// [UpdateDatabaseDdl][google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabaseDdl].
     /// Defaults to 1 hour, if not set.
     ///
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabaseDdl]: crate::traits::DatabaseAdmin::update_database_ddl
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabaseDdl]: crate::client::DatabaseAdmin::update_database_ddl
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub version_retention_period: std::string::String,
 
@@ -2614,7 +2614,7 @@ pub mod database {
 /// The request for
 /// [ListDatabases][google.spanner.admin.database.v1.DatabaseAdmin.ListDatabases].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.ListDatabases]: crate::traits::DatabaseAdmin::list_databases
+/// [google.spanner.admin.database.v1.DatabaseAdmin.ListDatabases]: crate::client::DatabaseAdmin::list_databases
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2669,7 +2669,7 @@ impl wkt::message::Message for ListDatabasesRequest {
 /// The response for
 /// [ListDatabases][google.spanner.admin.database.v1.DatabaseAdmin.ListDatabases].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.ListDatabases]: crate::traits::DatabaseAdmin::list_databases
+/// [google.spanner.admin.database.v1.DatabaseAdmin.ListDatabases]: crate::client::DatabaseAdmin::list_databases
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2683,7 +2683,7 @@ pub struct ListDatabasesResponse {
     /// [ListDatabases][google.spanner.admin.database.v1.DatabaseAdmin.ListDatabases]
     /// call to fetch more of the matching databases.
     ///
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.ListDatabases]: crate::traits::DatabaseAdmin::list_databases
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.ListDatabases]: crate::client::DatabaseAdmin::list_databases
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub next_page_token: std::string::String,
 }
@@ -2727,7 +2727,7 @@ impl gax::paginator::PageableResponse for ListDatabasesResponse {
 /// The request for
 /// [CreateDatabase][google.spanner.admin.database.v1.DatabaseAdmin.CreateDatabase].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.CreateDatabase]: crate::traits::DatabaseAdmin::create_database
+/// [google.spanner.admin.database.v1.DatabaseAdmin.CreateDatabase]: crate::client::DatabaseAdmin::create_database
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2845,7 +2845,7 @@ impl wkt::message::Message for CreateDatabaseRequest {
 /// Metadata type for the operation returned by
 /// [CreateDatabase][google.spanner.admin.database.v1.DatabaseAdmin.CreateDatabase].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.CreateDatabase]: crate::traits::DatabaseAdmin::create_database
+/// [google.spanner.admin.database.v1.DatabaseAdmin.CreateDatabase]: crate::client::DatabaseAdmin::create_database
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2873,7 +2873,7 @@ impl wkt::message::Message for CreateDatabaseMetadata {
 /// The request for
 /// [GetDatabase][google.spanner.admin.database.v1.DatabaseAdmin.GetDatabase].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.GetDatabase]: crate::traits::DatabaseAdmin::get_database
+/// [google.spanner.admin.database.v1.DatabaseAdmin.GetDatabase]: crate::client::DatabaseAdmin::get_database
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2902,7 +2902,7 @@ impl wkt::message::Message for GetDatabaseRequest {
 /// The request for
 /// [UpdateDatabase][google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabase].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabase]: crate::traits::DatabaseAdmin::update_database
+/// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabase]: crate::client::DatabaseAdmin::update_database
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2949,7 +2949,7 @@ impl wkt::message::Message for UpdateDatabaseRequest {
 /// Metadata type for the operation returned by
 /// [UpdateDatabase][google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabase].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabase]: crate::traits::DatabaseAdmin::update_database
+/// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabase]: crate::client::DatabaseAdmin::update_database
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2958,7 +2958,7 @@ pub struct UpdateDatabaseMetadata {
     /// The request for
     /// [UpdateDatabase][google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabase].
     ///
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabase]: crate::traits::DatabaseAdmin::update_database
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabase]: crate::client::DatabaseAdmin::update_database
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub request: std::option::Option<crate::model::UpdateDatabaseRequest>,
 
@@ -2966,7 +2966,7 @@ pub struct UpdateDatabaseMetadata {
     /// [UpdateDatabase][google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabase]
     /// operation.
     ///
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabase]: crate::traits::DatabaseAdmin::update_database
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabase]: crate::client::DatabaseAdmin::update_database
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub progress: std::option::Option<crate::model::OperationProgress>,
 
@@ -3032,7 +3032,7 @@ impl wkt::message::Message for UpdateDatabaseMetadata {
 /// [operation_id][google.spanner.admin.database.v1.UpdateDatabaseDdlRequest.operation_id]
 /// field for more details.
 ///
-/// [google.longrunning.Operations]: longrunning::traits::Operations
+/// [google.longrunning.Operations]: longrunning::client::Operations
 /// [google.spanner.admin.database.v1.UpdateDatabaseDdlRequest.operation_id]: crate::model::UpdateDatabaseDdlRequest::operation_id
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -3071,7 +3071,7 @@ pub struct UpdateDatabaseDdlRequest {
     ///
     /// [google.longrunning.Operation]: longrunning::model::Operation
     /// [google.longrunning.Operation.name]: longrunning::model::Operation::name
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabaseDdl]: crate::traits::DatabaseAdmin::update_database_ddl
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabaseDdl]: crate::client::DatabaseAdmin::update_database_ddl
     /// [google.spanner.admin.database.v1.UpdateDatabaseDdlRequest.database]: crate::model::UpdateDatabaseDdlRequest::database
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub operation_id: std::string::String,
@@ -3136,7 +3136,7 @@ impl wkt::message::Message for UpdateDatabaseDdlRequest {
 /// display the brief info of the DDL statement for the operation
 /// [UpdateDatabaseDdl][google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabaseDdl].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabaseDdl]: crate::traits::DatabaseAdmin::update_database_ddl
+/// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabaseDdl]: crate::client::DatabaseAdmin::update_database_ddl
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3195,7 +3195,7 @@ impl wkt::message::Message for DdlStatementActionInfo {
 /// Metadata type for the operation returned by
 /// [UpdateDatabaseDdl][google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabaseDdl].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabaseDdl]: crate::traits::DatabaseAdmin::update_database_ddl
+/// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabaseDdl]: crate::client::DatabaseAdmin::update_database_ddl
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3229,7 +3229,7 @@ pub struct UpdateDatabaseDdlMetadata {
     /// timestamp of operation, as well as a progress of 100% once the operation
     /// has completed.
     ///
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabaseDdl]: crate::traits::DatabaseAdmin::update_database_ddl
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabaseDdl]: crate::client::DatabaseAdmin::update_database_ddl
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub progress: std::vec::Vec<crate::model::OperationProgress>,
 
@@ -3300,7 +3300,7 @@ impl wkt::message::Message for UpdateDatabaseDdlMetadata {
 /// The request for
 /// [DropDatabase][google.spanner.admin.database.v1.DatabaseAdmin.DropDatabase].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.DropDatabase]: crate::traits::DatabaseAdmin::drop_database
+/// [google.spanner.admin.database.v1.DatabaseAdmin.DropDatabase]: crate::client::DatabaseAdmin::drop_database
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3328,7 +3328,7 @@ impl wkt::message::Message for DropDatabaseRequest {
 /// The request for
 /// [GetDatabaseDdl][google.spanner.admin.database.v1.DatabaseAdmin.GetDatabaseDdl].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.GetDatabaseDdl]: crate::traits::DatabaseAdmin::get_database_ddl
+/// [google.spanner.admin.database.v1.DatabaseAdmin.GetDatabaseDdl]: crate::client::DatabaseAdmin::get_database_ddl
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3358,7 +3358,7 @@ impl wkt::message::Message for GetDatabaseDdlRequest {
 /// The response for
 /// [GetDatabaseDdl][google.spanner.admin.database.v1.DatabaseAdmin.GetDatabaseDdl].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.GetDatabaseDdl]: crate::traits::DatabaseAdmin::get_database_ddl
+/// [google.spanner.admin.database.v1.DatabaseAdmin.GetDatabaseDdl]: crate::client::DatabaseAdmin::get_database_ddl
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3405,7 +3405,7 @@ impl wkt::message::Message for GetDatabaseDdlResponse {
 /// The request for
 /// [ListDatabaseOperations][google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseOperations].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseOperations]: crate::traits::DatabaseAdmin::list_database_operations
+/// [google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseOperations]: crate::client::DatabaseAdmin::list_database_operations
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3518,7 +3518,7 @@ impl wkt::message::Message for ListDatabaseOperationsRequest {
 /// The response for
 /// [ListDatabaseOperations][google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseOperations].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseOperations]: crate::traits::DatabaseAdmin::list_database_operations
+/// [google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseOperations]: crate::client::DatabaseAdmin::list_database_operations
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3539,7 +3539,7 @@ pub struct ListDatabaseOperationsResponse {
     /// [ListDatabaseOperations][google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseOperations]
     /// call to fetch more of the matching metadata.
     ///
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseOperations]: crate::traits::DatabaseAdmin::list_database_operations
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseOperations]: crate::client::DatabaseAdmin::list_database_operations
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub next_page_token: std::string::String,
 }
@@ -3583,7 +3583,7 @@ impl gax::paginator::PageableResponse for ListDatabaseOperationsResponse {
 /// The request for
 /// [RestoreDatabase][google.spanner.admin.database.v1.DatabaseAdmin.RestoreDatabase].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.RestoreDatabase]: crate::traits::DatabaseAdmin::restore_database
+/// [google.spanner.admin.database.v1.DatabaseAdmin.RestoreDatabase]: crate::client::DatabaseAdmin::restore_database
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3799,7 +3799,7 @@ pub mod restore_database_encryption_config {
 /// Metadata type for the long-running operation returned by
 /// [RestoreDatabase][google.spanner.admin.database.v1.DatabaseAdmin.RestoreDatabase].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.RestoreDatabase]: crate::traits::DatabaseAdmin::restore_database
+/// [google.spanner.admin.database.v1.DatabaseAdmin.RestoreDatabase]: crate::client::DatabaseAdmin::restore_database
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3816,7 +3816,7 @@ pub struct RestoreDatabaseMetadata {
     /// [RestoreDatabase][google.spanner.admin.database.v1.DatabaseAdmin.RestoreDatabase]
     /// operation.
     ///
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.RestoreDatabase]: crate::traits::DatabaseAdmin::restore_database
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.RestoreDatabase]: crate::client::DatabaseAdmin::restore_database
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub progress: std::option::Option<crate::model::OperationProgress>,
 
@@ -4020,7 +4020,7 @@ impl wkt::message::Message for DatabaseRole {
 /// The request for
 /// [ListDatabaseRoles][google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseRoles].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseRoles]: crate::traits::DatabaseAdmin::list_database_roles
+/// [google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseRoles]: crate::client::DatabaseAdmin::list_database_roles
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -4076,7 +4076,7 @@ impl wkt::message::Message for ListDatabaseRolesRequest {
 /// The response for
 /// [ListDatabaseRoles][google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseRoles].
 ///
-/// [google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseRoles]: crate::traits::DatabaseAdmin::list_database_roles
+/// [google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseRoles]: crate::client::DatabaseAdmin::list_database_roles
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -4090,7 +4090,7 @@ pub struct ListDatabaseRolesResponse {
     /// [ListDatabaseRoles][google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseRoles]
     /// call to fetch more of the matching roles.
     ///
-    /// [google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseRoles]: crate::traits::DatabaseAdmin::list_database_roles
+    /// [google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseRoles]: crate::client::DatabaseAdmin::list_database_roles
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub next_page_token: std::string::String,
 }

--- a/src/generated/spanner/admin/database/v1/src/traits/mod.rs
+++ b/src/generated/spanner/admin/database/v1/src/traits/mod.rs
@@ -178,7 +178,7 @@ pub trait DatabaseAdmin: std::fmt::Debug + Send + Sync {
     /// DDL statements. This method does not show pending schema updates, those may
     /// be queried using the [Operations][google.longrunning.Operations] API.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn get_database_ddl(
         &self,
         _req: crate::model::GetDatabaseDdlRequest,
@@ -511,7 +511,7 @@ pub trait DatabaseAdmin: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn list_operations(
         &self,
         _req: longrunning::model::ListOperationsRequest,
@@ -525,7 +525,7 @@ pub trait DatabaseAdmin: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn get_operation(
         &self,
         _req: longrunning::model::GetOperationRequest,
@@ -539,7 +539,7 @@ pub trait DatabaseAdmin: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn delete_operation(
         &self,
         _req: longrunning::model::DeleteOperationRequest,
@@ -550,7 +550,7 @@ pub trait DatabaseAdmin: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn cancel_operation(
         &self,
         _req: longrunning::model::CancelOperationRequest,

--- a/src/generated/spanner/admin/instance/v1/src/client.rs
+++ b/src/generated/spanner/admin/instance/v1/src/client.rs
@@ -1310,7 +1310,7 @@ impl InstanceAdmin {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
         name: impl Into<std::string::String>,
@@ -1321,7 +1321,7 @@ impl InstanceAdmin {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -1331,7 +1331,7 @@ impl InstanceAdmin {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
         name: impl Into<std::string::String>,
@@ -1342,7 +1342,7 @@ impl InstanceAdmin {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn cancel_operation(
         &self,
         name: impl Into<std::string::String>,

--- a/src/generated/spanner/admin/instance/v1/src/model.rs
+++ b/src/generated/spanner/admin/instance/v1/src/model.rs
@@ -1022,7 +1022,7 @@ pub struct Instance {
     /// also [InstanceConfig][google.spanner.admin.instance.v1.InstanceConfig] and
     /// [ListInstanceConfigs][google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigs].
     ///
-    /// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigs]: crate::traits::InstanceAdmin::list_instance_configs
+    /// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigs]: crate::client::InstanceAdmin::list_instance_configs
     /// [google.spanner.admin.instance.v1.InstanceConfig]: crate::model::InstanceConfig
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub config: std::string::String,
@@ -1086,8 +1086,8 @@ pub struct Instance {
     /// [UpdateInstance][google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstance],
     /// the state must be either omitted or set to `READY`.
     ///
-    /// [google.spanner.admin.instance.v1.InstanceAdmin.CreateInstance]: crate::traits::InstanceAdmin::create_instance
-    /// [google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstance]: crate::traits::InstanceAdmin::update_instance
+    /// [google.spanner.admin.instance.v1.InstanceAdmin.CreateInstance]: crate::client::InstanceAdmin::create_instance
+    /// [google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstance]: crate::client::InstanceAdmin::update_instance
     pub state: crate::model::instance::State,
 
     /// Cloud Labels are a flexible and lightweight mechanism for organizing cloud
@@ -1443,7 +1443,7 @@ pub mod instance {
 /// The request for
 /// [ListInstanceConfigs][google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigs].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigs]: crate::traits::InstanceAdmin::list_instance_configs
+/// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigs]: crate::client::InstanceAdmin::list_instance_configs
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1499,7 +1499,7 @@ impl wkt::message::Message for ListInstanceConfigsRequest {
 /// The response for
 /// [ListInstanceConfigs][google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigs].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigs]: crate::traits::InstanceAdmin::list_instance_configs
+/// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigs]: crate::client::InstanceAdmin::list_instance_configs
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1513,7 +1513,7 @@ pub struct ListInstanceConfigsResponse {
     /// [ListInstanceConfigs][google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigs]
     /// call to fetch more of the matching instance configurations.
     ///
-    /// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigs]: crate::traits::InstanceAdmin::list_instance_configs
+    /// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigs]: crate::client::InstanceAdmin::list_instance_configs
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub next_page_token: std::string::String,
 }
@@ -1559,7 +1559,7 @@ impl gax::paginator::PageableResponse for ListInstanceConfigsResponse {
 /// The request for
 /// [GetInstanceConfigRequest][google.spanner.admin.instance.v1.InstanceAdmin.GetInstanceConfig].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.GetInstanceConfig]: crate::traits::InstanceAdmin::get_instance_config
+/// [google.spanner.admin.instance.v1.InstanceAdmin.GetInstanceConfig]: crate::client::InstanceAdmin::get_instance_config
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1588,7 +1588,7 @@ impl wkt::message::Message for GetInstanceConfigRequest {
 /// The request for
 /// [CreateInstanceConfig][google.spanner.admin.instance.v1.InstanceAdmin.CreateInstanceConfig].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.CreateInstanceConfig]: crate::traits::InstanceAdmin::create_instance_config
+/// [google.spanner.admin.instance.v1.InstanceAdmin.CreateInstanceConfig]: crate::client::InstanceAdmin::create_instance_config
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1662,7 +1662,7 @@ impl wkt::message::Message for CreateInstanceConfigRequest {
 /// The request for
 /// [UpdateInstanceConfig][google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstanceConfig].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstanceConfig]: crate::traits::InstanceAdmin::update_instance_config
+/// [google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstanceConfig]: crate::client::InstanceAdmin::update_instance_config
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1734,7 +1734,7 @@ impl wkt::message::Message for UpdateInstanceConfigRequest {
 /// The request for
 /// [DeleteInstanceConfig][google.spanner.admin.instance.v1.InstanceAdmin.DeleteInstanceConfig].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.DeleteInstanceConfig]: crate::traits::InstanceAdmin::delete_instance_config
+/// [google.spanner.admin.instance.v1.InstanceAdmin.DeleteInstanceConfig]: crate::client::InstanceAdmin::delete_instance_config
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1790,7 +1790,7 @@ impl wkt::message::Message for DeleteInstanceConfigRequest {
 /// The request for
 /// [ListInstanceConfigOperations][google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigOperations].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigOperations]: crate::traits::InstanceAdmin::list_instance_config_operations
+/// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigOperations]: crate::client::InstanceAdmin::list_instance_config_operations
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1899,7 +1899,7 @@ impl wkt::message::Message for ListInstanceConfigOperationsRequest {
 /// The response for
 /// [ListInstanceConfigOperations][google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigOperations].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigOperations]: crate::traits::InstanceAdmin::list_instance_config_operations
+/// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigOperations]: crate::client::InstanceAdmin::list_instance_config_operations
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1917,7 +1917,7 @@ pub struct ListInstanceConfigOperationsResponse {
     /// [ListInstanceConfigOperations][google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigOperations]
     /// call to fetch more of the matching metadata.
     ///
-    /// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigOperations]: crate::traits::InstanceAdmin::list_instance_config_operations
+    /// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigOperations]: crate::client::InstanceAdmin::list_instance_config_operations
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub next_page_token: std::string::String,
 }
@@ -1961,7 +1961,7 @@ impl gax::paginator::PageableResponse for ListInstanceConfigOperationsResponse {
 /// The request for
 /// [GetInstance][google.spanner.admin.instance.v1.InstanceAdmin.GetInstance].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.GetInstance]: crate::traits::InstanceAdmin::get_instance
+/// [google.spanner.admin.instance.v1.InstanceAdmin.GetInstance]: crate::client::InstanceAdmin::get_instance
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2008,7 +2008,7 @@ impl wkt::message::Message for GetInstanceRequest {
 /// The request for
 /// [CreateInstance][google.spanner.admin.instance.v1.InstanceAdmin.CreateInstance].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.CreateInstance]: crate::traits::InstanceAdmin::create_instance
+/// [google.spanner.admin.instance.v1.InstanceAdmin.CreateInstance]: crate::client::InstanceAdmin::create_instance
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2063,7 +2063,7 @@ impl wkt::message::Message for CreateInstanceRequest {
 /// The request for
 /// [ListInstances][google.spanner.admin.instance.v1.InstanceAdmin.ListInstances].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstances]: crate::traits::InstanceAdmin::list_instances
+/// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstances]: crate::client::InstanceAdmin::list_instances
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2167,7 +2167,7 @@ impl wkt::message::Message for ListInstancesRequest {
 /// The response for
 /// [ListInstances][google.spanner.admin.instance.v1.InstanceAdmin.ListInstances].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstances]: crate::traits::InstanceAdmin::list_instances
+/// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstances]: crate::client::InstanceAdmin::list_instances
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2181,7 +2181,7 @@ pub struct ListInstancesResponse {
     /// [ListInstances][google.spanner.admin.instance.v1.InstanceAdmin.ListInstances]
     /// call to fetch more of the matching instances.
     ///
-    /// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstances]: crate::traits::InstanceAdmin::list_instances
+    /// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstances]: crate::client::InstanceAdmin::list_instances
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub next_page_token: std::string::String,
 
@@ -2243,7 +2243,7 @@ impl gax::paginator::PageableResponse for ListInstancesResponse {
 /// The request for
 /// [UpdateInstance][google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstance].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstance]: crate::traits::InstanceAdmin::update_instance
+/// [google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstance]: crate::client::InstanceAdmin::update_instance
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2298,7 +2298,7 @@ impl wkt::message::Message for UpdateInstanceRequest {
 /// The request for
 /// [DeleteInstance][google.spanner.admin.instance.v1.InstanceAdmin.DeleteInstance].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.DeleteInstance]: crate::traits::InstanceAdmin::delete_instance
+/// [google.spanner.admin.instance.v1.InstanceAdmin.DeleteInstance]: crate::client::InstanceAdmin::delete_instance
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2327,7 +2327,7 @@ impl wkt::message::Message for DeleteInstanceRequest {
 /// Metadata type for the operation returned by
 /// [CreateInstance][google.spanner.admin.instance.v1.InstanceAdmin.CreateInstance].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.CreateInstance]: crate::traits::InstanceAdmin::create_instance
+/// [google.spanner.admin.instance.v1.InstanceAdmin.CreateInstance]: crate::client::InstanceAdmin::create_instance
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2341,7 +2341,7 @@ pub struct CreateInstanceMetadata {
     /// [CreateInstance][google.spanner.admin.instance.v1.InstanceAdmin.CreateInstance]
     /// request was received.
     ///
-    /// [google.spanner.admin.instance.v1.InstanceAdmin.CreateInstance]: crate::traits::InstanceAdmin::create_instance
+    /// [google.spanner.admin.instance.v1.InstanceAdmin.CreateInstance]: crate::client::InstanceAdmin::create_instance
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub start_time: std::option::Option<wkt::Timestamp>,
 
@@ -2417,7 +2417,7 @@ impl wkt::message::Message for CreateInstanceMetadata {
 /// Metadata type for the operation returned by
 /// [UpdateInstance][google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstance].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstance]: crate::traits::InstanceAdmin::update_instance
+/// [google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstance]: crate::client::InstanceAdmin::update_instance
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2431,7 +2431,7 @@ pub struct UpdateInstanceMetadata {
     /// [UpdateInstance][google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstance]
     /// request was received.
     ///
-    /// [google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstance]: crate::traits::InstanceAdmin::update_instance
+    /// [google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstance]: crate::client::InstanceAdmin::update_instance
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub start_time: std::option::Option<wkt::Timestamp>,
 
@@ -2607,7 +2607,7 @@ pub mod free_instance_metadata {
 /// Metadata type for the operation returned by
 /// [CreateInstanceConfig][google.spanner.admin.instance.v1.InstanceAdmin.CreateInstanceConfig].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.CreateInstanceConfig]: crate::traits::InstanceAdmin::create_instance_config
+/// [google.spanner.admin.instance.v1.InstanceAdmin.CreateInstanceConfig]: crate::client::InstanceAdmin::create_instance_config
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2621,7 +2621,7 @@ pub struct CreateInstanceConfigMetadata {
     /// [CreateInstanceConfig][google.spanner.admin.instance.v1.InstanceAdmin.CreateInstanceConfig]
     /// operation.
     ///
-    /// [google.spanner.admin.instance.v1.InstanceAdmin.CreateInstanceConfig]: crate::traits::InstanceAdmin::create_instance_config
+    /// [google.spanner.admin.instance.v1.InstanceAdmin.CreateInstanceConfig]: crate::client::InstanceAdmin::create_instance_config
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub progress: std::option::Option<crate::model::OperationProgress>,
 
@@ -2672,7 +2672,7 @@ impl wkt::message::Message for CreateInstanceConfigMetadata {
 /// Metadata type for the operation returned by
 /// [UpdateInstanceConfig][google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstanceConfig].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstanceConfig]: crate::traits::InstanceAdmin::update_instance_config
+/// [google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstanceConfig]: crate::client::InstanceAdmin::update_instance_config
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2686,7 +2686,7 @@ pub struct UpdateInstanceConfigMetadata {
     /// [UpdateInstanceConfig][google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstanceConfig]
     /// operation.
     ///
-    /// [google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstanceConfig]: crate::traits::InstanceAdmin::update_instance_config
+    /// [google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstanceConfig]: crate::client::InstanceAdmin::update_instance_config
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub progress: std::option::Option<crate::model::OperationProgress>,
 
@@ -2755,7 +2755,7 @@ pub struct InstancePartition {
     /// [InstanceConfig][google.spanner.admin.instance.v1.InstanceConfig] and
     /// [ListInstanceConfigs][google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigs].
     ///
-    /// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigs]: crate::traits::InstanceAdmin::list_instance_configs
+    /// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigs]: crate::client::InstanceAdmin::list_instance_configs
     /// [google.spanner.admin.instance.v1.InstanceConfig]: crate::model::InstanceConfig
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub config: std::string::String,
@@ -2973,7 +2973,7 @@ pub mod instance_partition {
 /// Metadata type for the operation returned by
 /// [CreateInstancePartition][google.spanner.admin.instance.v1.InstanceAdmin.CreateInstancePartition].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.CreateInstancePartition]: crate::traits::InstanceAdmin::create_instance_partition
+/// [google.spanner.admin.instance.v1.InstanceAdmin.CreateInstancePartition]: crate::client::InstanceAdmin::create_instance_partition
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2987,7 +2987,7 @@ pub struct CreateInstancePartitionMetadata {
     /// [CreateInstancePartition][google.spanner.admin.instance.v1.InstanceAdmin.CreateInstancePartition]
     /// request was received.
     ///
-    /// [google.spanner.admin.instance.v1.InstanceAdmin.CreateInstancePartition]: crate::traits::InstanceAdmin::create_instance_partition
+    /// [google.spanner.admin.instance.v1.InstanceAdmin.CreateInstancePartition]: crate::client::InstanceAdmin::create_instance_partition
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub start_time: std::option::Option<wkt::Timestamp>,
 
@@ -3051,7 +3051,7 @@ impl wkt::message::Message for CreateInstancePartitionMetadata {
 /// The request for
 /// [CreateInstancePartition][google.spanner.admin.instance.v1.InstanceAdmin.CreateInstancePartition].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.CreateInstancePartition]: crate::traits::InstanceAdmin::create_instance_partition
+/// [google.spanner.admin.instance.v1.InstanceAdmin.CreateInstancePartition]: crate::client::InstanceAdmin::create_instance_partition
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3113,7 +3113,7 @@ impl wkt::message::Message for CreateInstancePartitionRequest {
 /// The request for
 /// [DeleteInstancePartition][google.spanner.admin.instance.v1.InstanceAdmin.DeleteInstancePartition].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.DeleteInstancePartition]: crate::traits::InstanceAdmin::delete_instance_partition
+/// [google.spanner.admin.instance.v1.InstanceAdmin.DeleteInstancePartition]: crate::client::InstanceAdmin::delete_instance_partition
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3156,7 +3156,7 @@ impl wkt::message::Message for DeleteInstancePartitionRequest {
 /// The request for
 /// [GetInstancePartition][google.spanner.admin.instance.v1.InstanceAdmin.GetInstancePartition].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.GetInstancePartition]: crate::traits::InstanceAdmin::get_instance_partition
+/// [google.spanner.admin.instance.v1.InstanceAdmin.GetInstancePartition]: crate::client::InstanceAdmin::get_instance_partition
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3186,7 +3186,7 @@ impl wkt::message::Message for GetInstancePartitionRequest {
 /// The request for
 /// [UpdateInstancePartition][google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstancePartition].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstancePartition]: crate::traits::InstanceAdmin::update_instance_partition
+/// [google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstancePartition]: crate::client::InstanceAdmin::update_instance_partition
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3244,7 +3244,7 @@ impl wkt::message::Message for UpdateInstancePartitionRequest {
 /// Metadata type for the operation returned by
 /// [UpdateInstancePartition][google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstancePartition].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstancePartition]: crate::traits::InstanceAdmin::update_instance_partition
+/// [google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstancePartition]: crate::client::InstanceAdmin::update_instance_partition
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3258,7 +3258,7 @@ pub struct UpdateInstancePartitionMetadata {
     /// [UpdateInstancePartition][google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstancePartition]
     /// request was received.
     ///
-    /// [google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstancePartition]: crate::traits::InstanceAdmin::update_instance_partition
+    /// [google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstancePartition]: crate::client::InstanceAdmin::update_instance_partition
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub start_time: std::option::Option<wkt::Timestamp>,
 
@@ -3322,7 +3322,7 @@ impl wkt::message::Message for UpdateInstancePartitionMetadata {
 /// The request for
 /// [ListInstancePartitions][google.spanner.admin.instance.v1.InstanceAdmin.ListInstancePartitions].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstancePartitions]: crate::traits::InstanceAdmin::list_instance_partitions
+/// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstancePartitions]: crate::client::InstanceAdmin::list_instance_partitions
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3402,7 +3402,7 @@ impl wkt::message::Message for ListInstancePartitionsRequest {
 /// The response for
 /// [ListInstancePartitions][google.spanner.admin.instance.v1.InstanceAdmin.ListInstancePartitions].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstancePartitions]: crate::traits::InstanceAdmin::list_instance_partitions
+/// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstancePartitions]: crate::client::InstanceAdmin::list_instance_partitions
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3416,7 +3416,7 @@ pub struct ListInstancePartitionsResponse {
     /// [ListInstancePartitions][google.spanner.admin.instance.v1.InstanceAdmin.ListInstancePartitions]
     /// call to fetch more of the matching instance partitions.
     ///
-    /// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstancePartitions]: crate::traits::InstanceAdmin::list_instance_partitions
+    /// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstancePartitions]: crate::client::InstanceAdmin::list_instance_partitions
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub next_page_token: std::string::String,
 
@@ -3480,7 +3480,7 @@ impl gax::paginator::PageableResponse for ListInstancePartitionsResponse {
 /// The request for
 /// [ListInstancePartitionOperations][google.spanner.admin.instance.v1.InstanceAdmin.ListInstancePartitionOperations].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstancePartitionOperations]: crate::traits::InstanceAdmin::list_instance_partition_operations
+/// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstancePartitionOperations]: crate::client::InstanceAdmin::list_instance_partition_operations
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3612,7 +3612,7 @@ impl wkt::message::Message for ListInstancePartitionOperationsRequest {
 /// The response for
 /// [ListInstancePartitionOperations][google.spanner.admin.instance.v1.InstanceAdmin.ListInstancePartitionOperations].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstancePartitionOperations]: crate::traits::InstanceAdmin::list_instance_partition_operations
+/// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstancePartitionOperations]: crate::client::InstanceAdmin::list_instance_partition_operations
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3630,7 +3630,7 @@ pub struct ListInstancePartitionOperationsResponse {
     /// [ListInstancePartitionOperations][google.spanner.admin.instance.v1.InstanceAdmin.ListInstancePartitionOperations]
     /// call to fetch more of the matching metadata.
     ///
-    /// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstancePartitionOperations]: crate::traits::InstanceAdmin::list_instance_partition_operations
+    /// [google.spanner.admin.instance.v1.InstanceAdmin.ListInstancePartitionOperations]: crate::client::InstanceAdmin::list_instance_partition_operations
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub next_page_token: std::string::String,
 
@@ -3694,7 +3694,7 @@ impl gax::paginator::PageableResponse for ListInstancePartitionOperationsRespons
 /// The request for
 /// [MoveInstance][google.spanner.admin.instance.v1.InstanceAdmin.MoveInstance].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.MoveInstance]: crate::traits::InstanceAdmin::move_instance
+/// [google.spanner.admin.instance.v1.InstanceAdmin.MoveInstance]: crate::client::InstanceAdmin::move_instance
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3734,7 +3734,7 @@ impl wkt::message::Message for MoveInstanceRequest {
 /// The response for
 /// [MoveInstance][google.spanner.admin.instance.v1.InstanceAdmin.MoveInstance].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.MoveInstance]: crate::traits::InstanceAdmin::move_instance
+/// [google.spanner.admin.instance.v1.InstanceAdmin.MoveInstance]: crate::client::InstanceAdmin::move_instance
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3752,7 +3752,7 @@ impl wkt::message::Message for MoveInstanceResponse {
 /// Metadata type for the operation returned by
 /// [MoveInstance][google.spanner.admin.instance.v1.InstanceAdmin.MoveInstance].
 ///
-/// [google.spanner.admin.instance.v1.InstanceAdmin.MoveInstance]: crate::traits::InstanceAdmin::move_instance
+/// [google.spanner.admin.instance.v1.InstanceAdmin.MoveInstance]: crate::client::InstanceAdmin::move_instance
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -3769,7 +3769,7 @@ pub struct MoveInstanceMetadata {
     /// [progress_percent][google.spanner.admin.instance.v1.OperationProgress.progress_percent]
     /// is reset when cancellation is requested.
     ///
-    /// [google.spanner.admin.instance.v1.InstanceAdmin.MoveInstance]: crate::traits::InstanceAdmin::move_instance
+    /// [google.spanner.admin.instance.v1.InstanceAdmin.MoveInstance]: crate::client::InstanceAdmin::move_instance
     /// [google.spanner.admin.instance.v1.OperationProgress.progress_percent]: crate::model::OperationProgress::progress_percent
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub progress: std::option::Option<crate::model::OperationProgress>,

--- a/src/generated/spanner/admin/instance/v1/src/traits/mod.rs
+++ b/src/generated/spanner/admin/instance/v1/src/traits/mod.rs
@@ -688,7 +688,7 @@ pub trait InstanceAdmin: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn list_operations(
         &self,
         _req: longrunning::model::ListOperationsRequest,
@@ -702,7 +702,7 @@ pub trait InstanceAdmin: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn get_operation(
         &self,
         _req: longrunning::model::GetOperationRequest,
@@ -716,7 +716,7 @@ pub trait InstanceAdmin: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn delete_operation(
         &self,
         _req: longrunning::model::DeleteOperationRequest,
@@ -727,7 +727,7 @@ pub trait InstanceAdmin: std::fmt::Debug + Send + Sync {
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
-    /// [google.longrunning.Operations]: longrunning::traits::Operations
+    /// [google.longrunning.Operations]: longrunning::client::Operations
     fn cancel_operation(
         &self,
         _req: longrunning::model::CancelOperationRequest,


### PR DESCRIPTION
For services and methods it is better to link the documentation for the
client. That is the main API customers will use, and that is where we
are adding any additional documentation (and someday samples?).

Also fix the links to apply the correct transformations for naming
styles.

Fixes #839 