### PR TITLE
feat(generator/rust): improve setters

### DIFF
--- a/generator/internal/language/templates/rust/common/message.mustache
+++ b/generator/internal/language/templates/rust/common/message.mustache
@@ -43,14 +43,41 @@ pub struct {{Codec.Name}} {
 }
 
 impl {{Codec.Name}} {
-    {{#Codec.BasicFields}}
+    {{#Codec.SingularFields}}
 
-    /// Sets the value of `{{Codec.FieldName}}`.
+    /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Codec.SetterName}}].
     pub fn set_{{Codec.SetterName}}<T: std::convert::Into<{{{Codec.FieldType}}}>>(mut self, v: T) -> Self {
         self.{{Codec.FieldName}} = v.into();
         self
     }
-    {{/Codec.BasicFields}}
+    {{/Codec.SingularFields}}
+    {{#Codec.RepeatedFields}}
+
+    /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Codec.SetterName}}].
+    pub fn set_{{Codec.SetterName}}<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<{{{Codec.PrimitiveFieldType}}}>
+    {
+        use std::iter::Iterator;
+        self.{{Codec.FieldName}} = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+    {{/Codec.RepeatedFields}}
+    {{#Codec.MapFields}}
+
+    /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Codec.SetterName}}].
+    pub fn set_{{Codec.SetterName}}<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<{{{Codec.KeyType}}}>,
+        V: std::convert::Into<{{{Codec.ValueType}}}>,
+    {
+        use std::iter::Iterator;
+        self.{{Codec.FieldName}} = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+    {{/Codec.MapFields}}
     {{#OneOfs}}
 
     /// Sets the value of `{{Codec.FieldName}}`.

--- a/generator/internal/language/templates/rust/crate/src/builders.rs.mustache
+++ b/generator/internal/language/templates/rust/crate/src/builders.rs.mustache
@@ -132,14 +132,40 @@ pub mod {{NameToSnake}} {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
         {{/OperationInfo}}
-        {{#InputType.Codec.BasicFields}}
+        {{#InputType.Codec.SingularFields}}
 
-        /// Sets the value of `{{Codec.FieldName}}`.
+        /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Codec.SetterName}}].
         pub fn set_{{Codec.SetterName}}<T: Into<{{{Codec.FieldType}}}>>(mut self, v: T) -> Self {
             self.0.request.{{Codec.FieldName}} = v.into();
             self
         }
-        {{/InputType.Codec.BasicFields}}
+        {{/InputType.Codec.SingularFields}}
+        {{#InputType.Codec.RepeatedFields}}
+
+        /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Codec.SetterName}}].
+        pub fn set_{{Codec.SetterName}}<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<{{{Codec.PrimitiveFieldType}}}>
+        {
+            use std::iter::Iterator;
+            self.0.request.{{Codec.FieldName}} = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+        {{/InputType.Codec.RepeatedFields}}
+        {{#InputType.Codec.MapFields}}
+
+        /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Codec.SetterName}}].
+        pub fn set_{{Codec.SetterName}}<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<{{{Codec.KeyType}}}>,
+            V: std::convert::Into<{{{Codec.ValueType}}}>,
+        {
+            self.0.request.{{Codec.FieldName}} = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+        {{/InputType.Codec.MapFields}}
         {{#InputType.OneOfs}}
 
         /// Sets the value of `{{Codec.FieldName}}`.

--- a/generator/testdata/rust/openapi/golden/src/builders.rs
+++ b/generator/testdata/rust/openapi/golden/src/builders.rs
@@ -77,25 +77,25 @@ pub mod secret_manager_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::ListLocationsRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListLocationsRequest::filter].
         pub fn set_filter<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListLocationsRequest::page_size].
         pub fn set_page_size<T: Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListLocationsRequest::page_token].
         pub fn set_page_token<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -136,13 +136,13 @@ pub mod secret_manager_service {
             (*self.0.stub).get_location(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::GetLocationRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::GetLocationRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -195,25 +195,25 @@ pub mod secret_manager_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::ListSecretsRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListSecretsRequest::page_size].
         pub fn set_page_size<T: Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListSecretsRequest::page_token].
         pub fn set_page_token<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListSecretsRequest::filter].
         pub fn set_filter<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
@@ -254,19 +254,19 @@ pub mod secret_manager_service {
             (*self.0.stub).create_secret(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `request_body`.
+        /// Sets the value of [request_body][crate::model::CreateSecretRequest::request_body].
         pub fn set_request_body<T: Into<std::option::Option<crate::model::Secret>>>(mut self, v: T) -> Self {
             self.0.request.request_body = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::CreateSecretRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret_id`.
+        /// Sets the value of [secret_id][crate::model::CreateSecretRequest::secret_id].
         pub fn set_secret_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret_id = v.into();
             self
@@ -319,31 +319,31 @@ pub mod secret_manager_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::ListSecretsByProjectAndLocationRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::ListSecretsByProjectAndLocationRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListSecretsByProjectAndLocationRequest::page_size].
         pub fn set_page_size<T: Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListSecretsByProjectAndLocationRequest::page_token].
         pub fn set_page_token<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListSecretsByProjectAndLocationRequest::filter].
         pub fn set_filter<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
@@ -384,25 +384,25 @@ pub mod secret_manager_service {
             (*self.0.stub).create_secret_by_project_and_location(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `request_body`.
+        /// Sets the value of [request_body][crate::model::CreateSecretByProjectAndLocationRequest::request_body].
         pub fn set_request_body<T: Into<std::option::Option<crate::model::Secret>>>(mut self, v: T) -> Self {
             self.0.request.request_body = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::CreateSecretByProjectAndLocationRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::CreateSecretByProjectAndLocationRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
         }
 
-        /// Sets the value of `secret_id`.
+        /// Sets the value of [secret_id][crate::model::CreateSecretByProjectAndLocationRequest::secret_id].
         pub fn set_secret_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret_id = v.into();
             self
@@ -443,25 +443,25 @@ pub mod secret_manager_service {
             (*self.0.stub).add_secret_version(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `payload`.
+        /// Sets the value of [payload][crate::model::AddSecretVersionRequest::payload].
         pub fn set_payload<T: Into<std::option::Option<crate::model::SecretPayload>>>(mut self, v: T) -> Self {
             self.0.request.payload = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::AddSecretVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::AddSecretVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::AddSecretVersionRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -502,25 +502,25 @@ pub mod secret_manager_service {
             (*self.0.stub).add_secret_version_by_project_and_location_and_secret(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `payload`.
+        /// Sets the value of [payload][crate::model::AddSecretVersionRequest::payload].
         pub fn set_payload<T: Into<std::option::Option<crate::model::SecretPayload>>>(mut self, v: T) -> Self {
             self.0.request.payload = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::AddSecretVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::AddSecretVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::AddSecretVersionRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -561,13 +561,13 @@ pub mod secret_manager_service {
             (*self.0.stub).get_secret(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::GetSecretRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::GetSecretRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
@@ -608,19 +608,19 @@ pub mod secret_manager_service {
             (*self.0.stub).delete_secret(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::DeleteSecretRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::DeleteSecretRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DeleteSecretRequest::etag].
         pub fn set_etag<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -661,25 +661,25 @@ pub mod secret_manager_service {
             (*self.0.stub).update_secret(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `request_body`.
+        /// Sets the value of [request_body][crate::model::UpdateSecretRequest::request_body].
         pub fn set_request_body<T: Into<std::option::Option<crate::model::Secret>>>(mut self, v: T) -> Self {
             self.0.request.request_body = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::UpdateSecretRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::UpdateSecretRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateSecretRequest::update_mask].
         pub fn set_update_mask<T: Into<wkt::FieldMask>>(mut self, v: T) -> Self {
             self.0.request.update_mask = v.into();
             self
@@ -720,19 +720,19 @@ pub mod secret_manager_service {
             (*self.0.stub).get_secret_by_project_and_location_and_secret(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::GetSecretByProjectAndLocationAndSecretRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::GetSecretByProjectAndLocationAndSecretRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::GetSecretByProjectAndLocationAndSecretRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
@@ -773,25 +773,25 @@ pub mod secret_manager_service {
             (*self.0.stub).delete_secret_by_project_and_location_and_secret(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::DeleteSecretByProjectAndLocationAndSecretRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::DeleteSecretByProjectAndLocationAndSecretRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::DeleteSecretByProjectAndLocationAndSecretRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DeleteSecretByProjectAndLocationAndSecretRequest::etag].
         pub fn set_etag<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -832,31 +832,31 @@ pub mod secret_manager_service {
             (*self.0.stub).update_secret_by_project_and_location_and_secret(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `request_body`.
+        /// Sets the value of [request_body][crate::model::UpdateSecretByProjectAndLocationAndSecretRequest::request_body].
         pub fn set_request_body<T: Into<std::option::Option<crate::model::Secret>>>(mut self, v: T) -> Self {
             self.0.request.request_body = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::UpdateSecretByProjectAndLocationAndSecretRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::UpdateSecretByProjectAndLocationAndSecretRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::UpdateSecretByProjectAndLocationAndSecretRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateSecretByProjectAndLocationAndSecretRequest::update_mask].
         pub fn set_update_mask<T: Into<wkt::FieldMask>>(mut self, v: T) -> Self {
             self.0.request.update_mask = v.into();
             self
@@ -909,31 +909,31 @@ pub mod secret_manager_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::ListSecretVersionsRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::ListSecretVersionsRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListSecretVersionsRequest::page_size].
         pub fn set_page_size<T: Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListSecretVersionsRequest::page_token].
         pub fn set_page_token<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListSecretVersionsRequest::filter].
         pub fn set_filter<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
@@ -986,37 +986,37 @@ pub mod secret_manager_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::page_size].
         pub fn set_page_size<T: Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::page_token].
         pub fn set_page_token<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::filter].
         pub fn set_filter<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
@@ -1057,19 +1057,19 @@ pub mod secret_manager_service {
             (*self.0.stub).get_secret_version(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::GetSecretVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::GetSecretVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `version`.
+        /// Sets the value of [version][crate::model::GetSecretVersionRequest::version].
         pub fn set_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.version = v.into();
             self
@@ -1110,25 +1110,25 @@ pub mod secret_manager_service {
             (*self.0.stub).get_secret_version_by_project_and_location_and_secret_and_version(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `version`.
+        /// Sets the value of [version][crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest::version].
         pub fn set_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.version = v.into();
             self
@@ -1169,19 +1169,19 @@ pub mod secret_manager_service {
             (*self.0.stub).access_secret_version(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::AccessSecretVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::AccessSecretVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `version`.
+        /// Sets the value of [version][crate::model::AccessSecretVersionRequest::version].
         pub fn set_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.version = v.into();
             self
@@ -1222,25 +1222,25 @@ pub mod secret_manager_service {
             (*self.0.stub).access_secret_version_by_project_and_location_and_secret_and_version(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `version`.
+        /// Sets the value of [version][crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest::version].
         pub fn set_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.version = v.into();
             self
@@ -1281,31 +1281,31 @@ pub mod secret_manager_service {
             (*self.0.stub).disable_secret_version(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DisableSecretVersionRequest::etag].
         pub fn set_etag<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::DisableSecretVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::DisableSecretVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `version`.
+        /// Sets the value of [version][crate::model::DisableSecretVersionRequest::version].
         pub fn set_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.version = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::DisableSecretVersionRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -1346,31 +1346,31 @@ pub mod secret_manager_service {
             (*self.0.stub).disable_secret_version_by_project_and_location_and_secret_and_version(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DisableSecretVersionRequest::etag].
         pub fn set_etag<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::DisableSecretVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::DisableSecretVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `version`.
+        /// Sets the value of [version][crate::model::DisableSecretVersionRequest::version].
         pub fn set_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.version = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::DisableSecretVersionRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -1411,31 +1411,31 @@ pub mod secret_manager_service {
             (*self.0.stub).enable_secret_version(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::EnableSecretVersionRequest::etag].
         pub fn set_etag<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::EnableSecretVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::EnableSecretVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `version`.
+        /// Sets the value of [version][crate::model::EnableSecretVersionRequest::version].
         pub fn set_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.version = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::EnableSecretVersionRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -1476,31 +1476,31 @@ pub mod secret_manager_service {
             (*self.0.stub).enable_secret_version_by_project_and_location_and_secret_and_version(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::EnableSecretVersionRequest::etag].
         pub fn set_etag<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::EnableSecretVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::EnableSecretVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `version`.
+        /// Sets the value of [version][crate::model::EnableSecretVersionRequest::version].
         pub fn set_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.version = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::EnableSecretVersionRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -1541,31 +1541,31 @@ pub mod secret_manager_service {
             (*self.0.stub).destroy_secret_version(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DestroySecretVersionRequest::etag].
         pub fn set_etag<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::DestroySecretVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::DestroySecretVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `version`.
+        /// Sets the value of [version][crate::model::DestroySecretVersionRequest::version].
         pub fn set_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.version = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::DestroySecretVersionRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -1606,31 +1606,31 @@ pub mod secret_manager_service {
             (*self.0.stub).destroy_secret_version_by_project_and_location_and_secret_and_version(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DestroySecretVersionRequest::etag].
         pub fn set_etag<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::DestroySecretVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::DestroySecretVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `version`.
+        /// Sets the value of [version][crate::model::DestroySecretVersionRequest::version].
         pub fn set_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.version = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::DestroySecretVersionRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -1671,31 +1671,31 @@ pub mod secret_manager_service {
             (*self.0.stub).set_iam_policy(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][crate::model::SetIamPolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<crate::model::Policy>>>(mut self, v: T) -> Self {
             self.0.request.policy = v.into();
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::SetIamPolicyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(mut self, v: T) -> Self {
             self.0.request.update_mask = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SetIamPolicyRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::SetIamPolicyRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::SetIamPolicyRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -1736,31 +1736,31 @@ pub mod secret_manager_service {
             (*self.0.stub).set_iam_policy_by_project_and_location_and_secret(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][crate::model::SetIamPolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<crate::model::Policy>>>(mut self, v: T) -> Self {
             self.0.request.policy = v.into();
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::SetIamPolicyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(mut self, v: T) -> Self {
             self.0.request.update_mask = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SetIamPolicyRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::SetIamPolicyRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::SetIamPolicyRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -1801,19 +1801,19 @@ pub mod secret_manager_service {
             (*self.0.stub).get_iam_policy(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::GetIamPolicyRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::GetIamPolicyRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `options_requested_policy_version`.
+        /// Sets the value of [options_requested_policy_version][crate::model::GetIamPolicyRequest::options_requested_policy_version].
         pub fn set_options_requested_policy_version<T: Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
             self.0.request.options_requested_policy_version = v.into();
             self
@@ -1854,25 +1854,25 @@ pub mod secret_manager_service {
             (*self.0.stub).get_iam_policy_by_project_and_location_and_secret(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `options_requested_policy_version`.
+        /// Sets the value of [options_requested_policy_version][crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest::options_requested_policy_version].
         pub fn set_options_requested_policy_version<T: Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
             self.0.request.options_requested_policy_version = v.into();
             self
@@ -1913,27 +1913,32 @@ pub mod secret_manager_service {
             (*self.0.stub).test_iam_permissions(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `permissions`.
-        pub fn set_permissions<T: Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-            self.0.request.permissions = v.into();
-            self
-        }
-
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::TestIamPermissionsRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::TestIamPermissionsRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::TestIamPermissionsRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
+            self
+        }
+
+        /// Sets the value of [permissions][crate::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1972,27 +1977,32 @@ pub mod secret_manager_service {
             (*self.0.stub).test_iam_permissions_by_project_and_location_and_secret(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `permissions`.
-        pub fn set_permissions<T: Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-            self.0.request.permissions = v.into();
-            self
-        }
-
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::TestIamPermissionsRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::TestIamPermissionsRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::TestIamPermissionsRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
+            self
+        }
+
+        /// Sets the value of [permissions][crate::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/generator/testdata/rust/openapi/golden/src/model.rs
+++ b/generator/testdata/rust/openapi/golden/src/model.rs
@@ -39,15 +39,20 @@ pub struct ListLocationsResponse {
 
 impl ListLocationsResponse {
 
-    /// Sets the value of `locations`.
-    pub fn set_locations<T: std::convert::Into<std::vec::Vec<crate::model::Location>>>(mut self, v: T) -> Self {
-        self.locations = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListLocationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [locations][crate::model::ListLocationsResponse::locations].
+    pub fn set_locations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Location>
+    {
+        use std::iter::Iterator;
+        self.locations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -108,33 +113,39 @@ pub struct Location {
 
 impl Location {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Location::name].
     pub fn set_name<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `location_id`.
+    /// Sets the value of [location_id][crate::model::Location::location_id].
     pub fn set_location_id<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.location_id = v.into();
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::Location::display_name].
     pub fn set_display_name<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.display_name = v.into();
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<T: std::convert::Into<std::collections::HashMap<std::string::String,std::string::String>>>(mut self, v: T) -> Self {
-        self.labels = v.into();
+    /// Sets the value of [metadata][crate::model::Location::metadata].
+    pub fn set_metadata<T: std::convert::Into<std::option::Option<wkt::Any>>>(mut self, v: T) -> Self {
+        self.metadata = v.into();
         self
     }
 
-    /// Sets the value of `metadata`.
-    pub fn set_metadata<T: std::convert::Into<std::option::Option<wkt::Any>>>(mut self, v: T) -> Self {
-        self.metadata = v.into();
+    /// Sets the value of [labels][crate::model::Location::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -170,21 +181,26 @@ pub struct ListSecretsResponse {
 
 impl ListSecretsResponse {
 
-    /// Sets the value of `secrets`.
-    pub fn set_secrets<T: std::convert::Into<std::vec::Vec<crate::model::Secret>>>(mut self, v: T) -> Self {
-        self.secrets = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListSecretsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `total_size`.
+    /// Sets the value of [total_size][crate::model::ListSecretsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
         self.total_size = v.into();
+        self
+    }
+
+    /// Sets the value of [secrets][crate::model::ListSecretsResponse::secrets].
+    pub fn set_secrets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Secret>
+    {
+        use std::iter::Iterator;
+        self.secrets = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -321,81 +337,104 @@ pub struct Secret {
 
 impl Secret {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Secret::name].
     pub fn set_name<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `replication`.
+    /// Sets the value of [replication][crate::model::Secret::replication].
     pub fn set_replication<T: std::convert::Into<std::option::Option<crate::model::Replication>>>(mut self, v: T) -> Self {
         self.replication = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::Secret::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.create_time = v.into();
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<T: std::convert::Into<std::collections::HashMap<std::string::String,std::string::String>>>(mut self, v: T) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `topics`.
-    pub fn set_topics<T: std::convert::Into<std::vec::Vec<crate::model::Topic>>>(mut self, v: T) -> Self {
-        self.topics = v.into();
-        self
-    }
-
-    /// Sets the value of `expire_time`.
+    /// Sets the value of [expire_time][crate::model::Secret::expire_time].
     pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.expire_time = v.into();
         self
     }
 
-    /// Sets the value of `ttl`.
+    /// Sets the value of [ttl][crate::model::Secret::ttl].
     pub fn set_ttl<T: std::convert::Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
         self.ttl = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::Secret::etag].
     pub fn set_etag<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `rotation`.
+    /// Sets the value of [rotation][crate::model::Secret::rotation].
     pub fn set_rotation<T: std::convert::Into<std::option::Option<crate::model::Rotation>>>(mut self, v: T) -> Self {
         self.rotation = v.into();
         self
     }
 
-    /// Sets the value of `version_aliases`.
-    pub fn set_version_aliases<T: std::convert::Into<std::collections::HashMap<std::string::String,i64>>>(mut self, v: T) -> Self {
-        self.version_aliases = v.into();
-        self
-    }
-
-    /// Sets the value of `annotations`.
-    pub fn set_annotations<T: std::convert::Into<std::collections::HashMap<std::string::String,std::string::String>>>(mut self, v: T) -> Self {
-        self.annotations = v.into();
-        self
-    }
-
-    /// Sets the value of `version_destroy_ttl`.
+    /// Sets the value of [version_destroy_ttl][crate::model::Secret::version_destroy_ttl].
     pub fn set_version_destroy_ttl<T: std::convert::Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
         self.version_destroy_ttl = v.into();
         self
     }
 
-    /// Sets the value of `customer_managed_encryption`.
+    /// Sets the value of [customer_managed_encryption][crate::model::Secret::customer_managed_encryption].
     pub fn set_customer_managed_encryption<T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryption>>>(mut self, v: T) -> Self {
         self.customer_managed_encryption = v.into();
+        self
+    }
+
+    /// Sets the value of [topics][crate::model::Secret::topics].
+    pub fn set_topics<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Topic>
+    {
+        use std::iter::Iterator;
+        self.topics = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Secret::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [version_aliases][crate::model::Secret::version_aliases].
+    pub fn set_version_aliases<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<i64>,
+    {
+        use std::iter::Iterator;
+        self.version_aliases = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::Secret::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -424,13 +463,13 @@ pub struct Replication {
 
 impl Replication {
 
-    /// Sets the value of `automatic`.
+    /// Sets the value of [automatic][crate::model::Replication::automatic].
     pub fn set_automatic<T: std::convert::Into<std::option::Option<crate::model::Automatic>>>(mut self, v: T) -> Self {
         self.automatic = v.into();
         self
     }
 
-    /// Sets the value of `user_managed`.
+    /// Sets the value of [user_managed][crate::model::Replication::user_managed].
     pub fn set_user_managed<T: std::convert::Into<std::option::Option<crate::model::UserManaged>>>(mut self, v: T) -> Self {
         self.user_managed = v.into();
         self
@@ -463,7 +502,7 @@ pub struct Automatic {
 
 impl Automatic {
 
-    /// Sets the value of `customer_managed_encryption`.
+    /// Sets the value of [customer_managed_encryption][crate::model::Automatic::customer_managed_encryption].
     pub fn set_customer_managed_encryption<T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryption>>>(mut self, v: T) -> Self {
         self.customer_managed_encryption = v.into();
         self
@@ -501,7 +540,7 @@ pub struct CustomerManagedEncryption {
 
 impl CustomerManagedEncryption {
 
-    /// Sets the value of `kms_key_name`.
+    /// Sets the value of [kms_key_name][crate::model::CustomerManagedEncryption::kms_key_name].
     pub fn set_kms_key_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kms_key_name = v.into();
         self
@@ -531,9 +570,14 @@ pub struct UserManaged {
 
 impl UserManaged {
 
-    /// Sets the value of `replicas`.
-    pub fn set_replicas<T: std::convert::Into<std::vec::Vec<crate::model::Replica>>>(mut self, v: T) -> Self {
-        self.replicas = v.into();
+    /// Sets the value of [replicas][crate::model::UserManaged::replicas].
+    pub fn set_replicas<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Replica>
+    {
+        use std::iter::Iterator;
+        self.replicas = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -569,13 +613,13 @@ pub struct Replica {
 
 impl Replica {
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::Replica::location].
     pub fn set_location<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `customer_managed_encryption`.
+    /// Sets the value of [customer_managed_encryption][crate::model::Replica::customer_managed_encryption].
     pub fn set_customer_managed_encryption<T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryption>>>(mut self, v: T) -> Self {
         self.customer_managed_encryption = v.into();
         self
@@ -607,7 +651,7 @@ pub struct Topic {
 
 impl Topic {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Topic::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -649,13 +693,13 @@ pub struct Rotation {
 
 impl Rotation {
 
-    /// Sets the value of `next_rotation_time`.
+    /// Sets the value of [next_rotation_time][crate::model::Rotation::next_rotation_time].
     pub fn set_next_rotation_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.next_rotation_time = v.into();
         self
     }
 
-    /// Sets the value of `rotation_period`.
+    /// Sets the value of [rotation_period][crate::model::Rotation::rotation_period].
     pub fn set_rotation_period<T: std::convert::Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
         self.rotation_period = v.into();
         self
@@ -700,25 +744,25 @@ pub struct AddSecretVersionRequest {
 
 impl AddSecretVersionRequest {
 
-    /// Sets the value of `payload`.
+    /// Sets the value of [payload][crate::model::AddSecretVersionRequest::payload].
     pub fn set_payload<T: std::convert::Into<std::option::Option<crate::model::SecretPayload>>>(mut self, v: T) -> Self {
         self.payload = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::AddSecretVersionRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::AddSecretVersionRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::AddSecretVersionRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
@@ -756,13 +800,13 @@ pub struct SecretPayload {
 
 impl SecretPayload {
 
-    /// Sets the value of `data`.
+    /// Sets the value of [data][crate::model::SecretPayload::data].
     pub fn set_data<T: std::convert::Into<std::option::Option<bytes::Bytes>>>(mut self, v: T) -> Self {
         self.data = v.into();
         self
     }
 
-    /// Sets the value of `data_crc_32_c`.
+    /// Sets the value of [data_crc_32_c][crate::model::SecretPayload::data_crc_32_c].
     pub fn set_data_crc_32_c<T: std::convert::Into<std::option::Option<i64>>>(mut self, v: T) -> Self {
         self.data_crc_32_c = v.into();
         self
@@ -835,55 +879,55 @@ pub struct SecretVersion {
 
 impl SecretVersion {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::SecretVersion::name].
     pub fn set_name<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::SecretVersion::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.create_time = v.into();
         self
     }
 
-    /// Sets the value of `destroy_time`.
+    /// Sets the value of [destroy_time][crate::model::SecretVersion::destroy_time].
     pub fn set_destroy_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.destroy_time = v.into();
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::SecretVersion::state].
     pub fn set_state<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.state = v.into();
         self
     }
 
-    /// Sets the value of `replication_status`.
+    /// Sets the value of [replication_status][crate::model::SecretVersion::replication_status].
     pub fn set_replication_status<T: std::convert::Into<std::option::Option<crate::model::ReplicationStatus>>>(mut self, v: T) -> Self {
         self.replication_status = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::SecretVersion::etag].
     pub fn set_etag<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `client_specified_payload_checksum`.
+    /// Sets the value of [client_specified_payload_checksum][crate::model::SecretVersion::client_specified_payload_checksum].
     pub fn set_client_specified_payload_checksum<T: std::convert::Into<std::option::Option<bool>>>(mut self, v: T) -> Self {
         self.client_specified_payload_checksum = v.into();
         self
     }
 
-    /// Sets the value of `scheduled_destroy_time`.
+    /// Sets the value of [scheduled_destroy_time][crate::model::SecretVersion::scheduled_destroy_time].
     pub fn set_scheduled_destroy_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.scheduled_destroy_time = v.into();
         self
     }
 
-    /// Sets the value of `customer_managed_encryption`.
+    /// Sets the value of [customer_managed_encryption][crate::model::SecretVersion::customer_managed_encryption].
     pub fn set_customer_managed_encryption<T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryptionStatus>>>(mut self, v: T) -> Self {
         self.customer_managed_encryption = v.into();
         self
@@ -922,13 +966,13 @@ pub struct ReplicationStatus {
 
 impl ReplicationStatus {
 
-    /// Sets the value of `automatic`.
+    /// Sets the value of [automatic][crate::model::ReplicationStatus::automatic].
     pub fn set_automatic<T: std::convert::Into<std::option::Option<crate::model::AutomaticStatus>>>(mut self, v: T) -> Self {
         self.automatic = v.into();
         self
     }
 
-    /// Sets the value of `user_managed`.
+    /// Sets the value of [user_managed][crate::model::ReplicationStatus::user_managed].
     pub fn set_user_managed<T: std::convert::Into<std::option::Option<crate::model::UserManagedStatus>>>(mut self, v: T) -> Self {
         self.user_managed = v.into();
         self
@@ -959,7 +1003,7 @@ pub struct AutomaticStatus {
 
 impl AutomaticStatus {
 
-    /// Sets the value of `customer_managed_encryption`.
+    /// Sets the value of [customer_managed_encryption][crate::model::AutomaticStatus::customer_managed_encryption].
     pub fn set_customer_managed_encryption<T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryptionStatus>>>(mut self, v: T) -> Self {
         self.customer_managed_encryption = v.into();
         self
@@ -988,7 +1032,7 @@ pub struct CustomerManagedEncryptionStatus {
 
 impl CustomerManagedEncryptionStatus {
 
-    /// Sets the value of `kms_key_version_name`.
+    /// Sets the value of [kms_key_version_name][crate::model::CustomerManagedEncryptionStatus::kms_key_version_name].
     pub fn set_kms_key_version_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kms_key_version_name = v.into();
         self
@@ -1019,9 +1063,14 @@ pub struct UserManagedStatus {
 
 impl UserManagedStatus {
 
-    /// Sets the value of `replicas`.
-    pub fn set_replicas<T: std::convert::Into<std::vec::Vec<crate::model::ReplicaStatus>>>(mut self, v: T) -> Self {
-        self.replicas = v.into();
+    /// Sets the value of [replicas][crate::model::UserManagedStatus::replicas].
+    pub fn set_replicas<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ReplicaStatus>
+    {
+        use std::iter::Iterator;
+        self.replicas = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1052,13 +1101,13 @@ pub struct ReplicaStatus {
 
 impl ReplicaStatus {
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::ReplicaStatus::location].
     pub fn set_location<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `customer_managed_encryption`.
+    /// Sets the value of [customer_managed_encryption][crate::model::ReplicaStatus::customer_managed_encryption].
     pub fn set_customer_managed_encryption<T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryptionStatus>>>(mut self, v: T) -> Self {
         self.customer_managed_encryption = v.into();
         self
@@ -1121,21 +1170,26 @@ pub struct ListSecretVersionsResponse {
 
 impl ListSecretVersionsResponse {
 
-    /// Sets the value of `versions`.
-    pub fn set_versions<T: std::convert::Into<std::vec::Vec<crate::model::SecretVersion>>>(mut self, v: T) -> Self {
-        self.versions = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListSecretVersionsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `total_size`.
+    /// Sets the value of [total_size][crate::model::ListSecretVersionsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
         self.total_size = v.into();
+        self
+    }
+
+    /// Sets the value of [versions][crate::model::ListSecretVersionsResponse::versions].
+    pub fn set_versions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SecretVersion>
+    {
+        use std::iter::Iterator;
+        self.versions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1179,13 +1233,13 @@ pub struct AccessSecretVersionResponse {
 
 impl AccessSecretVersionResponse {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::AccessSecretVersionResponse::name].
     pub fn set_name<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `payload`.
+    /// Sets the value of [payload][crate::model::AccessSecretVersionResponse::payload].
     pub fn set_payload<T: std::convert::Into<std::option::Option<crate::model::SecretPayload>>>(mut self, v: T) -> Self {
         self.payload = v.into();
         self
@@ -1238,31 +1292,31 @@ pub struct DisableSecretVersionRequest {
 
 impl DisableSecretVersionRequest {
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DisableSecretVersionRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::DisableSecretVersionRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::DisableSecretVersionRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::DisableSecretVersionRequest::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::DisableSecretVersionRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
@@ -1309,31 +1363,31 @@ pub struct EnableSecretVersionRequest {
 
 impl EnableSecretVersionRequest {
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::EnableSecretVersionRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::EnableSecretVersionRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::EnableSecretVersionRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::EnableSecretVersionRequest::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::EnableSecretVersionRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
@@ -1380,31 +1434,31 @@ pub struct DestroySecretVersionRequest {
 
 impl DestroySecretVersionRequest {
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DestroySecretVersionRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::DestroySecretVersionRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::DestroySecretVersionRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::DestroySecretVersionRequest::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::DestroySecretVersionRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
@@ -1454,31 +1508,31 @@ pub struct SetIamPolicyRequest {
 
 impl SetIamPolicyRequest {
 
-    /// Sets the value of `policy`.
+    /// Sets the value of [policy][crate::model::SetIamPolicyRequest::policy].
     pub fn set_policy<T: std::convert::Into<std::option::Option<crate::model::Policy>>>(mut self, v: T) -> Self {
         self.policy = v.into();
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::SetIamPolicyRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(mut self, v: T) -> Self {
         self.update_mask = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SetIamPolicyRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::SetIamPolicyRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::SetIamPolicyRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
@@ -1624,27 +1678,37 @@ pub struct Policy {
 
 impl Policy {
 
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::Policy::version].
     pub fn set_version<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
     }
 
-    /// Sets the value of `bindings`.
-    pub fn set_bindings<T: std::convert::Into<std::vec::Vec<crate::model::Binding>>>(mut self, v: T) -> Self {
-        self.bindings = v.into();
-        self
-    }
-
-    /// Sets the value of `audit_configs`.
-    pub fn set_audit_configs<T: std::convert::Into<std::vec::Vec<crate::model::AuditConfig>>>(mut self, v: T) -> Self {
-        self.audit_configs = v.into();
-        self
-    }
-
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::Policy::etag].
     pub fn set_etag<T: std::convert::Into<std::option::Option<bytes::Bytes>>>(mut self, v: T) -> Self {
         self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [bindings][crate::model::Policy::bindings].
+    pub fn set_bindings<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Binding>
+    {
+        use std::iter::Iterator;
+        self.bindings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [audit_configs][crate::model::Policy::audit_configs].
+    pub fn set_audit_configs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AuditConfig>
+    {
+        use std::iter::Iterator;
+        self.audit_configs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1771,21 +1835,26 @@ pub struct Binding {
 
 impl Binding {
 
-    /// Sets the value of `role`.
+    /// Sets the value of [role][crate::model::Binding::role].
     pub fn set_role<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.role = v.into();
         self
     }
 
-    /// Sets the value of `members`.
-    pub fn set_members<T: std::convert::Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-        self.members = v.into();
+    /// Sets the value of [condition][crate::model::Binding::condition].
+    pub fn set_condition<T: std::convert::Into<std::option::Option<crate::model::Expr>>>(mut self, v: T) -> Self {
+        self.condition = v.into();
         self
     }
 
-    /// Sets the value of `condition`.
-    pub fn set_condition<T: std::convert::Into<std::option::Option<crate::model::Expr>>>(mut self, v: T) -> Self {
-        self.condition = v.into();
+    /// Sets the value of [members][crate::model::Binding::members].
+    pub fn set_members<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.members = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1865,25 +1934,25 @@ pub struct Expr {
 
 impl Expr {
 
-    /// Sets the value of `expression`.
+    /// Sets the value of [expression][crate::model::Expr::expression].
     pub fn set_expression<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.expression = v.into();
         self
     }
 
-    /// Sets the value of `title`.
+    /// Sets the value of [title][crate::model::Expr::title].
     pub fn set_title<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.title = v.into();
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::Expr::description].
     pub fn set_description<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::Expr::location].
     pub fn set_location<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
@@ -1968,15 +2037,20 @@ pub struct AuditConfig {
 
 impl AuditConfig {
 
-    /// Sets the value of `service`.
+    /// Sets the value of [service][crate::model::AuditConfig::service].
     pub fn set_service<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.service = v.into();
         self
     }
 
-    /// Sets the value of `audit_log_configs`.
-    pub fn set_audit_log_configs<T: std::convert::Into<std::vec::Vec<crate::model::AuditLogConfig>>>(mut self, v: T) -> Self {
-        self.audit_log_configs = v.into();
+    /// Sets the value of [audit_log_configs][crate::model::AuditConfig::audit_log_configs].
+    pub fn set_audit_log_configs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AuditLogConfig>
+    {
+        use std::iter::Iterator;
+        self.audit_log_configs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2027,15 +2101,20 @@ pub struct AuditLogConfig {
 
 impl AuditLogConfig {
 
-    /// Sets the value of `log_type`.
+    /// Sets the value of [log_type][crate::model::AuditLogConfig::log_type].
     pub fn set_log_type<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.log_type = v.into();
         self
     }
 
-    /// Sets the value of `exempted_members`.
-    pub fn set_exempted_members<T: std::convert::Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-        self.exempted_members = v.into();
+    /// Sets the value of [exempted_members][crate::model::AuditLogConfig::exempted_members].
+    pub fn set_exempted_members<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.exempted_members = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2081,27 +2160,32 @@ pub struct TestIamPermissionsRequest {
 
 impl TestIamPermissionsRequest {
 
-    /// Sets the value of `permissions`.
-    pub fn set_permissions<T: std::convert::Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-        self.permissions = v.into();
-        self
-    }
-
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::TestIamPermissionsRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::TestIamPermissionsRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::TestIamPermissionsRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
+        self
+    }
+
+    /// Sets the value of [permissions][crate::model::TestIamPermissionsRequest::permissions].
+    pub fn set_permissions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.permissions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2121,9 +2205,14 @@ pub struct TestIamPermissionsResponse {
 
 impl TestIamPermissionsResponse {
 
-    /// Sets the value of `permissions`.
-    pub fn set_permissions<T: std::convert::Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-        self.permissions = v.into();
+    /// Sets the value of [permissions][crate::model::TestIamPermissionsResponse::permissions].
+    pub fn set_permissions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.permissions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2166,25 +2255,25 @@ pub struct ListLocationsRequest {
 
 impl ListLocationsRequest {
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::ListLocationsRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListLocationsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListLocationsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListLocationsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -2213,13 +2302,13 @@ pub struct GetLocationRequest {
 
 impl GetLocationRequest {
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::GetLocationRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::GetLocationRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
@@ -2261,25 +2350,25 @@ pub struct ListSecretsRequest {
 
 impl ListSecretsRequest {
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::ListSecretsRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListSecretsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListSecretsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListSecretsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
@@ -2314,19 +2403,19 @@ pub struct CreateSecretRequest {
 
 impl CreateSecretRequest {
 
-    /// Sets the value of `request_body`.
+    /// Sets the value of [request_body][crate::model::CreateSecretRequest::request_body].
     pub fn set_request_body<T: std::convert::Into<std::option::Option<crate::model::Secret>>>(mut self, v: T) -> Self {
         self.request_body = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::CreateSecretRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret_id`.
+    /// Sets the value of [secret_id][crate::model::CreateSecretRequest::secret_id].
     pub fn set_secret_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret_id = v.into();
         self
@@ -2374,31 +2463,31 @@ pub struct ListSecretsByProjectAndLocationRequest {
 
 impl ListSecretsByProjectAndLocationRequest {
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::ListSecretsByProjectAndLocationRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::ListSecretsByProjectAndLocationRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListSecretsByProjectAndLocationRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListSecretsByProjectAndLocationRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListSecretsByProjectAndLocationRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
@@ -2439,25 +2528,25 @@ pub struct CreateSecretByProjectAndLocationRequest {
 
 impl CreateSecretByProjectAndLocationRequest {
 
-    /// Sets the value of `request_body`.
+    /// Sets the value of [request_body][crate::model::CreateSecretByProjectAndLocationRequest::request_body].
     pub fn set_request_body<T: std::convert::Into<std::option::Option<crate::model::Secret>>>(mut self, v: T) -> Self {
         self.request_body = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::CreateSecretByProjectAndLocationRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::CreateSecretByProjectAndLocationRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `secret_id`.
+    /// Sets the value of [secret_id][crate::model::CreateSecretByProjectAndLocationRequest::secret_id].
     pub fn set_secret_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret_id = v.into();
         self
@@ -2486,13 +2575,13 @@ pub struct GetSecretRequest {
 
 impl GetSecretRequest {
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::GetSecretRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::GetSecretRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
@@ -2527,19 +2616,19 @@ pub struct DeleteSecretRequest {
 
 impl DeleteSecretRequest {
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::DeleteSecretRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::DeleteSecretRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DeleteSecretRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
@@ -2576,25 +2665,25 @@ pub struct UpdateSecretRequest {
 
 impl UpdateSecretRequest {
 
-    /// Sets the value of `request_body`.
+    /// Sets the value of [request_body][crate::model::UpdateSecretRequest::request_body].
     pub fn set_request_body<T: std::convert::Into<std::option::Option<crate::model::Secret>>>(mut self, v: T) -> Self {
         self.request_body = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::UpdateSecretRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::UpdateSecretRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateSecretRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<wkt::FieldMask>>(mut self, v: T) -> Self {
         self.update_mask = v.into();
         self
@@ -2629,19 +2718,19 @@ pub struct GetSecretByProjectAndLocationAndSecretRequest {
 
 impl GetSecretByProjectAndLocationAndSecretRequest {
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::GetSecretByProjectAndLocationAndSecretRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::GetSecretByProjectAndLocationAndSecretRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::GetSecretByProjectAndLocationAndSecretRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
@@ -2682,25 +2771,25 @@ pub struct DeleteSecretByProjectAndLocationAndSecretRequest {
 
 impl DeleteSecretByProjectAndLocationAndSecretRequest {
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::DeleteSecretByProjectAndLocationAndSecretRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::DeleteSecretByProjectAndLocationAndSecretRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::DeleteSecretByProjectAndLocationAndSecretRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DeleteSecretByProjectAndLocationAndSecretRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
@@ -2743,31 +2832,31 @@ pub struct UpdateSecretByProjectAndLocationAndSecretRequest {
 
 impl UpdateSecretByProjectAndLocationAndSecretRequest {
 
-    /// Sets the value of `request_body`.
+    /// Sets the value of [request_body][crate::model::UpdateSecretByProjectAndLocationAndSecretRequest::request_body].
     pub fn set_request_body<T: std::convert::Into<std::option::Option<crate::model::Secret>>>(mut self, v: T) -> Self {
         self.request_body = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::UpdateSecretByProjectAndLocationAndSecretRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::UpdateSecretByProjectAndLocationAndSecretRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::UpdateSecretByProjectAndLocationAndSecretRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateSecretByProjectAndLocationAndSecretRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<wkt::FieldMask>>(mut self, v: T) -> Self {
         self.update_mask = v.into();
         self
@@ -2815,31 +2904,31 @@ pub struct ListSecretVersionsRequest {
 
 impl ListSecretVersionsRequest {
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::ListSecretVersionsRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::ListSecretVersionsRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListSecretVersionsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListSecretVersionsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListSecretVersionsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
@@ -2893,37 +2982,37 @@ pub struct ListSecretVersionsByProjectAndLocationAndSecretRequest {
 
 impl ListSecretVersionsByProjectAndLocationAndSecretRequest {
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
@@ -2958,19 +3047,19 @@ pub struct GetSecretVersionRequest {
 
 impl GetSecretVersionRequest {
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::GetSecretVersionRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::GetSecretVersionRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::GetSecretVersionRequest::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
@@ -3011,25 +3100,25 @@ pub struct GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest {
 
 impl GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest {
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
@@ -3064,19 +3153,19 @@ pub struct AccessSecretVersionRequest {
 
 impl AccessSecretVersionRequest {
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::AccessSecretVersionRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::AccessSecretVersionRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::AccessSecretVersionRequest::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
@@ -3117,25 +3206,25 @@ pub struct AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest {
 
 impl AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest {
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
@@ -3185,19 +3274,19 @@ pub struct GetIamPolicyRequest {
 
 impl GetIamPolicyRequest {
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::GetIamPolicyRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::GetIamPolicyRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `options_requested_policy_version`.
+    /// Sets the value of [options_requested_policy_version][crate::model::GetIamPolicyRequest::options_requested_policy_version].
     pub fn set_options_requested_policy_version<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
         self.options_requested_policy_version = v.into();
         self
@@ -3253,25 +3342,25 @@ pub struct GetIamPolicyByProjectAndLocationAndSecretRequest {
 
 impl GetIamPolicyByProjectAndLocationAndSecretRequest {
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `options_requested_policy_version`.
+    /// Sets the value of [options_requested_policy_version][crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest::options_requested_policy_version].
     pub fn set_options_requested_policy_version<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
         self.options_requested_policy_version = v.into();
         self

--- a/generator/testdata/rust/protobuf/golden/iam/v1/src/builders.rs
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/src/builders.rs
@@ -65,19 +65,19 @@ pub mod iam_policy {
             (*self.0.stub).set_iam_policy(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][crate::model::SetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][crate::model::SetIamPolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<crate::model::Policy>>>(mut self, v: T) -> Self {
             self.0.request.policy = v.into();
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::SetIamPolicyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(mut self, v: T) -> Self {
             self.0.request.update_mask = v.into();
             self
@@ -118,13 +118,13 @@ pub mod iam_policy {
             (*self.0.stub).get_iam_policy(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][crate::model::GetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `options`.
+        /// Sets the value of [options][crate::model::GetIamPolicyRequest::options].
         pub fn set_options<T: Into<std::option::Option<crate::model::GetPolicyOptions>>>(mut self, v: T) -> Self {
             self.0.request.options = v.into();
             self
@@ -165,15 +165,20 @@ pub mod iam_policy {
             (*self.0.stub).test_iam_permissions(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][crate::model::TestIamPermissionsRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `permissions`.
-        pub fn set_permissions<T: Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-            self.0.request.permissions = v.into();
+        /// Sets the value of [permissions][crate::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/generator/testdata/rust/protobuf/golden/iam/v1/src/model.rs
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/src/model.rs
@@ -52,19 +52,19 @@ pub struct SetIamPolicyRequest {
 
 impl SetIamPolicyRequest {
 
-    /// Sets the value of `resource`.
+    /// Sets the value of [resource][crate::model::SetIamPolicyRequest::resource].
     pub fn set_resource<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.resource = v.into();
         self
     }
 
-    /// Sets the value of `policy`.
+    /// Sets the value of [policy][crate::model::SetIamPolicyRequest::policy].
     pub fn set_policy<T: std::convert::Into<std::option::Option<crate::model::Policy>>>(mut self, v: T) -> Self {
         self.policy = v.into();
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::SetIamPolicyRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(mut self, v: T) -> Self {
         self.update_mask = v.into();
         self
@@ -97,13 +97,13 @@ pub struct GetIamPolicyRequest {
 
 impl GetIamPolicyRequest {
 
-    /// Sets the value of `resource`.
+    /// Sets the value of [resource][crate::model::GetIamPolicyRequest::resource].
     pub fn set_resource<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.resource = v.into();
         self
     }
 
-    /// Sets the value of `options`.
+    /// Sets the value of [options][crate::model::GetIamPolicyRequest::options].
     pub fn set_options<T: std::convert::Into<std::option::Option<crate::model::GetPolicyOptions>>>(mut self, v: T) -> Self {
         self.options = v.into();
         self
@@ -138,15 +138,20 @@ pub struct TestIamPermissionsRequest {
 
 impl TestIamPermissionsRequest {
 
-    /// Sets the value of `resource`.
+    /// Sets the value of [resource][crate::model::TestIamPermissionsRequest::resource].
     pub fn set_resource<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.resource = v.into();
         self
     }
 
-    /// Sets the value of `permissions`.
-    pub fn set_permissions<T: std::convert::Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-        self.permissions = v.into();
+    /// Sets the value of [permissions][crate::model::TestIamPermissionsRequest::permissions].
+    pub fn set_permissions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.permissions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -172,9 +177,14 @@ pub struct TestIamPermissionsResponse {
 
 impl TestIamPermissionsResponse {
 
-    /// Sets the value of `permissions`.
-    pub fn set_permissions<T: std::convert::Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-        self.permissions = v.into();
+    /// Sets the value of [permissions][crate::model::TestIamPermissionsResponse::permissions].
+    pub fn set_permissions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.permissions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -215,7 +225,7 @@ pub struct GetPolicyOptions {
 
 impl GetPolicyOptions {
 
-    /// Sets the value of `requested_policy_version`.
+    /// Sets the value of [requested_policy_version][crate::model::GetPolicyOptions::requested_policy_version].
     pub fn set_requested_policy_version<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.requested_policy_version = v.into();
         self
@@ -369,27 +379,37 @@ pub struct Policy {
 
 impl Policy {
 
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::Policy::version].
     pub fn set_version<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
     }
 
-    /// Sets the value of `bindings`.
-    pub fn set_bindings<T: std::convert::Into<std::vec::Vec<crate::model::Binding>>>(mut self, v: T) -> Self {
-        self.bindings = v.into();
-        self
-    }
-
-    /// Sets the value of `audit_configs`.
-    pub fn set_audit_configs<T: std::convert::Into<std::vec::Vec<crate::model::AuditConfig>>>(mut self, v: T) -> Self {
-        self.audit_configs = v.into();
-        self
-    }
-
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::Policy::etag].
     pub fn set_etag<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [bindings][crate::model::Policy::bindings].
+    pub fn set_bindings<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Binding>
+    {
+        use std::iter::Iterator;
+        self.bindings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [audit_configs][crate::model::Policy::audit_configs].
+    pub fn set_audit_configs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AuditConfig>
+    {
+        use std::iter::Iterator;
+        self.audit_configs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -474,21 +494,26 @@ pub struct Binding {
 
 impl Binding {
 
-    /// Sets the value of `role`.
+    /// Sets the value of [role][crate::model::Binding::role].
     pub fn set_role<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.role = v.into();
         self
     }
 
-    /// Sets the value of `members`.
-    pub fn set_members<T: std::convert::Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-        self.members = v.into();
+    /// Sets the value of [condition][crate::model::Binding::condition].
+    pub fn set_condition<T: std::convert::Into<std::option::Option<gtype::model::Expr>>>(mut self, v: T) -> Self {
+        self.condition = v.into();
         self
     }
 
-    /// Sets the value of `condition`.
-    pub fn set_condition<T: std::convert::Into<std::option::Option<gtype::model::Expr>>>(mut self, v: T) -> Self {
-        self.condition = v.into();
+    /// Sets the value of [members][crate::model::Binding::members].
+    pub fn set_members<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.members = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -571,15 +596,20 @@ pub struct AuditConfig {
 
 impl AuditConfig {
 
-    /// Sets the value of `service`.
+    /// Sets the value of [service][crate::model::AuditConfig::service].
     pub fn set_service<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service = v.into();
         self
     }
 
-    /// Sets the value of `audit_log_configs`.
-    pub fn set_audit_log_configs<T: std::convert::Into<std::vec::Vec<crate::model::AuditLogConfig>>>(mut self, v: T) -> Self {
-        self.audit_log_configs = v.into();
+    /// Sets the value of [audit_log_configs][crate::model::AuditConfig::audit_log_configs].
+    pub fn set_audit_log_configs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AuditLogConfig>
+    {
+        use std::iter::Iterator;
+        self.audit_log_configs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -632,15 +662,20 @@ pub struct AuditLogConfig {
 
 impl AuditLogConfig {
 
-    /// Sets the value of `log_type`.
+    /// Sets the value of [log_type][crate::model::AuditLogConfig::log_type].
     pub fn set_log_type<T: std::convert::Into<crate::model::audit_log_config::LogType>>(mut self, v: T) -> Self {
         self.log_type = v.into();
         self
     }
 
-    /// Sets the value of `exempted_members`.
-    pub fn set_exempted_members<T: std::convert::Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-        self.exempted_members = v.into();
+    /// Sets the value of [exempted_members][crate::model::AuditLogConfig::exempted_members].
+    pub fn set_exempted_members<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.exempted_members = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -710,15 +745,25 @@ pub struct PolicyDelta {
 
 impl PolicyDelta {
 
-    /// Sets the value of `binding_deltas`.
-    pub fn set_binding_deltas<T: std::convert::Into<std::vec::Vec<crate::model::BindingDelta>>>(mut self, v: T) -> Self {
-        self.binding_deltas = v.into();
+    /// Sets the value of [binding_deltas][crate::model::PolicyDelta::binding_deltas].
+    pub fn set_binding_deltas<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::BindingDelta>
+    {
+        use std::iter::Iterator;
+        self.binding_deltas = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
-    /// Sets the value of `audit_config_deltas`.
-    pub fn set_audit_config_deltas<T: std::convert::Into<std::vec::Vec<crate::model::AuditConfigDelta>>>(mut self, v: T) -> Self {
-        self.audit_config_deltas = v.into();
+    /// Sets the value of [audit_config_deltas][crate::model::PolicyDelta::audit_config_deltas].
+    pub fn set_audit_config_deltas<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AuditConfigDelta>
+    {
+        use std::iter::Iterator;
+        self.audit_config_deltas = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -760,25 +805,25 @@ pub struct BindingDelta {
 
 impl BindingDelta {
 
-    /// Sets the value of `action`.
+    /// Sets the value of [action][crate::model::BindingDelta::action].
     pub fn set_action<T: std::convert::Into<crate::model::binding_delta::Action>>(mut self, v: T) -> Self {
         self.action = v.into();
         self
     }
 
-    /// Sets the value of `role`.
+    /// Sets the value of [role][crate::model::BindingDelta::role].
     pub fn set_role<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.role = v.into();
         self
     }
 
-    /// Sets the value of `member`.
+    /// Sets the value of [member][crate::model::BindingDelta::member].
     pub fn set_member<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.member = v.into();
         self
     }
 
-    /// Sets the value of `condition`.
+    /// Sets the value of [condition][crate::model::BindingDelta::condition].
     pub fn set_condition<T: std::convert::Into<std::option::Option<gtype::model::Expr>>>(mut self, v: T) -> Self {
         self.condition = v.into();
         self
@@ -862,25 +907,25 @@ pub struct AuditConfigDelta {
 
 impl AuditConfigDelta {
 
-    /// Sets the value of `action`.
+    /// Sets the value of [action][crate::model::AuditConfigDelta::action].
     pub fn set_action<T: std::convert::Into<crate::model::audit_config_delta::Action>>(mut self, v: T) -> Self {
         self.action = v.into();
         self
     }
 
-    /// Sets the value of `service`.
+    /// Sets the value of [service][crate::model::AuditConfigDelta::service].
     pub fn set_service<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service = v.into();
         self
     }
 
-    /// Sets the value of `exempted_member`.
+    /// Sets the value of [exempted_member][crate::model::AuditConfigDelta::exempted_member].
     pub fn set_exempted_member<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.exempted_member = v.into();
         self
     }
 
-    /// Sets the value of `log_type`.
+    /// Sets the value of [log_type][crate::model::AuditConfigDelta::log_type].
     pub fn set_log_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.log_type = v.into();
         self

--- a/generator/testdata/rust/protobuf/golden/location/src/builders.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/builders.rs
@@ -77,25 +77,25 @@ pub mod locations {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::ListLocationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListLocationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListLocationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListLocationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -136,7 +136,7 @@ pub mod locations {
             (*self.0.stub).get_location(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetLocationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self

--- a/generator/testdata/rust/protobuf/golden/location/src/model.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/model.rs
@@ -48,25 +48,25 @@ pub struct ListLocationsRequest {
 
 impl ListLocationsRequest {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::ListLocationsRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListLocationsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListLocationsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListLocationsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -99,15 +99,20 @@ pub struct ListLocationsResponse {
 
 impl ListLocationsResponse {
 
-    /// Sets the value of `locations`.
-    pub fn set_locations<T: std::convert::Into<std::vec::Vec<crate::model::Location>>>(mut self, v: T) -> Self {
-        self.locations = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListLocationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [locations][crate::model::ListLocationsResponse::locations].
+    pub fn set_locations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Location>
+    {
+        use std::iter::Iterator;
+        self.locations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -147,7 +152,7 @@ pub struct GetLocationRequest {
 
 impl GetLocationRequest {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetLocationRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -197,33 +202,39 @@ pub struct Location {
 
 impl Location {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Location::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `location_id`.
+    /// Sets the value of [location_id][crate::model::Location::location_id].
     pub fn set_location_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location_id = v.into();
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::Location::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<T: std::convert::Into<std::collections::HashMap<std::string::String,std::string::String>>>(mut self, v: T) -> Self {
-        self.labels = v.into();
+    /// Sets the value of [metadata][crate::model::Location::metadata].
+    pub fn set_metadata<T: std::convert::Into<std::option::Option<wkt::Any>>>(mut self, v: T) -> Self {
+        self.metadata = v.into();
         self
     }
 
-    /// Sets the value of `metadata`.
-    pub fn set_metadata<T: std::convert::Into<std::option::Option<wkt::Any>>>(mut self, v: T) -> Self {
-        self.metadata = v.into();
+    /// Sets the value of [labels][crate::model::Location::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }

--- a/generator/testdata/rust/protobuf/golden/module/rpc/mod.rs
+++ b/generator/testdata/rust/protobuf/golden/module/rpc/mod.rs
@@ -82,21 +82,27 @@ pub struct ErrorInfo {
 
 impl ErrorInfo {
 
-    /// Sets the value of `reason`.
+    /// Sets the value of [reason][crate::error::rpc::generated::ErrorInfo::reason].
     pub fn set_reason<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.reason = v.into();
         self
     }
 
-    /// Sets the value of `domain`.
+    /// Sets the value of [domain][crate::error::rpc::generated::ErrorInfo::domain].
     pub fn set_domain<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.domain = v.into();
         self
     }
 
-    /// Sets the value of `metadata`.
-    pub fn set_metadata<T: std::convert::Into<std::collections::HashMap<std::string::String,std::string::String>>>(mut self, v: T) -> Self {
-        self.metadata = v.into();
+    /// Sets the value of [metadata][crate::error::rpc::generated::ErrorInfo::metadata].
+    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -133,7 +139,7 @@ pub struct RetryInfo {
 
 impl RetryInfo {
 
-    /// Sets the value of `retry_delay`.
+    /// Sets the value of [retry_delay][crate::error::rpc::generated::RetryInfo::retry_delay].
     pub fn set_retry_delay<T: std::convert::Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
         self.retry_delay = v.into();
         self
@@ -164,15 +170,20 @@ pub struct DebugInfo {
 
 impl DebugInfo {
 
-    /// Sets the value of `stack_entries`.
-    pub fn set_stack_entries<T: std::convert::Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-        self.stack_entries = v.into();
+    /// Sets the value of [detail][crate::error::rpc::generated::DebugInfo::detail].
+    pub fn set_detail<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.detail = v.into();
         self
     }
 
-    /// Sets the value of `detail`.
-    pub fn set_detail<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.detail = v.into();
+    /// Sets the value of [stack_entries][crate::error::rpc::generated::DebugInfo::stack_entries].
+    pub fn set_stack_entries<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.stack_entries = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -207,9 +218,14 @@ pub struct QuotaFailure {
 
 impl QuotaFailure {
 
-    /// Sets the value of `violations`.
-    pub fn set_violations<T: std::convert::Into<std::vec::Vec<crate::error::rpc::generated::quota_failure::Violation>>>(mut self, v: T) -> Self {
-        self.violations = v.into();
+    /// Sets the value of [violations][crate::error::rpc::generated::QuotaFailure::violations].
+    pub fn set_violations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::error::rpc::generated::quota_failure::Violation>
+    {
+        use std::iter::Iterator;
+        self.violations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -253,13 +269,13 @@ pub mod quota_failure {
 
     impl Violation {
 
-        /// Sets the value of `subject`.
+        /// Sets the value of [subject][crate::error::rpc::generated::quota_failure::Violation::subject].
         pub fn set_subject<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.subject = v.into();
             self
         }
 
-        /// Sets the value of `description`.
+        /// Sets the value of [description][crate::error::rpc::generated::quota_failure::Violation::description].
         pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.description = v.into();
             self
@@ -291,9 +307,14 @@ pub struct PreconditionFailure {
 
 impl PreconditionFailure {
 
-    /// Sets the value of `violations`.
-    pub fn set_violations<T: std::convert::Into<std::vec::Vec<crate::error::rpc::generated::precondition_failure::Violation>>>(mut self, v: T) -> Self {
-        self.violations = v.into();
+    /// Sets the value of [violations][crate::error::rpc::generated::PreconditionFailure::violations].
+    pub fn set_violations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::error::rpc::generated::precondition_failure::Violation>
+    {
+        use std::iter::Iterator;
+        self.violations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -340,19 +361,19 @@ pub mod precondition_failure {
 
     impl Violation {
 
-        /// Sets the value of `r#type`.
+        /// Sets the value of [r#type][crate::error::rpc::generated::precondition_failure::Violation::type].
         pub fn set_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.r#type = v.into();
             self
         }
 
-        /// Sets the value of `subject`.
+        /// Sets the value of [subject][crate::error::rpc::generated::precondition_failure::Violation::subject].
         pub fn set_subject<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.subject = v.into();
             self
         }
 
-        /// Sets the value of `description`.
+        /// Sets the value of [description][crate::error::rpc::generated::precondition_failure::Violation::description].
         pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.description = v.into();
             self
@@ -381,9 +402,14 @@ pub struct BadRequest {
 
 impl BadRequest {
 
-    /// Sets the value of `field_violations`.
-    pub fn set_field_violations<T: std::convert::Into<std::vec::Vec<crate::error::rpc::generated::bad_request::FieldViolation>>>(mut self, v: T) -> Self {
-        self.field_violations = v.into();
+    /// Sets the value of [field_violations][crate::error::rpc::generated::BadRequest::field_violations].
+    pub fn set_field_violations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::error::rpc::generated::bad_request::FieldViolation>
+    {
+        use std::iter::Iterator;
+        self.field_violations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -456,13 +482,13 @@ pub mod bad_request {
 
     impl FieldViolation {
 
-        /// Sets the value of `field`.
+        /// Sets the value of [field][crate::error::rpc::generated::bad_request::FieldViolation::field].
         pub fn set_field<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.field = v.into();
             self
         }
 
-        /// Sets the value of `description`.
+        /// Sets the value of [description][crate::error::rpc::generated::bad_request::FieldViolation::description].
         pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.description = v.into();
             self
@@ -497,13 +523,13 @@ pub struct RequestInfo {
 
 impl RequestInfo {
 
-    /// Sets the value of `request_id`.
+    /// Sets the value of [request_id][crate::error::rpc::generated::RequestInfo::request_id].
     pub fn set_request_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.request_id = v.into();
         self
     }
 
-    /// Sets the value of `serving_data`.
+    /// Sets the value of [serving_data][crate::error::rpc::generated::RequestInfo::serving_data].
     pub fn set_serving_data<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.serving_data = v.into();
         self
@@ -553,25 +579,25 @@ pub struct ResourceInfo {
 
 impl ResourceInfo {
 
-    /// Sets the value of `resource_type`.
+    /// Sets the value of [resource_type][crate::error::rpc::generated::ResourceInfo::resource_type].
     pub fn set_resource_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.resource_type = v.into();
         self
     }
 
-    /// Sets the value of `resource_name`.
+    /// Sets the value of [resource_name][crate::error::rpc::generated::ResourceInfo::resource_name].
     pub fn set_resource_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.resource_name = v.into();
         self
     }
 
-    /// Sets the value of `owner`.
+    /// Sets the value of [owner][crate::error::rpc::generated::ResourceInfo::owner].
     pub fn set_owner<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.owner = v.into();
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::error::rpc::generated::ResourceInfo::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
@@ -602,9 +628,14 @@ pub struct Help {
 
 impl Help {
 
-    /// Sets the value of `links`.
-    pub fn set_links<T: std::convert::Into<std::vec::Vec<crate::error::rpc::generated::help::Link>>>(mut self, v: T) -> Self {
-        self.links = v.into();
+    /// Sets the value of [links][crate::error::rpc::generated::Help::links].
+    pub fn set_links<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::error::rpc::generated::help::Link>
+    {
+        use std::iter::Iterator;
+        self.links = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -639,13 +670,13 @@ pub mod help {
 
     impl Link {
 
-        /// Sets the value of `description`.
+        /// Sets the value of [description][crate::error::rpc::generated::help::Link::description].
         pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.description = v.into();
             self
         }
 
-        /// Sets the value of `url`.
+        /// Sets the value of [url][crate::error::rpc::generated::help::Link::url].
         pub fn set_url<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.url = v.into();
             self
@@ -680,13 +711,13 @@ pub struct LocalizedMessage {
 
 impl LocalizedMessage {
 
-    /// Sets the value of `locale`.
+    /// Sets the value of [locale][crate::error::rpc::generated::LocalizedMessage::locale].
     pub fn set_locale<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.locale = v.into();
         self
     }
 
-    /// Sets the value of `message`.
+    /// Sets the value of [message][crate::error::rpc::generated::LocalizedMessage::message].
     pub fn set_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.message = v.into();
         self
@@ -735,21 +766,26 @@ pub struct Status {
 
 impl Status {
 
-    /// Sets the value of `code`.
+    /// Sets the value of [code][crate::error::rpc::generated::Status::code].
     pub fn set_code<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.code = v.into();
         self
     }
 
-    /// Sets the value of `message`.
+    /// Sets the value of [message][crate::error::rpc::generated::Status::message].
     pub fn set_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.message = v.into();
         self
     }
 
-    /// Sets the value of `details`.
-    pub fn set_details<T: std::convert::Into<std::vec::Vec<wkt::Any>>>(mut self, v: T) -> Self {
-        self.details = v.into();
+    /// Sets the value of [details][crate::error::rpc::generated::Status::details].
+    pub fn set_details<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Any>
+    {
+        use std::iter::Iterator;
+        self.details = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/generator/testdata/rust/protobuf/golden/module/type/mod.rs
+++ b/generator/testdata/rust/protobuf/golden/module/type/mod.rs
@@ -86,25 +86,25 @@ pub struct Expr {
 
 impl Expr {
 
-    /// Sets the value of `expression`.
+    /// Sets the value of [expression][crate::model::Expr::expression].
     pub fn set_expression<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.expression = v.into();
         self
     }
 
-    /// Sets the value of `title`.
+    /// Sets the value of [title][crate::model::Expr::title].
     pub fn set_title<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.title = v.into();
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::Expr::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::Expr::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/builders.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/builders.rs
@@ -77,25 +77,25 @@ pub mod secret_manager_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListSecretsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListSecretsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListSecretsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListSecretsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
@@ -136,19 +136,19 @@ pub mod secret_manager_service {
             (*self.0.stub).create_secret(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateSecretRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `secret_id`.
+        /// Sets the value of [secret_id][crate::model::CreateSecretRequest::secret_id].
         pub fn set_secret_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret_id = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::CreateSecretRequest::secret].
         pub fn set_secret<T: Into<std::option::Option<crate::model::Secret>>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
@@ -189,13 +189,13 @@ pub mod secret_manager_service {
             (*self.0.stub).add_secret_version(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::AddSecretVersionRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `payload`.
+        /// Sets the value of [payload][crate::model::AddSecretVersionRequest::payload].
         pub fn set_payload<T: Into<std::option::Option<crate::model::SecretPayload>>>(mut self, v: T) -> Self {
             self.0.request.payload = v.into();
             self
@@ -236,7 +236,7 @@ pub mod secret_manager_service {
             (*self.0.stub).get_secret(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetSecretRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -277,13 +277,13 @@ pub mod secret_manager_service {
             (*self.0.stub).update_secret(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::UpdateSecretRequest::secret].
         pub fn set_secret<T: Into<std::option::Option<crate::model::Secret>>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateSecretRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(mut self, v: T) -> Self {
             self.0.request.update_mask = v.into();
             self
@@ -324,13 +324,13 @@ pub mod secret_manager_service {
             (*self.0.stub).delete_secret(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteSecretRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DeleteSecretRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -383,25 +383,25 @@ pub mod secret_manager_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListSecretVersionsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListSecretVersionsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListSecretVersionsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListSecretVersionsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
@@ -442,7 +442,7 @@ pub mod secret_manager_service {
             (*self.0.stub).get_secret_version(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetSecretVersionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -483,7 +483,7 @@ pub mod secret_manager_service {
             (*self.0.stub).access_secret_version(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::AccessSecretVersionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -524,13 +524,13 @@ pub mod secret_manager_service {
             (*self.0.stub).disable_secret_version(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DisableSecretVersionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DisableSecretVersionRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -571,13 +571,13 @@ pub mod secret_manager_service {
             (*self.0.stub).enable_secret_version(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::EnableSecretVersionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::EnableSecretVersionRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -618,13 +618,13 @@ pub mod secret_manager_service {
             (*self.0.stub).destroy_secret_version(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DestroySecretVersionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DestroySecretVersionRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -665,19 +665,19 @@ pub mod secret_manager_service {
             (*self.0.stub).set_iam_policy(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam::model::SetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][iam::model::SetIamPolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<iam::model::Policy>>>(mut self, v: T) -> Self {
             self.0.request.policy = v.into();
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][iam::model::SetIamPolicyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(mut self, v: T) -> Self {
             self.0.request.update_mask = v.into();
             self
@@ -718,13 +718,13 @@ pub mod secret_manager_service {
             (*self.0.stub).get_iam_policy(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam::model::GetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `options`.
+        /// Sets the value of [options][iam::model::GetIamPolicyRequest::options].
         pub fn set_options<T: Into<std::option::Option<iam::model::GetPolicyOptions>>>(mut self, v: T) -> Self {
             self.0.request.options = v.into();
             self
@@ -765,15 +765,20 @@ pub mod secret_manager_service {
             (*self.0.stub).test_iam_permissions(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam::model::TestIamPermissionsRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `permissions`.
-        pub fn set_permissions<T: Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-            self.0.request.permissions = v.into();
+        /// Sets the value of [permissions][iam::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -824,25 +829,25 @@ pub mod secret_manager_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][location::model::ListLocationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][location::model::ListLocationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][location::model::ListLocationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][location::model::ListLocationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -883,7 +888,7 @@ pub mod secret_manager_service {
             (*self.0.stub).get_location(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][location::model::GetLocationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/model.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/model.rs
@@ -170,69 +170,92 @@ pub struct Secret {
 
 impl Secret {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Secret::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `replication`.
+    /// Sets the value of [replication][crate::model::Secret::replication].
     pub fn set_replication<T: std::convert::Into<std::option::Option<crate::model::Replication>>>(mut self, v: T) -> Self {
         self.replication = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::Secret::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.create_time = v.into();
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<T: std::convert::Into<std::collections::HashMap<std::string::String,std::string::String>>>(mut self, v: T) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `topics`.
-    pub fn set_topics<T: std::convert::Into<std::vec::Vec<crate::model::Topic>>>(mut self, v: T) -> Self {
-        self.topics = v.into();
-        self
-    }
-
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::Secret::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `rotation`.
+    /// Sets the value of [rotation][crate::model::Secret::rotation].
     pub fn set_rotation<T: std::convert::Into<std::option::Option<crate::model::Rotation>>>(mut self, v: T) -> Self {
         self.rotation = v.into();
         self
     }
 
-    /// Sets the value of `version_aliases`.
-    pub fn set_version_aliases<T: std::convert::Into<std::collections::HashMap<std::string::String,i64>>>(mut self, v: T) -> Self {
-        self.version_aliases = v.into();
-        self
-    }
-
-    /// Sets the value of `annotations`.
-    pub fn set_annotations<T: std::convert::Into<std::collections::HashMap<std::string::String,std::string::String>>>(mut self, v: T) -> Self {
-        self.annotations = v.into();
-        self
-    }
-
-    /// Sets the value of `version_destroy_ttl`.
+    /// Sets the value of [version_destroy_ttl][crate::model::Secret::version_destroy_ttl].
     pub fn set_version_destroy_ttl<T: std::convert::Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
         self.version_destroy_ttl = v.into();
         self
     }
 
-    /// Sets the value of `customer_managed_encryption`.
+    /// Sets the value of [customer_managed_encryption][crate::model::Secret::customer_managed_encryption].
     pub fn set_customer_managed_encryption<T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryption>>>(mut self, v: T) -> Self {
         self.customer_managed_encryption = v.into();
+        self
+    }
+
+    /// Sets the value of [topics][crate::model::Secret::topics].
+    pub fn set_topics<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Topic>
+    {
+        use std::iter::Iterator;
+        self.topics = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Secret::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [version_aliases][crate::model::Secret::version_aliases].
+    pub fn set_version_aliases<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<i64>,
+    {
+        use std::iter::Iterator;
+        self.version_aliases = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::Secret::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -380,55 +403,55 @@ pub struct SecretVersion {
 
 impl SecretVersion {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::SecretVersion::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::SecretVersion::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.create_time = v.into();
         self
     }
 
-    /// Sets the value of `destroy_time`.
+    /// Sets the value of [destroy_time][crate::model::SecretVersion::destroy_time].
     pub fn set_destroy_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.destroy_time = v.into();
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::SecretVersion::state].
     pub fn set_state<T: std::convert::Into<crate::model::secret_version::State>>(mut self, v: T) -> Self {
         self.state = v.into();
         self
     }
 
-    /// Sets the value of `replication_status`.
+    /// Sets the value of [replication_status][crate::model::SecretVersion::replication_status].
     pub fn set_replication_status<T: std::convert::Into<std::option::Option<crate::model::ReplicationStatus>>>(mut self, v: T) -> Self {
         self.replication_status = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::SecretVersion::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `client_specified_payload_checksum`.
+    /// Sets the value of [client_specified_payload_checksum][crate::model::SecretVersion::client_specified_payload_checksum].
     pub fn set_client_specified_payload_checksum<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.client_specified_payload_checksum = v.into();
         self
     }
 
-    /// Sets the value of `scheduled_destroy_time`.
+    /// Sets the value of [scheduled_destroy_time][crate::model::SecretVersion::scheduled_destroy_time].
     pub fn set_scheduled_destroy_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.scheduled_destroy_time = v.into();
         self
     }
 
-    /// Sets the value of `customer_managed_encryption`.
+    /// Sets the value of [customer_managed_encryption][crate::model::SecretVersion::customer_managed_encryption].
     pub fn set_customer_managed_encryption<T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryptionStatus>>>(mut self, v: T) -> Self {
         self.customer_managed_encryption = v.into();
         self
@@ -561,7 +584,7 @@ pub mod replication {
 
     impl Automatic {
 
-        /// Sets the value of `customer_managed_encryption`.
+        /// Sets the value of [customer_managed_encryption][crate::model::replication::Automatic::customer_managed_encryption].
         pub fn set_customer_managed_encryption<T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryption>>>(mut self, v: T) -> Self {
             self.customer_managed_encryption = v.into();
             self
@@ -597,9 +620,14 @@ pub mod replication {
 
     impl UserManaged {
 
-        /// Sets the value of `replicas`.
-        pub fn set_replicas<T: std::convert::Into<std::vec::Vec<crate::model::replication::user_managed::Replica>>>(mut self, v: T) -> Self {
-            self.replicas = v.into();
+        /// Sets the value of [replicas][crate::model::replication::UserManaged::replicas].
+        pub fn set_replicas<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::replication::user_managed::Replica>
+        {
+            use std::iter::Iterator;
+            self.replicas = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -649,13 +677,13 @@ pub mod replication {
 
         impl Replica {
 
-            /// Sets the value of `location`.
+            /// Sets the value of [location][crate::model::replication::user_managed::Replica::location].
             pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
                 self.location = v.into();
                 self
             }
 
-            /// Sets the value of `customer_managed_encryption`.
+            /// Sets the value of [customer_managed_encryption][crate::model::replication::user_managed::Replica::customer_managed_encryption].
             pub fn set_customer_managed_encryption<T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryption>>>(mut self, v: T) -> Self {
                 self.customer_managed_encryption = v.into();
                 self
@@ -717,7 +745,7 @@ pub struct CustomerManagedEncryption {
 
 impl CustomerManagedEncryption {
 
-    /// Sets the value of `kms_key_name`.
+    /// Sets the value of [kms_key_name][crate::model::CustomerManagedEncryption::kms_key_name].
     pub fn set_kms_key_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kms_key_name = v.into();
         self
@@ -795,7 +823,7 @@ pub mod replication_status {
 
     impl AutomaticStatus {
 
-        /// Sets the value of `customer_managed_encryption`.
+        /// Sets the value of [customer_managed_encryption][crate::model::replication_status::AutomaticStatus::customer_managed_encryption].
         pub fn set_customer_managed_encryption<T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryptionStatus>>>(mut self, v: T) -> Self {
             self.customer_managed_encryption = v.into();
             self
@@ -833,9 +861,14 @@ pub mod replication_status {
 
     impl UserManagedStatus {
 
-        /// Sets the value of `replicas`.
-        pub fn set_replicas<T: std::convert::Into<std::vec::Vec<crate::model::replication_status::user_managed_status::ReplicaStatus>>>(mut self, v: T) -> Self {
-            self.replicas = v.into();
+        /// Sets the value of [replicas][crate::model::replication_status::UserManagedStatus::replicas].
+        pub fn set_replicas<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::replication_status::user_managed_status::ReplicaStatus>
+        {
+            use std::iter::Iterator;
+            self.replicas = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -878,13 +911,13 @@ pub mod replication_status {
 
         impl ReplicaStatus {
 
-            /// Sets the value of `location`.
+            /// Sets the value of [location][crate::model::replication_status::user_managed_status::ReplicaStatus::location].
             pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
                 self.location = v.into();
                 self
             }
 
-            /// Sets the value of `customer_managed_encryption`.
+            /// Sets the value of [customer_managed_encryption][crate::model::replication_status::user_managed_status::ReplicaStatus::customer_managed_encryption].
             pub fn set_customer_managed_encryption<T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryptionStatus>>>(mut self, v: T) -> Self {
                 self.customer_managed_encryption = v.into();
                 self
@@ -947,7 +980,7 @@ pub struct CustomerManagedEncryptionStatus {
 
 impl CustomerManagedEncryptionStatus {
 
-    /// Sets the value of `kms_key_version_name`.
+    /// Sets the value of [kms_key_version_name][crate::model::CustomerManagedEncryptionStatus::kms_key_version_name].
     pub fn set_kms_key_version_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kms_key_version_name = v.into();
         self
@@ -979,7 +1012,7 @@ pub struct Topic {
 
 impl Topic {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Topic::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1042,13 +1075,13 @@ pub struct Rotation {
 
 impl Rotation {
 
-    /// Sets the value of `next_rotation_time`.
+    /// Sets the value of [next_rotation_time][crate::model::Rotation::next_rotation_time].
     pub fn set_next_rotation_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.next_rotation_time = v.into();
         self
     }
 
-    /// Sets the value of `rotation_period`.
+    /// Sets the value of [rotation_period][crate::model::Rotation::rotation_period].
     pub fn set_rotation_period<T: std::convert::Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
         self.rotation_period = v.into();
         self
@@ -1106,13 +1139,13 @@ pub struct SecretPayload {
 
 impl SecretPayload {
 
-    /// Sets the value of `data`.
+    /// Sets the value of [data][crate::model::SecretPayload::data].
     pub fn set_data<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.data = v.into();
         self
     }
 
-    /// Sets the value of `data_crc32c`.
+    /// Sets the value of [data_crc32c][crate::model::SecretPayload::data_crc32c].
     pub fn set_data_crc32c<T: std::convert::Into<std::option::Option<i64>>>(mut self, v: T) -> Self {
         self.data_crc32c = v.into();
         self
@@ -1166,25 +1199,25 @@ pub struct ListSecretsRequest {
 
 impl ListSecretsRequest {
 
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListSecretsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListSecretsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListSecretsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListSecretsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
@@ -1234,21 +1267,26 @@ pub struct ListSecretsResponse {
 
 impl ListSecretsResponse {
 
-    /// Sets the value of `secrets`.
-    pub fn set_secrets<T: std::convert::Into<std::vec::Vec<crate::model::Secret>>>(mut self, v: T) -> Self {
-        self.secrets = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListSecretsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `total_size`.
+    /// Sets the value of [total_size][crate::model::ListSecretsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
+        self
+    }
+
+    /// Sets the value of [secrets][crate::model::ListSecretsResponse::secrets].
+    pub fn set_secrets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Secret>
+    {
+        use std::iter::Iterator;
+        self.secrets = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1308,19 +1346,19 @@ pub struct CreateSecretRequest {
 
 impl CreateSecretRequest {
 
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateSecretRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `secret_id`.
+    /// Sets the value of [secret_id][crate::model::CreateSecretRequest::secret_id].
     pub fn set_secret_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret_id = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::CreateSecretRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::option::Option<crate::model::Secret>>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
@@ -1363,13 +1401,13 @@ pub struct AddSecretVersionRequest {
 
 impl AddSecretVersionRequest {
 
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::AddSecretVersionRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `payload`.
+    /// Sets the value of [payload][crate::model::AddSecretVersionRequest::payload].
     pub fn set_payload<T: std::convert::Into<std::option::Option<crate::model::SecretPayload>>>(mut self, v: T) -> Self {
         self.payload = v.into();
         self
@@ -1403,7 +1441,7 @@ pub struct GetSecretRequest {
 
 impl GetSecretRequest {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetSecretRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1457,25 +1495,25 @@ pub struct ListSecretVersionsRequest {
 
 impl ListSecretVersionsRequest {
 
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListSecretVersionsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListSecretVersionsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListSecretVersionsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListSecretVersionsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
@@ -1526,21 +1564,26 @@ pub struct ListSecretVersionsResponse {
 
 impl ListSecretVersionsResponse {
 
-    /// Sets the value of `versions`.
-    pub fn set_versions<T: std::convert::Into<std::vec::Vec<crate::model::SecretVersion>>>(mut self, v: T) -> Self {
-        self.versions = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListSecretVersionsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `total_size`.
+    /// Sets the value of [total_size][crate::model::ListSecretVersionsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
+        self
+    }
+
+    /// Sets the value of [versions][crate::model::ListSecretVersionsResponse::versions].
+    pub fn set_versions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SecretVersion>
+    {
+        use std::iter::Iterator;
+        self.versions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1591,7 +1634,7 @@ pub struct GetSecretVersionRequest {
 
 impl GetSecretVersionRequest {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetSecretVersionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1628,13 +1671,13 @@ pub struct UpdateSecretRequest {
 
 impl UpdateSecretRequest {
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::UpdateSecretRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::option::Option<crate::model::Secret>>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateSecretRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(mut self, v: T) -> Self {
         self.update_mask = v.into();
         self
@@ -1674,7 +1717,7 @@ pub struct AccessSecretVersionRequest {
 
 impl AccessSecretVersionRequest {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::AccessSecretVersionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1713,13 +1756,13 @@ pub struct AccessSecretVersionResponse {
 
 impl AccessSecretVersionResponse {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::AccessSecretVersionResponse::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `payload`.
+    /// Sets the value of [payload][crate::model::AccessSecretVersionResponse::payload].
     pub fn set_payload<T: std::convert::Into<std::option::Option<crate::model::SecretPayload>>>(mut self, v: T) -> Self {
         self.payload = v.into();
         self
@@ -1761,13 +1804,13 @@ pub struct DeleteSecretRequest {
 
 impl DeleteSecretRequest {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteSecretRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DeleteSecretRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
@@ -1811,13 +1854,13 @@ pub struct DisableSecretVersionRequest {
 
 impl DisableSecretVersionRequest {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DisableSecretVersionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DisableSecretVersionRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
@@ -1861,13 +1904,13 @@ pub struct EnableSecretVersionRequest {
 
 impl EnableSecretVersionRequest {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::EnableSecretVersionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::EnableSecretVersionRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
@@ -1911,13 +1954,13 @@ pub struct DestroySecretVersionRequest {
 
 impl DestroySecretVersionRequest {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DestroySecretVersionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DestroySecretVersionRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self

--- a/generator/testdata/rust/protobuf/golden/type/src/model.rs
+++ b/generator/testdata/rust/protobuf/golden/type/src/model.rs
@@ -89,25 +89,25 @@ pub struct Expr {
 
 impl Expr {
 
-    /// Sets the value of `expression`.
+    /// Sets the value of [expression][crate::model::Expr::expression].
     pub fn set_expression<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.expression = v.into();
         self
     }
 
-    /// Sets the value of `title`.
+    /// Sets the value of [title][crate::model::Expr::title].
     pub fn set_title<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.title = v.into();
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::Expr::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::Expr::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self

--- a/generator/testdata/rust/protobuf/golden/wkt/generated/wkt/mod.rs
+++ b/generator/testdata/rust/protobuf/golden/wkt/generated/wkt/mod.rs
@@ -34,7 +34,7 @@ pub struct SourceContext {
 
 impl SourceContext {
 
-    /// Sets the value of `file_name`.
+    /// Sets the value of [file_name][crate::SourceContext::file_name].
     pub fn set_file_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.file_name = v.into();
         self

--- a/src/gax/src/error/rpc/mod.rs
+++ b/src/gax/src/error/rpc/mod.rs
@@ -414,7 +414,6 @@ mod test {
     use rpc::model::ResourceInfo;
     use rpc::model::RetryInfo;
     use serde_json::json;
-    use std::collections::HashMap;
     use test_case::test_case;
     type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
@@ -440,7 +439,7 @@ mod test {
                         ErrorInfo::default()
                             .set_reason("reason")
                             .set_domain("domain")
-                            .set_metadata(HashMap::new()),
+                            .set_metadata([("", "")].into_iter().take(0)),
                     ),
                     StatusDetails::Help(Help::default().set_links(
                         vec![rpc::model::help::Link::default()

--- a/src/generated/api/src/model.rs
+++ b/src/generated/api/src/model.rs
@@ -61,21 +61,25 @@ pub struct Authentication {
 }
 
 impl Authentication {
-    /// Sets the value of `rules`.
-    pub fn set_rules<T: std::convert::Into<std::vec::Vec<crate::model::AuthenticationRule>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rules = v.into();
+    /// Sets the value of [rules][crate::model::Authentication::rules].
+    pub fn set_rules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AuthenticationRule>,
+    {
+        use std::iter::Iterator;
+        self.rules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
-    /// Sets the value of `providers`.
-    pub fn set_providers<T: std::convert::Into<std::vec::Vec<crate::model::AuthProvider>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.providers = v.into();
+    /// Sets the value of [providers][crate::model::Authentication::providers].
+    pub fn set_providers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AuthProvider>,
+    {
+        use std::iter::Iterator;
+        self.providers = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -123,13 +127,13 @@ pub struct AuthenticationRule {
 }
 
 impl AuthenticationRule {
-    /// Sets the value of `selector`.
+    /// Sets the value of [selector][crate::model::AuthenticationRule::selector].
     pub fn set_selector<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.selector = v.into();
         self
     }
 
-    /// Sets the value of `oauth`.
+    /// Sets the value of [oauth][crate::model::AuthenticationRule::oauth].
     pub fn set_oauth<
         T: std::convert::Into<std::option::Option<crate::model::OAuthRequirements>>,
     >(
@@ -140,18 +144,20 @@ impl AuthenticationRule {
         self
     }
 
-    /// Sets the value of `allow_without_credential`.
+    /// Sets the value of [allow_without_credential][crate::model::AuthenticationRule::allow_without_credential].
     pub fn set_allow_without_credential<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.allow_without_credential = v.into();
         self
     }
 
-    /// Sets the value of `requirements`.
-    pub fn set_requirements<T: std::convert::Into<std::vec::Vec<crate::model::AuthRequirement>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.requirements = v.into();
+    /// Sets the value of [requirements][crate::model::AuthenticationRule::requirements].
+    pub fn set_requirements<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AuthRequirement>,
+    {
+        use std::iter::Iterator;
+        self.requirements = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -184,7 +190,7 @@ pub struct JwtLocation {
 }
 
 impl JwtLocation {
-    /// Sets the value of `value_prefix`.
+    /// Sets the value of [value_prefix][crate::model::JwtLocation::value_prefix].
     pub fn set_value_prefix<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.value_prefix = v.into();
         self
@@ -318,31 +324,31 @@ pub struct AuthProvider {
 }
 
 impl AuthProvider {
-    /// Sets the value of `id`.
+    /// Sets the value of [id][crate::model::AuthProvider::id].
     pub fn set_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.id = v.into();
         self
     }
 
-    /// Sets the value of `issuer`.
+    /// Sets the value of [issuer][crate::model::AuthProvider::issuer].
     pub fn set_issuer<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.issuer = v.into();
         self
     }
 
-    /// Sets the value of `jwks_uri`.
+    /// Sets the value of [jwks_uri][crate::model::AuthProvider::jwks_uri].
     pub fn set_jwks_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.jwks_uri = v.into();
         self
     }
 
-    /// Sets the value of `audiences`.
+    /// Sets the value of [audiences][crate::model::AuthProvider::audiences].
     pub fn set_audiences<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.audiences = v.into();
         self
     }
 
-    /// Sets the value of `authorization_url`.
+    /// Sets the value of [authorization_url][crate::model::AuthProvider::authorization_url].
     pub fn set_authorization_url<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -351,12 +357,14 @@ impl AuthProvider {
         self
     }
 
-    /// Sets the value of `jwt_locations`.
-    pub fn set_jwt_locations<T: std::convert::Into<std::vec::Vec<crate::model::JwtLocation>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.jwt_locations = v.into();
+    /// Sets the value of [jwt_locations][crate::model::AuthProvider::jwt_locations].
+    pub fn set_jwt_locations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::JwtLocation>,
+    {
+        use std::iter::Iterator;
+        self.jwt_locations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -404,7 +412,7 @@ pub struct OAuthRequirements {
 }
 
 impl OAuthRequirements {
-    /// Sets the value of `canonical_scopes`.
+    /// Sets the value of [canonical_scopes][crate::model::OAuthRequirements::canonical_scopes].
     pub fn set_canonical_scopes<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -466,13 +474,13 @@ pub struct AuthRequirement {
 }
 
 impl AuthRequirement {
-    /// Sets the value of `provider_id`.
+    /// Sets the value of [provider_id][crate::model::AuthRequirement::provider_id].
     pub fn set_provider_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.provider_id = v.into();
         self
     }
 
-    /// Sets the value of `audiences`.
+    /// Sets the value of [audiences][crate::model::AuthRequirement::audiences].
     pub fn set_audiences<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.audiences = v.into();
         self
@@ -499,12 +507,14 @@ pub struct Backend {
 }
 
 impl Backend {
-    /// Sets the value of `rules`.
-    pub fn set_rules<T: std::convert::Into<std::vec::Vec<crate::model::BackendRule>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rules = v.into();
+    /// Sets the value of [rules][crate::model::Backend::rules].
+    pub fn set_rules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::BackendRule>,
+    {
+        use std::iter::Iterator;
+        self.rules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -619,37 +629,37 @@ pub struct BackendRule {
 }
 
 impl BackendRule {
-    /// Sets the value of `selector`.
+    /// Sets the value of [selector][crate::model::BackendRule::selector].
     pub fn set_selector<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.selector = v.into();
         self
     }
 
-    /// Sets the value of `address`.
+    /// Sets the value of [address][crate::model::BackendRule::address].
     pub fn set_address<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.address = v.into();
         self
     }
 
-    /// Sets the value of `deadline`.
+    /// Sets the value of [deadline][crate::model::BackendRule::deadline].
     pub fn set_deadline<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
         self.deadline = v.into();
         self
     }
 
-    /// Sets the value of `min_deadline`.
+    /// Sets the value of [min_deadline][crate::model::BackendRule::min_deadline].
     pub fn set_min_deadline<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
         self.min_deadline = v.into();
         self
     }
 
-    /// Sets the value of `operation_deadline`.
+    /// Sets the value of [operation_deadline][crate::model::BackendRule::operation_deadline].
     pub fn set_operation_deadline<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
         self.operation_deadline = v.into();
         self
     }
 
-    /// Sets the value of `path_translation`.
+    /// Sets the value of [path_translation][crate::model::BackendRule::path_translation].
     pub fn set_path_translation<
         T: std::convert::Into<crate::model::backend_rule::PathTranslation>,
     >(
@@ -660,22 +670,22 @@ impl BackendRule {
         self
     }
 
-    /// Sets the value of `protocol`.
+    /// Sets the value of [protocol][crate::model::BackendRule::protocol].
     pub fn set_protocol<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.protocol = v.into();
         self
     }
 
-    /// Sets the value of `overrides_by_request_protocol`.
-    pub fn set_overrides_by_request_protocol<
-        T: std::convert::Into<
-            std::collections::HashMap<std::string::String, crate::model::BackendRule>,
-        >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.overrides_by_request_protocol = v.into();
+    /// Sets the value of [overrides_by_request_protocol][crate::model::BackendRule::overrides_by_request_protocol].
+    pub fn set_overrides_by_request_protocol<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::BackendRule>,
+    {
+        use std::iter::Iterator;
+        self.overrides_by_request_protocol =
+            v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -862,14 +872,14 @@ pub struct Billing {
 }
 
 impl Billing {
-    /// Sets the value of `consumer_destinations`.
-    pub fn set_consumer_destinations<
-        T: std::convert::Into<std::vec::Vec<crate::model::billing::BillingDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.consumer_destinations = v.into();
+    /// Sets the value of [consumer_destinations][crate::model::Billing::consumer_destinations].
+    pub fn set_consumer_destinations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::billing::BillingDestination>,
+    {
+        use std::iter::Iterator;
+        self.consumer_destinations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -910,7 +920,7 @@ pub mod billing {
     }
 
     impl BillingDestination {
-        /// Sets the value of `monitored_resource`.
+        /// Sets the value of [monitored_resource][crate::model::billing::BillingDestination::monitored_resource].
         pub fn set_monitored_resource<T: std::convert::Into<std::string::String>>(
             mut self,
             v: T,
@@ -919,12 +929,14 @@ pub mod billing {
             self
         }
 
-        /// Sets the value of `metrics`.
-        pub fn set_metrics<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.metrics = v.into();
+        /// Sets the value of [metrics][crate::model::billing::BillingDestination::metrics].
+        pub fn set_metrics<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.metrics = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -957,7 +969,7 @@ pub struct CommonLanguageSettings {
 }
 
 impl CommonLanguageSettings {
-    /// Sets the value of `reference_docs_uri`.
+    /// Sets the value of [reference_docs_uri][crate::model::CommonLanguageSettings::reference_docs_uri].
     pub fn set_reference_docs_uri<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -966,18 +978,7 @@ impl CommonLanguageSettings {
         self
     }
 
-    /// Sets the value of `destinations`.
-    pub fn set_destinations<
-        T: std::convert::Into<std::vec::Vec<crate::model::ClientLibraryDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destinations = v.into();
-        self
-    }
-
-    /// Sets the value of `selective_gapic_generation`.
+    /// Sets the value of [selective_gapic_generation][crate::model::CommonLanguageSettings::selective_gapic_generation].
     pub fn set_selective_gapic_generation<
         T: std::convert::Into<std::option::Option<crate::model::SelectiveGapicGeneration>>,
     >(
@@ -985,6 +986,17 @@ impl CommonLanguageSettings {
         v: T,
     ) -> Self {
         self.selective_gapic_generation = v.into();
+        self
+    }
+
+    /// Sets the value of [destinations][crate::model::CommonLanguageSettings::destinations].
+    pub fn set_destinations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ClientLibraryDestination>,
+    {
+        use std::iter::Iterator;
+        self.destinations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1048,13 +1060,13 @@ pub struct ClientLibrarySettings {
 }
 
 impl ClientLibrarySettings {
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::ClientLibrarySettings::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
     }
 
-    /// Sets the value of `launch_stage`.
+    /// Sets the value of [launch_stage][crate::model::ClientLibrarySettings::launch_stage].
     pub fn set_launch_stage<T: std::convert::Into<crate::model::LaunchStage>>(
         mut self,
         v: T,
@@ -1063,13 +1075,13 @@ impl ClientLibrarySettings {
         self
     }
 
-    /// Sets the value of `rest_numeric_enums`.
+    /// Sets the value of [rest_numeric_enums][crate::model::ClientLibrarySettings::rest_numeric_enums].
     pub fn set_rest_numeric_enums<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.rest_numeric_enums = v.into();
         self
     }
 
-    /// Sets the value of `java_settings`.
+    /// Sets the value of [java_settings][crate::model::ClientLibrarySettings::java_settings].
     pub fn set_java_settings<
         T: std::convert::Into<std::option::Option<crate::model::JavaSettings>>,
     >(
@@ -1080,7 +1092,7 @@ impl ClientLibrarySettings {
         self
     }
 
-    /// Sets the value of `cpp_settings`.
+    /// Sets the value of [cpp_settings][crate::model::ClientLibrarySettings::cpp_settings].
     pub fn set_cpp_settings<
         T: std::convert::Into<std::option::Option<crate::model::CppSettings>>,
     >(
@@ -1091,7 +1103,7 @@ impl ClientLibrarySettings {
         self
     }
 
-    /// Sets the value of `php_settings`.
+    /// Sets the value of [php_settings][crate::model::ClientLibrarySettings::php_settings].
     pub fn set_php_settings<
         T: std::convert::Into<std::option::Option<crate::model::PhpSettings>>,
     >(
@@ -1102,7 +1114,7 @@ impl ClientLibrarySettings {
         self
     }
 
-    /// Sets the value of `python_settings`.
+    /// Sets the value of [python_settings][crate::model::ClientLibrarySettings::python_settings].
     pub fn set_python_settings<
         T: std::convert::Into<std::option::Option<crate::model::PythonSettings>>,
     >(
@@ -1113,7 +1125,7 @@ impl ClientLibrarySettings {
         self
     }
 
-    /// Sets the value of `node_settings`.
+    /// Sets the value of [node_settings][crate::model::ClientLibrarySettings::node_settings].
     pub fn set_node_settings<
         T: std::convert::Into<std::option::Option<crate::model::NodeSettings>>,
     >(
@@ -1124,7 +1136,7 @@ impl ClientLibrarySettings {
         self
     }
 
-    /// Sets the value of `dotnet_settings`.
+    /// Sets the value of [dotnet_settings][crate::model::ClientLibrarySettings::dotnet_settings].
     pub fn set_dotnet_settings<
         T: std::convert::Into<std::option::Option<crate::model::DotnetSettings>>,
     >(
@@ -1135,7 +1147,7 @@ impl ClientLibrarySettings {
         self
     }
 
-    /// Sets the value of `ruby_settings`.
+    /// Sets the value of [ruby_settings][crate::model::ClientLibrarySettings::ruby_settings].
     pub fn set_ruby_settings<
         T: std::convert::Into<std::option::Option<crate::model::RubySettings>>,
     >(
@@ -1146,7 +1158,7 @@ impl ClientLibrarySettings {
         self
     }
 
-    /// Sets the value of `go_settings`.
+    /// Sets the value of [go_settings][crate::model::ClientLibrarySettings::go_settings].
     pub fn set_go_settings<T: std::convert::Into<std::option::Option<crate::model::GoSettings>>>(
         mut self,
         v: T,
@@ -1226,24 +1238,13 @@ pub struct Publishing {
 }
 
 impl Publishing {
-    /// Sets the value of `method_settings`.
-    pub fn set_method_settings<
-        T: std::convert::Into<std::vec::Vec<crate::model::MethodSettings>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.method_settings = v.into();
-        self
-    }
-
-    /// Sets the value of `new_issue_uri`.
+    /// Sets the value of [new_issue_uri][crate::model::Publishing::new_issue_uri].
     pub fn set_new_issue_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.new_issue_uri = v.into();
         self
     }
 
-    /// Sets the value of `documentation_uri`.
+    /// Sets the value of [documentation_uri][crate::model::Publishing::documentation_uri].
     pub fn set_documentation_uri<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -1252,34 +1253,25 @@ impl Publishing {
         self
     }
 
-    /// Sets the value of `api_short_name`.
+    /// Sets the value of [api_short_name][crate::model::Publishing::api_short_name].
     pub fn set_api_short_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.api_short_name = v.into();
         self
     }
 
-    /// Sets the value of `github_label`.
+    /// Sets the value of [github_label][crate::model::Publishing::github_label].
     pub fn set_github_label<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.github_label = v.into();
         self
     }
 
-    /// Sets the value of `codeowner_github_teams`.
-    pub fn set_codeowner_github_teams<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.codeowner_github_teams = v.into();
-        self
-    }
-
-    /// Sets the value of `doc_tag_prefix`.
+    /// Sets the value of [doc_tag_prefix][crate::model::Publishing::doc_tag_prefix].
     pub fn set_doc_tag_prefix<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.doc_tag_prefix = v.into();
         self
     }
 
-    /// Sets the value of `organization`.
+    /// Sets the value of [organization][crate::model::Publishing::organization].
     pub fn set_organization<T: std::convert::Into<crate::model::ClientLibraryOrganization>>(
         mut self,
         v: T,
@@ -1288,18 +1280,7 @@ impl Publishing {
         self
     }
 
-    /// Sets the value of `library_settings`.
-    pub fn set_library_settings<
-        T: std::convert::Into<std::vec::Vec<crate::model::ClientLibrarySettings>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.library_settings = v.into();
-        self
-    }
-
-    /// Sets the value of `proto_reference_documentation_uri`.
+    /// Sets the value of [proto_reference_documentation_uri][crate::model::Publishing::proto_reference_documentation_uri].
     pub fn set_proto_reference_documentation_uri<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -1308,12 +1289,45 @@ impl Publishing {
         self
     }
 
-    /// Sets the value of `rest_reference_documentation_uri`.
+    /// Sets the value of [rest_reference_documentation_uri][crate::model::Publishing::rest_reference_documentation_uri].
     pub fn set_rest_reference_documentation_uri<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
     ) -> Self {
         self.rest_reference_documentation_uri = v.into();
+        self
+    }
+
+    /// Sets the value of [method_settings][crate::model::Publishing::method_settings].
+    pub fn set_method_settings<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::MethodSettings>,
+    {
+        use std::iter::Iterator;
+        self.method_settings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [codeowner_github_teams][crate::model::Publishing::codeowner_github_teams].
+    pub fn set_codeowner_github_teams<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.codeowner_github_teams = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [library_settings][crate::model::Publishing::library_settings].
+    pub fn set_library_settings<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ClientLibrarySettings>,
+    {
+        use std::iter::Iterator;
+        self.library_settings = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1367,24 +1381,13 @@ pub struct JavaSettings {
 }
 
 impl JavaSettings {
-    /// Sets the value of `library_package`.
+    /// Sets the value of [library_package][crate::model::JavaSettings::library_package].
     pub fn set_library_package<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.library_package = v.into();
         self
     }
 
-    /// Sets the value of `service_class_names`.
-    pub fn set_service_class_names<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.service_class_names = v.into();
-        self
-    }
-
-    /// Sets the value of `common`.
+    /// Sets the value of [common][crate::model::JavaSettings::common].
     pub fn set_common<
         T: std::convert::Into<std::option::Option<crate::model::CommonLanguageSettings>>,
     >(
@@ -1392,6 +1395,18 @@ impl JavaSettings {
         v: T,
     ) -> Self {
         self.common = v.into();
+        self
+    }
+
+    /// Sets the value of [service_class_names][crate::model::JavaSettings::service_class_names].
+    pub fn set_service_class_names<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.service_class_names = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1414,7 +1429,7 @@ pub struct CppSettings {
 }
 
 impl CppSettings {
-    /// Sets the value of `common`.
+    /// Sets the value of [common][crate::model::CppSettings::common].
     pub fn set_common<
         T: std::convert::Into<std::option::Option<crate::model::CommonLanguageSettings>>,
     >(
@@ -1444,7 +1459,7 @@ pub struct PhpSettings {
 }
 
 impl PhpSettings {
-    /// Sets the value of `common`.
+    /// Sets the value of [common][crate::model::PhpSettings::common].
     pub fn set_common<
         T: std::convert::Into<std::option::Option<crate::model::CommonLanguageSettings>>,
     >(
@@ -1479,7 +1494,7 @@ pub struct PythonSettings {
 }
 
 impl PythonSettings {
-    /// Sets the value of `common`.
+    /// Sets the value of [common][crate::model::PythonSettings::common].
     pub fn set_common<
         T: std::convert::Into<std::option::Option<crate::model::CommonLanguageSettings>>,
     >(
@@ -1490,7 +1505,7 @@ impl PythonSettings {
         self
     }
 
-    /// Sets the value of `experimental_features`.
+    /// Sets the value of [experimental_features][crate::model::PythonSettings::experimental_features].
     pub fn set_experimental_features<
         T: std::convert::Into<
             std::option::Option<crate::model::python_settings::ExperimentalFeatures>,
@@ -1537,13 +1552,13 @@ pub mod python_settings {
     }
 
     impl ExperimentalFeatures {
-        /// Sets the value of `rest_async_io_enabled`.
+        /// Sets the value of [rest_async_io_enabled][crate::model::python_settings::ExperimentalFeatures::rest_async_io_enabled].
         pub fn set_rest_async_io_enabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.rest_async_io_enabled = v.into();
             self
         }
 
-        /// Sets the value of `protobuf_pythonic_types_enabled`.
+        /// Sets the value of [protobuf_pythonic_types_enabled][crate::model::python_settings::ExperimentalFeatures::protobuf_pythonic_types_enabled].
         pub fn set_protobuf_pythonic_types_enabled<T: std::convert::Into<bool>>(
             mut self,
             v: T,
@@ -1572,7 +1587,7 @@ pub struct NodeSettings {
 }
 
 impl NodeSettings {
-    /// Sets the value of `common`.
+    /// Sets the value of [common][crate::model::NodeSettings::common].
     pub fn set_common<
         T: std::convert::Into<std::option::Option<crate::model::CommonLanguageSettings>>,
     >(
@@ -1637,7 +1652,7 @@ pub struct DotnetSettings {
 }
 
 impl DotnetSettings {
-    /// Sets the value of `common`.
+    /// Sets the value of [common][crate::model::DotnetSettings::common].
     pub fn set_common<
         T: std::convert::Into<std::option::Option<crate::model::CommonLanguageSettings>>,
     >(
@@ -1648,54 +1663,60 @@ impl DotnetSettings {
         self
     }
 
-    /// Sets the value of `renamed_services`.
-    pub fn set_renamed_services<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.renamed_services = v.into();
+    /// Sets the value of [ignored_resources][crate::model::DotnetSettings::ignored_resources].
+    pub fn set_ignored_resources<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.ignored_resources = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
-    /// Sets the value of `renamed_resources`.
-    pub fn set_renamed_resources<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.renamed_resources = v.into();
+    /// Sets the value of [forced_namespace_aliases][crate::model::DotnetSettings::forced_namespace_aliases].
+    pub fn set_forced_namespace_aliases<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.forced_namespace_aliases = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
-    /// Sets the value of `ignored_resources`.
-    pub fn set_ignored_resources<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.ignored_resources = v.into();
+    /// Sets the value of [handwritten_signatures][crate::model::DotnetSettings::handwritten_signatures].
+    pub fn set_handwritten_signatures<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.handwritten_signatures = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
-    /// Sets the value of `forced_namespace_aliases`.
-    pub fn set_forced_namespace_aliases<
-        T: std::convert::Into<std::vec::Vec<std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.forced_namespace_aliases = v.into();
+    /// Sets the value of [renamed_services][crate::model::DotnetSettings::renamed_services].
+    pub fn set_renamed_services<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.renamed_services = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
-    /// Sets the value of `handwritten_signatures`.
-    pub fn set_handwritten_signatures<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.handwritten_signatures = v.into();
+    /// Sets the value of [renamed_resources][crate::model::DotnetSettings::renamed_resources].
+    pub fn set_renamed_resources<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.renamed_resources = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1718,7 +1739,7 @@ pub struct RubySettings {
 }
 
 impl RubySettings {
-    /// Sets the value of `common`.
+    /// Sets the value of [common][crate::model::RubySettings::common].
     pub fn set_common<
         T: std::convert::Into<std::option::Option<crate::model::CommonLanguageSettings>>,
     >(
@@ -1759,7 +1780,7 @@ pub struct GoSettings {
 }
 
 impl GoSettings {
-    /// Sets the value of `common`.
+    /// Sets the value of [common][crate::model::GoSettings::common].
     pub fn set_common<
         T: std::convert::Into<std::option::Option<crate::model::CommonLanguageSettings>>,
     >(
@@ -1770,14 +1791,15 @@ impl GoSettings {
         self
     }
 
-    /// Sets the value of `renamed_services`.
-    pub fn set_renamed_services<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.renamed_services = v.into();
+    /// Sets the value of [renamed_services][crate::model::GoSettings::renamed_services].
+    pub fn set_renamed_services<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.renamed_services = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1839,13 +1861,13 @@ pub struct MethodSettings {
 }
 
 impl MethodSettings {
-    /// Sets the value of `selector`.
+    /// Sets the value of [selector][crate::model::MethodSettings::selector].
     pub fn set_selector<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.selector = v.into();
         self
     }
 
-    /// Sets the value of `long_running`.
+    /// Sets the value of [long_running][crate::model::MethodSettings::long_running].
     pub fn set_long_running<
         T: std::convert::Into<std::option::Option<crate::model::method_settings::LongRunning>>,
     >(
@@ -1856,12 +1878,14 @@ impl MethodSettings {
         self
     }
 
-    /// Sets the value of `auto_populated_fields`.
-    pub fn set_auto_populated_fields<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.auto_populated_fields = v.into();
+    /// Sets the value of [auto_populated_fields][crate::model::MethodSettings::auto_populated_fields].
+    pub fn set_auto_populated_fields<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.auto_populated_fields = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1909,7 +1933,7 @@ pub mod method_settings {
     }
 
     impl LongRunning {
-        /// Sets the value of `initial_poll_delay`.
+        /// Sets the value of [initial_poll_delay][crate::model::method_settings::LongRunning::initial_poll_delay].
         pub fn set_initial_poll_delay<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
             mut self,
             v: T,
@@ -1918,13 +1942,13 @@ pub mod method_settings {
             self
         }
 
-        /// Sets the value of `poll_delay_multiplier`.
+        /// Sets the value of [poll_delay_multiplier][crate::model::method_settings::LongRunning::poll_delay_multiplier].
         pub fn set_poll_delay_multiplier<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
             self.poll_delay_multiplier = v.into();
             self
         }
 
-        /// Sets the value of `max_poll_delay`.
+        /// Sets the value of [max_poll_delay][crate::model::method_settings::LongRunning::max_poll_delay].
         pub fn set_max_poll_delay<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
             mut self,
             v: T,
@@ -1933,7 +1957,7 @@ pub mod method_settings {
             self
         }
 
-        /// Sets the value of `total_poll_timeout`.
+        /// Sets the value of [total_poll_timeout][crate::model::method_settings::LongRunning::total_poll_timeout].
         pub fn set_total_poll_timeout<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
             mut self,
             v: T,
@@ -1964,12 +1988,14 @@ pub struct SelectiveGapicGeneration {
 }
 
 impl SelectiveGapicGeneration {
-    /// Sets the value of `methods`.
-    pub fn set_methods<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.methods = v.into();
+    /// Sets the value of [methods][crate::model::SelectiveGapicGeneration::methods].
+    pub fn set_methods<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.methods = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2024,25 +2050,25 @@ pub struct ConfigChange {
 }
 
 impl ConfigChange {
-    /// Sets the value of `element`.
+    /// Sets the value of [element][crate::model::ConfigChange::element].
     pub fn set_element<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.element = v.into();
         self
     }
 
-    /// Sets the value of `old_value`.
+    /// Sets the value of [old_value][crate::model::ConfigChange::old_value].
     pub fn set_old_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.old_value = v.into();
         self
     }
 
-    /// Sets the value of `new_value`.
+    /// Sets the value of [new_value][crate::model::ConfigChange::new_value].
     pub fn set_new_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.new_value = v.into();
         self
     }
 
-    /// Sets the value of `change_type`.
+    /// Sets the value of [change_type][crate::model::ConfigChange::change_type].
     pub fn set_change_type<T: std::convert::Into<crate::model::ChangeType>>(
         mut self,
         v: T,
@@ -2051,12 +2077,14 @@ impl ConfigChange {
         self
     }
 
-    /// Sets the value of `advices`.
-    pub fn set_advices<T: std::convert::Into<std::vec::Vec<crate::model::Advice>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.advices = v.into();
+    /// Sets the value of [advices][crate::model::ConfigChange::advices].
+    pub fn set_advices<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Advice>,
+    {
+        use std::iter::Iterator;
+        self.advices = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2081,7 +2109,7 @@ pub struct Advice {
 }
 
 impl Advice {
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::Advice::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
@@ -2121,12 +2149,14 @@ pub struct ProjectProperties {
 }
 
 impl ProjectProperties {
-    /// Sets the value of `properties`.
-    pub fn set_properties<T: std::convert::Into<std::vec::Vec<crate::model::Property>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.properties = v.into();
+    /// Sets the value of [properties][crate::model::ProjectProperties::properties].
+    pub fn set_properties<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Property>,
+    {
+        use std::iter::Iterator;
+        self.properties = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2166,13 +2196,13 @@ pub struct Property {
 }
 
 impl Property {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Property::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `r#type`.
+    /// Sets the value of [r#type][crate::model::Property::type].
     pub fn set_type<T: std::convert::Into<crate::model::property::PropertyType>>(
         mut self,
         v: T,
@@ -2181,7 +2211,7 @@ impl Property {
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::Property::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
@@ -2289,12 +2319,14 @@ pub struct Context {
 }
 
 impl Context {
-    /// Sets the value of `rules`.
-    pub fn set_rules<T: std::convert::Into<std::vec::Vec<crate::model::ContextRule>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rules = v.into();
+    /// Sets the value of [rules][crate::model::Context::rules].
+    pub fn set_rules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ContextRule>,
+    {
+        use std::iter::Iterator;
+        self.rules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2343,49 +2375,53 @@ pub struct ContextRule {
 }
 
 impl ContextRule {
-    /// Sets the value of `selector`.
+    /// Sets the value of [selector][crate::model::ContextRule::selector].
     pub fn set_selector<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.selector = v.into();
         self
     }
 
-    /// Sets the value of `requested`.
-    pub fn set_requested<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.requested = v.into();
+    /// Sets the value of [requested][crate::model::ContextRule::requested].
+    pub fn set_requested<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.requested = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
-    /// Sets the value of `provided`.
-    pub fn set_provided<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.provided = v.into();
+    /// Sets the value of [provided][crate::model::ContextRule::provided].
+    pub fn set_provided<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.provided = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
-    /// Sets the value of `allowed_request_extensions`.
-    pub fn set_allowed_request_extensions<
-        T: std::convert::Into<std::vec::Vec<std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.allowed_request_extensions = v.into();
+    /// Sets the value of [allowed_request_extensions][crate::model::ContextRule::allowed_request_extensions].
+    pub fn set_allowed_request_extensions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.allowed_request_extensions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
-    /// Sets the value of `allowed_response_extensions`.
-    pub fn set_allowed_response_extensions<
-        T: std::convert::Into<std::vec::Vec<std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.allowed_response_extensions = v.into();
+    /// Sets the value of [allowed_response_extensions][crate::model::ContextRule::allowed_response_extensions].
+    pub fn set_allowed_response_extensions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.allowed_response_extensions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2421,18 +2457,20 @@ pub struct Control {
 }
 
 impl Control {
-    /// Sets the value of `environment`.
+    /// Sets the value of [environment][crate::model::Control::environment].
     pub fn set_environment<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.environment = v.into();
         self
     }
 
-    /// Sets the value of `method_policies`.
-    pub fn set_method_policies<T: std::convert::Into<std::vec::Vec<crate::model::MethodPolicy>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.method_policies = v.into();
+    /// Sets the value of [method_policies][crate::model::Control::method_policies].
+    pub fn set_method_policies<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::MethodPolicy>,
+    {
+        use std::iter::Iterator;
+        self.method_policies = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2520,25 +2558,25 @@ pub struct Distribution {
 }
 
 impl Distribution {
-    /// Sets the value of `count`.
+    /// Sets the value of [count][crate::model::Distribution::count].
     pub fn set_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.count = v.into();
         self
     }
 
-    /// Sets the value of `mean`.
+    /// Sets the value of [mean][crate::model::Distribution::mean].
     pub fn set_mean<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
         self.mean = v.into();
         self
     }
 
-    /// Sets the value of `sum_of_squared_deviation`.
+    /// Sets the value of [sum_of_squared_deviation][crate::model::Distribution::sum_of_squared_deviation].
     pub fn set_sum_of_squared_deviation<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
         self.sum_of_squared_deviation = v.into();
         self
     }
 
-    /// Sets the value of `range`.
+    /// Sets the value of [range][crate::model::Distribution::range].
     pub fn set_range<
         T: std::convert::Into<std::option::Option<crate::model::distribution::Range>>,
     >(
@@ -2549,7 +2587,7 @@ impl Distribution {
         self
     }
 
-    /// Sets the value of `bucket_options`.
+    /// Sets the value of [bucket_options][crate::model::Distribution::bucket_options].
     pub fn set_bucket_options<
         T: std::convert::Into<std::option::Option<crate::model::distribution::BucketOptions>>,
     >(
@@ -2560,20 +2598,25 @@ impl Distribution {
         self
     }
 
-    /// Sets the value of `bucket_counts`.
-    pub fn set_bucket_counts<T: std::convert::Into<std::vec::Vec<i64>>>(mut self, v: T) -> Self {
-        self.bucket_counts = v.into();
+    /// Sets the value of [bucket_counts][crate::model::Distribution::bucket_counts].
+    pub fn set_bucket_counts<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<i64>,
+    {
+        use std::iter::Iterator;
+        self.bucket_counts = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
-    /// Sets the value of `exemplars`.
-    pub fn set_exemplars<
-        T: std::convert::Into<std::vec::Vec<crate::model::distribution::Exemplar>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.exemplars = v.into();
+    /// Sets the value of [exemplars][crate::model::Distribution::exemplars].
+    pub fn set_exemplars<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::distribution::Exemplar>,
+    {
+        use std::iter::Iterator;
+        self.exemplars = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2603,13 +2646,13 @@ pub mod distribution {
     }
 
     impl Range {
-        /// Sets the value of `min`.
+        /// Sets the value of [min][crate::model::distribution::Range::min].
         pub fn set_min<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
             self.min = v.into();
             self
         }
 
-        /// Sets the value of `max`.
+        /// Sets the value of [max][crate::model::distribution::Range::max].
         pub fn set_max<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
             self.max = v.into();
             self
@@ -2699,19 +2742,19 @@ pub mod distribution {
         }
 
         impl Linear {
-            /// Sets the value of `num_finite_buckets`.
+            /// Sets the value of [num_finite_buckets][crate::model::distribution::bucket_options::Linear::num_finite_buckets].
             pub fn set_num_finite_buckets<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
                 self.num_finite_buckets = v.into();
                 self
             }
 
-            /// Sets the value of `width`.
+            /// Sets the value of [width][crate::model::distribution::bucket_options::Linear::width].
             pub fn set_width<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
                 self.width = v.into();
                 self
             }
 
-            /// Sets the value of `offset`.
+            /// Sets the value of [offset][crate::model::distribution::bucket_options::Linear::offset].
             pub fn set_offset<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
                 self.offset = v.into();
                 self
@@ -2750,19 +2793,19 @@ pub mod distribution {
         }
 
         impl Exponential {
-            /// Sets the value of `num_finite_buckets`.
+            /// Sets the value of [num_finite_buckets][crate::model::distribution::bucket_options::Exponential::num_finite_buckets].
             pub fn set_num_finite_buckets<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
                 self.num_finite_buckets = v.into();
                 self
             }
 
-            /// Sets the value of `growth_factor`.
+            /// Sets the value of [growth_factor][crate::model::distribution::bucket_options::Exponential::growth_factor].
             pub fn set_growth_factor<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
                 self.growth_factor = v.into();
                 self
             }
 
-            /// Sets the value of `scale`.
+            /// Sets the value of [scale][crate::model::distribution::bucket_options::Exponential::scale].
             pub fn set_scale<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
                 self.scale = v.into();
                 self
@@ -2797,9 +2840,14 @@ pub mod distribution {
         }
 
         impl Explicit {
-            /// Sets the value of `bounds`.
-            pub fn set_bounds<T: std::convert::Into<std::vec::Vec<f64>>>(mut self, v: T) -> Self {
-                self.bounds = v.into();
+            /// Sets the value of [bounds][crate::model::distribution::bucket_options::Explicit::bounds].
+            pub fn set_bounds<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<f64>,
+            {
+                use std::iter::Iterator;
+                self.bounds = v.into_iter().map(|i| i.into()).collect();
                 self
             }
         }
@@ -2858,13 +2906,13 @@ pub mod distribution {
     }
 
     impl Exemplar {
-        /// Sets the value of `value`.
+        /// Sets the value of [value][crate::model::distribution::Exemplar::value].
         pub fn set_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
             self.value = v.into();
             self
         }
 
-        /// Sets the value of `timestamp`.
+        /// Sets the value of [timestamp][crate::model::distribution::Exemplar::timestamp].
         pub fn set_timestamp<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
             mut self,
             v: T,
@@ -2873,12 +2921,14 @@ pub mod distribution {
             self
         }
 
-        /// Sets the value of `attachments`.
-        pub fn set_attachments<T: std::convert::Into<std::vec::Vec<wkt::Any>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.attachments = v.into();
+        /// Sets the value of [attachments][crate::model::distribution::Exemplar::attachments].
+        pub fn set_attachments<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<wkt::Any>,
+        {
+            use std::iter::Iterator;
+            self.attachments = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -2968,31 +3018,13 @@ pub struct Documentation {
 }
 
 impl Documentation {
-    /// Sets the value of `summary`.
+    /// Sets the value of [summary][crate::model::Documentation::summary].
     pub fn set_summary<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.summary = v.into();
         self
     }
 
-    /// Sets the value of `pages`.
-    pub fn set_pages<T: std::convert::Into<std::vec::Vec<crate::model::Page>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.pages = v.into();
-        self
-    }
-
-    /// Sets the value of `rules`.
-    pub fn set_rules<T: std::convert::Into<std::vec::Vec<crate::model::DocumentationRule>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rules = v.into();
-        self
-    }
-
-    /// Sets the value of `documentation_root_url`.
+    /// Sets the value of [documentation_root_url][crate::model::Documentation::documentation_root_url].
     pub fn set_documentation_root_url<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -3001,7 +3033,7 @@ impl Documentation {
         self
     }
 
-    /// Sets the value of `service_root_url`.
+    /// Sets the value of [service_root_url][crate::model::Documentation::service_root_url].
     pub fn set_service_root_url<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -3010,9 +3042,31 @@ impl Documentation {
         self
     }
 
-    /// Sets the value of `overview`.
+    /// Sets the value of [overview][crate::model::Documentation::overview].
     pub fn set_overview<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.overview = v.into();
+        self
+    }
+
+    /// Sets the value of [pages][crate::model::Documentation::pages].
+    pub fn set_pages<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Page>,
+    {
+        use std::iter::Iterator;
+        self.pages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [rules][crate::model::Documentation::rules].
+    pub fn set_rules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DocumentationRule>,
+    {
+        use std::iter::Iterator;
+        self.rules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3052,19 +3106,19 @@ pub struct DocumentationRule {
 }
 
 impl DocumentationRule {
-    /// Sets the value of `selector`.
+    /// Sets the value of [selector][crate::model::DocumentationRule::selector].
     pub fn set_selector<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.selector = v.into();
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::DocumentationRule::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
     }
 
-    /// Sets the value of `deprecation_description`.
+    /// Sets the value of [deprecation_description][crate::model::DocumentationRule::deprecation_description].
     pub fn set_deprecation_description<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -3111,24 +3165,26 @@ pub struct Page {
 }
 
 impl Page {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Page::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `content`.
+    /// Sets the value of [content][crate::model::Page::content].
     pub fn set_content<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.content = v.into();
         self
     }
 
-    /// Sets the value of `subpages`.
-    pub fn set_subpages<T: std::convert::Into<std::vec::Vec<crate::model::Page>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.subpages = v.into();
+    /// Sets the value of [subpages][crate::model::Page::subpages].
+    pub fn set_subpages<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Page>,
+    {
+        use std::iter::Iterator;
+        self.subpages = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3195,30 +3251,32 @@ pub struct Endpoint {
 }
 
 impl Endpoint {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Endpoint::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `aliases`.
-    pub fn set_aliases<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.aliases = v.into();
-        self
-    }
-
-    /// Sets the value of `target`.
+    /// Sets the value of [target][crate::model::Endpoint::target].
     pub fn set_target<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.target = v.into();
         self
     }
 
-    /// Sets the value of `allow_cors`.
+    /// Sets the value of [allow_cors][crate::model::Endpoint::allow_cors].
     pub fn set_allow_cors<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.allow_cors = v.into();
+        self
+    }
+
+    /// Sets the value of [aliases][crate::model::Endpoint::aliases].
+    pub fn set_aliases<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.aliases = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3249,7 +3307,7 @@ pub struct FieldInfo {
 }
 
 impl FieldInfo {
-    /// Sets the value of `format`.
+    /// Sets the value of [format][crate::model::FieldInfo::format].
     pub fn set_format<T: std::convert::Into<crate::model::field_info::Format>>(
         mut self,
         v: T,
@@ -3258,14 +3316,14 @@ impl FieldInfo {
         self
     }
 
-    /// Sets the value of `referenced_types`.
-    pub fn set_referenced_types<
-        T: std::convert::Into<std::vec::Vec<crate::model::TypeReference>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.referenced_types = v.into();
+    /// Sets the value of [referenced_types][crate::model::FieldInfo::referenced_types].
+    pub fn set_referenced_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::TypeReference>,
+    {
+        use std::iter::Iterator;
+        self.referenced_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3354,7 +3412,7 @@ pub struct TypeReference {
 }
 
 impl TypeReference {
-    /// Sets the value of `type_name`.
+    /// Sets the value of [type_name][crate::model::TypeReference::type_name].
     pub fn set_type_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.type_name = v.into();
         self
@@ -3393,21 +3451,23 @@ pub struct Http {
 }
 
 impl Http {
-    /// Sets the value of `rules`.
-    pub fn set_rules<T: std::convert::Into<std::vec::Vec<crate::model::HttpRule>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rules = v.into();
-        self
-    }
-
-    /// Sets the value of `fully_decode_reserved_expansion`.
+    /// Sets the value of [fully_decode_reserved_expansion][crate::model::Http::fully_decode_reserved_expansion].
     pub fn set_fully_decode_reserved_expansion<T: std::convert::Into<bool>>(
         mut self,
         v: T,
     ) -> Self {
         self.fully_decode_reserved_expansion = v.into();
+        self
+    }
+
+    /// Sets the value of [rules][crate::model::Http::rules].
+    pub fn set_rules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::HttpRule>,
+    {
+        use std::iter::Iterator;
+        self.rules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3746,30 +3806,32 @@ pub struct HttpRule {
 }
 
 impl HttpRule {
-    /// Sets the value of `selector`.
+    /// Sets the value of [selector][crate::model::HttpRule::selector].
     pub fn set_selector<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.selector = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::HttpRule::body].
     pub fn set_body<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
     }
 
-    /// Sets the value of `response_body`.
+    /// Sets the value of [response_body][crate::model::HttpRule::response_body].
     pub fn set_response_body<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.response_body = v.into();
         self
     }
 
-    /// Sets the value of `additional_bindings`.
-    pub fn set_additional_bindings<T: std::convert::Into<std::vec::Vec<crate::model::HttpRule>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.additional_bindings = v.into();
+    /// Sets the value of [additional_bindings][crate::model::HttpRule::additional_bindings].
+    pub fn set_additional_bindings<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::HttpRule>,
+    {
+        use std::iter::Iterator;
+        self.additional_bindings = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -3838,13 +3900,13 @@ pub struct CustomHttpPattern {
 }
 
 impl CustomHttpPattern {
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::CustomHttpPattern::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `path`.
+    /// Sets the value of [path][crate::model::CustomHttpPattern::path].
     pub fn set_path<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.path = v.into();
         self
@@ -3924,21 +3986,26 @@ pub struct HttpBody {
 }
 
 impl HttpBody {
-    /// Sets the value of `content_type`.
+    /// Sets the value of [content_type][crate::model::HttpBody::content_type].
     pub fn set_content_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.content_type = v.into();
         self
     }
 
-    /// Sets the value of `data`.
+    /// Sets the value of [data][crate::model::HttpBody::data].
     pub fn set_data<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.data = v.into();
         self
     }
 
-    /// Sets the value of `extensions`.
-    pub fn set_extensions<T: std::convert::Into<std::vec::Vec<wkt::Any>>>(mut self, v: T) -> Self {
-        self.extensions = v.into();
+    /// Sets the value of [extensions][crate::model::HttpBody::extensions].
+    pub fn set_extensions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Any>,
+    {
+        use std::iter::Iterator;
+        self.extensions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3968,13 +4035,13 @@ pub struct LabelDescriptor {
 }
 
 impl LabelDescriptor {
-    /// Sets the value of `key`.
+    /// Sets the value of [key][crate::model::LabelDescriptor::key].
     pub fn set_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.key = v.into();
         self
     }
 
-    /// Sets the value of `value_type`.
+    /// Sets the value of [value_type][crate::model::LabelDescriptor::value_type].
     pub fn set_value_type<T: std::convert::Into<crate::model::label_descriptor::ValueType>>(
         mut self,
         v: T,
@@ -3983,7 +4050,7 @@ impl LabelDescriptor {
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::LabelDescriptor::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
@@ -4072,30 +4139,32 @@ pub struct LogDescriptor {
 }
 
 impl LogDescriptor {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::LogDescriptor::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<T: std::convert::Into<std::vec::Vec<crate::model::LabelDescriptor>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::LogDescriptor::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::LogDescriptor::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::LogDescriptor::labels].
+    pub fn set_labels<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::LabelDescriptor>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4158,25 +4227,25 @@ pub struct Logging {
 }
 
 impl Logging {
-    /// Sets the value of `producer_destinations`.
-    pub fn set_producer_destinations<
-        T: std::convert::Into<std::vec::Vec<crate::model::logging::LoggingDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.producer_destinations = v.into();
+    /// Sets the value of [producer_destinations][crate::model::Logging::producer_destinations].
+    pub fn set_producer_destinations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::logging::LoggingDestination>,
+    {
+        use std::iter::Iterator;
+        self.producer_destinations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
-    /// Sets the value of `consumer_destinations`.
-    pub fn set_consumer_destinations<
-        T: std::convert::Into<std::vec::Vec<crate::model::logging::LoggingDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.consumer_destinations = v.into();
+    /// Sets the value of [consumer_destinations][crate::model::Logging::consumer_destinations].
+    pub fn set_consumer_destinations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::logging::LoggingDestination>,
+    {
+        use std::iter::Iterator;
+        self.consumer_destinations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4218,7 +4287,7 @@ pub mod logging {
     }
 
     impl LoggingDestination {
-        /// Sets the value of `monitored_resource`.
+        /// Sets the value of [monitored_resource][crate::model::logging::LoggingDestination::monitored_resource].
         pub fn set_monitored_resource<T: std::convert::Into<std::string::String>>(
             mut self,
             v: T,
@@ -4227,12 +4296,14 @@ pub mod logging {
             self
         }
 
-        /// Sets the value of `logs`.
-        pub fn set_logs<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.logs = v.into();
+        /// Sets the value of [logs][crate::model::logging::LoggingDestination::logs].
+        pub fn set_logs<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.logs = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -4444,28 +4515,19 @@ pub struct MetricDescriptor {
 }
 
 impl MetricDescriptor {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::MetricDescriptor::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `r#type`.
+    /// Sets the value of [r#type][crate::model::MetricDescriptor::type].
     pub fn set_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.r#type = v.into();
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<T: std::convert::Into<std::vec::Vec<crate::model::LabelDescriptor>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `metric_kind`.
+    /// Sets the value of [metric_kind][crate::model::MetricDescriptor::metric_kind].
     pub fn set_metric_kind<T: std::convert::Into<crate::model::metric_descriptor::MetricKind>>(
         mut self,
         v: T,
@@ -4474,7 +4536,7 @@ impl MetricDescriptor {
         self
     }
 
-    /// Sets the value of `value_type`.
+    /// Sets the value of [value_type][crate::model::MetricDescriptor::value_type].
     pub fn set_value_type<T: std::convert::Into<crate::model::metric_descriptor::ValueType>>(
         mut self,
         v: T,
@@ -4483,25 +4545,25 @@ impl MetricDescriptor {
         self
     }
 
-    /// Sets the value of `unit`.
+    /// Sets the value of [unit][crate::model::MetricDescriptor::unit].
     pub fn set_unit<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.unit = v.into();
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::MetricDescriptor::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::MetricDescriptor::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
         self
     }
 
-    /// Sets the value of `metadata`.
+    /// Sets the value of [metadata][crate::model::MetricDescriptor::metadata].
     pub fn set_metadata<
         T: std::convert::Into<
             std::option::Option<crate::model::metric_descriptor::MetricDescriptorMetadata>,
@@ -4514,7 +4576,7 @@ impl MetricDescriptor {
         self
     }
 
-    /// Sets the value of `launch_stage`.
+    /// Sets the value of [launch_stage][crate::model::MetricDescriptor::launch_stage].
     pub fn set_launch_stage<T: std::convert::Into<crate::model::LaunchStage>>(
         mut self,
         v: T,
@@ -4523,14 +4585,25 @@ impl MetricDescriptor {
         self
     }
 
-    /// Sets the value of `monitored_resource_types`.
-    pub fn set_monitored_resource_types<
-        T: std::convert::Into<std::vec::Vec<std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.monitored_resource_types = v.into();
+    /// Sets the value of [labels][crate::model::MetricDescriptor::labels].
+    pub fn set_labels<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::LabelDescriptor>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [monitored_resource_types][crate::model::MetricDescriptor::monitored_resource_types].
+    pub fn set_monitored_resource_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.monitored_resource_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4579,7 +4652,7 @@ pub mod metric_descriptor {
     }
 
     impl MetricDescriptorMetadata {
-        /// Sets the value of `launch_stage`.
+        /// Sets the value of [launch_stage][crate::model::metric_descriptor::MetricDescriptorMetadata::launch_stage].
         pub fn set_launch_stage<T: std::convert::Into<crate::model::LaunchStage>>(
             mut self,
             v: T,
@@ -4588,7 +4661,7 @@ pub mod metric_descriptor {
             self
         }
 
-        /// Sets the value of `sample_period`.
+        /// Sets the value of [sample_period][crate::model::metric_descriptor::MetricDescriptorMetadata::sample_period].
         pub fn set_sample_period<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
             mut self,
             v: T,
@@ -4597,7 +4670,7 @@ pub mod metric_descriptor {
             self
         }
 
-        /// Sets the value of `ingest_delay`.
+        /// Sets the value of [ingest_delay][crate::model::metric_descriptor::MetricDescriptorMetadata::ingest_delay].
         pub fn set_ingest_delay<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
             mut self,
             v: T,
@@ -4606,9 +4679,14 @@ pub mod metric_descriptor {
             self
         }
 
-        /// Sets the value of `time_series_resource_hierarchy_level`.
-        pub fn set_time_series_resource_hierarchy_level<T: std::convert::Into<std::vec::Vec<crate::model::metric_descriptor::metric_descriptor_metadata::TimeSeriesResourceHierarchyLevel>>>(mut self, v: T) -> Self{
-            self.time_series_resource_hierarchy_level = v.into();
+        /// Sets the value of [time_series_resource_hierarchy_level][crate::model::metric_descriptor::MetricDescriptorMetadata::time_series_resource_hierarchy_level].
+        pub fn set_time_series_resource_hierarchy_level<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::metric_descriptor::metric_descriptor_metadata::TimeSeriesResourceHierarchyLevel>
+        {
+            use std::iter::Iterator;
+            self.time_series_resource_hierarchy_level = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -4770,20 +4848,21 @@ pub struct Metric {
 }
 
 impl Metric {
-    /// Sets the value of `r#type`.
+    /// Sets the value of [r#type][crate::model::Metric::type].
     pub fn set_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.r#type = v.into();
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
+    /// Sets the value of [labels][crate::model::Metric::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4853,45 +4932,47 @@ pub struct MonitoredResourceDescriptor {
 }
 
 impl MonitoredResourceDescriptor {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::MonitoredResourceDescriptor::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `r#type`.
+    /// Sets the value of [r#type][crate::model::MonitoredResourceDescriptor::type].
     pub fn set_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.r#type = v.into();
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::MonitoredResourceDescriptor::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::MonitoredResourceDescriptor::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<T: std::convert::Into<std::vec::Vec<crate::model::LabelDescriptor>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `launch_stage`.
+    /// Sets the value of [launch_stage][crate::model::MonitoredResourceDescriptor::launch_stage].
     pub fn set_launch_stage<T: std::convert::Into<crate::model::LaunchStage>>(
         mut self,
         v: T,
     ) -> Self {
         self.launch_stage = v.into();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::MonitoredResourceDescriptor::labels].
+    pub fn set_labels<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::LabelDescriptor>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4948,20 +5029,21 @@ pub struct MonitoredResource {
 }
 
 impl MonitoredResource {
-    /// Sets the value of `r#type`.
+    /// Sets the value of [r#type][crate::model::MonitoredResource::type].
     pub fn set_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.r#type = v.into();
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
+    /// Sets the value of [labels][crate::model::MonitoredResource::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -5006,7 +5088,7 @@ pub struct MonitoredResourceMetadata {
 }
 
 impl MonitoredResourceMetadata {
-    /// Sets the value of `system_labels`.
+    /// Sets the value of [system_labels][crate::model::MonitoredResourceMetadata::system_labels].
     pub fn set_system_labels<T: std::convert::Into<std::option::Option<wkt::Struct>>>(
         mut self,
         v: T,
@@ -5015,14 +5097,15 @@ impl MonitoredResourceMetadata {
         self
     }
 
-    /// Sets the value of `user_labels`.
-    pub fn set_user_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.user_labels = v.into();
+    /// Sets the value of [user_labels][crate::model::MonitoredResourceMetadata::user_labels].
+    pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -5112,25 +5195,25 @@ pub struct Monitoring {
 }
 
 impl Monitoring {
-    /// Sets the value of `producer_destinations`.
-    pub fn set_producer_destinations<
-        T: std::convert::Into<std::vec::Vec<crate::model::monitoring::MonitoringDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.producer_destinations = v.into();
+    /// Sets the value of [producer_destinations][crate::model::Monitoring::producer_destinations].
+    pub fn set_producer_destinations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::monitoring::MonitoringDestination>,
+    {
+        use std::iter::Iterator;
+        self.producer_destinations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
-    /// Sets the value of `consumer_destinations`.
-    pub fn set_consumer_destinations<
-        T: std::convert::Into<std::vec::Vec<crate::model::monitoring::MonitoringDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.consumer_destinations = v.into();
+    /// Sets the value of [consumer_destinations][crate::model::Monitoring::consumer_destinations].
+    pub fn set_consumer_destinations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::monitoring::MonitoringDestination>,
+    {
+        use std::iter::Iterator;
+        self.consumer_destinations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5171,7 +5254,7 @@ pub mod monitoring {
     }
 
     impl MonitoringDestination {
-        /// Sets the value of `monitored_resource`.
+        /// Sets the value of [monitored_resource][crate::model::monitoring::MonitoringDestination::monitored_resource].
         pub fn set_monitored_resource<T: std::convert::Into<std::string::String>>(
             mut self,
             v: T,
@@ -5180,12 +5263,14 @@ pub mod monitoring {
             self
         }
 
-        /// Sets the value of `metrics`.
-        pub fn set_metrics<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.metrics = v.into();
+        /// Sets the value of [metrics][crate::model::monitoring::MonitoringDestination::metrics].
+        pub fn set_metrics<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.metrics = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -5236,13 +5321,13 @@ pub struct FieldPolicy {
 }
 
 impl FieldPolicy {
-    /// Sets the value of `selector`.
+    /// Sets the value of [selector][crate::model::FieldPolicy::selector].
     pub fn set_selector<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.selector = v.into();
         self
     }
 
-    /// Sets the value of `resource_permission`.
+    /// Sets the value of [resource_permission][crate::model::FieldPolicy::resource_permission].
     pub fn set_resource_permission<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -5251,7 +5336,7 @@ impl FieldPolicy {
         self
     }
 
-    /// Sets the value of `resource_type`.
+    /// Sets the value of [resource_type][crate::model::FieldPolicy::resource_type].
     pub fn set_resource_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.resource_type = v.into();
         self
@@ -5289,18 +5374,20 @@ pub struct MethodPolicy {
 }
 
 impl MethodPolicy {
-    /// Sets the value of `selector`.
+    /// Sets the value of [selector][crate::model::MethodPolicy::selector].
     pub fn set_selector<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.selector = v.into();
         self
     }
 
-    /// Sets the value of `request_policies`.
-    pub fn set_request_policies<T: std::convert::Into<std::vec::Vec<crate::model::FieldPolicy>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request_policies = v.into();
+    /// Sets the value of [request_policies][crate::model::MethodPolicy::request_policies].
+    pub fn set_request_policies<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::FieldPolicy>,
+    {
+        use std::iter::Iterator;
+        self.request_policies = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5381,21 +5468,25 @@ pub struct Quota {
 }
 
 impl Quota {
-    /// Sets the value of `limits`.
-    pub fn set_limits<T: std::convert::Into<std::vec::Vec<crate::model::QuotaLimit>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.limits = v.into();
+    /// Sets the value of [limits][crate::model::Quota::limits].
+    pub fn set_limits<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::QuotaLimit>,
+    {
+        use std::iter::Iterator;
+        self.limits = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
-    /// Sets the value of `metric_rules`.
-    pub fn set_metric_rules<T: std::convert::Into<std::vec::Vec<crate::model::MetricRule>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metric_rules = v.into();
+    /// Sets the value of [metric_rules][crate::model::Quota::metric_rules].
+    pub fn set_metric_rules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::MetricRule>,
+    {
+        use std::iter::Iterator;
+        self.metric_rules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5434,20 +5525,21 @@ pub struct MetricRule {
 }
 
 impl MetricRule {
-    /// Sets the value of `selector`.
+    /// Sets the value of [selector][crate::model::MetricRule::selector].
     pub fn set_selector<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.selector = v.into();
         self
     }
 
-    /// Sets the value of `metric_costs`.
-    pub fn set_metric_costs<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, i64>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metric_costs = v.into();
+    /// Sets the value of [metric_costs][crate::model::MetricRule::metric_costs].
+    pub fn set_metric_costs<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<i64>,
+    {
+        use std::iter::Iterator;
+        self.metric_costs = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -5560,68 +5652,69 @@ pub struct QuotaLimit {
 }
 
 impl QuotaLimit {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::QuotaLimit::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::QuotaLimit::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
     }
 
-    /// Sets the value of `default_limit`.
+    /// Sets the value of [default_limit][crate::model::QuotaLimit::default_limit].
     pub fn set_default_limit<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.default_limit = v.into();
         self
     }
 
-    /// Sets the value of `max_limit`.
+    /// Sets the value of [max_limit][crate::model::QuotaLimit::max_limit].
     pub fn set_max_limit<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.max_limit = v.into();
         self
     }
 
-    /// Sets the value of `free_tier`.
+    /// Sets the value of [free_tier][crate::model::QuotaLimit::free_tier].
     pub fn set_free_tier<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.free_tier = v.into();
         self
     }
 
-    /// Sets the value of `duration`.
+    /// Sets the value of [duration][crate::model::QuotaLimit::duration].
     pub fn set_duration<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.duration = v.into();
         self
     }
 
-    /// Sets the value of `metric`.
+    /// Sets the value of [metric][crate::model::QuotaLimit::metric].
     pub fn set_metric<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.metric = v.into();
         self
     }
 
-    /// Sets the value of `unit`.
+    /// Sets the value of [unit][crate::model::QuotaLimit::unit].
     pub fn set_unit<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.unit = v.into();
         self
     }
 
-    /// Sets the value of `values`.
-    pub fn set_values<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, i64>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.values = v.into();
+    /// Sets the value of [display_name][crate::model::QuotaLimit::display_name].
+    pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.display_name = v.into();
         self
     }
 
-    /// Sets the value of `display_name`.
-    pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.display_name = v.into();
+    /// Sets the value of [values][crate::model::QuotaLimit::values].
+    pub fn set_values<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<i64>,
+    {
+        use std::iter::Iterator;
+        self.values = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -5786,28 +5879,19 @@ pub struct ResourceDescriptor {
 }
 
 impl ResourceDescriptor {
-    /// Sets the value of `r#type`.
+    /// Sets the value of [r#type][crate::model::ResourceDescriptor::type].
     pub fn set_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.r#type = v.into();
         self
     }
 
-    /// Sets the value of `pattern`.
-    pub fn set_pattern<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.pattern = v.into();
-        self
-    }
-
-    /// Sets the value of `name_field`.
+    /// Sets the value of [name_field][crate::model::ResourceDescriptor::name_field].
     pub fn set_name_field<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name_field = v.into();
         self
     }
 
-    /// Sets the value of `history`.
+    /// Sets the value of [history][crate::model::ResourceDescriptor::history].
     pub fn set_history<T: std::convert::Into<crate::model::resource_descriptor::History>>(
         mut self,
         v: T,
@@ -5816,26 +5900,37 @@ impl ResourceDescriptor {
         self
     }
 
-    /// Sets the value of `plural`.
+    /// Sets the value of [plural][crate::model::ResourceDescriptor::plural].
     pub fn set_plural<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.plural = v.into();
         self
     }
 
-    /// Sets the value of `singular`.
+    /// Sets the value of [singular][crate::model::ResourceDescriptor::singular].
     pub fn set_singular<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.singular = v.into();
         self
     }
 
-    /// Sets the value of `style`.
-    pub fn set_style<
-        T: std::convert::Into<std::vec::Vec<crate::model::resource_descriptor::Style>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.style = v.into();
+    /// Sets the value of [pattern][crate::model::ResourceDescriptor::pattern].
+    pub fn set_pattern<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.pattern = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [style][crate::model::ResourceDescriptor::style].
+    pub fn set_style<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::resource_descriptor::Style>,
+    {
+        use std::iter::Iterator;
+        self.style = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5973,13 +6068,13 @@ pub struct ResourceReference {
 }
 
 impl ResourceReference {
-    /// Sets the value of `r#type`.
+    /// Sets the value of [r#type][crate::model::ResourceReference::type].
     pub fn set_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.r#type = v.into();
         self
     }
 
-    /// Sets the value of `child_type`.
+    /// Sets the value of [child_type][crate::model::ResourceReference::child_type].
     pub fn set_child_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.child_type = v.into();
         self
@@ -6419,14 +6514,14 @@ pub struct RoutingRule {
 }
 
 impl RoutingRule {
-    /// Sets the value of `routing_parameters`.
-    pub fn set_routing_parameters<
-        T: std::convert::Into<std::vec::Vec<crate::model::RoutingParameter>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.routing_parameters = v.into();
+    /// Sets the value of [routing_parameters][crate::model::RoutingRule::routing_parameters].
+    pub fn set_routing_parameters<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::RoutingParameter>,
+    {
+        use std::iter::Iterator;
+        self.routing_parameters = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -6514,13 +6609,13 @@ pub struct RoutingParameter {
 }
 
 impl RoutingParameter {
-    /// Sets the value of `field`.
+    /// Sets the value of [field][crate::model::RoutingParameter::field].
     pub fn set_field<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.field = v.into();
         self
     }
 
-    /// Sets the value of `path_template`.
+    /// Sets the value of [path_template][crate::model::RoutingParameter::path_template].
     pub fn set_path_template<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.path_template = v.into();
         self
@@ -6721,19 +6816,19 @@ pub struct Service {
 }
 
 impl Service {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Service::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `title`.
+    /// Sets the value of [title][crate::model::Service::title].
     pub fn set_title<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.title = v.into();
         self
     }
 
-    /// Sets the value of `producer_project_id`.
+    /// Sets the value of [producer_project_id][crate::model::Service::producer_project_id].
     pub fn set_producer_project_id<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -6742,31 +6837,13 @@ impl Service {
         self
     }
 
-    /// Sets the value of `id`.
+    /// Sets the value of [id][crate::model::Service::id].
     pub fn set_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.id = v.into();
         self
     }
 
-    /// Sets the value of `apis`.
-    pub fn set_apis<T: std::convert::Into<std::vec::Vec<wkt::Api>>>(mut self, v: T) -> Self {
-        self.apis = v.into();
-        self
-    }
-
-    /// Sets the value of `types`.
-    pub fn set_types<T: std::convert::Into<std::vec::Vec<wkt::Type>>>(mut self, v: T) -> Self {
-        self.types = v.into();
-        self
-    }
-
-    /// Sets the value of `enums`.
-    pub fn set_enums<T: std::convert::Into<std::vec::Vec<wkt::Enum>>>(mut self, v: T) -> Self {
-        self.enums = v.into();
-        self
-    }
-
-    /// Sets the value of `documentation`.
+    /// Sets the value of [documentation][crate::model::Service::documentation].
     pub fn set_documentation<
         T: std::convert::Into<std::option::Option<crate::model::Documentation>>,
     >(
@@ -6777,7 +6854,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `backend`.
+    /// Sets the value of [backend][crate::model::Service::backend].
     pub fn set_backend<T: std::convert::Into<std::option::Option<crate::model::Backend>>>(
         mut self,
         v: T,
@@ -6786,7 +6863,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `http`.
+    /// Sets the value of [http][crate::model::Service::http].
     pub fn set_http<T: std::convert::Into<std::option::Option<crate::model::Http>>>(
         mut self,
         v: T,
@@ -6795,7 +6872,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `quota`.
+    /// Sets the value of [quota][crate::model::Service::quota].
     pub fn set_quota<T: std::convert::Into<std::option::Option<crate::model::Quota>>>(
         mut self,
         v: T,
@@ -6804,7 +6881,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `authentication`.
+    /// Sets the value of [authentication][crate::model::Service::authentication].
     pub fn set_authentication<
         T: std::convert::Into<std::option::Option<crate::model::Authentication>>,
     >(
@@ -6815,7 +6892,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `context`.
+    /// Sets the value of [context][crate::model::Service::context].
     pub fn set_context<T: std::convert::Into<std::option::Option<crate::model::Context>>>(
         mut self,
         v: T,
@@ -6824,7 +6901,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `usage`.
+    /// Sets the value of [usage][crate::model::Service::usage].
     pub fn set_usage<T: std::convert::Into<std::option::Option<crate::model::Usage>>>(
         mut self,
         v: T,
@@ -6833,16 +6910,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `endpoints`.
-    pub fn set_endpoints<T: std::convert::Into<std::vec::Vec<crate::model::Endpoint>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.endpoints = v.into();
-        self
-    }
-
-    /// Sets the value of `control`.
+    /// Sets the value of [control][crate::model::Service::control].
     pub fn set_control<T: std::convert::Into<std::option::Option<crate::model::Control>>>(
         mut self,
         v: T,
@@ -6851,36 +6919,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `logs`.
-    pub fn set_logs<T: std::convert::Into<std::vec::Vec<crate::model::LogDescriptor>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.logs = v.into();
-        self
-    }
-
-    /// Sets the value of `metrics`.
-    pub fn set_metrics<T: std::convert::Into<std::vec::Vec<crate::model::MetricDescriptor>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metrics = v.into();
-        self
-    }
-
-    /// Sets the value of `monitored_resources`.
-    pub fn set_monitored_resources<
-        T: std::convert::Into<std::vec::Vec<crate::model::MonitoredResourceDescriptor>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.monitored_resources = v.into();
-        self
-    }
-
-    /// Sets the value of `billing`.
+    /// Sets the value of [billing][crate::model::Service::billing].
     pub fn set_billing<T: std::convert::Into<std::option::Option<crate::model::Billing>>>(
         mut self,
         v: T,
@@ -6889,7 +6928,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `logging`.
+    /// Sets the value of [logging][crate::model::Service::logging].
     pub fn set_logging<T: std::convert::Into<std::option::Option<crate::model::Logging>>>(
         mut self,
         v: T,
@@ -6898,7 +6937,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `monitoring`.
+    /// Sets the value of [monitoring][crate::model::Service::monitoring].
     pub fn set_monitoring<T: std::convert::Into<std::option::Option<crate::model::Monitoring>>>(
         mut self,
         v: T,
@@ -6907,7 +6946,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `system_parameters`.
+    /// Sets the value of [system_parameters][crate::model::Service::system_parameters].
     pub fn set_system_parameters<
         T: std::convert::Into<std::option::Option<crate::model::SystemParameters>>,
     >(
@@ -6918,7 +6957,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `source_info`.
+    /// Sets the value of [source_info][crate::model::Service::source_info].
     pub fn set_source_info<T: std::convert::Into<std::option::Option<crate::model::SourceInfo>>>(
         mut self,
         v: T,
@@ -6927,7 +6966,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `publishing`.
+    /// Sets the value of [publishing][crate::model::Service::publishing].
     pub fn set_publishing<T: std::convert::Into<std::option::Option<crate::model::Publishing>>>(
         mut self,
         v: T,
@@ -6936,12 +6975,89 @@ impl Service {
         self
     }
 
-    /// Sets the value of `config_version`.
+    /// Sets the value of [config_version][crate::model::Service::config_version].
     pub fn set_config_version<T: std::convert::Into<std::option::Option<wkt::UInt32Value>>>(
         mut self,
         v: T,
     ) -> Self {
         self.config_version = v.into();
+        self
+    }
+
+    /// Sets the value of [apis][crate::model::Service::apis].
+    pub fn set_apis<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Api>,
+    {
+        use std::iter::Iterator;
+        self.apis = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [types][crate::model::Service::types].
+    pub fn set_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Type>,
+    {
+        use std::iter::Iterator;
+        self.types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [enums][crate::model::Service::enums].
+    pub fn set_enums<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Enum>,
+    {
+        use std::iter::Iterator;
+        self.enums = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [endpoints][crate::model::Service::endpoints].
+    pub fn set_endpoints<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Endpoint>,
+    {
+        use std::iter::Iterator;
+        self.endpoints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [logs][crate::model::Service::logs].
+    pub fn set_logs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::LogDescriptor>,
+    {
+        use std::iter::Iterator;
+        self.logs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [metrics][crate::model::Service::metrics].
+    pub fn set_metrics<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::MetricDescriptor>,
+    {
+        use std::iter::Iterator;
+        self.metrics = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [monitored_resources][crate::model::Service::monitored_resources].
+    pub fn set_monitored_resources<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::MonitoredResourceDescriptor>,
+    {
+        use std::iter::Iterator;
+        self.monitored_resources = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -6964,12 +7080,14 @@ pub struct SourceInfo {
 }
 
 impl SourceInfo {
-    /// Sets the value of `source_files`.
-    pub fn set_source_files<T: std::convert::Into<std::vec::Vec<wkt::Any>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_files = v.into();
+    /// Sets the value of [source_files][crate::model::SourceInfo::source_files].
+    pub fn set_source_files<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Any>,
+    {
+        use std::iter::Iterator;
+        self.source_files = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -7028,12 +7146,14 @@ pub struct SystemParameters {
 }
 
 impl SystemParameters {
-    /// Sets the value of `rules`.
-    pub fn set_rules<T: std::convert::Into<std::vec::Vec<crate::model::SystemParameterRule>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rules = v.into();
+    /// Sets the value of [rules][crate::model::SystemParameters::rules].
+    pub fn set_rules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SystemParameterRule>,
+    {
+        use std::iter::Iterator;
+        self.rules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -7071,18 +7191,20 @@ pub struct SystemParameterRule {
 }
 
 impl SystemParameterRule {
-    /// Sets the value of `selector`.
+    /// Sets the value of [selector][crate::model::SystemParameterRule::selector].
     pub fn set_selector<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.selector = v.into();
         self
     }
 
-    /// Sets the value of `parameters`.
-    pub fn set_parameters<T: std::convert::Into<std::vec::Vec<crate::model::SystemParameter>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.parameters = v.into();
+    /// Sets the value of [parameters][crate::model::SystemParameterRule::parameters].
+    pub fn set_parameters<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SystemParameter>,
+    {
+        use std::iter::Iterator;
+        self.parameters = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -7117,19 +7239,19 @@ pub struct SystemParameter {
 }
 
 impl SystemParameter {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::SystemParameter::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `http_header`.
+    /// Sets the value of [http_header][crate::model::SystemParameter::http_header].
     pub fn set_http_header<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.http_header = v.into();
         self
     }
 
-    /// Sets the value of `url_query_parameter`.
+    /// Sets the value of [url_query_parameter][crate::model::SystemParameter::url_query_parameter].
     pub fn set_url_query_parameter<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -7182,30 +7304,34 @@ pub struct Usage {
 }
 
 impl Usage {
-    /// Sets the value of `requirements`.
-    pub fn set_requirements<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.requirements = v.into();
-        self
-    }
-
-    /// Sets the value of `rules`.
-    pub fn set_rules<T: std::convert::Into<std::vec::Vec<crate::model::UsageRule>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rules = v.into();
-        self
-    }
-
-    /// Sets the value of `producer_notification_channel`.
+    /// Sets the value of [producer_notification_channel][crate::model::Usage::producer_notification_channel].
     pub fn set_producer_notification_channel<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
     ) -> Self {
         self.producer_notification_channel = v.into();
+        self
+    }
+
+    /// Sets the value of [requirements][crate::model::Usage::requirements].
+    pub fn set_requirements<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.requirements = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [rules][crate::model::Usage::rules].
+    pub fn set_rules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::UsageRule>,
+    {
+        use std::iter::Iterator;
+        self.rules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -7271,19 +7397,19 @@ pub struct UsageRule {
 }
 
 impl UsageRule {
-    /// Sets the value of `selector`.
+    /// Sets the value of [selector][crate::model::UsageRule::selector].
     pub fn set_selector<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.selector = v.into();
         self
     }
 
-    /// Sets the value of `allow_unregistered_calls`.
+    /// Sets the value of [allow_unregistered_calls][crate::model::UsageRule::allow_unregistered_calls].
     pub fn set_allow_unregistered_calls<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.allow_unregistered_calls = v.into();
         self
     }
 
-    /// Sets the value of `skip_service_control`.
+    /// Sets the value of [skip_service_control][crate::model::UsageRule::skip_service_control].
     pub fn set_skip_service_control<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.skip_service_control = v.into();
         self
@@ -7334,12 +7460,14 @@ pub struct Visibility {
 }
 
 impl Visibility {
-    /// Sets the value of `rules`.
-    pub fn set_rules<T: std::convert::Into<std::vec::Vec<crate::model::VisibilityRule>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rules = v.into();
+    /// Sets the value of [rules][crate::model::Visibility::rules].
+    pub fn set_rules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::VisibilityRule>,
+    {
+        use std::iter::Iterator;
+        self.rules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -7388,13 +7516,13 @@ pub struct VisibilityRule {
 }
 
 impl VisibilityRule {
-    /// Sets the value of `selector`.
+    /// Sets the value of [selector][crate::model::VisibilityRule::selector].
     pub fn set_selector<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.selector = v.into();
         self
     }
 
-    /// Sets the value of `restriction`.
+    /// Sets the value of [restriction][crate::model::VisibilityRule::restriction].
     pub fn set_restriction<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.restriction = v.into();
         self

--- a/src/generated/bigtable/admin/v2/src/builders.rs
+++ b/src/generated/bigtable/admin/v2/src/builders.rs
@@ -106,19 +106,19 @@ pub mod bigtable_instance_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateInstanceRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `instance_id`.
+        /// Sets the value of [instance_id][crate::model::CreateInstanceRequest::instance_id].
         pub fn set_instance_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance_id = v.into();
             self
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::CreateInstanceRequest::instance].
         pub fn set_instance<T: Into<std::option::Option<crate::model::Instance>>>(
             mut self,
             v: T,
@@ -127,14 +127,14 @@ pub mod bigtable_instance_admin {
             self
         }
 
-        /// Sets the value of `clusters`.
-        pub fn set_clusters<
-            T: Into<std::collections::HashMap<std::string::String, crate::model::Cluster>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.clusters = v.into();
+        /// Sets the value of [clusters][crate::model::CreateInstanceRequest::clusters].
+        pub fn set_clusters<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<crate::model::Cluster>,
+        {
+            self.0.request.clusters = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -173,7 +173,7 @@ pub mod bigtable_instance_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetInstanceRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -214,13 +214,13 @@ pub mod bigtable_instance_admin {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListInstancesRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListInstancesRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -261,42 +261,31 @@ pub mod bigtable_instance_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::Instance::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `display_name`.
+        /// Sets the value of [display_name][crate::model::Instance::display_name].
         pub fn set_display_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.display_name = v.into();
             self
         }
 
-        /// Sets the value of `state`.
+        /// Sets the value of [state][crate::model::Instance::state].
         pub fn set_state<T: Into<crate::model::instance::State>>(mut self, v: T) -> Self {
             self.0.request.state = v.into();
             self
         }
 
-        /// Sets the value of `r#type`.
+        /// Sets the value of [r#type][crate::model::Instance::type].
         pub fn set_type<T: Into<crate::model::instance::Type>>(mut self, v: T) -> Self {
             self.0.request.r#type = v.into();
             self
         }
 
-        /// Sets the value of `labels`.
-        pub fn set_labels<
-            T: Into<std::collections::HashMap<std::string::String, std::string::String>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.labels = v.into();
-            self
-        }
-
-        /// Sets the value of `create_time`.
+        /// Sets the value of [create_time][crate::model::Instance::create_time].
         pub fn set_create_time<T: Into<std::option::Option<wkt::Timestamp>>>(
             mut self,
             v: T,
@@ -305,9 +294,20 @@ pub mod bigtable_instance_admin {
             self
         }
 
-        /// Sets the value of `satisfies_pzs`.
+        /// Sets the value of [satisfies_pzs][crate::model::Instance::satisfies_pzs].
         pub fn set_satisfies_pzs<T: Into<std::option::Option<bool>>>(mut self, v: T) -> Self {
             self.0.request.satisfies_pzs = v.into();
+            self
+        }
+
+        /// Sets the value of [labels][crate::model::Instance::labels].
+        pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            self.0.request.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -388,7 +388,7 @@ pub mod bigtable_instance_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::PartialUpdateInstanceRequest::instance].
         pub fn set_instance<T: Into<std::option::Option<crate::model::Instance>>>(
             mut self,
             v: T,
@@ -397,7 +397,7 @@ pub mod bigtable_instance_admin {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::PartialUpdateInstanceRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -441,7 +441,7 @@ pub mod bigtable_instance_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteInstanceRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -520,19 +520,19 @@ pub mod bigtable_instance_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateClusterRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `cluster_id`.
+        /// Sets the value of [cluster_id][crate::model::CreateClusterRequest::cluster_id].
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
         }
 
-        /// Sets the value of `cluster`.
+        /// Sets the value of [cluster][crate::model::CreateClusterRequest::cluster].
         pub fn set_cluster<T: Into<std::option::Option<crate::model::Cluster>>>(
             mut self,
             v: T,
@@ -576,7 +576,7 @@ pub mod bigtable_instance_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetClusterRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -617,13 +617,13 @@ pub mod bigtable_instance_admin {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListClustersRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListClustersRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -702,31 +702,31 @@ pub mod bigtable_instance_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::Cluster::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::Cluster::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
         }
 
-        /// Sets the value of `state`.
+        /// Sets the value of [state][crate::model::Cluster::state].
         pub fn set_state<T: Into<crate::model::cluster::State>>(mut self, v: T) -> Self {
             self.0.request.state = v.into();
             self
         }
 
-        /// Sets the value of `serve_nodes`.
+        /// Sets the value of [serve_nodes][crate::model::Cluster::serve_nodes].
         pub fn set_serve_nodes<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.serve_nodes = v.into();
             self
         }
 
-        /// Sets the value of `node_scaling_factor`.
+        /// Sets the value of [node_scaling_factor][crate::model::Cluster::node_scaling_factor].
         pub fn set_node_scaling_factor<T: Into<crate::model::cluster::NodeScalingFactor>>(
             mut self,
             v: T,
@@ -735,7 +735,7 @@ pub mod bigtable_instance_admin {
             self
         }
 
-        /// Sets the value of `default_storage_type`.
+        /// Sets the value of [default_storage_type][crate::model::Cluster::default_storage_type].
         pub fn set_default_storage_type<T: Into<crate::model::StorageType>>(
             mut self,
             v: T,
@@ -744,7 +744,7 @@ pub mod bigtable_instance_admin {
             self
         }
 
-        /// Sets the value of `encryption_config`.
+        /// Sets the value of [encryption_config][crate::model::Cluster::encryption_config].
         pub fn set_encryption_config<
             T: Into<std::option::Option<crate::model::cluster::EncryptionConfig>>,
         >(
@@ -838,7 +838,7 @@ pub mod bigtable_instance_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `cluster`.
+        /// Sets the value of [cluster][crate::model::PartialUpdateClusterRequest::cluster].
         pub fn set_cluster<T: Into<std::option::Option<crate::model::Cluster>>>(
             mut self,
             v: T,
@@ -847,7 +847,7 @@ pub mod bigtable_instance_admin {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::PartialUpdateClusterRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -891,7 +891,7 @@ pub mod bigtable_instance_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteClusterRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -935,19 +935,19 @@ pub mod bigtable_instance_admin {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateAppProfileRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `app_profile_id`.
+        /// Sets the value of [app_profile_id][crate::model::CreateAppProfileRequest::app_profile_id].
         pub fn set_app_profile_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.app_profile_id = v.into();
             self
         }
 
-        /// Sets the value of `app_profile`.
+        /// Sets the value of [app_profile][crate::model::CreateAppProfileRequest::app_profile].
         pub fn set_app_profile<T: Into<std::option::Option<crate::model::AppProfile>>>(
             mut self,
             v: T,
@@ -956,7 +956,7 @@ pub mod bigtable_instance_admin {
             self
         }
 
-        /// Sets the value of `ignore_warnings`.
+        /// Sets the value of [ignore_warnings][crate::model::CreateAppProfileRequest::ignore_warnings].
         pub fn set_ignore_warnings<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.ignore_warnings = v.into();
             self
@@ -997,7 +997,7 @@ pub mod bigtable_instance_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetAppProfileRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1053,19 +1053,19 @@ pub mod bigtable_instance_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListAppProfilesRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListAppProfilesRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListAppProfilesRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -1148,7 +1148,7 @@ pub mod bigtable_instance_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `app_profile`.
+        /// Sets the value of [app_profile][crate::model::UpdateAppProfileRequest::app_profile].
         pub fn set_app_profile<T: Into<std::option::Option<crate::model::AppProfile>>>(
             mut self,
             v: T,
@@ -1157,7 +1157,7 @@ pub mod bigtable_instance_admin {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateAppProfileRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -1166,7 +1166,7 @@ pub mod bigtable_instance_admin {
             self
         }
 
-        /// Sets the value of `ignore_warnings`.
+        /// Sets the value of [ignore_warnings][crate::model::UpdateAppProfileRequest::ignore_warnings].
         pub fn set_ignore_warnings<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.ignore_warnings = v.into();
             self
@@ -1210,13 +1210,13 @@ pub mod bigtable_instance_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteAppProfileRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `ignore_warnings`.
+        /// Sets the value of [ignore_warnings][crate::model::DeleteAppProfileRequest::ignore_warnings].
         pub fn set_ignore_warnings<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.ignore_warnings = v.into();
             self
@@ -1257,13 +1257,13 @@ pub mod bigtable_instance_admin {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::GetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `options`.
+        /// Sets the value of [options][iam_v1::model::GetIamPolicyRequest::options].
         pub fn set_options<T: Into<std::option::Option<iam_v1::model::GetPolicyOptions>>>(
             mut self,
             v: T,
@@ -1307,13 +1307,13 @@ pub mod bigtable_instance_admin {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::SetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][iam_v1::model::SetIamPolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<iam_v1::model::Policy>>>(
             mut self,
             v: T,
@@ -1322,7 +1322,7 @@ pub mod bigtable_instance_admin {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][iam_v1::model::SetIamPolicyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -1369,18 +1369,20 @@ pub mod bigtable_instance_admin {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::TestIamPermissionsRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `permissions`.
-        pub fn set_permissions<T: Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.permissions = v.into();
+        /// Sets the value of [permissions][iam_v1::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1434,13 +1436,13 @@ pub mod bigtable_instance_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListHotTabletsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `start_time`.
+        /// Sets the value of [start_time][crate::model::ListHotTabletsRequest::start_time].
         pub fn set_start_time<T: Into<std::option::Option<wkt::Timestamp>>>(
             mut self,
             v: T,
@@ -1449,19 +1451,19 @@ pub mod bigtable_instance_admin {
             self
         }
 
-        /// Sets the value of `end_time`.
+        /// Sets the value of [end_time][crate::model::ListHotTabletsRequest::end_time].
         pub fn set_end_time<T: Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
             self.0.request.end_time = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListHotTabletsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListHotTabletsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -1520,25 +1522,25 @@ pub mod bigtable_instance_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::ListOperationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][longrunning::model::ListOperationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][longrunning::model::ListOperationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][longrunning::model::ListOperationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -1582,7 +1584,7 @@ pub mod bigtable_instance_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::GetOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1626,7 +1628,7 @@ pub mod bigtable_instance_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::DeleteOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1670,7 +1672,7 @@ pub mod bigtable_instance_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::CancelOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1737,19 +1739,19 @@ pub mod bigtable_table_admin {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateTableRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `table_id`.
+        /// Sets the value of [table_id][crate::model::CreateTableRequest::table_id].
         pub fn set_table_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.table_id = v.into();
             self
         }
 
-        /// Sets the value of `table`.
+        /// Sets the value of [table][crate::model::CreateTableRequest::table].
         pub fn set_table<T: Into<std::option::Option<crate::model::Table>>>(
             mut self,
             v: T,
@@ -1758,14 +1760,14 @@ pub mod bigtable_table_admin {
             self
         }
 
-        /// Sets the value of `initial_splits`.
-        pub fn set_initial_splits<
-            T: Into<std::vec::Vec<crate::model::create_table_request::Split>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.initial_splits = v.into();
+        /// Sets the value of [initial_splits][crate::model::CreateTableRequest::initial_splits].
+        pub fn set_initial_splits<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::create_table_request::Split>,
+        {
+            use std::iter::Iterator;
+            self.0.request.initial_splits = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1848,19 +1850,19 @@ pub mod bigtable_table_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateTableFromSnapshotRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `table_id`.
+        /// Sets the value of [table_id][crate::model::CreateTableFromSnapshotRequest::table_id].
         pub fn set_table_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.table_id = v.into();
             self
         }
 
-        /// Sets the value of `source_snapshot`.
+        /// Sets the value of [source_snapshot][crate::model::CreateTableFromSnapshotRequest::source_snapshot].
         pub fn set_source_snapshot<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.source_snapshot = v.into();
             self
@@ -1916,25 +1918,25 @@ pub mod bigtable_table_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListTablesRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `view`.
+        /// Sets the value of [view][crate::model::ListTablesRequest::view].
         pub fn set_view<T: Into<crate::model::table::View>>(mut self, v: T) -> Self {
             self.0.request.view = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListTablesRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListTablesRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -1975,13 +1977,13 @@ pub mod bigtable_table_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetTableRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `view`.
+        /// Sets the value of [view][crate::model::GetTableRequest::view].
         pub fn set_view<T: Into<crate::model::table::View>>(mut self, v: T) -> Self {
             self.0.request.view = v.into();
             self
@@ -2059,7 +2061,7 @@ pub mod bigtable_table_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `table`.
+        /// Sets the value of [table][crate::model::UpdateTableRequest::table].
         pub fn set_table<T: Into<std::option::Option<crate::model::Table>>>(
             mut self,
             v: T,
@@ -2068,7 +2070,7 @@ pub mod bigtable_table_admin {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateTableRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -2112,7 +2114,7 @@ pub mod bigtable_table_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteTableRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2191,7 +2193,7 @@ pub mod bigtable_table_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::UndeleteTableRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2276,19 +2278,19 @@ pub mod bigtable_table_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateAuthorizedViewRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `authorized_view_id`.
+        /// Sets the value of [authorized_view_id][crate::model::CreateAuthorizedViewRequest::authorized_view_id].
         pub fn set_authorized_view_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.authorized_view_id = v.into();
             self
         }
 
-        /// Sets the value of `authorized_view`.
+        /// Sets the value of [authorized_view][crate::model::CreateAuthorizedViewRequest::authorized_view].
         pub fn set_authorized_view<T: Into<std::option::Option<crate::model::AuthorizedView>>>(
             mut self,
             v: T,
@@ -2350,25 +2352,25 @@ pub mod bigtable_table_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListAuthorizedViewsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListAuthorizedViewsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListAuthorizedViewsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `view`.
+        /// Sets the value of [view][crate::model::ListAuthorizedViewsRequest::view].
         pub fn set_view<T: Into<crate::model::authorized_view::ResponseView>>(
             mut self,
             v: T,
@@ -2415,13 +2417,13 @@ pub mod bigtable_table_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetAuthorizedViewRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `view`.
+        /// Sets the value of [view][crate::model::GetAuthorizedViewRequest::view].
         pub fn set_view<T: Into<crate::model::authorized_view::ResponseView>>(
             mut self,
             v: T,
@@ -2509,7 +2511,7 @@ pub mod bigtable_table_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `authorized_view`.
+        /// Sets the value of [authorized_view][crate::model::UpdateAuthorizedViewRequest::authorized_view].
         pub fn set_authorized_view<T: Into<std::option::Option<crate::model::AuthorizedView>>>(
             mut self,
             v: T,
@@ -2518,7 +2520,7 @@ pub mod bigtable_table_admin {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateAuthorizedViewRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -2527,7 +2529,7 @@ pub mod bigtable_table_admin {
             self
         }
 
-        /// Sets the value of `ignore_warnings`.
+        /// Sets the value of [ignore_warnings][crate::model::UpdateAuthorizedViewRequest::ignore_warnings].
         pub fn set_ignore_warnings<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.ignore_warnings = v.into();
             self
@@ -2571,13 +2573,13 @@ pub mod bigtable_table_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteAuthorizedViewRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DeleteAuthorizedViewRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -2621,26 +2623,26 @@ pub mod bigtable_table_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::ModifyColumnFamiliesRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `modifications`.
-        pub fn set_modifications<
-            T: Into<std::vec::Vec<crate::model::modify_column_families_request::Modification>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.modifications = v.into();
+        /// Sets the value of [ignore_warnings][crate::model::ModifyColumnFamiliesRequest::ignore_warnings].
+        pub fn set_ignore_warnings<T: Into<bool>>(mut self, v: T) -> Self {
+            self.0.request.ignore_warnings = v.into();
             self
         }
 
-        /// Sets the value of `ignore_warnings`.
-        pub fn set_ignore_warnings<T: Into<bool>>(mut self, v: T) -> Self {
-            self.0.request.ignore_warnings = v.into();
+        /// Sets the value of [modifications][crate::model::ModifyColumnFamiliesRequest::modifications].
+        pub fn set_modifications<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::modify_column_families_request::Modification>,
+        {
+            use std::iter::Iterator;
+            self.0.request.modifications = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -2679,7 +2681,7 @@ pub mod bigtable_table_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DropRowRangeRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2734,7 +2736,7 @@ pub mod bigtable_table_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GenerateConsistencyTokenRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2778,13 +2780,13 @@ pub mod bigtable_table_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::CheckConsistencyRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `consistency_token`.
+        /// Sets the value of [consistency_token][crate::model::CheckConsistencyRequest::consistency_token].
         pub fn set_consistency_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.consistency_token = v.into();
             self
@@ -2872,31 +2874,31 @@ pub mod bigtable_table_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::SnapshotTableRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `cluster`.
+        /// Sets the value of [cluster][crate::model::SnapshotTableRequest::cluster].
         pub fn set_cluster<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster = v.into();
             self
         }
 
-        /// Sets the value of `snapshot_id`.
+        /// Sets the value of [snapshot_id][crate::model::SnapshotTableRequest::snapshot_id].
         pub fn set_snapshot_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.snapshot_id = v.into();
             self
         }
 
-        /// Sets the value of `ttl`.
+        /// Sets the value of [ttl][crate::model::SnapshotTableRequest::ttl].
         pub fn set_ttl<T: Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
             self.0.request.ttl = v.into();
             self
         }
 
-        /// Sets the value of `description`.
+        /// Sets the value of [description][crate::model::SnapshotTableRequest::description].
         pub fn set_description<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.description = v.into();
             self
@@ -2937,7 +2939,7 @@ pub mod bigtable_table_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetSnapshotRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2993,19 +2995,19 @@ pub mod bigtable_table_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListSnapshotsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListSnapshotsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListSnapshotsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -3046,7 +3048,7 @@ pub mod bigtable_table_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteSnapshotRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -3125,19 +3127,19 @@ pub mod bigtable_table_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateBackupRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `backup_id`.
+        /// Sets the value of [backup_id][crate::model::CreateBackupRequest::backup_id].
         pub fn set_backup_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.backup_id = v.into();
             self
         }
 
-        /// Sets the value of `backup`.
+        /// Sets the value of [backup][crate::model::CreateBackupRequest::backup].
         pub fn set_backup<T: Into<std::option::Option<crate::model::Backup>>>(
             mut self,
             v: T,
@@ -3181,7 +3183,7 @@ pub mod bigtable_table_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetBackupRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -3222,7 +3224,7 @@ pub mod bigtable_table_admin {
                 .await
         }
 
-        /// Sets the value of `backup`.
+        /// Sets the value of [backup][crate::model::UpdateBackupRequest::backup].
         pub fn set_backup<T: Into<std::option::Option<crate::model::Backup>>>(
             mut self,
             v: T,
@@ -3231,7 +3233,7 @@ pub mod bigtable_table_admin {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateBackupRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -3275,7 +3277,7 @@ pub mod bigtable_table_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteBackupRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -3331,31 +3333,31 @@ pub mod bigtable_table_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListBackupsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListBackupsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `order_by`.
+        /// Sets the value of [order_by][crate::model::ListBackupsRequest::order_by].
         pub fn set_order_by<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.order_by = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListBackupsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListBackupsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -3434,13 +3436,13 @@ pub mod bigtable_table_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::RestoreTableRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `table_id`.
+        /// Sets the value of [table_id][crate::model::RestoreTableRequest::table_id].
         pub fn set_table_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.table_id = v.into();
             self
@@ -3527,25 +3529,25 @@ pub mod bigtable_table_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CopyBackupRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `backup_id`.
+        /// Sets the value of [backup_id][crate::model::CopyBackupRequest::backup_id].
         pub fn set_backup_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.backup_id = v.into();
             self
         }
 
-        /// Sets the value of `source_backup`.
+        /// Sets the value of [source_backup][crate::model::CopyBackupRequest::source_backup].
         pub fn set_source_backup<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.source_backup = v.into();
             self
         }
 
-        /// Sets the value of `expire_time`.
+        /// Sets the value of [expire_time][crate::model::CopyBackupRequest::expire_time].
         pub fn set_expire_time<T: Into<std::option::Option<wkt::Timestamp>>>(
             mut self,
             v: T,
@@ -3589,13 +3591,13 @@ pub mod bigtable_table_admin {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::GetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `options`.
+        /// Sets the value of [options][iam_v1::model::GetIamPolicyRequest::options].
         pub fn set_options<T: Into<std::option::Option<iam_v1::model::GetPolicyOptions>>>(
             mut self,
             v: T,
@@ -3639,13 +3641,13 @@ pub mod bigtable_table_admin {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::SetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][iam_v1::model::SetIamPolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<iam_v1::model::Policy>>>(
             mut self,
             v: T,
@@ -3654,7 +3656,7 @@ pub mod bigtable_table_admin {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][iam_v1::model::SetIamPolicyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -3701,18 +3703,20 @@ pub mod bigtable_table_admin {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::TestIamPermissionsRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `permissions`.
-        pub fn set_permissions<T: Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.permissions = v.into();
+        /// Sets the value of [permissions][iam_v1::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -3769,25 +3773,25 @@ pub mod bigtable_table_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::ListOperationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][longrunning::model::ListOperationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][longrunning::model::ListOperationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][longrunning::model::ListOperationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -3831,7 +3835,7 @@ pub mod bigtable_table_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::GetOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -3875,7 +3879,7 @@ pub mod bigtable_table_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::DeleteOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -3919,7 +3923,7 @@ pub mod bigtable_table_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::CancelOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self

--- a/src/generated/bigtable/admin/v2/src/model.rs
+++ b/src/generated/bigtable/admin/v2/src/model.rs
@@ -66,19 +66,19 @@ pub struct CreateInstanceRequest {
 }
 
 impl CreateInstanceRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateInstanceRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `instance_id`.
+    /// Sets the value of [instance_id][crate::model::CreateInstanceRequest::instance_id].
     pub fn set_instance_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance_id = v.into();
         self
     }
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::CreateInstanceRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::option::Option<crate::model::Instance>>>(
         mut self,
         v: T,
@@ -87,14 +87,15 @@ impl CreateInstanceRequest {
         self
     }
 
-    /// Sets the value of `clusters`.
-    pub fn set_clusters<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, crate::model::Cluster>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.clusters = v.into();
+    /// Sets the value of [clusters][crate::model::CreateInstanceRequest::clusters].
+    pub fn set_clusters<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::Cluster>,
+    {
+        use std::iter::Iterator;
+        self.clusters = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -118,7 +119,7 @@ pub struct GetInstanceRequest {
 }
 
 impl GetInstanceRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetInstanceRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -148,13 +149,13 @@ pub struct ListInstancesRequest {
 }
 
 impl ListInstancesRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListInstancesRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListInstancesRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -192,27 +193,31 @@ pub struct ListInstancesResponse {
 }
 
 impl ListInstancesResponse {
-    /// Sets the value of `instances`.
-    pub fn set_instances<T: std::convert::Into<std::vec::Vec<crate::model::Instance>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.instances = v.into();
-        self
-    }
-
-    /// Sets the value of `failed_locations`.
-    pub fn set_failed_locations<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.failed_locations = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
+        self
+    }
+
+    /// Sets the value of [instances][crate::model::ListInstancesResponse::instances].
+    pub fn set_instances<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Instance>,
+    {
+        use std::iter::Iterator;
+        self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [failed_locations][crate::model::ListInstancesResponse::failed_locations].
+    pub fn set_failed_locations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.failed_locations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -240,7 +245,7 @@ pub struct PartialUpdateInstanceRequest {
 }
 
 impl PartialUpdateInstanceRequest {
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::PartialUpdateInstanceRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::option::Option<crate::model::Instance>>>(
         mut self,
         v: T,
@@ -249,7 +254,7 @@ impl PartialUpdateInstanceRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::PartialUpdateInstanceRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -278,7 +283,7 @@ pub struct DeleteInstanceRequest {
 }
 
 impl DeleteInstanceRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteInstanceRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -315,19 +320,19 @@ pub struct CreateClusterRequest {
 }
 
 impl CreateClusterRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateClusterRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `cluster_id`.
+    /// Sets the value of [cluster_id][crate::model::CreateClusterRequest::cluster_id].
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
     }
 
-    /// Sets the value of `cluster`.
+    /// Sets the value of [cluster][crate::model::CreateClusterRequest::cluster].
     pub fn set_cluster<T: std::convert::Into<std::option::Option<crate::model::Cluster>>>(
         mut self,
         v: T,
@@ -356,7 +361,7 @@ pub struct GetClusterRequest {
 }
 
 impl GetClusterRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetClusterRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -389,13 +394,13 @@ pub struct ListClustersRequest {
 }
 
 impl ListClustersRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListClustersRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListClustersRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -432,27 +437,31 @@ pub struct ListClustersResponse {
 }
 
 impl ListClustersResponse {
-    /// Sets the value of `clusters`.
-    pub fn set_clusters<T: std::convert::Into<std::vec::Vec<crate::model::Cluster>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.clusters = v.into();
-        self
-    }
-
-    /// Sets the value of `failed_locations`.
-    pub fn set_failed_locations<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.failed_locations = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListClustersResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
+        self
+    }
+
+    /// Sets the value of [clusters][crate::model::ListClustersResponse::clusters].
+    pub fn set_clusters<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Cluster>,
+    {
+        use std::iter::Iterator;
+        self.clusters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [failed_locations][crate::model::ListClustersResponse::failed_locations].
+    pub fn set_failed_locations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.failed_locations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -476,7 +485,7 @@ pub struct DeleteClusterRequest {
 }
 
 impl DeleteClusterRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteClusterRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -509,7 +518,7 @@ pub struct CreateInstanceMetadata {
 }
 
 impl CreateInstanceMetadata {
-    /// Sets the value of `original_request`.
+    /// Sets the value of [original_request][crate::model::CreateInstanceMetadata::original_request].
     pub fn set_original_request<
         T: std::convert::Into<std::option::Option<crate::model::CreateInstanceRequest>>,
     >(
@@ -520,7 +529,7 @@ impl CreateInstanceMetadata {
         self
     }
 
-    /// Sets the value of `request_time`.
+    /// Sets the value of [request_time][crate::model::CreateInstanceMetadata::request_time].
     pub fn set_request_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -529,7 +538,7 @@ impl CreateInstanceMetadata {
         self
     }
 
-    /// Sets the value of `finish_time`.
+    /// Sets the value of [finish_time][crate::model::CreateInstanceMetadata::finish_time].
     pub fn set_finish_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -565,7 +574,7 @@ pub struct UpdateInstanceMetadata {
 }
 
 impl UpdateInstanceMetadata {
-    /// Sets the value of `original_request`.
+    /// Sets the value of [original_request][crate::model::UpdateInstanceMetadata::original_request].
     pub fn set_original_request<
         T: std::convert::Into<std::option::Option<crate::model::PartialUpdateInstanceRequest>>,
     >(
@@ -576,7 +585,7 @@ impl UpdateInstanceMetadata {
         self
     }
 
-    /// Sets the value of `request_time`.
+    /// Sets the value of [request_time][crate::model::UpdateInstanceMetadata::request_time].
     pub fn set_request_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -585,7 +594,7 @@ impl UpdateInstanceMetadata {
         self
     }
 
-    /// Sets the value of `finish_time`.
+    /// Sets the value of [finish_time][crate::model::UpdateInstanceMetadata::finish_time].
     pub fn set_finish_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -635,7 +644,7 @@ pub struct CreateClusterMetadata {
 }
 
 impl CreateClusterMetadata {
-    /// Sets the value of `original_request`.
+    /// Sets the value of [original_request][crate::model::CreateClusterMetadata::original_request].
     pub fn set_original_request<
         T: std::convert::Into<std::option::Option<crate::model::CreateClusterRequest>>,
     >(
@@ -646,7 +655,7 @@ impl CreateClusterMetadata {
         self
     }
 
-    /// Sets the value of `request_time`.
+    /// Sets the value of [request_time][crate::model::CreateClusterMetadata::request_time].
     pub fn set_request_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -655,7 +664,7 @@ impl CreateClusterMetadata {
         self
     }
 
-    /// Sets the value of `finish_time`.
+    /// Sets the value of [finish_time][crate::model::CreateClusterMetadata::finish_time].
     pub fn set_finish_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -664,19 +673,15 @@ impl CreateClusterMetadata {
         self
     }
 
-    /// Sets the value of `tables`.
-    pub fn set_tables<
-        T: std::convert::Into<
-            std::collections::HashMap<
-                std::string::String,
-                crate::model::create_cluster_metadata::TableProgress,
-            >,
-        >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.tables = v.into();
+    /// Sets the value of [tables][crate::model::CreateClusterMetadata::tables].
+    pub fn set_tables<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::create_cluster_metadata::TableProgress>,
+    {
+        use std::iter::Iterator;
+        self.tables = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -712,19 +717,19 @@ pub mod create_cluster_metadata {
     }
 
     impl TableProgress {
-        /// Sets the value of `estimated_size_bytes`.
+        /// Sets the value of [estimated_size_bytes][crate::model::create_cluster_metadata::TableProgress::estimated_size_bytes].
         pub fn set_estimated_size_bytes<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
             self.estimated_size_bytes = v.into();
             self
         }
 
-        /// Sets the value of `estimated_copied_bytes`.
+        /// Sets the value of [estimated_copied_bytes][crate::model::create_cluster_metadata::TableProgress::estimated_copied_bytes].
         pub fn set_estimated_copied_bytes<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
             self.estimated_copied_bytes = v.into();
             self
         }
 
-        /// Sets the value of `state`.
+        /// Sets the value of [state][crate::model::create_cluster_metadata::TableProgress::state].
         pub fn set_state<
             T: std::convert::Into<crate::model::create_cluster_metadata::table_progress::State>,
         >(
@@ -805,7 +810,7 @@ pub struct UpdateClusterMetadata {
 }
 
 impl UpdateClusterMetadata {
-    /// Sets the value of `original_request`.
+    /// Sets the value of [original_request][crate::model::UpdateClusterMetadata::original_request].
     pub fn set_original_request<
         T: std::convert::Into<std::option::Option<crate::model::Cluster>>,
     >(
@@ -816,7 +821,7 @@ impl UpdateClusterMetadata {
         self
     }
 
-    /// Sets the value of `request_time`.
+    /// Sets the value of [request_time][crate::model::UpdateClusterMetadata::request_time].
     pub fn set_request_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -825,7 +830,7 @@ impl UpdateClusterMetadata {
         self
     }
 
-    /// Sets the value of `finish_time`.
+    /// Sets the value of [finish_time][crate::model::UpdateClusterMetadata::finish_time].
     pub fn set_finish_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -861,7 +866,7 @@ pub struct PartialUpdateClusterMetadata {
 }
 
 impl PartialUpdateClusterMetadata {
-    /// Sets the value of `request_time`.
+    /// Sets the value of [request_time][crate::model::PartialUpdateClusterMetadata::request_time].
     pub fn set_request_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -870,7 +875,7 @@ impl PartialUpdateClusterMetadata {
         self
     }
 
-    /// Sets the value of `finish_time`.
+    /// Sets the value of [finish_time][crate::model::PartialUpdateClusterMetadata::finish_time].
     pub fn set_finish_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -879,7 +884,7 @@ impl PartialUpdateClusterMetadata {
         self
     }
 
-    /// Sets the value of `original_request`.
+    /// Sets the value of [original_request][crate::model::PartialUpdateClusterMetadata::original_request].
     pub fn set_original_request<
         T: std::convert::Into<std::option::Option<crate::model::PartialUpdateClusterRequest>>,
     >(
@@ -914,7 +919,7 @@ pub struct PartialUpdateClusterRequest {
 }
 
 impl PartialUpdateClusterRequest {
-    /// Sets the value of `cluster`.
+    /// Sets the value of [cluster][crate::model::PartialUpdateClusterRequest::cluster].
     pub fn set_cluster<T: std::convert::Into<std::option::Option<crate::model::Cluster>>>(
         mut self,
         v: T,
@@ -923,7 +928,7 @@ impl PartialUpdateClusterRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::PartialUpdateClusterRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -966,19 +971,19 @@ pub struct CreateAppProfileRequest {
 }
 
 impl CreateAppProfileRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateAppProfileRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `app_profile_id`.
+    /// Sets the value of [app_profile_id][crate::model::CreateAppProfileRequest::app_profile_id].
     pub fn set_app_profile_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.app_profile_id = v.into();
         self
     }
 
-    /// Sets the value of `app_profile`.
+    /// Sets the value of [app_profile][crate::model::CreateAppProfileRequest::app_profile].
     pub fn set_app_profile<T: std::convert::Into<std::option::Option<crate::model::AppProfile>>>(
         mut self,
         v: T,
@@ -987,7 +992,7 @@ impl CreateAppProfileRequest {
         self
     }
 
-    /// Sets the value of `ignore_warnings`.
+    /// Sets the value of [ignore_warnings][crate::model::CreateAppProfileRequest::ignore_warnings].
     pub fn set_ignore_warnings<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.ignore_warnings = v.into();
         self
@@ -1013,7 +1018,7 @@ pub struct GetAppProfileRequest {
 }
 
 impl GetAppProfileRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetAppProfileRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1057,19 +1062,19 @@ pub struct ListAppProfilesRequest {
 }
 
 impl ListAppProfilesRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListAppProfilesRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListAppProfilesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListAppProfilesRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -1107,27 +1112,31 @@ pub struct ListAppProfilesResponse {
 }
 
 impl ListAppProfilesResponse {
-    /// Sets the value of `app_profiles`.
-    pub fn set_app_profiles<T: std::convert::Into<std::vec::Vec<crate::model::AppProfile>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.app_profiles = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListAppProfilesResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `failed_locations`.
-    pub fn set_failed_locations<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.failed_locations = v.into();
+    /// Sets the value of [app_profiles][crate::model::ListAppProfilesResponse::app_profiles].
+    pub fn set_app_profiles<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AppProfile>,
+    {
+        use std::iter::Iterator;
+        self.app_profiles = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [failed_locations][crate::model::ListAppProfilesResponse::failed_locations].
+    pub fn set_failed_locations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.failed_locations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1171,7 +1180,7 @@ pub struct UpdateAppProfileRequest {
 }
 
 impl UpdateAppProfileRequest {
-    /// Sets the value of `app_profile`.
+    /// Sets the value of [app_profile][crate::model::UpdateAppProfileRequest::app_profile].
     pub fn set_app_profile<T: std::convert::Into<std::option::Option<crate::model::AppProfile>>>(
         mut self,
         v: T,
@@ -1180,7 +1189,7 @@ impl UpdateAppProfileRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateAppProfileRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -1189,7 +1198,7 @@ impl UpdateAppProfileRequest {
         self
     }
 
-    /// Sets the value of `ignore_warnings`.
+    /// Sets the value of [ignore_warnings][crate::model::UpdateAppProfileRequest::ignore_warnings].
     pub fn set_ignore_warnings<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.ignore_warnings = v.into();
         self
@@ -1219,13 +1228,13 @@ pub struct DeleteAppProfileRequest {
 }
 
 impl DeleteAppProfileRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteAppProfileRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `ignore_warnings`.
+    /// Sets the value of [ignore_warnings][crate::model::DeleteAppProfileRequest::ignore_warnings].
     pub fn set_ignore_warnings<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.ignore_warnings = v.into();
         self
@@ -1295,13 +1304,13 @@ pub struct ListHotTabletsRequest {
 }
 
 impl ListHotTabletsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListHotTabletsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `start_time`.
+    /// Sets the value of [start_time][crate::model::ListHotTabletsRequest::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1310,7 +1319,7 @@ impl ListHotTabletsRequest {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::ListHotTabletsRequest::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1319,13 +1328,13 @@ impl ListHotTabletsRequest {
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListHotTabletsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListHotTabletsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -1360,18 +1369,20 @@ pub struct ListHotTabletsResponse {
 }
 
 impl ListHotTabletsResponse {
-    /// Sets the value of `hot_tablets`.
-    pub fn set_hot_tablets<T: std::convert::Into<std::vec::Vec<crate::model::HotTablet>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.hot_tablets = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListHotTabletsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [hot_tablets][crate::model::ListHotTabletsResponse::hot_tablets].
+    pub fn set_hot_tablets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::HotTablet>,
+    {
+        use std::iter::Iterator;
+        self.hot_tablets = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1422,13 +1433,13 @@ pub struct RestoreTableRequest {
 }
 
 impl RestoreTableRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::RestoreTableRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `table_id`.
+    /// Sets the value of [table_id][crate::model::RestoreTableRequest::table_id].
     pub fn set_table_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.table_id = v.into();
         self
@@ -1516,13 +1527,13 @@ pub struct RestoreTableMetadata {
 }
 
 impl RestoreTableMetadata {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::RestoreTableMetadata::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `source_type`.
+    /// Sets the value of [source_type][crate::model::RestoreTableMetadata::source_type].
     pub fn set_source_type<T: std::convert::Into<crate::model::RestoreSourceType>>(
         mut self,
         v: T,
@@ -1531,7 +1542,7 @@ impl RestoreTableMetadata {
         self
     }
 
-    /// Sets the value of `optimize_table_operation_name`.
+    /// Sets the value of [optimize_table_operation_name][crate::model::RestoreTableMetadata::optimize_table_operation_name].
     pub fn set_optimize_table_operation_name<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -1540,7 +1551,7 @@ impl RestoreTableMetadata {
         self
     }
 
-    /// Sets the value of `progress`.
+    /// Sets the value of [progress][crate::model::RestoreTableMetadata::progress].
     pub fn set_progress<
         T: std::convert::Into<std::option::Option<crate::model::OperationProgress>>,
     >(
@@ -1606,13 +1617,13 @@ pub struct OptimizeRestoredTableMetadata {
 }
 
 impl OptimizeRestoredTableMetadata {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::OptimizeRestoredTableMetadata::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `progress`.
+    /// Sets the value of [progress][crate::model::OptimizeRestoredTableMetadata::progress].
     pub fn set_progress<
         T: std::convert::Into<std::option::Option<crate::model::OperationProgress>>,
     >(
@@ -1675,19 +1686,19 @@ pub struct CreateTableRequest {
 }
 
 impl CreateTableRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateTableRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `table_id`.
+    /// Sets the value of [table_id][crate::model::CreateTableRequest::table_id].
     pub fn set_table_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.table_id = v.into();
         self
     }
 
-    /// Sets the value of `table`.
+    /// Sets the value of [table][crate::model::CreateTableRequest::table].
     pub fn set_table<T: std::convert::Into<std::option::Option<crate::model::Table>>>(
         mut self,
         v: T,
@@ -1696,14 +1707,14 @@ impl CreateTableRequest {
         self
     }
 
-    /// Sets the value of `initial_splits`.
-    pub fn set_initial_splits<
-        T: std::convert::Into<std::vec::Vec<crate::model::create_table_request::Split>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.initial_splits = v.into();
+    /// Sets the value of [initial_splits][crate::model::CreateTableRequest::initial_splits].
+    pub fn set_initial_splits<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::create_table_request::Split>,
+    {
+        use std::iter::Iterator;
+        self.initial_splits = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1732,7 +1743,7 @@ pub mod create_table_request {
     }
 
     impl Split {
-        /// Sets the value of `key`.
+        /// Sets the value of [key][crate::model::create_table_request::Split::key].
         pub fn set_key<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.key = v.into();
             self
@@ -1779,19 +1790,19 @@ pub struct CreateTableFromSnapshotRequest {
 }
 
 impl CreateTableFromSnapshotRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateTableFromSnapshotRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `table_id`.
+    /// Sets the value of [table_id][crate::model::CreateTableFromSnapshotRequest::table_id].
     pub fn set_table_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.table_id = v.into();
         self
     }
 
-    /// Sets the value of `source_snapshot`.
+    /// Sets the value of [source_snapshot][crate::model::CreateTableFromSnapshotRequest::source_snapshot].
     pub fn set_source_snapshot<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.source_snapshot = v.into();
         self
@@ -1825,7 +1836,7 @@ pub struct DropRowRangeRequest {
 }
 
 impl DropRowRangeRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DropRowRangeRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1902,25 +1913,25 @@ pub struct ListTablesRequest {
 }
 
 impl ListTablesRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListTablesRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `view`.
+    /// Sets the value of [view][crate::model::ListTablesRequest::view].
     pub fn set_view<T: std::convert::Into<crate::model::table::View>>(mut self, v: T) -> Self {
         self.view = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListTablesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListTablesRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -1954,18 +1965,20 @@ pub struct ListTablesResponse {
 }
 
 impl ListTablesResponse {
-    /// Sets the value of `tables`.
-    pub fn set_tables<T: std::convert::Into<std::vec::Vec<crate::model::Table>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.tables = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListTablesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [tables][crate::model::ListTablesResponse::tables].
+    pub fn set_tables<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Table>,
+    {
+        use std::iter::Iterator;
+        self.tables = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2010,13 +2023,13 @@ pub struct GetTableRequest {
 }
 
 impl GetTableRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetTableRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `view`.
+    /// Sets the value of [view][crate::model::GetTableRequest::view].
     pub fn set_view<T: std::convert::Into<crate::model::table::View>>(mut self, v: T) -> Self {
         self.view = v.into();
         self
@@ -2060,7 +2073,7 @@ pub struct UpdateTableRequest {
 }
 
 impl UpdateTableRequest {
-    /// Sets the value of `table`.
+    /// Sets the value of [table][crate::model::UpdateTableRequest::table].
     pub fn set_table<T: std::convert::Into<std::option::Option<crate::model::Table>>>(
         mut self,
         v: T,
@@ -2069,7 +2082,7 @@ impl UpdateTableRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateTableRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -2108,13 +2121,13 @@ pub struct UpdateTableMetadata {
 }
 
 impl UpdateTableMetadata {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::UpdateTableMetadata::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `start_time`.
+    /// Sets the value of [start_time][crate::model::UpdateTableMetadata::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2123,7 +2136,7 @@ impl UpdateTableMetadata {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::UpdateTableMetadata::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2156,7 +2169,7 @@ pub struct DeleteTableRequest {
 }
 
 impl DeleteTableRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteTableRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -2186,7 +2199,7 @@ pub struct UndeleteTableRequest {
 }
 
 impl UndeleteTableRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::UndeleteTableRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -2222,13 +2235,13 @@ pub struct UndeleteTableMetadata {
 }
 
 impl UndeleteTableMetadata {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::UndeleteTableMetadata::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `start_time`.
+    /// Sets the value of [start_time][crate::model::UndeleteTableMetadata::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2237,7 +2250,7 @@ impl UndeleteTableMetadata {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::UndeleteTableMetadata::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2280,28 +2293,26 @@ pub struct ModifyColumnFamiliesRequest {
 }
 
 impl ModifyColumnFamiliesRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::ModifyColumnFamiliesRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `modifications`.
-    pub fn set_modifications<
-        T: std::convert::Into<
-            std::vec::Vec<crate::model::modify_column_families_request::Modification>,
-        >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.modifications = v.into();
+    /// Sets the value of [ignore_warnings][crate::model::ModifyColumnFamiliesRequest::ignore_warnings].
+    pub fn set_ignore_warnings<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.ignore_warnings = v.into();
         self
     }
 
-    /// Sets the value of `ignore_warnings`.
-    pub fn set_ignore_warnings<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.ignore_warnings = v.into();
+    /// Sets the value of [modifications][crate::model::ModifyColumnFamiliesRequest::modifications].
+    pub fn set_modifications<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::modify_column_families_request::Modification>,
+    {
+        use std::iter::Iterator;
+        self.modifications = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2340,13 +2351,13 @@ pub mod modify_column_families_request {
     }
 
     impl Modification {
-        /// Sets the value of `id`.
+        /// Sets the value of [id][crate::model::modify_column_families_request::Modification::id].
         pub fn set_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.id = v.into();
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::modify_column_families_request::Modification::update_mask].
         pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -2417,7 +2428,7 @@ pub struct GenerateConsistencyTokenRequest {
 }
 
 impl GenerateConsistencyTokenRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GenerateConsistencyTokenRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -2445,7 +2456,7 @@ pub struct GenerateConsistencyTokenResponse {
 }
 
 impl GenerateConsistencyTokenResponse {
-    /// Sets the value of `consistency_token`.
+    /// Sets the value of [consistency_token][crate::model::GenerateConsistencyTokenResponse::consistency_token].
     pub fn set_consistency_token<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -2487,13 +2498,13 @@ pub struct CheckConsistencyRequest {
 }
 
 impl CheckConsistencyRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::CheckConsistencyRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `consistency_token`.
+    /// Sets the value of [consistency_token][crate::model::CheckConsistencyRequest::consistency_token].
     pub fn set_consistency_token<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -2589,7 +2600,7 @@ pub struct CheckConsistencyResponse {
 }
 
 impl CheckConsistencyResponse {
-    /// Sets the value of `consistent`.
+    /// Sets the value of [consistent][crate::model::CheckConsistencyResponse::consistent].
     pub fn set_consistent<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.consistent = v.into();
         self
@@ -2648,25 +2659,25 @@ pub struct SnapshotTableRequest {
 }
 
 impl SnapshotTableRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::SnapshotTableRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `cluster`.
+    /// Sets the value of [cluster][crate::model::SnapshotTableRequest::cluster].
     pub fn set_cluster<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster = v.into();
         self
     }
 
-    /// Sets the value of `snapshot_id`.
+    /// Sets the value of [snapshot_id][crate::model::SnapshotTableRequest::snapshot_id].
     pub fn set_snapshot_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.snapshot_id = v.into();
         self
     }
 
-    /// Sets the value of `ttl`.
+    /// Sets the value of [ttl][crate::model::SnapshotTableRequest::ttl].
     pub fn set_ttl<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
@@ -2675,7 +2686,7 @@ impl SnapshotTableRequest {
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::SnapshotTableRequest::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
@@ -2710,7 +2721,7 @@ pub struct GetSnapshotRequest {
 }
 
 impl GetSnapshotRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetSnapshotRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -2755,19 +2766,19 @@ pub struct ListSnapshotsRequest {
 }
 
 impl ListSnapshotsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListSnapshotsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListSnapshotsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListSnapshotsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -2806,18 +2817,20 @@ pub struct ListSnapshotsResponse {
 }
 
 impl ListSnapshotsResponse {
-    /// Sets the value of `snapshots`.
-    pub fn set_snapshots<T: std::convert::Into<std::vec::Vec<crate::model::Snapshot>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.snapshots = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListSnapshotsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [snapshots][crate::model::ListSnapshotsResponse::snapshots].
+    pub fn set_snapshots<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Snapshot>,
+    {
+        use std::iter::Iterator;
+        self.snapshots = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2863,7 +2876,7 @@ pub struct DeleteSnapshotRequest {
 }
 
 impl DeleteSnapshotRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteSnapshotRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -2901,7 +2914,7 @@ pub struct SnapshotTableMetadata {
 }
 
 impl SnapshotTableMetadata {
-    /// Sets the value of `original_request`.
+    /// Sets the value of [original_request][crate::model::SnapshotTableMetadata::original_request].
     pub fn set_original_request<
         T: std::convert::Into<std::option::Option<crate::model::SnapshotTableRequest>>,
     >(
@@ -2912,7 +2925,7 @@ impl SnapshotTableMetadata {
         self
     }
 
-    /// Sets the value of `request_time`.
+    /// Sets the value of [request_time][crate::model::SnapshotTableMetadata::request_time].
     pub fn set_request_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2921,7 +2934,7 @@ impl SnapshotTableMetadata {
         self
     }
 
-    /// Sets the value of `finish_time`.
+    /// Sets the value of [finish_time][crate::model::SnapshotTableMetadata::finish_time].
     pub fn set_finish_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2963,7 +2976,7 @@ pub struct CreateTableFromSnapshotMetadata {
 }
 
 impl CreateTableFromSnapshotMetadata {
-    /// Sets the value of `original_request`.
+    /// Sets the value of [original_request][crate::model::CreateTableFromSnapshotMetadata::original_request].
     pub fn set_original_request<
         T: std::convert::Into<std::option::Option<crate::model::CreateTableFromSnapshotRequest>>,
     >(
@@ -2974,7 +2987,7 @@ impl CreateTableFromSnapshotMetadata {
         self
     }
 
-    /// Sets the value of `request_time`.
+    /// Sets the value of [request_time][crate::model::CreateTableFromSnapshotMetadata::request_time].
     pub fn set_request_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2983,7 +2996,7 @@ impl CreateTableFromSnapshotMetadata {
         self
     }
 
-    /// Sets the value of `finish_time`.
+    /// Sets the value of [finish_time][crate::model::CreateTableFromSnapshotMetadata::finish_time].
     pub fn set_finish_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3029,19 +3042,19 @@ pub struct CreateBackupRequest {
 }
 
 impl CreateBackupRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateBackupRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `backup_id`.
+    /// Sets the value of [backup_id][crate::model::CreateBackupRequest::backup_id].
     pub fn set_backup_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.backup_id = v.into();
         self
     }
 
-    /// Sets the value of `backup`.
+    /// Sets the value of [backup][crate::model::CreateBackupRequest::backup].
     pub fn set_backup<T: std::convert::Into<std::option::Option<crate::model::Backup>>>(
         mut self,
         v: T,
@@ -3084,19 +3097,19 @@ pub struct CreateBackupMetadata {
 }
 
 impl CreateBackupMetadata {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::CreateBackupMetadata::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `source_table`.
+    /// Sets the value of [source_table][crate::model::CreateBackupMetadata::source_table].
     pub fn set_source_table<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.source_table = v.into();
         self
     }
 
-    /// Sets the value of `start_time`.
+    /// Sets the value of [start_time][crate::model::CreateBackupMetadata::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3105,7 +3118,7 @@ impl CreateBackupMetadata {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::CreateBackupMetadata::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3148,7 +3161,7 @@ pub struct UpdateBackupRequest {
 }
 
 impl UpdateBackupRequest {
-    /// Sets the value of `backup`.
+    /// Sets the value of [backup][crate::model::UpdateBackupRequest::backup].
     pub fn set_backup<T: std::convert::Into<std::option::Option<crate::model::Backup>>>(
         mut self,
         v: T,
@@ -3157,7 +3170,7 @@ impl UpdateBackupRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateBackupRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -3190,7 +3203,7 @@ pub struct GetBackupRequest {
 }
 
 impl GetBackupRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetBackupRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -3220,7 +3233,7 @@ pub struct DeleteBackupRequest {
 }
 
 impl DeleteBackupRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteBackupRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -3329,31 +3342,31 @@ pub struct ListBackupsRequest {
 }
 
 impl ListBackupsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListBackupsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListBackupsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
     }
 
-    /// Sets the value of `order_by`.
+    /// Sets the value of [order_by][crate::model::ListBackupsRequest::order_by].
     pub fn set_order_by<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.order_by = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListBackupsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListBackupsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -3389,18 +3402,20 @@ pub struct ListBackupsResponse {
 }
 
 impl ListBackupsResponse {
-    /// Sets the value of `backups`.
-    pub fn set_backups<T: std::convert::Into<std::vec::Vec<crate::model::Backup>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.backups = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListBackupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [backups][crate::model::ListBackupsResponse::backups].
+    pub fn set_backups<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Backup>,
+    {
+        use std::iter::Iterator;
+        self.backups = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3468,25 +3483,25 @@ pub struct CopyBackupRequest {
 }
 
 impl CopyBackupRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CopyBackupRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `backup_id`.
+    /// Sets the value of [backup_id][crate::model::CopyBackupRequest::backup_id].
     pub fn set_backup_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.backup_id = v.into();
         self
     }
 
-    /// Sets the value of `source_backup`.
+    /// Sets the value of [source_backup][crate::model::CopyBackupRequest::source_backup].
     pub fn set_source_backup<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.source_backup = v.into();
         self
     }
 
-    /// Sets the value of `expire_time`.
+    /// Sets the value of [expire_time][crate::model::CopyBackupRequest::expire_time].
     pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3531,13 +3546,13 @@ pub struct CopyBackupMetadata {
 }
 
 impl CopyBackupMetadata {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::CopyBackupMetadata::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `source_backup_info`.
+    /// Sets the value of [source_backup_info][crate::model::CopyBackupMetadata::source_backup_info].
     pub fn set_source_backup_info<
         T: std::convert::Into<std::option::Option<crate::model::BackupInfo>>,
     >(
@@ -3548,7 +3563,7 @@ impl CopyBackupMetadata {
         self
     }
 
-    /// Sets the value of `progress`.
+    /// Sets the value of [progress][crate::model::CopyBackupMetadata::progress].
     pub fn set_progress<
         T: std::convert::Into<std::option::Option<crate::model::OperationProgress>>,
     >(
@@ -3594,13 +3609,13 @@ pub struct CreateAuthorizedViewRequest {
 }
 
 impl CreateAuthorizedViewRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateAuthorizedViewRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `authorized_view_id`.
+    /// Sets the value of [authorized_view_id][crate::model::CreateAuthorizedViewRequest::authorized_view_id].
     pub fn set_authorized_view_id<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -3609,7 +3624,7 @@ impl CreateAuthorizedViewRequest {
         self
     }
 
-    /// Sets the value of `authorized_view`.
+    /// Sets the value of [authorized_view][crate::model::CreateAuthorizedViewRequest::authorized_view].
     pub fn set_authorized_view<
         T: std::convert::Into<std::option::Option<crate::model::AuthorizedView>>,
     >(
@@ -3647,7 +3662,7 @@ pub struct CreateAuthorizedViewMetadata {
 }
 
 impl CreateAuthorizedViewMetadata {
-    /// Sets the value of `original_request`.
+    /// Sets the value of [original_request][crate::model::CreateAuthorizedViewMetadata::original_request].
     pub fn set_original_request<
         T: std::convert::Into<std::option::Option<crate::model::CreateAuthorizedViewRequest>>,
     >(
@@ -3658,7 +3673,7 @@ impl CreateAuthorizedViewMetadata {
         self
     }
 
-    /// Sets the value of `request_time`.
+    /// Sets the value of [request_time][crate::model::CreateAuthorizedViewMetadata::request_time].
     pub fn set_request_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3667,7 +3682,7 @@ impl CreateAuthorizedViewMetadata {
         self
     }
 
-    /// Sets the value of `finish_time`.
+    /// Sets the value of [finish_time][crate::model::CreateAuthorizedViewMetadata::finish_time].
     pub fn set_finish_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3719,25 +3734,25 @@ pub struct ListAuthorizedViewsRequest {
 }
 
 impl ListAuthorizedViewsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListAuthorizedViewsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListAuthorizedViewsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListAuthorizedViewsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `view`.
+    /// Sets the value of [view][crate::model::ListAuthorizedViewsRequest::view].
     pub fn set_view<T: std::convert::Into<crate::model::authorized_view::ResponseView>>(
         mut self,
         v: T,
@@ -3774,20 +3789,20 @@ pub struct ListAuthorizedViewsResponse {
 }
 
 impl ListAuthorizedViewsResponse {
-    /// Sets the value of `authorized_views`.
-    pub fn set_authorized_views<
-        T: std::convert::Into<std::vec::Vec<crate::model::AuthorizedView>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.authorized_views = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListAuthorizedViewsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [authorized_views][crate::model::ListAuthorizedViewsResponse::authorized_views].
+    pub fn set_authorized_views<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AuthorizedView>,
+    {
+        use std::iter::Iterator;
+        self.authorized_views = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3832,13 +3847,13 @@ pub struct GetAuthorizedViewRequest {
 }
 
 impl GetAuthorizedViewRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetAuthorizedViewRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `view`.
+    /// Sets the value of [view][crate::model::GetAuthorizedViewRequest::view].
     pub fn set_view<T: std::convert::Into<crate::model::authorized_view::ResponseView>>(
         mut self,
         v: T,
@@ -3886,7 +3901,7 @@ pub struct UpdateAuthorizedViewRequest {
 }
 
 impl UpdateAuthorizedViewRequest {
-    /// Sets the value of `authorized_view`.
+    /// Sets the value of [authorized_view][crate::model::UpdateAuthorizedViewRequest::authorized_view].
     pub fn set_authorized_view<
         T: std::convert::Into<std::option::Option<crate::model::AuthorizedView>>,
     >(
@@ -3897,7 +3912,7 @@ impl UpdateAuthorizedViewRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateAuthorizedViewRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -3906,7 +3921,7 @@ impl UpdateAuthorizedViewRequest {
         self
     }
 
-    /// Sets the value of `ignore_warnings`.
+    /// Sets the value of [ignore_warnings][crate::model::UpdateAuthorizedViewRequest::ignore_warnings].
     pub fn set_ignore_warnings<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.ignore_warnings = v.into();
         self
@@ -3943,7 +3958,7 @@ pub struct UpdateAuthorizedViewMetadata {
 }
 
 impl UpdateAuthorizedViewMetadata {
-    /// Sets the value of `original_request`.
+    /// Sets the value of [original_request][crate::model::UpdateAuthorizedViewMetadata::original_request].
     pub fn set_original_request<
         T: std::convert::Into<std::option::Option<crate::model::UpdateAuthorizedViewRequest>>,
     >(
@@ -3954,7 +3969,7 @@ impl UpdateAuthorizedViewMetadata {
         self
     }
 
-    /// Sets the value of `request_time`.
+    /// Sets the value of [request_time][crate::model::UpdateAuthorizedViewMetadata::request_time].
     pub fn set_request_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3963,7 +3978,7 @@ impl UpdateAuthorizedViewMetadata {
         self
     }
 
-    /// Sets the value of `finish_time`.
+    /// Sets the value of [finish_time][crate::model::UpdateAuthorizedViewMetadata::finish_time].
     pub fn set_finish_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -4003,13 +4018,13 @@ pub struct DeleteAuthorizedViewRequest {
 }
 
 impl DeleteAuthorizedViewRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteAuthorizedViewRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DeleteAuthorizedViewRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
@@ -4044,13 +4059,13 @@ pub struct OperationProgress {
 }
 
 impl OperationProgress {
-    /// Sets the value of `progress_percent`.
+    /// Sets the value of [progress_percent][crate::model::OperationProgress::progress_percent].
     pub fn set_progress_percent<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.progress_percent = v.into();
         self
     }
 
-    /// Sets the value of `start_time`.
+    /// Sets the value of [start_time][crate::model::OperationProgress::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -4059,7 +4074,7 @@ impl OperationProgress {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::OperationProgress::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -4132,42 +4147,31 @@ pub struct Instance {
 }
 
 impl Instance {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Instance::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::Instance::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::Instance::state].
     pub fn set_state<T: std::convert::Into<crate::model::instance::State>>(mut self, v: T) -> Self {
         self.state = v.into();
         self
     }
 
-    /// Sets the value of `r#type`.
+    /// Sets the value of [r#type][crate::model::Instance::type].
     pub fn set_type<T: std::convert::Into<crate::model::instance::Type>>(mut self, v: T) -> Self {
         self.r#type = v.into();
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::Instance::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -4176,12 +4180,24 @@ impl Instance {
         self
     }
 
-    /// Sets the value of `satisfies_pzs`.
+    /// Sets the value of [satisfies_pzs][crate::model::Instance::satisfies_pzs].
     pub fn set_satisfies_pzs<T: std::convert::Into<std::option::Option<bool>>>(
         mut self,
         v: T,
     ) -> Self {
         self.satisfies_pzs = v.into();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Instance::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4286,13 +4302,13 @@ pub struct AutoscalingTargets {
 }
 
 impl AutoscalingTargets {
-    /// Sets the value of `cpu_utilization_percent`.
+    /// Sets the value of [cpu_utilization_percent][crate::model::AutoscalingTargets::cpu_utilization_percent].
     pub fn set_cpu_utilization_percent<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.cpu_utilization_percent = v.into();
         self
     }
 
-    /// Sets the value of `storage_utilization_gib_per_node`.
+    /// Sets the value of [storage_utilization_gib_per_node][crate::model::AutoscalingTargets::storage_utilization_gib_per_node].
     pub fn set_storage_utilization_gib_per_node<T: std::convert::Into<i32>>(
         mut self,
         v: T,
@@ -4322,13 +4338,13 @@ pub struct AutoscalingLimits {
 }
 
 impl AutoscalingLimits {
-    /// Sets the value of `min_serve_nodes`.
+    /// Sets the value of [min_serve_nodes][crate::model::AutoscalingLimits::min_serve_nodes].
     pub fn set_min_serve_nodes<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.min_serve_nodes = v.into();
         self
     }
 
-    /// Sets the value of `max_serve_nodes`.
+    /// Sets the value of [max_serve_nodes][crate::model::AutoscalingLimits::max_serve_nodes].
     pub fn set_max_serve_nodes<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.max_serve_nodes = v.into();
         self
@@ -4387,31 +4403,31 @@ pub struct Cluster {
 }
 
 impl Cluster {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Cluster::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::Cluster::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::Cluster::state].
     pub fn set_state<T: std::convert::Into<crate::model::cluster::State>>(mut self, v: T) -> Self {
         self.state = v.into();
         self
     }
 
-    /// Sets the value of `serve_nodes`.
+    /// Sets the value of [serve_nodes][crate::model::Cluster::serve_nodes].
     pub fn set_serve_nodes<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.serve_nodes = v.into();
         self
     }
 
-    /// Sets the value of `node_scaling_factor`.
+    /// Sets the value of [node_scaling_factor][crate::model::Cluster::node_scaling_factor].
     pub fn set_node_scaling_factor<
         T: std::convert::Into<crate::model::cluster::NodeScalingFactor>,
     >(
@@ -4422,7 +4438,7 @@ impl Cluster {
         self
     }
 
-    /// Sets the value of `default_storage_type`.
+    /// Sets the value of [default_storage_type][crate::model::Cluster::default_storage_type].
     pub fn set_default_storage_type<T: std::convert::Into<crate::model::StorageType>>(
         mut self,
         v: T,
@@ -4431,7 +4447,7 @@ impl Cluster {
         self
     }
 
-    /// Sets the value of `encryption_config`.
+    /// Sets the value of [encryption_config][crate::model::Cluster::encryption_config].
     pub fn set_encryption_config<
         T: std::convert::Into<std::option::Option<crate::model::cluster::EncryptionConfig>>,
     >(
@@ -4479,7 +4495,7 @@ pub mod cluster {
     }
 
     impl ClusterAutoscalingConfig {
-        /// Sets the value of `autoscaling_limits`.
+        /// Sets the value of [autoscaling_limits][crate::model::cluster::ClusterAutoscalingConfig::autoscaling_limits].
         pub fn set_autoscaling_limits<
             T: std::convert::Into<std::option::Option<crate::model::AutoscalingLimits>>,
         >(
@@ -4490,7 +4506,7 @@ pub mod cluster {
             self
         }
 
-        /// Sets the value of `autoscaling_targets`.
+        /// Sets the value of [autoscaling_targets][crate::model::cluster::ClusterAutoscalingConfig::autoscaling_targets].
         pub fn set_autoscaling_targets<
             T: std::convert::Into<std::option::Option<crate::model::AutoscalingTargets>>,
         >(
@@ -4521,7 +4537,7 @@ pub mod cluster {
     }
 
     impl ClusterConfig {
-        /// Sets the value of `cluster_autoscaling_config`.
+        /// Sets the value of [cluster_autoscaling_config][crate::model::cluster::ClusterConfig::cluster_autoscaling_config].
         pub fn set_cluster_autoscaling_config<
             T: std::convert::Into<
                 std::option::Option<crate::model::cluster::ClusterAutoscalingConfig>,
@@ -4564,7 +4580,7 @@ pub mod cluster {
     }
 
     impl EncryptionConfig {
-        /// Sets the value of `kms_key_name`.
+        /// Sets the value of [kms_key_name][crate::model::cluster::EncryptionConfig::kms_key_name].
         pub fn set_kms_key_name<T: std::convert::Into<std::string::String>>(
             mut self,
             v: T,
@@ -4703,19 +4719,19 @@ pub struct AppProfile {
 }
 
 impl AppProfile {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::AppProfile::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::AppProfile::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::AppProfile::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
@@ -4784,12 +4800,14 @@ pub mod app_profile {
     }
 
     impl MultiClusterRoutingUseAny {
-        /// Sets the value of `cluster_ids`.
-        pub fn set_cluster_ids<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.cluster_ids = v.into();
+        /// Sets the value of [cluster_ids][crate::model::app_profile::MultiClusterRoutingUseAny::cluster_ids].
+        pub fn set_cluster_ids<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.cluster_ids = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -4880,13 +4898,13 @@ pub mod app_profile {
     }
 
     impl SingleClusterRouting {
-        /// Sets the value of `cluster_id`.
+        /// Sets the value of [cluster_id][crate::model::app_profile::SingleClusterRouting::cluster_id].
         pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.cluster_id = v.into();
             self
         }
 
-        /// Sets the value of `allow_transactional_writes`.
+        /// Sets the value of [allow_transactional_writes][crate::model::app_profile::SingleClusterRouting::allow_transactional_writes].
         pub fn set_allow_transactional_writes<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.allow_transactional_writes = v.into();
             self
@@ -4911,7 +4929,7 @@ pub mod app_profile {
     }
 
     impl StandardIsolation {
-        /// Sets the value of `priority`.
+        /// Sets the value of [priority][crate::model::app_profile::StandardIsolation::priority].
         pub fn set_priority<T: std::convert::Into<crate::model::app_profile::Priority>>(
             mut self,
             v: T,
@@ -4952,7 +4970,7 @@ pub mod app_profile {
     }
 
     impl DataBoostIsolationReadOnly {
-        /// Sets the value of `compute_billing_owner`.
+        /// Sets the value of [compute_billing_owner][crate::model::app_profile::DataBoostIsolationReadOnly::compute_billing_owner].
         pub fn set_compute_billing_owner<
             T: std::convert::Into<
                 std::option::Option<
@@ -5117,19 +5135,19 @@ pub struct HotTablet {
 }
 
 impl HotTablet {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::HotTablet::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `table_name`.
+    /// Sets the value of [table_name][crate::model::HotTablet::table_name].
     pub fn set_table_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.table_name = v.into();
         self
     }
 
-    /// Sets the value of `start_time`.
+    /// Sets the value of [start_time][crate::model::HotTablet::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -5138,7 +5156,7 @@ impl HotTablet {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::HotTablet::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -5147,19 +5165,19 @@ impl HotTablet {
         self
     }
 
-    /// Sets the value of `start_key`.
+    /// Sets the value of [start_key][crate::model::HotTablet::start_key].
     pub fn set_start_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.start_key = v.into();
         self
     }
 
-    /// Sets the value of `end_key`.
+    /// Sets the value of [end_key][crate::model::HotTablet::end_key].
     pub fn set_end_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.end_key = v.into();
         self
     }
 
-    /// Sets the value of `node_cpu_usage_percent`.
+    /// Sets the value of [node_cpu_usage_percent][crate::model::HotTablet::node_cpu_usage_percent].
     pub fn set_node_cpu_usage_percent<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
         self.node_cpu_usage_percent = v.into();
         self
@@ -5187,7 +5205,7 @@ pub struct RestoreInfo {
 }
 
 impl RestoreInfo {
-    /// Sets the value of `source_type`.
+    /// Sets the value of [source_type][crate::model::RestoreInfo::source_type].
     pub fn set_source_type<T: std::convert::Into<crate::model::RestoreSourceType>>(
         mut self,
         v: T,
@@ -5246,7 +5264,7 @@ pub struct ChangeStreamConfig {
 }
 
 impl ChangeStreamConfig {
-    /// Sets the value of `retention_period`.
+    /// Sets the value of [retention_period][crate::model::ChangeStreamConfig::retention_period].
     pub fn set_retention_period<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
@@ -5321,39 +5339,13 @@ pub struct Table {
 }
 
 impl Table {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Table::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `cluster_states`.
-    pub fn set_cluster_states<
-        T: std::convert::Into<
-            std::collections::HashMap<std::string::String, crate::model::table::ClusterState>,
-        >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cluster_states = v.into();
-        self
-    }
-
-    /// Sets the value of `column_families`.
-    pub fn set_column_families<
-        T: std::convert::Into<
-            std::collections::HashMap<std::string::String, crate::model::ColumnFamily>,
-        >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.column_families = v.into();
-        self
-    }
-
-    /// Sets the value of `granularity`.
+    /// Sets the value of [granularity][crate::model::Table::granularity].
     pub fn set_granularity<T: std::convert::Into<crate::model::table::TimestampGranularity>>(
         mut self,
         v: T,
@@ -5362,7 +5354,7 @@ impl Table {
         self
     }
 
-    /// Sets the value of `restore_info`.
+    /// Sets the value of [restore_info][crate::model::Table::restore_info].
     pub fn set_restore_info<
         T: std::convert::Into<std::option::Option<crate::model::RestoreInfo>>,
     >(
@@ -5373,7 +5365,7 @@ impl Table {
         self
     }
 
-    /// Sets the value of `change_stream_config`.
+    /// Sets the value of [change_stream_config][crate::model::Table::change_stream_config].
     pub fn set_change_stream_config<
         T: std::convert::Into<std::option::Option<crate::model::ChangeStreamConfig>>,
     >(
@@ -5384,9 +5376,33 @@ impl Table {
         self
     }
 
-    /// Sets the value of `deletion_protection`.
+    /// Sets the value of [deletion_protection][crate::model::Table::deletion_protection].
     pub fn set_deletion_protection<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.deletion_protection = v.into();
+        self
+    }
+
+    /// Sets the value of [cluster_states][crate::model::Table::cluster_states].
+    pub fn set_cluster_states<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::table::ClusterState>,
+    {
+        use std::iter::Iterator;
+        self.cluster_states = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [column_families][crate::model::Table::column_families].
+    pub fn set_column_families<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::ColumnFamily>,
+    {
+        use std::iter::Iterator;
+        self.column_families = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -5432,7 +5448,7 @@ pub mod table {
     }
 
     impl ClusterState {
-        /// Sets the value of `replication_state`.
+        /// Sets the value of [replication_state][crate::model::table::ClusterState::replication_state].
         pub fn set_replication_state<
             T: std::convert::Into<crate::model::table::cluster_state::ReplicationState>,
         >(
@@ -5443,14 +5459,14 @@ pub mod table {
             self
         }
 
-        /// Sets the value of `encryption_info`.
-        pub fn set_encryption_info<
-            T: std::convert::Into<std::vec::Vec<crate::model::EncryptionInfo>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.encryption_info = v.into();
+        /// Sets the value of [encryption_info][crate::model::table::ClusterState::encryption_info].
+        pub fn set_encryption_info<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::EncryptionInfo>,
+        {
+            use std::iter::Iterator;
+            self.encryption_info = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -5532,7 +5548,7 @@ pub mod table {
     }
 
     impl AutomatedBackupPolicy {
-        /// Sets the value of `retention_period`.
+        /// Sets the value of [retention_period][crate::model::table::AutomatedBackupPolicy::retention_period].
         pub fn set_retention_period<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
             mut self,
             v: T,
@@ -5541,7 +5557,7 @@ pub mod table {
             self
         }
 
-        /// Sets the value of `frequency`.
+        /// Sets the value of [frequency][crate::model::table::AutomatedBackupPolicy::frequency].
         pub fn set_frequency<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
             mut self,
             v: T,
@@ -5667,19 +5683,19 @@ pub struct AuthorizedView {
 }
 
 impl AuthorizedView {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::AuthorizedView::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::AuthorizedView::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `deletion_protection`.
+    /// Sets the value of [deletion_protection][crate::model::AuthorizedView::deletion_protection].
     pub fn set_deletion_protection<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.deletion_protection = v.into();
         self
@@ -5730,21 +5746,25 @@ pub mod authorized_view {
     }
 
     impl FamilySubsets {
-        /// Sets the value of `qualifiers`.
-        pub fn set_qualifiers<T: std::convert::Into<std::vec::Vec<bytes::Bytes>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.qualifiers = v.into();
+        /// Sets the value of [qualifiers][crate::model::authorized_view::FamilySubsets::qualifiers].
+        pub fn set_qualifiers<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<bytes::Bytes>,
+        {
+            use std::iter::Iterator;
+            self.qualifiers = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
-        /// Sets the value of `qualifier_prefixes`.
-        pub fn set_qualifier_prefixes<T: std::convert::Into<std::vec::Vec<bytes::Bytes>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.qualifier_prefixes = v.into();
+        /// Sets the value of [qualifier_prefixes][crate::model::authorized_view::FamilySubsets::qualifier_prefixes].
+        pub fn set_qualifier_prefixes<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<bytes::Bytes>,
+        {
+            use std::iter::Iterator;
+            self.qualifier_prefixes = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -5777,28 +5797,26 @@ pub mod authorized_view {
     }
 
     impl SubsetView {
-        /// Sets the value of `row_prefixes`.
-        pub fn set_row_prefixes<T: std::convert::Into<std::vec::Vec<bytes::Bytes>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.row_prefixes = v.into();
+        /// Sets the value of [row_prefixes][crate::model::authorized_view::SubsetView::row_prefixes].
+        pub fn set_row_prefixes<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<bytes::Bytes>,
+        {
+            use std::iter::Iterator;
+            self.row_prefixes = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
-        /// Sets the value of `family_subsets`.
-        pub fn set_family_subsets<
-            T: std::convert::Into<
-                std::collections::HashMap<
-                    std::string::String,
-                    crate::model::authorized_view::FamilySubsets,
-                >,
-            >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.family_subsets = v.into();
+        /// Sets the value of [family_subsets][crate::model::authorized_view::SubsetView::family_subsets].
+        pub fn set_family_subsets<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<crate::model::authorized_view::FamilySubsets>,
+        {
+            use std::iter::Iterator;
+            self.family_subsets = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -5883,7 +5901,7 @@ pub struct ColumnFamily {
 }
 
 impl ColumnFamily {
-    /// Sets the value of `gc_rule`.
+    /// Sets the value of [gc_rule][crate::model::ColumnFamily::gc_rule].
     pub fn set_gc_rule<T: std::convert::Into<std::option::Option<crate::model::GcRule>>>(
         mut self,
         v: T,
@@ -5892,7 +5910,7 @@ impl ColumnFamily {
         self
     }
 
-    /// Sets the value of `value_type`.
+    /// Sets the value of [value_type][crate::model::ColumnFamily::value_type].
     pub fn set_value_type<T: std::convert::Into<std::option::Option<crate::model::Type>>>(
         mut self,
         v: T,
@@ -5953,12 +5971,14 @@ pub mod gc_rule {
     }
 
     impl Intersection {
-        /// Sets the value of `rules`.
-        pub fn set_rules<T: std::convert::Into<std::vec::Vec<crate::model::GcRule>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.rules = v.into();
+        /// Sets the value of [rules][crate::model::gc_rule::Intersection::rules].
+        pub fn set_rules<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::GcRule>,
+        {
+            use std::iter::Iterator;
+            self.rules = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -5981,12 +6001,14 @@ pub mod gc_rule {
     }
 
     impl Union {
-        /// Sets the value of `rules`.
-        pub fn set_rules<T: std::convert::Into<std::vec::Vec<crate::model::GcRule>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.rules = v.into();
+        /// Sets the value of [rules][crate::model::gc_rule::Union::rules].
+        pub fn set_rules<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::GcRule>,
+        {
+            use std::iter::Iterator;
+            self.rules = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -6040,7 +6062,7 @@ pub struct EncryptionInfo {
 }
 
 impl EncryptionInfo {
-    /// Sets the value of `encryption_type`.
+    /// Sets the value of [encryption_type][crate::model::EncryptionInfo::encryption_type].
     pub fn set_encryption_type<
         T: std::convert::Into<crate::model::encryption_info::EncryptionType>,
     >(
@@ -6051,7 +6073,7 @@ impl EncryptionInfo {
         self
     }
 
-    /// Sets the value of `encryption_status`.
+    /// Sets the value of [encryption_status][crate::model::EncryptionInfo::encryption_status].
     pub fn set_encryption_status<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
         mut self,
         v: T,
@@ -6060,7 +6082,7 @@ impl EncryptionInfo {
         self
     }
 
-    /// Sets the value of `kms_key_version`.
+    /// Sets the value of [kms_key_version][crate::model::EncryptionInfo::kms_key_version].
     pub fn set_kms_key_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kms_key_version = v.into();
         self
@@ -6165,13 +6187,13 @@ pub struct Snapshot {
 }
 
 impl Snapshot {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Snapshot::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `source_table`.
+    /// Sets the value of [source_table][crate::model::Snapshot::source_table].
     pub fn set_source_table<T: std::convert::Into<std::option::Option<crate::model::Table>>>(
         mut self,
         v: T,
@@ -6180,13 +6202,13 @@ impl Snapshot {
         self
     }
 
-    /// Sets the value of `data_size_bytes`.
+    /// Sets the value of [data_size_bytes][crate::model::Snapshot::data_size_bytes].
     pub fn set_data_size_bytes<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.data_size_bytes = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::Snapshot::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -6195,7 +6217,7 @@ impl Snapshot {
         self
     }
 
-    /// Sets the value of `delete_time`.
+    /// Sets the value of [delete_time][crate::model::Snapshot::delete_time].
     pub fn set_delete_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -6204,13 +6226,13 @@ impl Snapshot {
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::Snapshot::state].
     pub fn set_state<T: std::convert::Into<crate::model::snapshot::State>>(mut self, v: T) -> Self {
         self.state = v.into();
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::Snapshot::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
@@ -6347,25 +6369,25 @@ pub struct Backup {
 }
 
 impl Backup {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Backup::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `source_table`.
+    /// Sets the value of [source_table][crate::model::Backup::source_table].
     pub fn set_source_table<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.source_table = v.into();
         self
     }
 
-    /// Sets the value of `source_backup`.
+    /// Sets the value of [source_backup][crate::model::Backup::source_backup].
     pub fn set_source_backup<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.source_backup = v.into();
         self
     }
 
-    /// Sets the value of `expire_time`.
+    /// Sets the value of [expire_time][crate::model::Backup::expire_time].
     pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -6374,7 +6396,7 @@ impl Backup {
         self
     }
 
-    /// Sets the value of `start_time`.
+    /// Sets the value of [start_time][crate::model::Backup::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -6383,7 +6405,7 @@ impl Backup {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::Backup::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -6392,19 +6414,19 @@ impl Backup {
         self
     }
 
-    /// Sets the value of `size_bytes`.
+    /// Sets the value of [size_bytes][crate::model::Backup::size_bytes].
     pub fn set_size_bytes<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.size_bytes = v.into();
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::Backup::state].
     pub fn set_state<T: std::convert::Into<crate::model::backup::State>>(mut self, v: T) -> Self {
         self.state = v.into();
         self
     }
 
-    /// Sets the value of `encryption_info`.
+    /// Sets the value of [encryption_info][crate::model::Backup::encryption_info].
     pub fn set_encryption_info<
         T: std::convert::Into<std::option::Option<crate::model::EncryptionInfo>>,
     >(
@@ -6415,7 +6437,7 @@ impl Backup {
         self
     }
 
-    /// Sets the value of `backup_type`.
+    /// Sets the value of [backup_type][crate::model::Backup::backup_type].
     pub fn set_backup_type<T: std::convert::Into<crate::model::backup::BackupType>>(
         mut self,
         v: T,
@@ -6424,7 +6446,7 @@ impl Backup {
         self
     }
 
-    /// Sets the value of `hot_to_standard_time`.
+    /// Sets the value of [hot_to_standard_time][crate::model::Backup::hot_to_standard_time].
     pub fn set_hot_to_standard_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -6545,13 +6567,13 @@ pub struct BackupInfo {
 }
 
 impl BackupInfo {
-    /// Sets the value of `backup`.
+    /// Sets the value of [backup][crate::model::BackupInfo::backup].
     pub fn set_backup<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.backup = v.into();
         self
     }
 
-    /// Sets the value of `start_time`.
+    /// Sets the value of [start_time][crate::model::BackupInfo::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -6560,7 +6582,7 @@ impl BackupInfo {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::BackupInfo::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -6569,13 +6591,13 @@ impl BackupInfo {
         self
     }
 
-    /// Sets the value of `source_table`.
+    /// Sets the value of [source_table][crate::model::BackupInfo::source_table].
     pub fn set_source_table<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.source_table = v.into();
         self
     }
 
-    /// Sets the value of `source_backup`.
+    /// Sets the value of [source_backup][crate::model::BackupInfo::source_backup].
     pub fn set_source_backup<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.source_backup = v.into();
         self
@@ -6657,7 +6679,7 @@ pub mod r#type {
     }
 
     impl Bytes {
-        /// Sets the value of `encoding`.
+        /// Sets the value of [encoding][crate::model::r#type::Bytes::encoding].
         pub fn set_encoding<
             T: std::convert::Into<std::option::Option<crate::model::r#type::bytes::Encoding>>,
         >(
@@ -6760,7 +6782,7 @@ pub mod r#type {
     }
 
     impl String {
-        /// Sets the value of `encoding`.
+        /// Sets the value of [encoding][crate::model::r#type::String::encoding].
         pub fn set_encoding<
             T: std::convert::Into<std::option::Option<crate::model::r#type::string::Encoding>>,
         >(
@@ -6883,7 +6905,7 @@ pub mod r#type {
     }
 
     impl Int64 {
-        /// Sets the value of `encoding`.
+        /// Sets the value of [encoding][crate::model::r#type::Int64::encoding].
         pub fn set_encoding<
             T: std::convert::Into<std::option::Option<crate::model::r#type::int_64::Encoding>>,
         >(
@@ -6963,7 +6985,7 @@ pub mod r#type {
             }
 
             impl BigEndianBytes {
-                /// Sets the value of `bytes_type`.
+                /// Sets the value of [bytes_type][crate::model::r#type::int_64::encoding::BigEndianBytes::bytes_type].
                 pub fn set_bytes_type<
                     T: std::convert::Into<std::option::Option<crate::model::r#type::Bytes>>,
                 >(
@@ -7087,14 +7109,14 @@ pub mod r#type {
     }
 
     impl Struct {
-        /// Sets the value of `fields`.
-        pub fn set_fields<
-            T: std::convert::Into<std::vec::Vec<crate::model::r#type::r#struct::Field>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.fields = v.into();
+        /// Sets the value of [fields][crate::model::r#type::Struct::fields].
+        pub fn set_fields<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::r#type::r#struct::Field>,
+        {
+            use std::iter::Iterator;
+            self.fields = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -7128,7 +7150,7 @@ pub mod r#type {
         }
 
         impl Field {
-            /// Sets the value of `field_name`.
+            /// Sets the value of [field_name][crate::model::r#type::r#struct::Field::field_name].
             pub fn set_field_name<T: std::convert::Into<std::string::String>>(
                 mut self,
                 v: T,
@@ -7137,7 +7159,7 @@ pub mod r#type {
                 self
             }
 
-            /// Sets the value of `r#type`.
+            /// Sets the value of [r#type][crate::model::r#type::r#struct::Field::type].
             pub fn set_type<
                 T: std::convert::Into<std::option::Option<std::boxed::Box<crate::model::Type>>>,
             >(
@@ -7169,7 +7191,7 @@ pub mod r#type {
     }
 
     impl Array {
-        /// Sets the value of `element_type`.
+        /// Sets the value of [element_type][crate::model::r#type::Array::element_type].
         pub fn set_element_type<
             T: std::convert::Into<std::option::Option<std::boxed::Box<crate::model::Type>>>,
         >(
@@ -7210,7 +7232,7 @@ pub mod r#type {
     }
 
     impl Map {
-        /// Sets the value of `key_type`.
+        /// Sets the value of [key_type][crate::model::r#type::Map::key_type].
         pub fn set_key_type<
             T: std::convert::Into<std::option::Option<std::boxed::Box<crate::model::Type>>>,
         >(
@@ -7221,7 +7243,7 @@ pub mod r#type {
             self
         }
 
-        /// Sets the value of `value_type`.
+        /// Sets the value of [value_type][crate::model::r#type::Map::value_type].
         pub fn set_value_type<
             T: std::convert::Into<std::option::Option<std::boxed::Box<crate::model::Type>>>,
         >(
@@ -7267,7 +7289,7 @@ pub mod r#type {
     }
 
     impl Aggregate {
-        /// Sets the value of `input_type`.
+        /// Sets the value of [input_type][crate::model::r#type::Aggregate::input_type].
         pub fn set_input_type<
             T: std::convert::Into<std::option::Option<std::boxed::Box<crate::model::Type>>>,
         >(
@@ -7278,7 +7300,7 @@ pub mod r#type {
             self
         }
 
-        /// Sets the value of `state_type`.
+        /// Sets the value of [state_type][crate::model::r#type::Aggregate::state_type].
         pub fn set_state_type<
             T: std::convert::Into<std::option::Option<std::boxed::Box<crate::model::Type>>>,
         >(

--- a/src/generated/cloud/functions/v2/src/builders.rs
+++ b/src/generated/cloud/functions/v2/src/builders.rs
@@ -67,13 +67,13 @@ pub mod function_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetFunctionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `revision`.
+        /// Sets the value of [revision][crate::model::GetFunctionRequest::revision].
         pub fn set_revision<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.revision = v.into();
             self
@@ -129,31 +129,31 @@ pub mod function_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListFunctionsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListFunctionsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListFunctionsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListFunctionsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `order_by`.
+        /// Sets the value of [order_by][crate::model::ListFunctionsRequest::order_by].
         pub fn set_order_by<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.order_by = v.into();
             self
@@ -232,13 +232,13 @@ pub mod function_service {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateFunctionRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `function`.
+        /// Sets the value of [function][crate::model::CreateFunctionRequest::function].
         pub fn set_function<T: Into<std::option::Option<crate::model::Function>>>(
             mut self,
             v: T,
@@ -247,7 +247,7 @@ pub mod function_service {
             self
         }
 
-        /// Sets the value of `function_id`.
+        /// Sets the value of [function_id][crate::model::CreateFunctionRequest::function_id].
         pub fn set_function_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.function_id = v.into();
             self
@@ -326,7 +326,7 @@ pub mod function_service {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `function`.
+        /// Sets the value of [function][crate::model::UpdateFunctionRequest::function].
         pub fn set_function<T: Into<std::option::Option<crate::model::Function>>>(
             mut self,
             v: T,
@@ -335,7 +335,7 @@ pub mod function_service {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateFunctionRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -414,7 +414,7 @@ pub mod function_service {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteFunctionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -458,19 +458,19 @@ pub mod function_service {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::GenerateUploadUrlRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `kms_key_name`.
+        /// Sets the value of [kms_key_name][crate::model::GenerateUploadUrlRequest::kms_key_name].
         pub fn set_kms_key_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.kms_key_name = v.into();
             self
         }
 
-        /// Sets the value of `environment`.
+        /// Sets the value of [environment][crate::model::GenerateUploadUrlRequest::environment].
         pub fn set_environment<T: Into<crate::model::Environment>>(mut self, v: T) -> Self {
             self.0.request.environment = v.into();
             self
@@ -514,7 +514,7 @@ pub mod function_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GenerateDownloadUrlRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -555,13 +555,13 @@ pub mod function_service {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListRuntimesRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListRuntimesRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
@@ -620,25 +620,25 @@ pub mod function_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][location::model::ListLocationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][location::model::ListLocationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][location::model::ListLocationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][location::model::ListLocationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -679,13 +679,13 @@ pub mod function_service {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::SetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][iam_v1::model::SetIamPolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<iam_v1::model::Policy>>>(
             mut self,
             v: T,
@@ -694,7 +694,7 @@ pub mod function_service {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][iam_v1::model::SetIamPolicyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -738,13 +738,13 @@ pub mod function_service {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::GetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `options`.
+        /// Sets the value of [options][iam_v1::model::GetIamPolicyRequest::options].
         pub fn set_options<T: Into<std::option::Option<iam_v1::model::GetPolicyOptions>>>(
             mut self,
             v: T,
@@ -791,18 +791,20 @@ pub mod function_service {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::TestIamPermissionsRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `permissions`.
-        pub fn set_permissions<T: Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.permissions = v.into();
+        /// Sets the value of [permissions][iam_v1::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -859,25 +861,25 @@ pub mod function_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::ListOperationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][longrunning::model::ListOperationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][longrunning::model::ListOperationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][longrunning::model::ListOperationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -921,7 +923,7 @@ pub mod function_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::GetOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self

--- a/src/generated/cloud/functions/v2/src/model.rs
+++ b/src/generated/cloud/functions/v2/src/model.rs
@@ -107,19 +107,19 @@ pub struct Function {
 }
 
 impl Function {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Function::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::Function::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
     }
 
-    /// Sets the value of `build_config`.
+    /// Sets the value of [build_config][crate::model::Function::build_config].
     pub fn set_build_config<
         T: std::convert::Into<std::option::Option<crate::model::BuildConfig>>,
     >(
@@ -130,7 +130,7 @@ impl Function {
         self
     }
 
-    /// Sets the value of `service_config`.
+    /// Sets the value of [service_config][crate::model::Function::service_config].
     pub fn set_service_config<
         T: std::convert::Into<std::option::Option<crate::model::ServiceConfig>>,
     >(
@@ -141,7 +141,7 @@ impl Function {
         self
     }
 
-    /// Sets the value of `event_trigger`.
+    /// Sets the value of [event_trigger][crate::model::Function::event_trigger].
     pub fn set_event_trigger<
         T: std::convert::Into<std::option::Option<crate::model::EventTrigger>>,
     >(
@@ -152,13 +152,13 @@ impl Function {
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::Function::state].
     pub fn set_state<T: std::convert::Into<crate::model::function::State>>(mut self, v: T) -> Self {
         self.state = v.into();
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::Function::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -167,27 +167,7 @@ impl Function {
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `state_messages`.
-    pub fn set_state_messages<T: std::convert::Into<std::vec::Vec<crate::model::StateMessage>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.state_messages = v.into();
-        self
-    }
-
-    /// Sets the value of `environment`.
+    /// Sets the value of [environment][crate::model::Function::environment].
     pub fn set_environment<T: std::convert::Into<crate::model::Environment>>(
         mut self,
         v: T,
@@ -196,30 +176,53 @@ impl Function {
         self
     }
 
-    /// Sets the value of `url`.
+    /// Sets the value of [url][crate::model::Function::url].
     pub fn set_url<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.url = v.into();
         self
     }
 
-    /// Sets the value of `kms_key_name`.
+    /// Sets the value of [kms_key_name][crate::model::Function::kms_key_name].
     pub fn set_kms_key_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kms_key_name = v.into();
         self
     }
 
-    /// Sets the value of `satisfies_pzs`.
+    /// Sets the value of [satisfies_pzs][crate::model::Function::satisfies_pzs].
     pub fn set_satisfies_pzs<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzs = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::Function::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
     ) -> Self {
         self.create_time = v.into();
+        self
+    }
+
+    /// Sets the value of [state_messages][crate::model::Function::state_messages].
+    pub fn set_state_messages<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::StateMessage>,
+    {
+        use std::iter::Iterator;
+        self.state_messages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Function::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -296,7 +299,7 @@ pub struct StateMessage {
 }
 
 impl StateMessage {
-    /// Sets the value of `severity`.
+    /// Sets the value of [severity][crate::model::StateMessage::severity].
     pub fn set_severity<T: std::convert::Into<crate::model::state_message::Severity>>(
         mut self,
         v: T,
@@ -305,13 +308,13 @@ impl StateMessage {
         self
     }
 
-    /// Sets the value of `r#type`.
+    /// Sets the value of [r#type][crate::model::StateMessage::type].
     pub fn set_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.r#type = v.into();
         self
     }
 
-    /// Sets the value of `message`.
+    /// Sets the value of [message][crate::model::StateMessage::message].
     pub fn set_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.message = v.into();
         self
@@ -395,25 +398,25 @@ pub struct StorageSource {
 }
 
 impl StorageSource {
-    /// Sets the value of `bucket`.
+    /// Sets the value of [bucket][crate::model::StorageSource::bucket].
     pub fn set_bucket<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.bucket = v.into();
         self
     }
 
-    /// Sets the value of `object`.
+    /// Sets the value of [object][crate::model::StorageSource::object].
     pub fn set_object<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.object = v.into();
         self
     }
 
-    /// Sets the value of `generation`.
+    /// Sets the value of [generation][crate::model::StorageSource::generation].
     pub fn set_generation<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.generation = v.into();
         self
     }
 
-    /// Sets the value of `source_upload_url`.
+    /// Sets the value of [source_upload_url][crate::model::StorageSource::source_upload_url].
     pub fn set_source_upload_url<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -463,25 +466,25 @@ pub struct RepoSource {
 }
 
 impl RepoSource {
-    /// Sets the value of `project_id`.
+    /// Sets the value of [project_id][crate::model::RepoSource::project_id].
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
-    /// Sets the value of `repo_name`.
+    /// Sets the value of [repo_name][crate::model::RepoSource::repo_name].
     pub fn set_repo_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.repo_name = v.into();
         self
     }
 
-    /// Sets the value of `dir`.
+    /// Sets the value of [dir][crate::model::RepoSource::dir].
     pub fn set_dir<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.dir = v.into();
         self
     }
 
-    /// Sets the value of `invert_regex`.
+    /// Sets the value of [invert_regex][crate::model::RepoSource::invert_regex].
     pub fn set_invert_regex<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.invert_regex = v.into();
         self
@@ -607,7 +610,7 @@ pub struct SourceProvenance {
 }
 
 impl SourceProvenance {
-    /// Sets the value of `resolved_storage_source`.
+    /// Sets the value of [resolved_storage_source][crate::model::SourceProvenance::resolved_storage_source].
     pub fn set_resolved_storage_source<
         T: std::convert::Into<std::option::Option<crate::model::StorageSource>>,
     >(
@@ -618,7 +621,7 @@ impl SourceProvenance {
         self
     }
 
-    /// Sets the value of `resolved_repo_source`.
+    /// Sets the value of [resolved_repo_source][crate::model::SourceProvenance::resolved_repo_source].
     pub fn set_resolved_repo_source<
         T: std::convert::Into<std::option::Option<crate::model::RepoSource>>,
     >(
@@ -629,7 +632,7 @@ impl SourceProvenance {
         self
     }
 
-    /// Sets the value of `git_uri`.
+    /// Sets the value of [git_uri][crate::model::SourceProvenance::git_uri].
     pub fn set_git_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.git_uri = v.into();
         self
@@ -733,25 +736,25 @@ pub struct BuildConfig {
 }
 
 impl BuildConfig {
-    /// Sets the value of `build`.
+    /// Sets the value of [build][crate::model::BuildConfig::build].
     pub fn set_build<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.build = v.into();
         self
     }
 
-    /// Sets the value of `runtime`.
+    /// Sets the value of [runtime][crate::model::BuildConfig::runtime].
     pub fn set_runtime<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.runtime = v.into();
         self
     }
 
-    /// Sets the value of `entry_point`.
+    /// Sets the value of [entry_point][crate::model::BuildConfig::entry_point].
     pub fn set_entry_point<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.entry_point = v.into();
         self
     }
 
-    /// Sets the value of `source`.
+    /// Sets the value of [source][crate::model::BuildConfig::source].
     pub fn set_source<T: std::convert::Into<std::option::Option<crate::model::Source>>>(
         mut self,
         v: T,
@@ -760,7 +763,7 @@ impl BuildConfig {
         self
     }
 
-    /// Sets the value of `source_provenance`.
+    /// Sets the value of [source_provenance][crate::model::BuildConfig::source_provenance].
     pub fn set_source_provenance<
         T: std::convert::Into<std::option::Option<crate::model::SourceProvenance>>,
     >(
@@ -771,24 +774,13 @@ impl BuildConfig {
         self
     }
 
-    /// Sets the value of `worker_pool`.
+    /// Sets the value of [worker_pool][crate::model::BuildConfig::worker_pool].
     pub fn set_worker_pool<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.worker_pool = v.into();
         self
     }
 
-    /// Sets the value of `environment_variables`.
-    pub fn set_environment_variables<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.environment_variables = v.into();
-        self
-    }
-
-    /// Sets the value of `docker_registry`.
+    /// Sets the value of [docker_registry][crate::model::BuildConfig::docker_registry].
     pub fn set_docker_registry<
         T: std::convert::Into<crate::model::build_config::DockerRegistry>,
     >(
@@ -799,7 +791,7 @@ impl BuildConfig {
         self
     }
 
-    /// Sets the value of `docker_repository`.
+    /// Sets the value of [docker_repository][crate::model::BuildConfig::docker_repository].
     pub fn set_docker_repository<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -808,9 +800,21 @@ impl BuildConfig {
         self
     }
 
-    /// Sets the value of `service_account`.
+    /// Sets the value of [service_account][crate::model::BuildConfig::service_account].
     pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_account = v.into();
+        self
+    }
+
+    /// Sets the value of [environment_variables][crate::model::BuildConfig::environment_variables].
+    pub fn set_environment_variables<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.environment_variables = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -1004,19 +1008,19 @@ pub struct ServiceConfig {
 }
 
 impl ServiceConfig {
-    /// Sets the value of `service`.
+    /// Sets the value of [service][crate::model::ServiceConfig::service].
     pub fn set_service<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service = v.into();
         self
     }
 
-    /// Sets the value of `timeout_seconds`.
+    /// Sets the value of [timeout_seconds][crate::model::ServiceConfig::timeout_seconds].
     pub fn set_timeout_seconds<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.timeout_seconds = v.into();
         self
     }
 
-    /// Sets the value of `available_memory`.
+    /// Sets the value of [available_memory][crate::model::ServiceConfig::available_memory].
     pub fn set_available_memory<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -1025,42 +1029,31 @@ impl ServiceConfig {
         self
     }
 
-    /// Sets the value of `available_cpu`.
+    /// Sets the value of [available_cpu][crate::model::ServiceConfig::available_cpu].
     pub fn set_available_cpu<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.available_cpu = v.into();
         self
     }
 
-    /// Sets the value of `environment_variables`.
-    pub fn set_environment_variables<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.environment_variables = v.into();
-        self
-    }
-
-    /// Sets the value of `max_instance_count`.
+    /// Sets the value of [max_instance_count][crate::model::ServiceConfig::max_instance_count].
     pub fn set_max_instance_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.max_instance_count = v.into();
         self
     }
 
-    /// Sets the value of `min_instance_count`.
+    /// Sets the value of [min_instance_count][crate::model::ServiceConfig::min_instance_count].
     pub fn set_min_instance_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.min_instance_count = v.into();
         self
     }
 
-    /// Sets the value of `vpc_connector`.
+    /// Sets the value of [vpc_connector][crate::model::ServiceConfig::vpc_connector].
     pub fn set_vpc_connector<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.vpc_connector = v.into();
         self
     }
 
-    /// Sets the value of `vpc_connector_egress_settings`.
+    /// Sets the value of [vpc_connector_egress_settings][crate::model::ServiceConfig::vpc_connector_egress_settings].
     pub fn set_vpc_connector_egress_settings<
         T: std::convert::Into<crate::model::service_config::VpcConnectorEgressSettings>,
     >(
@@ -1071,7 +1064,7 @@ impl ServiceConfig {
         self
     }
 
-    /// Sets the value of `ingress_settings`.
+    /// Sets the value of [ingress_settings][crate::model::ServiceConfig::ingress_settings].
     pub fn set_ingress_settings<
         T: std::convert::Into<crate::model::service_config::IngressSettings>,
     >(
@@ -1082,13 +1075,13 @@ impl ServiceConfig {
         self
     }
 
-    /// Sets the value of `uri`.
+    /// Sets the value of [uri][crate::model::ServiceConfig::uri].
     pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.uri = v.into();
         self
     }
 
-    /// Sets the value of `service_account_email`.
+    /// Sets the value of [service_account_email][crate::model::ServiceConfig::service_account_email].
     pub fn set_service_account_email<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -1097,39 +1090,19 @@ impl ServiceConfig {
         self
     }
 
-    /// Sets the value of `all_traffic_on_latest_revision`.
+    /// Sets the value of [all_traffic_on_latest_revision][crate::model::ServiceConfig::all_traffic_on_latest_revision].
     pub fn set_all_traffic_on_latest_revision<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.all_traffic_on_latest_revision = v.into();
         self
     }
 
-    /// Sets the value of `secret_environment_variables`.
-    pub fn set_secret_environment_variables<
-        T: std::convert::Into<std::vec::Vec<crate::model::SecretEnvVar>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.secret_environment_variables = v.into();
-        self
-    }
-
-    /// Sets the value of `secret_volumes`.
-    pub fn set_secret_volumes<T: std::convert::Into<std::vec::Vec<crate::model::SecretVolume>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.secret_volumes = v.into();
-        self
-    }
-
-    /// Sets the value of `revision`.
+    /// Sets the value of [revision][crate::model::ServiceConfig::revision].
     pub fn set_revision<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.revision = v.into();
         self
     }
 
-    /// Sets the value of `max_instance_request_concurrency`.
+    /// Sets the value of [max_instance_request_concurrency][crate::model::ServiceConfig::max_instance_request_concurrency].
     pub fn set_max_instance_request_concurrency<T: std::convert::Into<i32>>(
         mut self,
         v: T,
@@ -1138,7 +1111,7 @@ impl ServiceConfig {
         self
     }
 
-    /// Sets the value of `security_level`.
+    /// Sets the value of [security_level][crate::model::ServiceConfig::security_level].
     pub fn set_security_level<
         T: std::convert::Into<crate::model::service_config::SecurityLevel>,
     >(
@@ -1149,12 +1122,46 @@ impl ServiceConfig {
         self
     }
 
-    /// Sets the value of `binary_authorization_policy`.
+    /// Sets the value of [binary_authorization_policy][crate::model::ServiceConfig::binary_authorization_policy].
     pub fn set_binary_authorization_policy<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
     ) -> Self {
         self.binary_authorization_policy = v.into();
+        self
+    }
+
+    /// Sets the value of [secret_environment_variables][crate::model::ServiceConfig::secret_environment_variables].
+    pub fn set_secret_environment_variables<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SecretEnvVar>,
+    {
+        use std::iter::Iterator;
+        self.secret_environment_variables = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [secret_volumes][crate::model::ServiceConfig::secret_volumes].
+    pub fn set_secret_volumes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SecretVolume>,
+    {
+        use std::iter::Iterator;
+        self.secret_volumes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [environment_variables][crate::model::ServiceConfig::environment_variables].
+    pub fn set_environment_variables<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.environment_variables = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1313,25 +1320,25 @@ pub struct SecretEnvVar {
 }
 
 impl SecretEnvVar {
-    /// Sets the value of `key`.
+    /// Sets the value of [key][crate::model::SecretEnvVar::key].
     pub fn set_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.key = v.into();
         self
     }
 
-    /// Sets the value of `project_id`.
+    /// Sets the value of [project_id][crate::model::SecretEnvVar::project_id].
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::SecretEnvVar::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::SecretEnvVar::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
@@ -1378,32 +1385,32 @@ pub struct SecretVolume {
 }
 
 impl SecretVolume {
-    /// Sets the value of `mount_path`.
+    /// Sets the value of [mount_path][crate::model::SecretVolume::mount_path].
     pub fn set_mount_path<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.mount_path = v.into();
         self
     }
 
-    /// Sets the value of `project_id`.
+    /// Sets the value of [project_id][crate::model::SecretVolume::project_id].
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::SecretVolume::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `versions`.
-    pub fn set_versions<
-        T: std::convert::Into<std::vec::Vec<crate::model::secret_volume::SecretVersion>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.versions = v.into();
+    /// Sets the value of [versions][crate::model::SecretVolume::versions].
+    pub fn set_versions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::secret_volume::SecretVersion>,
+    {
+        use std::iter::Iterator;
+        self.versions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1440,13 +1447,13 @@ pub mod secret_volume {
     }
 
     impl SecretVersion {
-        /// Sets the value of `version`.
+        /// Sets the value of [version][crate::model::secret_volume::SecretVersion::version].
         pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.version = v.into();
             self
         }
 
-        /// Sets the value of `path`.
+        /// Sets the value of [path][crate::model::secret_volume::SecretVersion::path].
         pub fn set_path<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.path = v.into();
             self
@@ -1530,40 +1537,31 @@ pub struct EventTrigger {
 }
 
 impl EventTrigger {
-    /// Sets the value of `trigger`.
+    /// Sets the value of [trigger][crate::model::EventTrigger::trigger].
     pub fn set_trigger<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.trigger = v.into();
         self
     }
 
-    /// Sets the value of `trigger_region`.
+    /// Sets the value of [trigger_region][crate::model::EventTrigger::trigger_region].
     pub fn set_trigger_region<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.trigger_region = v.into();
         self
     }
 
-    /// Sets the value of `event_type`.
+    /// Sets the value of [event_type][crate::model::EventTrigger::event_type].
     pub fn set_event_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.event_type = v.into();
         self
     }
 
-    /// Sets the value of `event_filters`.
-    pub fn set_event_filters<T: std::convert::Into<std::vec::Vec<crate::model::EventFilter>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.event_filters = v.into();
-        self
-    }
-
-    /// Sets the value of `pubsub_topic`.
+    /// Sets the value of [pubsub_topic][crate::model::EventTrigger::pubsub_topic].
     pub fn set_pubsub_topic<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.pubsub_topic = v.into();
         self
     }
 
-    /// Sets the value of `service_account_email`.
+    /// Sets the value of [service_account_email][crate::model::EventTrigger::service_account_email].
     pub fn set_service_account_email<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -1572,7 +1570,7 @@ impl EventTrigger {
         self
     }
 
-    /// Sets the value of `retry_policy`.
+    /// Sets the value of [retry_policy][crate::model::EventTrigger::retry_policy].
     pub fn set_retry_policy<T: std::convert::Into<crate::model::event_trigger::RetryPolicy>>(
         mut self,
         v: T,
@@ -1581,15 +1579,26 @@ impl EventTrigger {
         self
     }
 
-    /// Sets the value of `channel`.
+    /// Sets the value of [channel][crate::model::EventTrigger::channel].
     pub fn set_channel<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.channel = v.into();
         self
     }
 
-    /// Sets the value of `service`.
+    /// Sets the value of [service][crate::model::EventTrigger::service].
     pub fn set_service<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service = v.into();
+        self
+    }
+
+    /// Sets the value of [event_filters][crate::model::EventTrigger::event_filters].
+    pub fn set_event_filters<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EventFilter>,
+    {
+        use std::iter::Iterator;
+        self.event_filters = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1661,19 +1670,19 @@ pub struct EventFilter {
 }
 
 impl EventFilter {
-    /// Sets the value of `attribute`.
+    /// Sets the value of [attribute][crate::model::EventFilter::attribute].
     pub fn set_attribute<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.attribute = v.into();
         self
     }
 
-    /// Sets the value of `value`.
+    /// Sets the value of [value][crate::model::EventFilter::value].
     pub fn set_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.value = v.into();
         self
     }
 
-    /// Sets the value of `operator`.
+    /// Sets the value of [operator][crate::model::EventFilter::operator].
     pub fn set_operator<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.operator = v.into();
         self
@@ -1707,13 +1716,13 @@ pub struct GetFunctionRequest {
 }
 
 impl GetFunctionRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetFunctionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `revision`.
+    /// Sets the value of [revision][crate::model::GetFunctionRequest::revision].
     pub fn set_revision<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.revision = v.into();
         self
@@ -1767,31 +1776,31 @@ pub struct ListFunctionsRequest {
 }
 
 impl ListFunctionsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListFunctionsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListFunctionsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListFunctionsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListFunctionsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
     }
 
-    /// Sets the value of `order_by`.
+    /// Sets the value of [order_by][crate::model::ListFunctionsRequest::order_by].
     pub fn set_order_by<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.order_by = v.into();
         self
@@ -1826,27 +1835,31 @@ pub struct ListFunctionsResponse {
 }
 
 impl ListFunctionsResponse {
-    /// Sets the value of `functions`.
-    pub fn set_functions<T: std::convert::Into<std::vec::Vec<crate::model::Function>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.functions = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListFunctionsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `unreachable`.
-    pub fn set_unreachable<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.unreachable = v.into();
+    /// Sets the value of [functions][crate::model::ListFunctionsResponse::functions].
+    pub fn set_functions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Function>,
+    {
+        use std::iter::Iterator;
+        self.functions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [unreachable][crate::model::ListFunctionsResponse::unreachable].
+    pub fn set_unreachable<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.unreachable = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1895,13 +1908,13 @@ pub struct CreateFunctionRequest {
 }
 
 impl CreateFunctionRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateFunctionRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `function`.
+    /// Sets the value of [function][crate::model::CreateFunctionRequest::function].
     pub fn set_function<T: std::convert::Into<std::option::Option<crate::model::Function>>>(
         mut self,
         v: T,
@@ -1910,7 +1923,7 @@ impl CreateFunctionRequest {
         self
     }
 
-    /// Sets the value of `function_id`.
+    /// Sets the value of [function_id][crate::model::CreateFunctionRequest::function_id].
     pub fn set_function_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.function_id = v.into();
         self
@@ -1940,7 +1953,7 @@ pub struct UpdateFunctionRequest {
 }
 
 impl UpdateFunctionRequest {
-    /// Sets the value of `function`.
+    /// Sets the value of [function][crate::model::UpdateFunctionRequest::function].
     pub fn set_function<T: std::convert::Into<std::option::Option<crate::model::Function>>>(
         mut self,
         v: T,
@@ -1949,7 +1962,7 @@ impl UpdateFunctionRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateFunctionRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -1977,7 +1990,7 @@ pub struct DeleteFunctionRequest {
 }
 
 impl DeleteFunctionRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteFunctionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -2027,19 +2040,19 @@ pub struct GenerateUploadUrlRequest {
 }
 
 impl GenerateUploadUrlRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::GenerateUploadUrlRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `kms_key_name`.
+    /// Sets the value of [kms_key_name][crate::model::GenerateUploadUrlRequest::kms_key_name].
     pub fn set_kms_key_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kms_key_name = v.into();
         self
     }
 
-    /// Sets the value of `environment`.
+    /// Sets the value of [environment][crate::model::GenerateUploadUrlRequest::environment].
     pub fn set_environment<T: std::convert::Into<crate::model::Environment>>(
         mut self,
         v: T,
@@ -2080,13 +2093,13 @@ pub struct GenerateUploadUrlResponse {
 }
 
 impl GenerateUploadUrlResponse {
-    /// Sets the value of `upload_url`.
+    /// Sets the value of [upload_url][crate::model::GenerateUploadUrlResponse::upload_url].
     pub fn set_upload_url<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.upload_url = v.into();
         self
     }
 
-    /// Sets the value of `storage_source`.
+    /// Sets the value of [storage_source][crate::model::GenerateUploadUrlResponse::storage_source].
     pub fn set_storage_source<
         T: std::convert::Into<std::option::Option<crate::model::StorageSource>>,
     >(
@@ -2117,7 +2130,7 @@ pub struct GenerateDownloadUrlRequest {
 }
 
 impl GenerateDownloadUrlRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GenerateDownloadUrlRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -2143,7 +2156,7 @@ pub struct GenerateDownloadUrlResponse {
 }
 
 impl GenerateDownloadUrlResponse {
-    /// Sets the value of `download_url`.
+    /// Sets the value of [download_url][crate::model::GenerateDownloadUrlResponse::download_url].
     pub fn set_download_url<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.download_url = v.into();
         self
@@ -2174,13 +2187,13 @@ pub struct ListRuntimesRequest {
 }
 
 impl ListRuntimesRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListRuntimesRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListRuntimesRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
@@ -2205,14 +2218,14 @@ pub struct ListRuntimesResponse {
 }
 
 impl ListRuntimesResponse {
-    /// Sets the value of `runtimes`.
-    pub fn set_runtimes<
-        T: std::convert::Into<std::vec::Vec<crate::model::list_runtimes_response::Runtime>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.runtimes = v.into();
+    /// Sets the value of [runtimes][crate::model::ListRuntimesResponse::runtimes].
+    pub fn set_runtimes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::list_runtimes_response::Runtime>,
+    {
+        use std::iter::Iterator;
+        self.runtimes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2263,13 +2276,13 @@ pub mod list_runtimes_response {
     }
 
     impl Runtime {
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::list_runtimes_response::Runtime::name].
         pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.name = v.into();
             self
         }
 
-        /// Sets the value of `display_name`.
+        /// Sets the value of [display_name][crate::model::list_runtimes_response::Runtime::display_name].
         pub fn set_display_name<T: std::convert::Into<std::string::String>>(
             mut self,
             v: T,
@@ -2278,7 +2291,7 @@ pub mod list_runtimes_response {
             self
         }
 
-        /// Sets the value of `stage`.
+        /// Sets the value of [stage][crate::model::list_runtimes_response::Runtime::stage].
         pub fn set_stage<
             T: std::convert::Into<crate::model::list_runtimes_response::RuntimeStage>,
         >(
@@ -2289,16 +2302,7 @@ pub mod list_runtimes_response {
             self
         }
 
-        /// Sets the value of `warnings`.
-        pub fn set_warnings<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.warnings = v.into();
-            self
-        }
-
-        /// Sets the value of `environment`.
+        /// Sets the value of [environment][crate::model::list_runtimes_response::Runtime::environment].
         pub fn set_environment<T: std::convert::Into<crate::model::Environment>>(
             mut self,
             v: T,
@@ -2307,7 +2311,7 @@ pub mod list_runtimes_response {
             self
         }
 
-        /// Sets the value of `deprecation_date`.
+        /// Sets the value of [deprecation_date][crate::model::list_runtimes_response::Runtime::deprecation_date].
         pub fn set_deprecation_date<
             T: std::convert::Into<std::option::Option<gtype::model::Date>>,
         >(
@@ -2318,7 +2322,7 @@ pub mod list_runtimes_response {
             self
         }
 
-        /// Sets the value of `decommission_date`.
+        /// Sets the value of [decommission_date][crate::model::list_runtimes_response::Runtime::decommission_date].
         pub fn set_decommission_date<
             T: std::convert::Into<std::option::Option<gtype::model::Date>>,
         >(
@@ -2326,6 +2330,17 @@ pub mod list_runtimes_response {
             v: T,
         ) -> Self {
             self.decommission_date = v.into();
+            self
+        }
+
+        /// Sets the value of [warnings][crate::model::list_runtimes_response::Runtime::warnings].
+        pub fn set_warnings<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.warnings = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -2408,7 +2423,7 @@ pub struct OnDeployUpdatePolicy {
 }
 
 impl OnDeployUpdatePolicy {
-    /// Sets the value of `runtime_version`.
+    /// Sets the value of [runtime_version][crate::model::OnDeployUpdatePolicy::runtime_version].
     pub fn set_runtime_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.runtime_version = v.into();
         self
@@ -2484,7 +2499,7 @@ pub struct OperationMetadata {
 }
 
 impl OperationMetadata {
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::OperationMetadata::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2493,7 +2508,7 @@ impl OperationMetadata {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::OperationMetadata::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2502,37 +2517,37 @@ impl OperationMetadata {
         self
     }
 
-    /// Sets the value of `target`.
+    /// Sets the value of [target][crate::model::OperationMetadata::target].
     pub fn set_target<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.target = v.into();
         self
     }
 
-    /// Sets the value of `verb`.
+    /// Sets the value of [verb][crate::model::OperationMetadata::verb].
     pub fn set_verb<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.verb = v.into();
         self
     }
 
-    /// Sets the value of `status_detail`.
+    /// Sets the value of [status_detail][crate::model::OperationMetadata::status_detail].
     pub fn set_status_detail<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.status_detail = v.into();
         self
     }
 
-    /// Sets the value of `cancel_requested`.
+    /// Sets the value of [cancel_requested][crate::model::OperationMetadata::cancel_requested].
     pub fn set_cancel_requested<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.cancel_requested = v.into();
         self
     }
 
-    /// Sets the value of `api_version`.
+    /// Sets the value of [api_version][crate::model::OperationMetadata::api_version].
     pub fn set_api_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.api_version = v.into();
         self
     }
 
-    /// Sets the value of `request_resource`.
+    /// Sets the value of [request_resource][crate::model::OperationMetadata::request_resource].
     pub fn set_request_resource<T: std::convert::Into<std::option::Option<wkt::Any>>>(
         mut self,
         v: T,
@@ -2541,33 +2556,35 @@ impl OperationMetadata {
         self
     }
 
-    /// Sets the value of `stages`.
-    pub fn set_stages<T: std::convert::Into<std::vec::Vec<crate::model::Stage>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.stages = v.into();
-        self
-    }
-
-    /// Sets the value of `source_token`.
+    /// Sets the value of [source_token][crate::model::OperationMetadata::source_token].
     pub fn set_source_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.source_token = v.into();
         self
     }
 
-    /// Sets the value of `build_name`.
+    /// Sets the value of [build_name][crate::model::OperationMetadata::build_name].
     pub fn set_build_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.build_name = v.into();
         self
     }
 
-    /// Sets the value of `operation_type`.
+    /// Sets the value of [operation_type][crate::model::OperationMetadata::operation_type].
     pub fn set_operation_type<T: std::convert::Into<crate::model::OperationType>>(
         mut self,
         v: T,
     ) -> Self {
         self.operation_type = v.into();
+        self
+    }
+
+    /// Sets the value of [stages][crate::model::OperationMetadata::stages].
+    pub fn set_stages<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Stage>,
+    {
+        use std::iter::Iterator;
+        self.stages = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2590,12 +2607,14 @@ pub struct LocationMetadata {
 }
 
 impl LocationMetadata {
-    /// Sets the value of `environments`.
-    pub fn set_environments<T: std::convert::Into<std::vec::Vec<crate::model::Environment>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.environments = v.into();
+    /// Sets the value of [environments][crate::model::LocationMetadata::environments].
+    pub fn set_environments<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Environment>,
+    {
+        use std::iter::Iterator;
+        self.environments = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2636,42 +2655,44 @@ pub struct Stage {
 }
 
 impl Stage {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Stage::name].
     pub fn set_name<T: std::convert::Into<crate::model::stage::Name>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `message`.
+    /// Sets the value of [message][crate::model::Stage::message].
     pub fn set_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.message = v.into();
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::Stage::state].
     pub fn set_state<T: std::convert::Into<crate::model::stage::State>>(mut self, v: T) -> Self {
         self.state = v.into();
         self
     }
 
-    /// Sets the value of `resource`.
+    /// Sets the value of [resource][crate::model::Stage::resource].
     pub fn set_resource<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.resource = v.into();
         self
     }
 
-    /// Sets the value of `resource_uri`.
+    /// Sets the value of [resource_uri][crate::model::Stage::resource_uri].
     pub fn set_resource_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.resource_uri = v.into();
         self
     }
 
-    /// Sets the value of `state_messages`.
-    pub fn set_state_messages<T: std::convert::Into<std::vec::Vec<crate::model::StateMessage>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.state_messages = v.into();
+    /// Sets the value of [state_messages][crate::model::Stage::state_messages].
+    pub fn set_state_messages<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::StateMessage>,
+    {
+        use std::iter::Iterator;
+        self.state_messages = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/cloud/kms/v1/src/builders.rs
+++ b/src/generated/cloud/kms/v1/src/builders.rs
@@ -106,19 +106,19 @@ pub mod autokey {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateKeyHandleRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `key_handle_id`.
+        /// Sets the value of [key_handle_id][crate::model::CreateKeyHandleRequest::key_handle_id].
         pub fn set_key_handle_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.key_handle_id = v.into();
             self
         }
 
-        /// Sets the value of `key_handle`.
+        /// Sets the value of [key_handle][crate::model::CreateKeyHandleRequest::key_handle].
         pub fn set_key_handle<T: Into<std::option::Option<crate::model::KeyHandle>>>(
             mut self,
             v: T,
@@ -162,7 +162,7 @@ pub mod autokey {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetKeyHandleRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -218,25 +218,25 @@ pub mod autokey {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListKeyHandlesRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListKeyHandlesRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListKeyHandlesRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListKeyHandlesRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
@@ -295,25 +295,25 @@ pub mod autokey {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][location::model::ListLocationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][location::model::ListLocationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][location::model::ListLocationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][location::model::ListLocationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -354,7 +354,7 @@ pub mod autokey {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][location::model::GetLocationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -395,13 +395,13 @@ pub mod autokey {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::SetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][iam_v1::model::SetIamPolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<iam_v1::model::Policy>>>(
             mut self,
             v: T,
@@ -410,7 +410,7 @@ pub mod autokey {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][iam_v1::model::SetIamPolicyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -454,13 +454,13 @@ pub mod autokey {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::GetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `options`.
+        /// Sets the value of [options][iam_v1::model::GetIamPolicyRequest::options].
         pub fn set_options<T: Into<std::option::Option<iam_v1::model::GetPolicyOptions>>>(
             mut self,
             v: T,
@@ -507,18 +507,20 @@ pub mod autokey {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::TestIamPermissionsRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `permissions`.
-        pub fn set_permissions<T: Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.permissions = v.into();
+        /// Sets the value of [permissions][iam_v1::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -560,7 +562,7 @@ pub mod autokey {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::GetOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -630,7 +632,7 @@ pub mod autokey_admin {
                 .await
         }
 
-        /// Sets the value of `autokey_config`.
+        /// Sets the value of [autokey_config][crate::model::UpdateAutokeyConfigRequest::autokey_config].
         pub fn set_autokey_config<T: Into<std::option::Option<crate::model::AutokeyConfig>>>(
             mut self,
             v: T,
@@ -639,7 +641,7 @@ pub mod autokey_admin {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateAutokeyConfigRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -686,7 +688,7 @@ pub mod autokey_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetAutokeyConfigRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -732,7 +734,7 @@ pub mod autokey_admin {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ShowEffectiveAutokeyConfigRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
@@ -791,25 +793,25 @@ pub mod autokey_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][location::model::ListLocationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][location::model::ListLocationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][location::model::ListLocationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][location::model::ListLocationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -850,7 +852,7 @@ pub mod autokey_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][location::model::GetLocationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -891,13 +893,13 @@ pub mod autokey_admin {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::SetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][iam_v1::model::SetIamPolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<iam_v1::model::Policy>>>(
             mut self,
             v: T,
@@ -906,7 +908,7 @@ pub mod autokey_admin {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][iam_v1::model::SetIamPolicyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -950,13 +952,13 @@ pub mod autokey_admin {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::GetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `options`.
+        /// Sets the value of [options][iam_v1::model::GetIamPolicyRequest::options].
         pub fn set_options<T: Into<std::option::Option<iam_v1::model::GetPolicyOptions>>>(
             mut self,
             v: T,
@@ -1003,18 +1005,20 @@ pub mod autokey_admin {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::TestIamPermissionsRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `permissions`.
-        pub fn set_permissions<T: Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.permissions = v.into();
+        /// Sets the value of [permissions][iam_v1::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1056,7 +1060,7 @@ pub mod autokey_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::GetOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1141,31 +1145,31 @@ pub mod ekm_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListEkmConnectionsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListEkmConnectionsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListEkmConnectionsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListEkmConnectionsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `order_by`.
+        /// Sets the value of [order_by][crate::model::ListEkmConnectionsRequest::order_by].
         pub fn set_order_by<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.order_by = v.into();
             self
@@ -1209,7 +1213,7 @@ pub mod ekm_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetEkmConnectionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1253,19 +1257,19 @@ pub mod ekm_service {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateEkmConnectionRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `ekm_connection_id`.
+        /// Sets the value of [ekm_connection_id][crate::model::CreateEkmConnectionRequest::ekm_connection_id].
         pub fn set_ekm_connection_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.ekm_connection_id = v.into();
             self
         }
 
-        /// Sets the value of `ekm_connection`.
+        /// Sets the value of [ekm_connection][crate::model::CreateEkmConnectionRequest::ekm_connection].
         pub fn set_ekm_connection<T: Into<std::option::Option<crate::model::EkmConnection>>>(
             mut self,
             v: T,
@@ -1312,7 +1316,7 @@ pub mod ekm_service {
                 .await
         }
 
-        /// Sets the value of `ekm_connection`.
+        /// Sets the value of [ekm_connection][crate::model::UpdateEkmConnectionRequest::ekm_connection].
         pub fn set_ekm_connection<T: Into<std::option::Option<crate::model::EkmConnection>>>(
             mut self,
             v: T,
@@ -1321,7 +1325,7 @@ pub mod ekm_service {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateEkmConnectionRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -1365,7 +1369,7 @@ pub mod ekm_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetEkmConfigRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1406,7 +1410,7 @@ pub mod ekm_service {
                 .await
         }
 
-        /// Sets the value of `ekm_config`.
+        /// Sets the value of [ekm_config][crate::model::UpdateEkmConfigRequest::ekm_config].
         pub fn set_ekm_config<T: Into<std::option::Option<crate::model::EkmConfig>>>(
             mut self,
             v: T,
@@ -1415,7 +1419,7 @@ pub mod ekm_service {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateEkmConfigRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -1462,7 +1466,7 @@ pub mod ekm_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::VerifyConnectivityRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1521,25 +1525,25 @@ pub mod ekm_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][location::model::ListLocationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][location::model::ListLocationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][location::model::ListLocationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][location::model::ListLocationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -1580,7 +1584,7 @@ pub mod ekm_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][location::model::GetLocationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1621,13 +1625,13 @@ pub mod ekm_service {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::SetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][iam_v1::model::SetIamPolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<iam_v1::model::Policy>>>(
             mut self,
             v: T,
@@ -1636,7 +1640,7 @@ pub mod ekm_service {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][iam_v1::model::SetIamPolicyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -1680,13 +1684,13 @@ pub mod ekm_service {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::GetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `options`.
+        /// Sets the value of [options][iam_v1::model::GetIamPolicyRequest::options].
         pub fn set_options<T: Into<std::option::Option<iam_v1::model::GetPolicyOptions>>>(
             mut self,
             v: T,
@@ -1733,18 +1737,20 @@ pub mod ekm_service {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::TestIamPermissionsRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `permissions`.
-        pub fn set_permissions<T: Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.permissions = v.into();
+        /// Sets the value of [permissions][iam_v1::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1786,7 +1792,7 @@ pub mod ekm_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::GetOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1868,31 +1874,31 @@ pub mod key_management_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListKeyRingsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListKeyRingsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListKeyRingsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListKeyRingsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `order_by`.
+        /// Sets the value of [order_by][crate::model::ListKeyRingsRequest::order_by].
         pub fn set_order_by<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.order_by = v.into();
             self
@@ -1948,25 +1954,25 @@ pub mod key_management_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListCryptoKeysRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListCryptoKeysRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListCryptoKeysRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `version_view`.
+        /// Sets the value of [version_view][crate::model::ListCryptoKeysRequest::version_view].
         pub fn set_version_view<T: Into<crate::model::crypto_key_version::CryptoKeyVersionView>>(
             mut self,
             v: T,
@@ -1975,13 +1981,13 @@ pub mod key_management_service {
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListCryptoKeysRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `order_by`.
+        /// Sets the value of [order_by][crate::model::ListCryptoKeysRequest::order_by].
         pub fn set_order_by<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.order_by = v.into();
             self
@@ -2040,25 +2046,25 @@ pub mod key_management_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListCryptoKeyVersionsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListCryptoKeyVersionsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListCryptoKeyVersionsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `view`.
+        /// Sets the value of [view][crate::model::ListCryptoKeyVersionsRequest::view].
         pub fn set_view<T: Into<crate::model::crypto_key_version::CryptoKeyVersionView>>(
             mut self,
             v: T,
@@ -2067,13 +2073,13 @@ pub mod key_management_service {
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListCryptoKeyVersionsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `order_by`.
+        /// Sets the value of [order_by][crate::model::ListCryptoKeyVersionsRequest::order_by].
         pub fn set_order_by<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.order_by = v.into();
             self
@@ -2129,31 +2135,31 @@ pub mod key_management_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListImportJobsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListImportJobsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListImportJobsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListImportJobsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `order_by`.
+        /// Sets the value of [order_by][crate::model::ListImportJobsRequest::order_by].
         pub fn set_order_by<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.order_by = v.into();
             self
@@ -2194,7 +2200,7 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetKeyRingRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2235,7 +2241,7 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetCryptoKeyRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2279,7 +2285,7 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetCryptoKeyVersionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2320,7 +2326,7 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetPublicKeyRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2361,7 +2367,7 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetImportJobRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2402,19 +2408,19 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateKeyRingRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `key_ring_id`.
+        /// Sets the value of [key_ring_id][crate::model::CreateKeyRingRequest::key_ring_id].
         pub fn set_key_ring_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.key_ring_id = v.into();
             self
         }
 
-        /// Sets the value of `key_ring`.
+        /// Sets the value of [key_ring][crate::model::CreateKeyRingRequest::key_ring].
         pub fn set_key_ring<T: Into<std::option::Option<crate::model::KeyRing>>>(
             mut self,
             v: T,
@@ -2458,19 +2464,19 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateCryptoKeyRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `crypto_key_id`.
+        /// Sets the value of [crypto_key_id][crate::model::CreateCryptoKeyRequest::crypto_key_id].
         pub fn set_crypto_key_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.crypto_key_id = v.into();
             self
         }
 
-        /// Sets the value of `crypto_key`.
+        /// Sets the value of [crypto_key][crate::model::CreateCryptoKeyRequest::crypto_key].
         pub fn set_crypto_key<T: Into<std::option::Option<crate::model::CryptoKey>>>(
             mut self,
             v: T,
@@ -2479,7 +2485,7 @@ pub mod key_management_service {
             self
         }
 
-        /// Sets the value of `skip_initial_version_creation`.
+        /// Sets the value of [skip_initial_version_creation][crate::model::CreateCryptoKeyRequest::skip_initial_version_creation].
         pub fn set_skip_initial_version_creation<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.skip_initial_version_creation = v.into();
             self
@@ -2523,13 +2529,13 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateCryptoKeyVersionRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `crypto_key_version`.
+        /// Sets the value of [crypto_key_version][crate::model::CreateCryptoKeyVersionRequest::crypto_key_version].
         pub fn set_crypto_key_version<
             T: Into<std::option::Option<crate::model::CryptoKeyVersion>>,
         >(
@@ -2578,19 +2584,19 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ImportCryptoKeyVersionRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `crypto_key_version`.
+        /// Sets the value of [crypto_key_version][crate::model::ImportCryptoKeyVersionRequest::crypto_key_version].
         pub fn set_crypto_key_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.crypto_key_version = v.into();
             self
         }
 
-        /// Sets the value of `algorithm`.
+        /// Sets the value of [algorithm][crate::model::ImportCryptoKeyVersionRequest::algorithm].
         pub fn set_algorithm<
             T: Into<crate::model::crypto_key_version::CryptoKeyVersionAlgorithm>,
         >(
@@ -2601,13 +2607,13 @@ pub mod key_management_service {
             self
         }
 
-        /// Sets the value of `import_job`.
+        /// Sets the value of [import_job][crate::model::ImportCryptoKeyVersionRequest::import_job].
         pub fn set_import_job<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.import_job = v.into();
             self
         }
 
-        /// Sets the value of `wrapped_key`.
+        /// Sets the value of [wrapped_key][crate::model::ImportCryptoKeyVersionRequest::wrapped_key].
         pub fn set_wrapped_key<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.wrapped_key = v.into();
             self
@@ -2659,19 +2665,19 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateImportJobRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `import_job_id`.
+        /// Sets the value of [import_job_id][crate::model::CreateImportJobRequest::import_job_id].
         pub fn set_import_job_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.import_job_id = v.into();
             self
         }
 
-        /// Sets the value of `import_job`.
+        /// Sets the value of [import_job][crate::model::CreateImportJobRequest::import_job].
         pub fn set_import_job<T: Into<std::option::Option<crate::model::ImportJob>>>(
             mut self,
             v: T,
@@ -2715,7 +2721,7 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `crypto_key`.
+        /// Sets the value of [crypto_key][crate::model::UpdateCryptoKeyRequest::crypto_key].
         pub fn set_crypto_key<T: Into<std::option::Option<crate::model::CryptoKey>>>(
             mut self,
             v: T,
@@ -2724,7 +2730,7 @@ pub mod key_management_service {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateCryptoKeyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -2771,7 +2777,7 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `crypto_key_version`.
+        /// Sets the value of [crypto_key_version][crate::model::UpdateCryptoKeyVersionRequest::crypto_key_version].
         pub fn set_crypto_key_version<
             T: Into<std::option::Option<crate::model::CryptoKeyVersion>>,
         >(
@@ -2782,7 +2788,7 @@ pub mod key_management_service {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateCryptoKeyVersionRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -2831,13 +2837,13 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::UpdateCryptoKeyPrimaryVersionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `crypto_key_version_id`.
+        /// Sets the value of [crypto_key_version_id][crate::model::UpdateCryptoKeyPrimaryVersionRequest::crypto_key_version_id].
         pub fn set_crypto_key_version_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.crypto_key_version_id = v.into();
             self
@@ -2883,7 +2889,7 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DestroyCryptoKeyVersionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2929,7 +2935,7 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::RestoreCryptoKeyVersionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2968,25 +2974,25 @@ pub mod key_management_service {
             (*self.0.stub).encrypt(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::EncryptRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `plaintext`.
+        /// Sets the value of [plaintext][crate::model::EncryptRequest::plaintext].
         pub fn set_plaintext<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.plaintext = v.into();
             self
         }
 
-        /// Sets the value of `additional_authenticated_data`.
+        /// Sets the value of [additional_authenticated_data][crate::model::EncryptRequest::additional_authenticated_data].
         pub fn set_additional_authenticated_data<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.additional_authenticated_data = v.into();
             self
         }
 
-        /// Sets the value of `plaintext_crc32c`.
+        /// Sets the value of [plaintext_crc32c][crate::model::EncryptRequest::plaintext_crc32c].
         pub fn set_plaintext_crc32c<T: Into<std::option::Option<wkt::Int64Value>>>(
             mut self,
             v: T,
@@ -2995,7 +3001,7 @@ pub mod key_management_service {
             self
         }
 
-        /// Sets the value of `additional_authenticated_data_crc32c`.
+        /// Sets the value of [additional_authenticated_data_crc32c][crate::model::EncryptRequest::additional_authenticated_data_crc32c].
         pub fn set_additional_authenticated_data_crc32c<
             T: Into<std::option::Option<wkt::Int64Value>>,
         >(
@@ -3039,25 +3045,25 @@ pub mod key_management_service {
             (*self.0.stub).decrypt(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DecryptRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `ciphertext`.
+        /// Sets the value of [ciphertext][crate::model::DecryptRequest::ciphertext].
         pub fn set_ciphertext<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.ciphertext = v.into();
             self
         }
 
-        /// Sets the value of `additional_authenticated_data`.
+        /// Sets the value of [additional_authenticated_data][crate::model::DecryptRequest::additional_authenticated_data].
         pub fn set_additional_authenticated_data<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.additional_authenticated_data = v.into();
             self
         }
 
-        /// Sets the value of `ciphertext_crc32c`.
+        /// Sets the value of [ciphertext_crc32c][crate::model::DecryptRequest::ciphertext_crc32c].
         pub fn set_ciphertext_crc32c<T: Into<std::option::Option<wkt::Int64Value>>>(
             mut self,
             v: T,
@@ -3066,7 +3072,7 @@ pub mod key_management_service {
             self
         }
 
-        /// Sets the value of `additional_authenticated_data_crc32c`.
+        /// Sets the value of [additional_authenticated_data_crc32c][crate::model::DecryptRequest::additional_authenticated_data_crc32c].
         pub fn set_additional_authenticated_data_crc32c<
             T: Into<std::option::Option<wkt::Int64Value>>,
         >(
@@ -3112,25 +3118,25 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::RawEncryptRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `plaintext`.
+        /// Sets the value of [plaintext][crate::model::RawEncryptRequest::plaintext].
         pub fn set_plaintext<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.plaintext = v.into();
             self
         }
 
-        /// Sets the value of `additional_authenticated_data`.
+        /// Sets the value of [additional_authenticated_data][crate::model::RawEncryptRequest::additional_authenticated_data].
         pub fn set_additional_authenticated_data<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.additional_authenticated_data = v.into();
             self
         }
 
-        /// Sets the value of `plaintext_crc32c`.
+        /// Sets the value of [plaintext_crc32c][crate::model::RawEncryptRequest::plaintext_crc32c].
         pub fn set_plaintext_crc32c<T: Into<std::option::Option<wkt::Int64Value>>>(
             mut self,
             v: T,
@@ -3139,7 +3145,7 @@ pub mod key_management_service {
             self
         }
 
-        /// Sets the value of `additional_authenticated_data_crc32c`.
+        /// Sets the value of [additional_authenticated_data_crc32c][crate::model::RawEncryptRequest::additional_authenticated_data_crc32c].
         pub fn set_additional_authenticated_data_crc32c<
             T: Into<std::option::Option<wkt::Int64Value>>,
         >(
@@ -3150,13 +3156,13 @@ pub mod key_management_service {
             self
         }
 
-        /// Sets the value of `initialization_vector`.
+        /// Sets the value of [initialization_vector][crate::model::RawEncryptRequest::initialization_vector].
         pub fn set_initialization_vector<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.initialization_vector = v.into();
             self
         }
 
-        /// Sets the value of `initialization_vector_crc32c`.
+        /// Sets the value of [initialization_vector_crc32c][crate::model::RawEncryptRequest::initialization_vector_crc32c].
         pub fn set_initialization_vector_crc32c<T: Into<std::option::Option<wkt::Int64Value>>>(
             mut self,
             v: T,
@@ -3200,37 +3206,37 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::RawDecryptRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `ciphertext`.
+        /// Sets the value of [ciphertext][crate::model::RawDecryptRequest::ciphertext].
         pub fn set_ciphertext<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.ciphertext = v.into();
             self
         }
 
-        /// Sets the value of `additional_authenticated_data`.
+        /// Sets the value of [additional_authenticated_data][crate::model::RawDecryptRequest::additional_authenticated_data].
         pub fn set_additional_authenticated_data<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.additional_authenticated_data = v.into();
             self
         }
 
-        /// Sets the value of `initialization_vector`.
+        /// Sets the value of [initialization_vector][crate::model::RawDecryptRequest::initialization_vector].
         pub fn set_initialization_vector<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.initialization_vector = v.into();
             self
         }
 
-        /// Sets the value of `tag_length`.
+        /// Sets the value of [tag_length][crate::model::RawDecryptRequest::tag_length].
         pub fn set_tag_length<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.tag_length = v.into();
             self
         }
 
-        /// Sets the value of `ciphertext_crc32c`.
+        /// Sets the value of [ciphertext_crc32c][crate::model::RawDecryptRequest::ciphertext_crc32c].
         pub fn set_ciphertext_crc32c<T: Into<std::option::Option<wkt::Int64Value>>>(
             mut self,
             v: T,
@@ -3239,7 +3245,7 @@ pub mod key_management_service {
             self
         }
 
-        /// Sets the value of `additional_authenticated_data_crc32c`.
+        /// Sets the value of [additional_authenticated_data_crc32c][crate::model::RawDecryptRequest::additional_authenticated_data_crc32c].
         pub fn set_additional_authenticated_data_crc32c<
             T: Into<std::option::Option<wkt::Int64Value>>,
         >(
@@ -3250,7 +3256,7 @@ pub mod key_management_service {
             self
         }
 
-        /// Sets the value of `initialization_vector_crc32c`.
+        /// Sets the value of [initialization_vector_crc32c][crate::model::RawDecryptRequest::initialization_vector_crc32c].
         pub fn set_initialization_vector_crc32c<T: Into<std::option::Option<wkt::Int64Value>>>(
             mut self,
             v: T,
@@ -3294,13 +3300,13 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::AsymmetricSignRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `digest`.
+        /// Sets the value of [digest][crate::model::AsymmetricSignRequest::digest].
         pub fn set_digest<T: Into<std::option::Option<crate::model::Digest>>>(
             mut self,
             v: T,
@@ -3309,7 +3315,7 @@ pub mod key_management_service {
             self
         }
 
-        /// Sets the value of `digest_crc32c`.
+        /// Sets the value of [digest_crc32c][crate::model::AsymmetricSignRequest::digest_crc32c].
         pub fn set_digest_crc32c<T: Into<std::option::Option<wkt::Int64Value>>>(
             mut self,
             v: T,
@@ -3318,13 +3324,13 @@ pub mod key_management_service {
             self
         }
 
-        /// Sets the value of `data`.
+        /// Sets the value of [data][crate::model::AsymmetricSignRequest::data].
         pub fn set_data<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.data = v.into();
             self
         }
 
-        /// Sets the value of `data_crc32c`.
+        /// Sets the value of [data_crc32c][crate::model::AsymmetricSignRequest::data_crc32c].
         pub fn set_data_crc32c<T: Into<std::option::Option<wkt::Int64Value>>>(
             mut self,
             v: T,
@@ -3371,19 +3377,19 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::AsymmetricDecryptRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `ciphertext`.
+        /// Sets the value of [ciphertext][crate::model::AsymmetricDecryptRequest::ciphertext].
         pub fn set_ciphertext<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.ciphertext = v.into();
             self
         }
 
-        /// Sets the value of `ciphertext_crc32c`.
+        /// Sets the value of [ciphertext_crc32c][crate::model::AsymmetricDecryptRequest::ciphertext_crc32c].
         pub fn set_ciphertext_crc32c<T: Into<std::option::Option<wkt::Int64Value>>>(
             mut self,
             v: T,
@@ -3427,19 +3433,19 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::MacSignRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `data`.
+        /// Sets the value of [data][crate::model::MacSignRequest::data].
         pub fn set_data<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.data = v.into();
             self
         }
 
-        /// Sets the value of `data_crc32c`.
+        /// Sets the value of [data_crc32c][crate::model::MacSignRequest::data_crc32c].
         pub fn set_data_crc32c<T: Into<std::option::Option<wkt::Int64Value>>>(
             mut self,
             v: T,
@@ -3483,19 +3489,19 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::MacVerifyRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `data`.
+        /// Sets the value of [data][crate::model::MacVerifyRequest::data].
         pub fn set_data<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.data = v.into();
             self
         }
 
-        /// Sets the value of `data_crc32c`.
+        /// Sets the value of [data_crc32c][crate::model::MacVerifyRequest::data_crc32c].
         pub fn set_data_crc32c<T: Into<std::option::Option<wkt::Int64Value>>>(
             mut self,
             v: T,
@@ -3504,13 +3510,13 @@ pub mod key_management_service {
             self
         }
 
-        /// Sets the value of `mac`.
+        /// Sets the value of [mac][crate::model::MacVerifyRequest::mac].
         pub fn set_mac<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.mac = v.into();
             self
         }
 
-        /// Sets the value of `mac_crc32c`.
+        /// Sets the value of [mac_crc32c][crate::model::MacVerifyRequest::mac_crc32c].
         pub fn set_mac_crc32c<T: Into<std::option::Option<wkt::Int64Value>>>(
             mut self,
             v: T,
@@ -3557,19 +3563,19 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::GenerateRandomBytesRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
         }
 
-        /// Sets the value of `length_bytes`.
+        /// Sets the value of [length_bytes][crate::model::GenerateRandomBytesRequest::length_bytes].
         pub fn set_length_bytes<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.length_bytes = v.into();
             self
         }
 
-        /// Sets the value of `protection_level`.
+        /// Sets the value of [protection_level][crate::model::GenerateRandomBytesRequest::protection_level].
         pub fn set_protection_level<T: Into<crate::model::ProtectionLevel>>(
             mut self,
             v: T,
@@ -3631,25 +3637,25 @@ pub mod key_management_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][location::model::ListLocationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][location::model::ListLocationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][location::model::ListLocationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][location::model::ListLocationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -3690,7 +3696,7 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][location::model::GetLocationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -3731,13 +3737,13 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::SetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][iam_v1::model::SetIamPolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<iam_v1::model::Policy>>>(
             mut self,
             v: T,
@@ -3746,7 +3752,7 @@ pub mod key_management_service {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][iam_v1::model::SetIamPolicyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -3790,13 +3796,13 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::GetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `options`.
+        /// Sets the value of [options][iam_v1::model::GetIamPolicyRequest::options].
         pub fn set_options<T: Into<std::option::Option<iam_v1::model::GetPolicyOptions>>>(
             mut self,
             v: T,
@@ -3843,18 +3849,20 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::TestIamPermissionsRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `permissions`.
-        pub fn set_permissions<T: Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.permissions = v.into();
+        /// Sets the value of [permissions][iam_v1::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -3896,7 +3904,7 @@ pub mod key_management_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::GetOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self

--- a/src/generated/cloud/kms/v1/src/model.rs
+++ b/src/generated/cloud/kms/v1/src/model.rs
@@ -67,19 +67,19 @@ pub struct CreateKeyHandleRequest {
 }
 
 impl CreateKeyHandleRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateKeyHandleRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `key_handle_id`.
+    /// Sets the value of [key_handle_id][crate::model::CreateKeyHandleRequest::key_handle_id].
     pub fn set_key_handle_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.key_handle_id = v.into();
         self
     }
 
-    /// Sets the value of `key_handle`.
+    /// Sets the value of [key_handle][crate::model::CreateKeyHandleRequest::key_handle].
     pub fn set_key_handle<T: std::convert::Into<std::option::Option<crate::model::KeyHandle>>>(
         mut self,
         v: T,
@@ -113,7 +113,7 @@ pub struct GetKeyHandleRequest {
 }
 
 impl GetKeyHandleRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetKeyHandleRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -172,19 +172,19 @@ pub struct KeyHandle {
 }
 
 impl KeyHandle {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::KeyHandle::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `kms_key`.
+    /// Sets the value of [kms_key][crate::model::KeyHandle::kms_key].
     pub fn set_kms_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kms_key = v.into();
         self
     }
 
-    /// Sets the value of `resource_type_selector`.
+    /// Sets the value of [resource_type_selector][crate::model::KeyHandle::resource_type_selector].
     pub fn set_resource_type_selector<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -266,25 +266,25 @@ pub struct ListKeyHandlesRequest {
 }
 
 impl ListKeyHandlesRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListKeyHandlesRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListKeyHandlesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListKeyHandlesRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListKeyHandlesRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
@@ -322,18 +322,20 @@ pub struct ListKeyHandlesResponse {
 }
 
 impl ListKeyHandlesResponse {
-    /// Sets the value of `key_handles`.
-    pub fn set_key_handles<T: std::convert::Into<std::vec::Vec<crate::model::KeyHandle>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.key_handles = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListKeyHandlesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [key_handles][crate::model::ListKeyHandlesResponse::key_handles].
+    pub fn set_key_handles<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::KeyHandle>,
+    {
+        use std::iter::Iterator;
+        self.key_handles = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -383,7 +385,7 @@ pub struct UpdateAutokeyConfigRequest {
 }
 
 impl UpdateAutokeyConfigRequest {
-    /// Sets the value of `autokey_config`.
+    /// Sets the value of [autokey_config][crate::model::UpdateAutokeyConfigRequest::autokey_config].
     pub fn set_autokey_config<
         T: std::convert::Into<std::option::Option<crate::model::AutokeyConfig>>,
     >(
@@ -394,7 +396,7 @@ impl UpdateAutokeyConfigRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateAutokeyConfigRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -428,7 +430,7 @@ pub struct GetAutokeyConfigRequest {
 }
 
 impl GetAutokeyConfigRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetAutokeyConfigRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -477,19 +479,19 @@ pub struct AutokeyConfig {
 }
 
 impl AutokeyConfig {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::AutokeyConfig::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `key_project`.
+    /// Sets the value of [key_project][crate::model::AutokeyConfig::key_project].
     pub fn set_key_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.key_project = v.into();
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::AutokeyConfig::state].
     pub fn set_state<T: std::convert::Into<crate::model::autokey_config::State>>(
         mut self,
         v: T,
@@ -563,7 +565,7 @@ pub struct ShowEffectiveAutokeyConfigRequest {
 }
 
 impl ShowEffectiveAutokeyConfigRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ShowEffectiveAutokeyConfigRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
@@ -592,7 +594,7 @@ pub struct ShowEffectiveAutokeyConfigResponse {
 }
 
 impl ShowEffectiveAutokeyConfigResponse {
-    /// Sets the value of `key_project`.
+    /// Sets the value of [key_project][crate::model::ShowEffectiveAutokeyConfigResponse::key_project].
     pub fn set_key_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.key_project = v.into();
         self
@@ -657,31 +659,31 @@ pub struct ListEkmConnectionsRequest {
 }
 
 impl ListEkmConnectionsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListEkmConnectionsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListEkmConnectionsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListEkmConnectionsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListEkmConnectionsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
     }
 
-    /// Sets the value of `order_by`.
+    /// Sets the value of [order_by][crate::model::ListEkmConnectionsRequest::order_by].
     pub fn set_order_by<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.order_by = v.into();
         self
@@ -725,26 +727,26 @@ pub struct ListEkmConnectionsResponse {
 }
 
 impl ListEkmConnectionsResponse {
-    /// Sets the value of `ekm_connections`.
-    pub fn set_ekm_connections<
-        T: std::convert::Into<std::vec::Vec<crate::model::EkmConnection>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.ekm_connections = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListEkmConnectionsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `total_size`.
+    /// Sets the value of [total_size][crate::model::ListEkmConnectionsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
+        self
+    }
+
+    /// Sets the value of [ekm_connections][crate::model::ListEkmConnectionsResponse::ekm_connections].
+    pub fn set_ekm_connections<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EkmConnection>,
+    {
+        use std::iter::Iterator;
+        self.ekm_connections = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -787,7 +789,7 @@ pub struct GetEkmConnectionRequest {
 }
 
 impl GetEkmConnectionRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetEkmConnectionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -831,13 +833,13 @@ pub struct CreateEkmConnectionRequest {
 }
 
 impl CreateEkmConnectionRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateEkmConnectionRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `ekm_connection_id`.
+    /// Sets the value of [ekm_connection_id][crate::model::CreateEkmConnectionRequest::ekm_connection_id].
     pub fn set_ekm_connection_id<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -846,7 +848,7 @@ impl CreateEkmConnectionRequest {
         self
     }
 
-    /// Sets the value of `ekm_connection`.
+    /// Sets the value of [ekm_connection][crate::model::CreateEkmConnectionRequest::ekm_connection].
     pub fn set_ekm_connection<
         T: std::convert::Into<std::option::Option<crate::model::EkmConnection>>,
     >(
@@ -886,7 +888,7 @@ pub struct UpdateEkmConnectionRequest {
 }
 
 impl UpdateEkmConnectionRequest {
-    /// Sets the value of `ekm_connection`.
+    /// Sets the value of [ekm_connection][crate::model::UpdateEkmConnectionRequest::ekm_connection].
     pub fn set_ekm_connection<
         T: std::convert::Into<std::option::Option<crate::model::EkmConnection>>,
     >(
@@ -897,7 +899,7 @@ impl UpdateEkmConnectionRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateEkmConnectionRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -932,7 +934,7 @@ pub struct GetEkmConfigRequest {
 }
 
 impl GetEkmConfigRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetEkmConfigRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -966,7 +968,7 @@ pub struct UpdateEkmConfigRequest {
 }
 
 impl UpdateEkmConfigRequest {
-    /// Sets the value of `ekm_config`.
+    /// Sets the value of [ekm_config][crate::model::UpdateEkmConfigRequest::ekm_config].
     pub fn set_ekm_config<T: std::convert::Into<std::option::Option<crate::model::EkmConfig>>>(
         mut self,
         v: T,
@@ -975,7 +977,7 @@ impl UpdateEkmConfigRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateEkmConfigRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -1059,42 +1061,31 @@ pub struct Certificate {
 }
 
 impl Certificate {
-    /// Sets the value of `raw_der`.
+    /// Sets the value of [raw_der][crate::model::Certificate::raw_der].
     pub fn set_raw_der<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.raw_der = v.into();
         self
     }
 
-    /// Sets the value of `parsed`.
+    /// Sets the value of [parsed][crate::model::Certificate::parsed].
     pub fn set_parsed<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.parsed = v.into();
         self
     }
 
-    /// Sets the value of `issuer`.
+    /// Sets the value of [issuer][crate::model::Certificate::issuer].
     pub fn set_issuer<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.issuer = v.into();
         self
     }
 
-    /// Sets the value of `subject`.
+    /// Sets the value of [subject][crate::model::Certificate::subject].
     pub fn set_subject<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.subject = v.into();
         self
     }
 
-    /// Sets the value of `subject_alternative_dns_names`.
-    pub fn set_subject_alternative_dns_names<
-        T: std::convert::Into<std::vec::Vec<std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.subject_alternative_dns_names = v.into();
-        self
-    }
-
-    /// Sets the value of `not_before_time`.
+    /// Sets the value of [not_before_time][crate::model::Certificate::not_before_time].
     pub fn set_not_before_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1103,7 +1094,7 @@ impl Certificate {
         self
     }
 
-    /// Sets the value of `not_after_time`.
+    /// Sets the value of [not_after_time][crate::model::Certificate::not_after_time].
     pub fn set_not_after_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1112,18 +1103,29 @@ impl Certificate {
         self
     }
 
-    /// Sets the value of `serial_number`.
+    /// Sets the value of [serial_number][crate::model::Certificate::serial_number].
     pub fn set_serial_number<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.serial_number = v.into();
         self
     }
 
-    /// Sets the value of `sha256_fingerprint`.
+    /// Sets the value of [sha256_fingerprint][crate::model::Certificate::sha256_fingerprint].
     pub fn set_sha256_fingerprint<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
     ) -> Self {
         self.sha256_fingerprint = v.into();
+        self
+    }
+
+    /// Sets the value of [subject_alternative_dns_names][crate::model::Certificate::subject_alternative_dns_names].
+    pub fn set_subject_alternative_dns_names<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.subject_alternative_dns_names = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1207,13 +1209,13 @@ pub struct EkmConnection {
 }
 
 impl EkmConnection {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::EkmConnection::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::EkmConnection::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1222,24 +1224,13 @@ impl EkmConnection {
         self
     }
 
-    /// Sets the value of `service_resolvers`.
-    pub fn set_service_resolvers<
-        T: std::convert::Into<std::vec::Vec<crate::model::ekm_connection::ServiceResolver>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.service_resolvers = v.into();
-        self
-    }
-
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::EkmConnection::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `key_management_mode`.
+    /// Sets the value of [key_management_mode][crate::model::EkmConnection::key_management_mode].
     pub fn set_key_management_mode<
         T: std::convert::Into<crate::model::ekm_connection::KeyManagementMode>,
     >(
@@ -1250,12 +1241,23 @@ impl EkmConnection {
         self
     }
 
-    /// Sets the value of `crypto_space_path`.
+    /// Sets the value of [crypto_space_path][crate::model::EkmConnection::crypto_space_path].
     pub fn set_crypto_space_path<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
     ) -> Self {
         self.crypto_space_path = v.into();
+        self
+    }
+
+    /// Sets the value of [service_resolvers][crate::model::EkmConnection::service_resolvers].
+    pub fn set_service_resolvers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ekm_connection::ServiceResolver>,
+    {
+        use std::iter::Iterator;
+        self.service_resolvers = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1311,7 +1313,7 @@ pub mod ekm_connection {
     }
 
     impl ServiceResolver {
-        /// Sets the value of `service_directory_service`.
+        /// Sets the value of [service_directory_service][crate::model::ekm_connection::ServiceResolver::service_directory_service].
         pub fn set_service_directory_service<T: std::convert::Into<std::string::String>>(
             mut self,
             v: T,
@@ -1320,7 +1322,7 @@ pub mod ekm_connection {
             self
         }
 
-        /// Sets the value of `endpoint_filter`.
+        /// Sets the value of [endpoint_filter][crate::model::ekm_connection::ServiceResolver::endpoint_filter].
         pub fn set_endpoint_filter<T: std::convert::Into<std::string::String>>(
             mut self,
             v: T,
@@ -1329,20 +1331,20 @@ pub mod ekm_connection {
             self
         }
 
-        /// Sets the value of `hostname`.
+        /// Sets the value of [hostname][crate::model::ekm_connection::ServiceResolver::hostname].
         pub fn set_hostname<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.hostname = v.into();
             self
         }
 
-        /// Sets the value of `server_certificates`.
-        pub fn set_server_certificates<
-            T: std::convert::Into<std::vec::Vec<crate::model::Certificate>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.server_certificates = v.into();
+        /// Sets the value of [server_certificates][crate::model::ekm_connection::ServiceResolver::server_certificates].
+        pub fn set_server_certificates<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::Certificate>,
+        {
+            use std::iter::Iterator;
+            self.server_certificates = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1461,13 +1463,13 @@ pub struct EkmConfig {
 }
 
 impl EkmConfig {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::EkmConfig::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `default_ekm_connection`.
+    /// Sets the value of [default_ekm_connection][crate::model::EkmConfig::default_ekm_connection].
     pub fn set_default_ekm_connection<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -1502,7 +1504,7 @@ pub struct VerifyConnectivityRequest {
 }
 
 impl VerifyConnectivityRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::VerifyConnectivityRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1560,13 +1562,13 @@ pub struct KeyRing {
 }
 
 impl KeyRing {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::KeyRing::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::KeyRing::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1734,13 +1736,13 @@ pub struct CryptoKey {
 }
 
 impl CryptoKey {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::CryptoKey::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `primary`.
+    /// Sets the value of [primary][crate::model::CryptoKey::primary].
     pub fn set_primary<
         T: std::convert::Into<std::option::Option<crate::model::CryptoKeyVersion>>,
     >(
@@ -1751,7 +1753,7 @@ impl CryptoKey {
         self
     }
 
-    /// Sets the value of `purpose`.
+    /// Sets the value of [purpose][crate::model::CryptoKey::purpose].
     pub fn set_purpose<T: std::convert::Into<crate::model::crypto_key::CryptoKeyPurpose>>(
         mut self,
         v: T,
@@ -1760,7 +1762,7 @@ impl CryptoKey {
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::CryptoKey::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1769,7 +1771,7 @@ impl CryptoKey {
         self
     }
 
-    /// Sets the value of `next_rotation_time`.
+    /// Sets the value of [next_rotation_time][crate::model::CryptoKey::next_rotation_time].
     pub fn set_next_rotation_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1778,7 +1780,7 @@ impl CryptoKey {
         self
     }
 
-    /// Sets the value of `version_template`.
+    /// Sets the value of [version_template][crate::model::CryptoKey::version_template].
     pub fn set_version_template<
         T: std::convert::Into<std::option::Option<crate::model::CryptoKeyVersionTemplate>>,
     >(
@@ -1789,24 +1791,13 @@ impl CryptoKey {
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `import_only`.
+    /// Sets the value of [import_only][crate::model::CryptoKey::import_only].
     pub fn set_import_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.import_only = v.into();
         self
     }
 
-    /// Sets the value of `destroy_scheduled_duration`.
+    /// Sets the value of [destroy_scheduled_duration][crate::model::CryptoKey::destroy_scheduled_duration].
     pub fn set_destroy_scheduled_duration<
         T: std::convert::Into<std::option::Option<wkt::Duration>>,
     >(
@@ -1817,7 +1808,7 @@ impl CryptoKey {
         self
     }
 
-    /// Sets the value of `crypto_key_backend`.
+    /// Sets the value of [crypto_key_backend][crate::model::CryptoKey::crypto_key_backend].
     pub fn set_crypto_key_backend<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -1826,7 +1817,7 @@ impl CryptoKey {
         self
     }
 
-    /// Sets the value of `key_access_justifications_policy`.
+    /// Sets the value of [key_access_justifications_policy][crate::model::CryptoKey::key_access_justifications_policy].
     pub fn set_key_access_justifications_policy<
         T: std::convert::Into<std::option::Option<crate::model::KeyAccessJustificationsPolicy>>,
     >(
@@ -1834,6 +1825,18 @@ impl CryptoKey {
         v: T,
     ) -> Self {
         self.key_access_justifications_policy = v.into();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::CryptoKey::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -2010,7 +2013,7 @@ pub struct CryptoKeyVersionTemplate {
 }
 
 impl CryptoKeyVersionTemplate {
-    /// Sets the value of `protection_level`.
+    /// Sets the value of [protection_level][crate::model::CryptoKeyVersionTemplate::protection_level].
     pub fn set_protection_level<T: std::convert::Into<crate::model::ProtectionLevel>>(
         mut self,
         v: T,
@@ -2019,7 +2022,7 @@ impl CryptoKeyVersionTemplate {
         self
     }
 
-    /// Sets the value of `algorithm`.
+    /// Sets the value of [algorithm][crate::model::CryptoKeyVersionTemplate::algorithm].
     pub fn set_algorithm<
         T: std::convert::Into<crate::model::crypto_key_version::CryptoKeyVersionAlgorithm>,
     >(
@@ -2061,7 +2064,7 @@ pub struct KeyOperationAttestation {
 }
 
 impl KeyOperationAttestation {
-    /// Sets the value of `format`.
+    /// Sets the value of [format][crate::model::KeyOperationAttestation::format].
     pub fn set_format<
         T: std::convert::Into<crate::model::key_operation_attestation::AttestationFormat>,
     >(
@@ -2072,13 +2075,13 @@ impl KeyOperationAttestation {
         self
     }
 
-    /// Sets the value of `content`.
+    /// Sets the value of [content][crate::model::KeyOperationAttestation::content].
     pub fn set_content<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.content = v.into();
         self
     }
 
-    /// Sets the value of `cert_chains`.
+    /// Sets the value of [cert_chains][crate::model::KeyOperationAttestation::cert_chains].
     pub fn set_cert_chains<
         T: std::convert::Into<
             std::option::Option<crate::model::key_operation_attestation::CertificateChains>,
@@ -2125,32 +2128,36 @@ pub mod key_operation_attestation {
     }
 
     impl CertificateChains {
-        /// Sets the value of `cavium_certs`.
-        pub fn set_cavium_certs<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.cavium_certs = v.into();
+        /// Sets the value of [cavium_certs][crate::model::key_operation_attestation::CertificateChains::cavium_certs].
+        pub fn set_cavium_certs<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.cavium_certs = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
-        /// Sets the value of `google_card_certs`.
-        pub fn set_google_card_certs<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.google_card_certs = v.into();
+        /// Sets the value of [google_card_certs][crate::model::key_operation_attestation::CertificateChains::google_card_certs].
+        pub fn set_google_card_certs<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.google_card_certs = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
-        /// Sets the value of `google_partition_certs`.
-        pub fn set_google_partition_certs<
-            T: std::convert::Into<std::vec::Vec<std::string::String>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.google_partition_certs = v.into();
+        /// Sets the value of [google_partition_certs][crate::model::key_operation_attestation::CertificateChains::google_partition_certs].
+        pub fn set_google_partition_certs<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.google_partition_certs = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -2364,13 +2371,13 @@ pub struct CryptoKeyVersion {
 }
 
 impl CryptoKeyVersion {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::CryptoKeyVersion::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::CryptoKeyVersion::state].
     pub fn set_state<
         T: std::convert::Into<crate::model::crypto_key_version::CryptoKeyVersionState>,
     >(
@@ -2381,7 +2388,7 @@ impl CryptoKeyVersion {
         self
     }
 
-    /// Sets the value of `protection_level`.
+    /// Sets the value of [protection_level][crate::model::CryptoKeyVersion::protection_level].
     pub fn set_protection_level<T: std::convert::Into<crate::model::ProtectionLevel>>(
         mut self,
         v: T,
@@ -2390,7 +2397,7 @@ impl CryptoKeyVersion {
         self
     }
 
-    /// Sets the value of `algorithm`.
+    /// Sets the value of [algorithm][crate::model::CryptoKeyVersion::algorithm].
     pub fn set_algorithm<
         T: std::convert::Into<crate::model::crypto_key_version::CryptoKeyVersionAlgorithm>,
     >(
@@ -2401,7 +2408,7 @@ impl CryptoKeyVersion {
         self
     }
 
-    /// Sets the value of `attestation`.
+    /// Sets the value of [attestation][crate::model::CryptoKeyVersion::attestation].
     pub fn set_attestation<
         T: std::convert::Into<std::option::Option<crate::model::KeyOperationAttestation>>,
     >(
@@ -2412,7 +2419,7 @@ impl CryptoKeyVersion {
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::CryptoKeyVersion::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2421,7 +2428,7 @@ impl CryptoKeyVersion {
         self
     }
 
-    /// Sets the value of `generate_time`.
+    /// Sets the value of [generate_time][crate::model::CryptoKeyVersion::generate_time].
     pub fn set_generate_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2430,7 +2437,7 @@ impl CryptoKeyVersion {
         self
     }
 
-    /// Sets the value of `destroy_time`.
+    /// Sets the value of [destroy_time][crate::model::CryptoKeyVersion::destroy_time].
     pub fn set_destroy_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2439,7 +2446,7 @@ impl CryptoKeyVersion {
         self
     }
 
-    /// Sets the value of `destroy_event_time`.
+    /// Sets the value of [destroy_event_time][crate::model::CryptoKeyVersion::destroy_event_time].
     pub fn set_destroy_event_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2448,13 +2455,13 @@ impl CryptoKeyVersion {
         self
     }
 
-    /// Sets the value of `import_job`.
+    /// Sets the value of [import_job][crate::model::CryptoKeyVersion::import_job].
     pub fn set_import_job<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.import_job = v.into();
         self
     }
 
-    /// Sets the value of `import_time`.
+    /// Sets the value of [import_time][crate::model::CryptoKeyVersion::import_time].
     pub fn set_import_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2463,7 +2470,7 @@ impl CryptoKeyVersion {
         self
     }
 
-    /// Sets the value of `import_failure_reason`.
+    /// Sets the value of [import_failure_reason][crate::model::CryptoKeyVersion::import_failure_reason].
     pub fn set_import_failure_reason<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -2472,7 +2479,7 @@ impl CryptoKeyVersion {
         self
     }
 
-    /// Sets the value of `generation_failure_reason`.
+    /// Sets the value of [generation_failure_reason][crate::model::CryptoKeyVersion::generation_failure_reason].
     pub fn set_generation_failure_reason<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -2481,7 +2488,7 @@ impl CryptoKeyVersion {
         self
     }
 
-    /// Sets the value of `external_destruction_failure_reason`.
+    /// Sets the value of [external_destruction_failure_reason][crate::model::CryptoKeyVersion::external_destruction_failure_reason].
     pub fn set_external_destruction_failure_reason<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -2490,7 +2497,7 @@ impl CryptoKeyVersion {
         self
     }
 
-    /// Sets the value of `external_protection_level_options`.
+    /// Sets the value of [external_protection_level_options][crate::model::CryptoKeyVersion::external_protection_level_options].
     pub fn set_external_protection_level_options<
         T: std::convert::Into<std::option::Option<crate::model::ExternalProtectionLevelOptions>>,
     >(
@@ -2501,7 +2508,7 @@ impl CryptoKeyVersion {
         self
     }
 
-    /// Sets the value of `reimport_eligible`.
+    /// Sets the value of [reimport_eligible][crate::model::CryptoKeyVersion::reimport_eligible].
     pub fn set_reimport_eligible<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.reimport_eligible = v.into();
         self
@@ -2934,13 +2941,13 @@ pub struct PublicKey {
 }
 
 impl PublicKey {
-    /// Sets the value of `pem`.
+    /// Sets the value of [pem][crate::model::PublicKey::pem].
     pub fn set_pem<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.pem = v.into();
         self
     }
 
-    /// Sets the value of `algorithm`.
+    /// Sets the value of [algorithm][crate::model::PublicKey::algorithm].
     pub fn set_algorithm<
         T: std::convert::Into<crate::model::crypto_key_version::CryptoKeyVersionAlgorithm>,
     >(
@@ -2951,7 +2958,7 @@ impl PublicKey {
         self
     }
 
-    /// Sets the value of `pem_crc32c`.
+    /// Sets the value of [pem_crc32c][crate::model::PublicKey::pem_crc32c].
     pub fn set_pem_crc32c<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(
         mut self,
         v: T,
@@ -2960,13 +2967,13 @@ impl PublicKey {
         self
     }
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::PublicKey::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `protection_level`.
+    /// Sets the value of [protection_level][crate::model::PublicKey::protection_level].
     pub fn set_protection_level<T: std::convert::Into<crate::model::ProtectionLevel>>(
         mut self,
         v: T,
@@ -3115,13 +3122,13 @@ pub struct ImportJob {
 }
 
 impl ImportJob {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::ImportJob::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `import_method`.
+    /// Sets the value of [import_method][crate::model::ImportJob::import_method].
     pub fn set_import_method<T: std::convert::Into<crate::model::import_job::ImportMethod>>(
         mut self,
         v: T,
@@ -3130,7 +3137,7 @@ impl ImportJob {
         self
     }
 
-    /// Sets the value of `protection_level`.
+    /// Sets the value of [protection_level][crate::model::ImportJob::protection_level].
     pub fn set_protection_level<T: std::convert::Into<crate::model::ProtectionLevel>>(
         mut self,
         v: T,
@@ -3139,7 +3146,7 @@ impl ImportJob {
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::ImportJob::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3148,7 +3155,7 @@ impl ImportJob {
         self
     }
 
-    /// Sets the value of `generate_time`.
+    /// Sets the value of [generate_time][crate::model::ImportJob::generate_time].
     pub fn set_generate_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3157,7 +3164,7 @@ impl ImportJob {
         self
     }
 
-    /// Sets the value of `expire_time`.
+    /// Sets the value of [expire_time][crate::model::ImportJob::expire_time].
     pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3166,7 +3173,7 @@ impl ImportJob {
         self
     }
 
-    /// Sets the value of `expire_event_time`.
+    /// Sets the value of [expire_event_time][crate::model::ImportJob::expire_event_time].
     pub fn set_expire_event_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3175,7 +3182,7 @@ impl ImportJob {
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::ImportJob::state].
     pub fn set_state<T: std::convert::Into<crate::model::import_job::ImportJobState>>(
         mut self,
         v: T,
@@ -3184,7 +3191,7 @@ impl ImportJob {
         self
     }
 
-    /// Sets the value of `public_key`.
+    /// Sets the value of [public_key][crate::model::ImportJob::public_key].
     pub fn set_public_key<
         T: std::convert::Into<std::option::Option<crate::model::import_job::WrappingPublicKey>>,
     >(
@@ -3195,7 +3202,7 @@ impl ImportJob {
         self
     }
 
-    /// Sets the value of `attestation`.
+    /// Sets the value of [attestation][crate::model::ImportJob::attestation].
     pub fn set_attestation<
         T: std::convert::Into<std::option::Option<crate::model::KeyOperationAttestation>>,
     >(
@@ -3238,7 +3245,7 @@ pub mod import_job {
     }
 
     impl WrappingPublicKey {
-        /// Sets the value of `pem`.
+        /// Sets the value of [pem][crate::model::import_job::WrappingPublicKey::pem].
         pub fn set_pem<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.pem = v.into();
             self
@@ -3406,7 +3413,7 @@ pub struct ExternalProtectionLevelOptions {
 }
 
 impl ExternalProtectionLevelOptions {
-    /// Sets the value of `external_key_uri`.
+    /// Sets the value of [external_key_uri][crate::model::ExternalProtectionLevelOptions::external_key_uri].
     pub fn set_external_key_uri<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -3415,7 +3422,7 @@ impl ExternalProtectionLevelOptions {
         self
     }
 
-    /// Sets the value of `ekm_connection_key_path`.
+    /// Sets the value of [ekm_connection_key_path][crate::model::ExternalProtectionLevelOptions::ekm_connection_key_path].
     pub fn set_ekm_connection_key_path<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -3457,14 +3464,14 @@ pub struct KeyAccessJustificationsPolicy {
 }
 
 impl KeyAccessJustificationsPolicy {
-    /// Sets the value of `allowed_access_reasons`.
-    pub fn set_allowed_access_reasons<
-        T: std::convert::Into<std::vec::Vec<crate::model::AccessReason>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.allowed_access_reasons = v.into();
+    /// Sets the value of [allowed_access_reasons][crate::model::KeyAccessJustificationsPolicy::allowed_access_reasons].
+    pub fn set_allowed_access_reasons<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AccessReason>,
+    {
+        use std::iter::Iterator;
+        self.allowed_access_reasons = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3527,31 +3534,31 @@ pub struct ListKeyRingsRequest {
 }
 
 impl ListKeyRingsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListKeyRingsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListKeyRingsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListKeyRingsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListKeyRingsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
     }
 
-    /// Sets the value of `order_by`.
+    /// Sets the value of [order_by][crate::model::ListKeyRingsRequest::order_by].
     pub fn set_order_by<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.order_by = v.into();
         self
@@ -3618,25 +3625,25 @@ pub struct ListCryptoKeysRequest {
 }
 
 impl ListCryptoKeysRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListCryptoKeysRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListCryptoKeysRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListCryptoKeysRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `version_view`.
+    /// Sets the value of [version_view][crate::model::ListCryptoKeysRequest::version_view].
     pub fn set_version_view<
         T: std::convert::Into<crate::model::crypto_key_version::CryptoKeyVersionView>,
     >(
@@ -3647,13 +3654,13 @@ impl ListCryptoKeysRequest {
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListCryptoKeysRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
     }
 
-    /// Sets the value of `order_by`.
+    /// Sets the value of [order_by][crate::model::ListCryptoKeysRequest::order_by].
     pub fn set_order_by<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.order_by = v.into();
         self
@@ -3721,25 +3728,25 @@ pub struct ListCryptoKeyVersionsRequest {
 }
 
 impl ListCryptoKeyVersionsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListCryptoKeyVersionsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListCryptoKeyVersionsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListCryptoKeyVersionsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `view`.
+    /// Sets the value of [view][crate::model::ListCryptoKeyVersionsRequest::view].
     pub fn set_view<
         T: std::convert::Into<crate::model::crypto_key_version::CryptoKeyVersionView>,
     >(
@@ -3750,13 +3757,13 @@ impl ListCryptoKeyVersionsRequest {
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListCryptoKeyVersionsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
     }
 
-    /// Sets the value of `order_by`.
+    /// Sets the value of [order_by][crate::model::ListCryptoKeyVersionsRequest::order_by].
     pub fn set_order_by<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.order_by = v.into();
         self
@@ -3820,31 +3827,31 @@ pub struct ListImportJobsRequest {
 }
 
 impl ListImportJobsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListImportJobsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListImportJobsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListImportJobsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListImportJobsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
     }
 
-    /// Sets the value of `order_by`.
+    /// Sets the value of [order_by][crate::model::ListImportJobsRequest::order_by].
     pub fn set_order_by<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.order_by = v.into();
         self
@@ -3888,24 +3895,26 @@ pub struct ListKeyRingsResponse {
 }
 
 impl ListKeyRingsResponse {
-    /// Sets the value of `key_rings`.
-    pub fn set_key_rings<T: std::convert::Into<std::vec::Vec<crate::model::KeyRing>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.key_rings = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListKeyRingsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `total_size`.
+    /// Sets the value of [total_size][crate::model::ListKeyRingsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
+        self
+    }
+
+    /// Sets the value of [key_rings][crate::model::ListKeyRingsResponse::key_rings].
+    pub fn set_key_rings<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::KeyRing>,
+    {
+        use std::iter::Iterator;
+        self.key_rings = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3960,24 +3969,26 @@ pub struct ListCryptoKeysResponse {
 }
 
 impl ListCryptoKeysResponse {
-    /// Sets the value of `crypto_keys`.
-    pub fn set_crypto_keys<T: std::convert::Into<std::vec::Vec<crate::model::CryptoKey>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.crypto_keys = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListCryptoKeysResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `total_size`.
+    /// Sets the value of [total_size][crate::model::ListCryptoKeysResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
+        self
+    }
+
+    /// Sets the value of [crypto_keys][crate::model::ListCryptoKeysResponse::crypto_keys].
+    pub fn set_crypto_keys<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::CryptoKey>,
+    {
+        use std::iter::Iterator;
+        self.crypto_keys = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4033,26 +4044,26 @@ pub struct ListCryptoKeyVersionsResponse {
 }
 
 impl ListCryptoKeyVersionsResponse {
-    /// Sets the value of `crypto_key_versions`.
-    pub fn set_crypto_key_versions<
-        T: std::convert::Into<std::vec::Vec<crate::model::CryptoKeyVersion>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.crypto_key_versions = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListCryptoKeyVersionsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `total_size`.
+    /// Sets the value of [total_size][crate::model::ListCryptoKeyVersionsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
+        self
+    }
+
+    /// Sets the value of [crypto_key_versions][crate::model::ListCryptoKeyVersionsResponse::crypto_key_versions].
+    pub fn set_crypto_key_versions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::CryptoKeyVersion>,
+    {
+        use std::iter::Iterator;
+        self.crypto_key_versions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4107,24 +4118,26 @@ pub struct ListImportJobsResponse {
 }
 
 impl ListImportJobsResponse {
-    /// Sets the value of `import_jobs`.
-    pub fn set_import_jobs<T: std::convert::Into<std::vec::Vec<crate::model::ImportJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.import_jobs = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListImportJobsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `total_size`.
+    /// Sets the value of [total_size][crate::model::ListImportJobsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
+        self
+    }
+
+    /// Sets the value of [import_jobs][crate::model::ListImportJobsResponse::import_jobs].
+    pub fn set_import_jobs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ImportJob>,
+    {
+        use std::iter::Iterator;
+        self.import_jobs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4167,7 +4180,7 @@ pub struct GetKeyRingRequest {
 }
 
 impl GetKeyRingRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetKeyRingRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -4199,7 +4212,7 @@ pub struct GetCryptoKeyRequest {
 }
 
 impl GetCryptoKeyRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetCryptoKeyRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -4231,7 +4244,7 @@ pub struct GetCryptoKeyVersionRequest {
 }
 
 impl GetCryptoKeyVersionRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetCryptoKeyVersionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -4263,7 +4276,7 @@ pub struct GetPublicKeyRequest {
 }
 
 impl GetPublicKeyRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetPublicKeyRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -4295,7 +4308,7 @@ pub struct GetImportJobRequest {
 }
 
 impl GetImportJobRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetImportJobRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -4339,19 +4352,19 @@ pub struct CreateKeyRingRequest {
 }
 
 impl CreateKeyRingRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateKeyRingRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `key_ring_id`.
+    /// Sets the value of [key_ring_id][crate::model::CreateKeyRingRequest::key_ring_id].
     pub fn set_key_ring_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.key_ring_id = v.into();
         self
     }
 
-    /// Sets the value of `key_ring`.
+    /// Sets the value of [key_ring][crate::model::CreateKeyRingRequest::key_ring].
     pub fn set_key_ring<T: std::convert::Into<std::option::Option<crate::model::KeyRing>>>(
         mut self,
         v: T,
@@ -4413,19 +4426,19 @@ pub struct CreateCryptoKeyRequest {
 }
 
 impl CreateCryptoKeyRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateCryptoKeyRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `crypto_key_id`.
+    /// Sets the value of [crypto_key_id][crate::model::CreateCryptoKeyRequest::crypto_key_id].
     pub fn set_crypto_key_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.crypto_key_id = v.into();
         self
     }
 
-    /// Sets the value of `crypto_key`.
+    /// Sets the value of [crypto_key][crate::model::CreateCryptoKeyRequest::crypto_key].
     pub fn set_crypto_key<T: std::convert::Into<std::option::Option<crate::model::CryptoKey>>>(
         mut self,
         v: T,
@@ -4434,7 +4447,7 @@ impl CreateCryptoKeyRequest {
         self
     }
 
-    /// Sets the value of `skip_initial_version_creation`.
+    /// Sets the value of [skip_initial_version_creation][crate::model::CreateCryptoKeyRequest::skip_initial_version_creation].
     pub fn set_skip_initial_version_creation<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.skip_initial_version_creation = v.into();
         self
@@ -4475,13 +4488,13 @@ pub struct CreateCryptoKeyVersionRequest {
 }
 
 impl CreateCryptoKeyVersionRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateCryptoKeyVersionRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `crypto_key_version`.
+    /// Sets the value of [crypto_key_version][crate::model::CreateCryptoKeyVersionRequest::crypto_key_version].
     pub fn set_crypto_key_version<
         T: std::convert::Into<std::option::Option<crate::model::CryptoKeyVersion>>,
     >(
@@ -4624,13 +4637,13 @@ pub struct ImportCryptoKeyVersionRequest {
 }
 
 impl ImportCryptoKeyVersionRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ImportCryptoKeyVersionRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `crypto_key_version`.
+    /// Sets the value of [crypto_key_version][crate::model::ImportCryptoKeyVersionRequest::crypto_key_version].
     pub fn set_crypto_key_version<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -4639,7 +4652,7 @@ impl ImportCryptoKeyVersionRequest {
         self
     }
 
-    /// Sets the value of `algorithm`.
+    /// Sets the value of [algorithm][crate::model::ImportCryptoKeyVersionRequest::algorithm].
     pub fn set_algorithm<
         T: std::convert::Into<crate::model::crypto_key_version::CryptoKeyVersionAlgorithm>,
     >(
@@ -4650,13 +4663,13 @@ impl ImportCryptoKeyVersionRequest {
         self
     }
 
-    /// Sets the value of `import_job`.
+    /// Sets the value of [import_job][crate::model::ImportCryptoKeyVersionRequest::import_job].
     pub fn set_import_job<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.import_job = v.into();
         self
     }
 
-    /// Sets the value of `wrapped_key`.
+    /// Sets the value of [wrapped_key][crate::model::ImportCryptoKeyVersionRequest::wrapped_key].
     pub fn set_wrapped_key<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.wrapped_key = v.into();
         self
@@ -4741,19 +4754,19 @@ pub struct CreateImportJobRequest {
 }
 
 impl CreateImportJobRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateImportJobRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `import_job_id`.
+    /// Sets the value of [import_job_id][crate::model::CreateImportJobRequest::import_job_id].
     pub fn set_import_job_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.import_job_id = v.into();
         self
     }
 
-    /// Sets the value of `import_job`.
+    /// Sets the value of [import_job][crate::model::CreateImportJobRequest::import_job].
     pub fn set_import_job<T: std::convert::Into<std::option::Option<crate::model::ImportJob>>>(
         mut self,
         v: T,
@@ -4790,7 +4803,7 @@ pub struct UpdateCryptoKeyRequest {
 }
 
 impl UpdateCryptoKeyRequest {
-    /// Sets the value of `crypto_key`.
+    /// Sets the value of [crypto_key][crate::model::UpdateCryptoKeyRequest::crypto_key].
     pub fn set_crypto_key<T: std::convert::Into<std::option::Option<crate::model::CryptoKey>>>(
         mut self,
         v: T,
@@ -4799,7 +4812,7 @@ impl UpdateCryptoKeyRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateCryptoKeyRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -4837,7 +4850,7 @@ pub struct UpdateCryptoKeyVersionRequest {
 }
 
 impl UpdateCryptoKeyVersionRequest {
-    /// Sets the value of `crypto_key_version`.
+    /// Sets the value of [crypto_key_version][crate::model::UpdateCryptoKeyVersionRequest::crypto_key_version].
     pub fn set_crypto_key_version<
         T: std::convert::Into<std::option::Option<crate::model::CryptoKeyVersion>>,
     >(
@@ -4848,7 +4861,7 @@ impl UpdateCryptoKeyVersionRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateCryptoKeyVersionRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -4889,13 +4902,13 @@ pub struct UpdateCryptoKeyPrimaryVersionRequest {
 }
 
 impl UpdateCryptoKeyPrimaryVersionRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::UpdateCryptoKeyPrimaryVersionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `crypto_key_version_id`.
+    /// Sets the value of [crypto_key_version_id][crate::model::UpdateCryptoKeyPrimaryVersionRequest::crypto_key_version_id].
     pub fn set_crypto_key_version_id<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -4929,7 +4942,7 @@ pub struct DestroyCryptoKeyVersionRequest {
 }
 
 impl DestroyCryptoKeyVersionRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DestroyCryptoKeyVersionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -4960,7 +4973,7 @@ pub struct RestoreCryptoKeyVersionRequest {
 }
 
 impl RestoreCryptoKeyVersionRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::RestoreCryptoKeyVersionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -5099,19 +5112,19 @@ pub struct EncryptRequest {
 }
 
 impl EncryptRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::EncryptRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `plaintext`.
+    /// Sets the value of [plaintext][crate::model::EncryptRequest::plaintext].
     pub fn set_plaintext<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.plaintext = v.into();
         self
     }
 
-    /// Sets the value of `additional_authenticated_data`.
+    /// Sets the value of [additional_authenticated_data][crate::model::EncryptRequest::additional_authenticated_data].
     pub fn set_additional_authenticated_data<T: std::convert::Into<bytes::Bytes>>(
         mut self,
         v: T,
@@ -5120,7 +5133,7 @@ impl EncryptRequest {
         self
     }
 
-    /// Sets the value of `plaintext_crc32c`.
+    /// Sets the value of [plaintext_crc32c][crate::model::EncryptRequest::plaintext_crc32c].
     pub fn set_plaintext_crc32c<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(
         mut self,
         v: T,
@@ -5129,7 +5142,7 @@ impl EncryptRequest {
         self
     }
 
-    /// Sets the value of `additional_authenticated_data_crc32c`.
+    /// Sets the value of [additional_authenticated_data_crc32c][crate::model::EncryptRequest::additional_authenticated_data_crc32c].
     pub fn set_additional_authenticated_data_crc32c<
         T: std::convert::Into<std::option::Option<wkt::Int64Value>>,
     >(
@@ -5238,19 +5251,19 @@ pub struct DecryptRequest {
 }
 
 impl DecryptRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DecryptRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `ciphertext`.
+    /// Sets the value of [ciphertext][crate::model::DecryptRequest::ciphertext].
     pub fn set_ciphertext<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.ciphertext = v.into();
         self
     }
 
-    /// Sets the value of `additional_authenticated_data`.
+    /// Sets the value of [additional_authenticated_data][crate::model::DecryptRequest::additional_authenticated_data].
     pub fn set_additional_authenticated_data<T: std::convert::Into<bytes::Bytes>>(
         mut self,
         v: T,
@@ -5259,7 +5272,7 @@ impl DecryptRequest {
         self
     }
 
-    /// Sets the value of `ciphertext_crc32c`.
+    /// Sets the value of [ciphertext_crc32c][crate::model::DecryptRequest::ciphertext_crc32c].
     pub fn set_ciphertext_crc32c<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(
         mut self,
         v: T,
@@ -5268,7 +5281,7 @@ impl DecryptRequest {
         self
     }
 
-    /// Sets the value of `additional_authenticated_data_crc32c`.
+    /// Sets the value of [additional_authenticated_data_crc32c][crate::model::DecryptRequest::additional_authenticated_data_crc32c].
     pub fn set_additional_authenticated_data_crc32c<
         T: std::convert::Into<std::option::Option<wkt::Int64Value>>,
     >(
@@ -5428,19 +5441,19 @@ pub struct RawEncryptRequest {
 }
 
 impl RawEncryptRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::RawEncryptRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `plaintext`.
+    /// Sets the value of [plaintext][crate::model::RawEncryptRequest::plaintext].
     pub fn set_plaintext<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.plaintext = v.into();
         self
     }
 
-    /// Sets the value of `additional_authenticated_data`.
+    /// Sets the value of [additional_authenticated_data][crate::model::RawEncryptRequest::additional_authenticated_data].
     pub fn set_additional_authenticated_data<T: std::convert::Into<bytes::Bytes>>(
         mut self,
         v: T,
@@ -5449,7 +5462,7 @@ impl RawEncryptRequest {
         self
     }
 
-    /// Sets the value of `plaintext_crc32c`.
+    /// Sets the value of [plaintext_crc32c][crate::model::RawEncryptRequest::plaintext_crc32c].
     pub fn set_plaintext_crc32c<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(
         mut self,
         v: T,
@@ -5458,7 +5471,7 @@ impl RawEncryptRequest {
         self
     }
 
-    /// Sets the value of `additional_authenticated_data_crc32c`.
+    /// Sets the value of [additional_authenticated_data_crc32c][crate::model::RawEncryptRequest::additional_authenticated_data_crc32c].
     pub fn set_additional_authenticated_data_crc32c<
         T: std::convert::Into<std::option::Option<wkt::Int64Value>>,
     >(
@@ -5469,13 +5482,13 @@ impl RawEncryptRequest {
         self
     }
 
-    /// Sets the value of `initialization_vector`.
+    /// Sets the value of [initialization_vector][crate::model::RawEncryptRequest::initialization_vector].
     pub fn set_initialization_vector<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.initialization_vector = v.into();
         self
     }
 
-    /// Sets the value of `initialization_vector_crc32c`.
+    /// Sets the value of [initialization_vector_crc32c][crate::model::RawEncryptRequest::initialization_vector_crc32c].
     pub fn set_initialization_vector_crc32c<
         T: std::convert::Into<std::option::Option<wkt::Int64Value>>,
     >(
@@ -5612,19 +5625,19 @@ pub struct RawDecryptRequest {
 }
 
 impl RawDecryptRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::RawDecryptRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `ciphertext`.
+    /// Sets the value of [ciphertext][crate::model::RawDecryptRequest::ciphertext].
     pub fn set_ciphertext<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.ciphertext = v.into();
         self
     }
 
-    /// Sets the value of `additional_authenticated_data`.
+    /// Sets the value of [additional_authenticated_data][crate::model::RawDecryptRequest::additional_authenticated_data].
     pub fn set_additional_authenticated_data<T: std::convert::Into<bytes::Bytes>>(
         mut self,
         v: T,
@@ -5633,19 +5646,19 @@ impl RawDecryptRequest {
         self
     }
 
-    /// Sets the value of `initialization_vector`.
+    /// Sets the value of [initialization_vector][crate::model::RawDecryptRequest::initialization_vector].
     pub fn set_initialization_vector<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.initialization_vector = v.into();
         self
     }
 
-    /// Sets the value of `tag_length`.
+    /// Sets the value of [tag_length][crate::model::RawDecryptRequest::tag_length].
     pub fn set_tag_length<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.tag_length = v.into();
         self
     }
 
-    /// Sets the value of `ciphertext_crc32c`.
+    /// Sets the value of [ciphertext_crc32c][crate::model::RawDecryptRequest::ciphertext_crc32c].
     pub fn set_ciphertext_crc32c<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(
         mut self,
         v: T,
@@ -5654,7 +5667,7 @@ impl RawDecryptRequest {
         self
     }
 
-    /// Sets the value of `additional_authenticated_data_crc32c`.
+    /// Sets the value of [additional_authenticated_data_crc32c][crate::model::RawDecryptRequest::additional_authenticated_data_crc32c].
     pub fn set_additional_authenticated_data_crc32c<
         T: std::convert::Into<std::option::Option<wkt::Int64Value>>,
     >(
@@ -5665,7 +5678,7 @@ impl RawDecryptRequest {
         self
     }
 
-    /// Sets the value of `initialization_vector_crc32c`.
+    /// Sets the value of [initialization_vector_crc32c][crate::model::RawDecryptRequest::initialization_vector_crc32c].
     pub fn set_initialization_vector_crc32c<
         T: std::convert::Into<std::option::Option<wkt::Int64Value>>,
     >(
@@ -5781,13 +5794,13 @@ pub struct AsymmetricSignRequest {
 }
 
 impl AsymmetricSignRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::AsymmetricSignRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `digest`.
+    /// Sets the value of [digest][crate::model::AsymmetricSignRequest::digest].
     pub fn set_digest<T: std::convert::Into<std::option::Option<crate::model::Digest>>>(
         mut self,
         v: T,
@@ -5796,7 +5809,7 @@ impl AsymmetricSignRequest {
         self
     }
 
-    /// Sets the value of `digest_crc32c`.
+    /// Sets the value of [digest_crc32c][crate::model::AsymmetricSignRequest::digest_crc32c].
     pub fn set_digest_crc32c<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(
         mut self,
         v: T,
@@ -5805,13 +5818,13 @@ impl AsymmetricSignRequest {
         self
     }
 
-    /// Sets the value of `data`.
+    /// Sets the value of [data][crate::model::AsymmetricSignRequest::data].
     pub fn set_data<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.data = v.into();
         self
     }
 
-    /// Sets the value of `data_crc32c`.
+    /// Sets the value of [data_crc32c][crate::model::AsymmetricSignRequest::data_crc32c].
     pub fn set_data_crc32c<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(
         mut self,
         v: T,
@@ -5883,19 +5896,19 @@ pub struct AsymmetricDecryptRequest {
 }
 
 impl AsymmetricDecryptRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::AsymmetricDecryptRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `ciphertext`.
+    /// Sets the value of [ciphertext][crate::model::AsymmetricDecryptRequest::ciphertext].
     pub fn set_ciphertext<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.ciphertext = v.into();
         self
     }
 
-    /// Sets the value of `ciphertext_crc32c`.
+    /// Sets the value of [ciphertext_crc32c][crate::model::AsymmetricDecryptRequest::ciphertext_crc32c].
     pub fn set_ciphertext_crc32c<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(
         mut self,
         v: T,
@@ -5962,19 +5975,19 @@ pub struct MacSignRequest {
 }
 
 impl MacSignRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::MacSignRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `data`.
+    /// Sets the value of [data][crate::model::MacSignRequest::data].
     pub fn set_data<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.data = v.into();
         self
     }
 
-    /// Sets the value of `data_crc32c`.
+    /// Sets the value of [data_crc32c][crate::model::MacSignRequest::data_crc32c].
     pub fn set_data_crc32c<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(
         mut self,
         v: T,
@@ -6076,19 +6089,19 @@ pub struct MacVerifyRequest {
 }
 
 impl MacVerifyRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::MacVerifyRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `data`.
+    /// Sets the value of [data][crate::model::MacVerifyRequest::data].
     pub fn set_data<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.data = v.into();
         self
     }
 
-    /// Sets the value of `data_crc32c`.
+    /// Sets the value of [data_crc32c][crate::model::MacVerifyRequest::data_crc32c].
     pub fn set_data_crc32c<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(
         mut self,
         v: T,
@@ -6097,13 +6110,13 @@ impl MacVerifyRequest {
         self
     }
 
-    /// Sets the value of `mac`.
+    /// Sets the value of [mac][crate::model::MacVerifyRequest::mac].
     pub fn set_mac<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.mac = v.into();
         self
     }
 
-    /// Sets the value of `mac_crc32c`.
+    /// Sets the value of [mac_crc32c][crate::model::MacVerifyRequest::mac_crc32c].
     pub fn set_mac_crc32c<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(
         mut self,
         v: T,
@@ -6148,19 +6161,19 @@ pub struct GenerateRandomBytesRequest {
 }
 
 impl GenerateRandomBytesRequest {
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::GenerateRandomBytesRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `length_bytes`.
+    /// Sets the value of [length_bytes][crate::model::GenerateRandomBytesRequest::length_bytes].
     pub fn set_length_bytes<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.length_bytes = v.into();
         self
     }
 
-    /// Sets the value of `protection_level`.
+    /// Sets the value of [protection_level][crate::model::GenerateRandomBytesRequest::protection_level].
     pub fn set_protection_level<T: std::convert::Into<crate::model::ProtectionLevel>>(
         mut self,
         v: T,
@@ -6271,19 +6284,19 @@ pub struct EncryptResponse {
 }
 
 impl EncryptResponse {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::EncryptResponse::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `ciphertext`.
+    /// Sets the value of [ciphertext][crate::model::EncryptResponse::ciphertext].
     pub fn set_ciphertext<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.ciphertext = v.into();
         self
     }
 
-    /// Sets the value of `ciphertext_crc32c`.
+    /// Sets the value of [ciphertext_crc32c][crate::model::EncryptResponse::ciphertext_crc32c].
     pub fn set_ciphertext_crc32c<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(
         mut self,
         v: T,
@@ -6292,13 +6305,13 @@ impl EncryptResponse {
         self
     }
 
-    /// Sets the value of `verified_plaintext_crc32c`.
+    /// Sets the value of [verified_plaintext_crc32c][crate::model::EncryptResponse::verified_plaintext_crc32c].
     pub fn set_verified_plaintext_crc32c<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.verified_plaintext_crc32c = v.into();
         self
     }
 
-    /// Sets the value of `verified_additional_authenticated_data_crc32c`.
+    /// Sets the value of [verified_additional_authenticated_data_crc32c][crate::model::EncryptResponse::verified_additional_authenticated_data_crc32c].
     pub fn set_verified_additional_authenticated_data_crc32c<T: std::convert::Into<bool>>(
         mut self,
         v: T,
@@ -6307,7 +6320,7 @@ impl EncryptResponse {
         self
     }
 
-    /// Sets the value of `protection_level`.
+    /// Sets the value of [protection_level][crate::model::EncryptResponse::protection_level].
     pub fn set_protection_level<T: std::convert::Into<crate::model::ProtectionLevel>>(
         mut self,
         v: T,
@@ -6379,13 +6392,13 @@ pub struct DecryptResponse {
 }
 
 impl DecryptResponse {
-    /// Sets the value of `plaintext`.
+    /// Sets the value of [plaintext][crate::model::DecryptResponse::plaintext].
     pub fn set_plaintext<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.plaintext = v.into();
         self
     }
 
-    /// Sets the value of `plaintext_crc32c`.
+    /// Sets the value of [plaintext_crc32c][crate::model::DecryptResponse::plaintext_crc32c].
     pub fn set_plaintext_crc32c<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(
         mut self,
         v: T,
@@ -6394,13 +6407,13 @@ impl DecryptResponse {
         self
     }
 
-    /// Sets the value of `used_primary`.
+    /// Sets the value of [used_primary][crate::model::DecryptResponse::used_primary].
     pub fn set_used_primary<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.used_primary = v.into();
         self
     }
 
-    /// Sets the value of `protection_level`.
+    /// Sets the value of [protection_level][crate::model::DecryptResponse::protection_level].
     pub fn set_protection_level<T: std::convert::Into<crate::model::ProtectionLevel>>(
         mut self,
         v: T,
@@ -6558,25 +6571,25 @@ pub struct RawEncryptResponse {
 }
 
 impl RawEncryptResponse {
-    /// Sets the value of `ciphertext`.
+    /// Sets the value of [ciphertext][crate::model::RawEncryptResponse::ciphertext].
     pub fn set_ciphertext<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.ciphertext = v.into();
         self
     }
 
-    /// Sets the value of `initialization_vector`.
+    /// Sets the value of [initialization_vector][crate::model::RawEncryptResponse::initialization_vector].
     pub fn set_initialization_vector<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.initialization_vector = v.into();
         self
     }
 
-    /// Sets the value of `tag_length`.
+    /// Sets the value of [tag_length][crate::model::RawEncryptResponse::tag_length].
     pub fn set_tag_length<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.tag_length = v.into();
         self
     }
 
-    /// Sets the value of `ciphertext_crc32c`.
+    /// Sets the value of [ciphertext_crc32c][crate::model::RawEncryptResponse::ciphertext_crc32c].
     pub fn set_ciphertext_crc32c<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(
         mut self,
         v: T,
@@ -6585,7 +6598,7 @@ impl RawEncryptResponse {
         self
     }
 
-    /// Sets the value of `initialization_vector_crc32c`.
+    /// Sets the value of [initialization_vector_crc32c][crate::model::RawEncryptResponse::initialization_vector_crc32c].
     pub fn set_initialization_vector_crc32c<
         T: std::convert::Into<std::option::Option<wkt::Int64Value>>,
     >(
@@ -6596,13 +6609,13 @@ impl RawEncryptResponse {
         self
     }
 
-    /// Sets the value of `verified_plaintext_crc32c`.
+    /// Sets the value of [verified_plaintext_crc32c][crate::model::RawEncryptResponse::verified_plaintext_crc32c].
     pub fn set_verified_plaintext_crc32c<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.verified_plaintext_crc32c = v.into();
         self
     }
 
-    /// Sets the value of `verified_additional_authenticated_data_crc32c`.
+    /// Sets the value of [verified_additional_authenticated_data_crc32c][crate::model::RawEncryptResponse::verified_additional_authenticated_data_crc32c].
     pub fn set_verified_additional_authenticated_data_crc32c<T: std::convert::Into<bool>>(
         mut self,
         v: T,
@@ -6611,7 +6624,7 @@ impl RawEncryptResponse {
         self
     }
 
-    /// Sets the value of `verified_initialization_vector_crc32c`.
+    /// Sets the value of [verified_initialization_vector_crc32c][crate::model::RawEncryptResponse::verified_initialization_vector_crc32c].
     pub fn set_verified_initialization_vector_crc32c<T: std::convert::Into<bool>>(
         mut self,
         v: T,
@@ -6620,13 +6633,13 @@ impl RawEncryptResponse {
         self
     }
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::RawEncryptResponse::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `protection_level`.
+    /// Sets the value of [protection_level][crate::model::RawEncryptResponse::protection_level].
     pub fn set_protection_level<T: std::convert::Into<crate::model::ProtectionLevel>>(
         mut self,
         v: T,
@@ -6747,13 +6760,13 @@ pub struct RawDecryptResponse {
 }
 
 impl RawDecryptResponse {
-    /// Sets the value of `plaintext`.
+    /// Sets the value of [plaintext][crate::model::RawDecryptResponse::plaintext].
     pub fn set_plaintext<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.plaintext = v.into();
         self
     }
 
-    /// Sets the value of `plaintext_crc32c`.
+    /// Sets the value of [plaintext_crc32c][crate::model::RawDecryptResponse::plaintext_crc32c].
     pub fn set_plaintext_crc32c<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(
         mut self,
         v: T,
@@ -6762,7 +6775,7 @@ impl RawDecryptResponse {
         self
     }
 
-    /// Sets the value of `protection_level`.
+    /// Sets the value of [protection_level][crate::model::RawDecryptResponse::protection_level].
     pub fn set_protection_level<T: std::convert::Into<crate::model::ProtectionLevel>>(
         mut self,
         v: T,
@@ -6771,13 +6784,13 @@ impl RawDecryptResponse {
         self
     }
 
-    /// Sets the value of `verified_ciphertext_crc32c`.
+    /// Sets the value of [verified_ciphertext_crc32c][crate::model::RawDecryptResponse::verified_ciphertext_crc32c].
     pub fn set_verified_ciphertext_crc32c<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.verified_ciphertext_crc32c = v.into();
         self
     }
 
-    /// Sets the value of `verified_additional_authenticated_data_crc32c`.
+    /// Sets the value of [verified_additional_authenticated_data_crc32c][crate::model::RawDecryptResponse::verified_additional_authenticated_data_crc32c].
     pub fn set_verified_additional_authenticated_data_crc32c<T: std::convert::Into<bool>>(
         mut self,
         v: T,
@@ -6786,7 +6799,7 @@ impl RawDecryptResponse {
         self
     }
 
-    /// Sets the value of `verified_initialization_vector_crc32c`.
+    /// Sets the value of [verified_initialization_vector_crc32c][crate::model::RawDecryptResponse::verified_initialization_vector_crc32c].
     pub fn set_verified_initialization_vector_crc32c<T: std::convert::Into<bool>>(
         mut self,
         v: T,
@@ -6895,13 +6908,13 @@ pub struct AsymmetricSignResponse {
 }
 
 impl AsymmetricSignResponse {
-    /// Sets the value of `signature`.
+    /// Sets the value of [signature][crate::model::AsymmetricSignResponse::signature].
     pub fn set_signature<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.signature = v.into();
         self
     }
 
-    /// Sets the value of `signature_crc32c`.
+    /// Sets the value of [signature_crc32c][crate::model::AsymmetricSignResponse::signature_crc32c].
     pub fn set_signature_crc32c<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(
         mut self,
         v: T,
@@ -6910,25 +6923,25 @@ impl AsymmetricSignResponse {
         self
     }
 
-    /// Sets the value of `verified_digest_crc32c`.
+    /// Sets the value of [verified_digest_crc32c][crate::model::AsymmetricSignResponse::verified_digest_crc32c].
     pub fn set_verified_digest_crc32c<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.verified_digest_crc32c = v.into();
         self
     }
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::AsymmetricSignResponse::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `verified_data_crc32c`.
+    /// Sets the value of [verified_data_crc32c][crate::model::AsymmetricSignResponse::verified_data_crc32c].
     pub fn set_verified_data_crc32c<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.verified_data_crc32c = v.into();
         self
     }
 
-    /// Sets the value of `protection_level`.
+    /// Sets the value of [protection_level][crate::model::AsymmetricSignResponse::protection_level].
     pub fn set_protection_level<T: std::convert::Into<crate::model::ProtectionLevel>>(
         mut self,
         v: T,
@@ -7009,13 +7022,13 @@ pub struct AsymmetricDecryptResponse {
 }
 
 impl AsymmetricDecryptResponse {
-    /// Sets the value of `plaintext`.
+    /// Sets the value of [plaintext][crate::model::AsymmetricDecryptResponse::plaintext].
     pub fn set_plaintext<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.plaintext = v.into();
         self
     }
 
-    /// Sets the value of `plaintext_crc32c`.
+    /// Sets the value of [plaintext_crc32c][crate::model::AsymmetricDecryptResponse::plaintext_crc32c].
     pub fn set_plaintext_crc32c<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(
         mut self,
         v: T,
@@ -7024,13 +7037,13 @@ impl AsymmetricDecryptResponse {
         self
     }
 
-    /// Sets the value of `verified_ciphertext_crc32c`.
+    /// Sets the value of [verified_ciphertext_crc32c][crate::model::AsymmetricDecryptResponse::verified_ciphertext_crc32c].
     pub fn set_verified_ciphertext_crc32c<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.verified_ciphertext_crc32c = v.into();
         self
     }
 
-    /// Sets the value of `protection_level`.
+    /// Sets the value of [protection_level][crate::model::AsymmetricDecryptResponse::protection_level].
     pub fn set_protection_level<T: std::convert::Into<crate::model::ProtectionLevel>>(
         mut self,
         v: T,
@@ -7118,19 +7131,19 @@ pub struct MacSignResponse {
 }
 
 impl MacSignResponse {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::MacSignResponse::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `mac`.
+    /// Sets the value of [mac][crate::model::MacSignResponse::mac].
     pub fn set_mac<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.mac = v.into();
         self
     }
 
-    /// Sets the value of `mac_crc32c`.
+    /// Sets the value of [mac_crc32c][crate::model::MacSignResponse::mac_crc32c].
     pub fn set_mac_crc32c<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(
         mut self,
         v: T,
@@ -7139,13 +7152,13 @@ impl MacSignResponse {
         self
     }
 
-    /// Sets the value of `verified_data_crc32c`.
+    /// Sets the value of [verified_data_crc32c][crate::model::MacSignResponse::verified_data_crc32c].
     pub fn set_verified_data_crc32c<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.verified_data_crc32c = v.into();
         self
     }
 
-    /// Sets the value of `protection_level`.
+    /// Sets the value of [protection_level][crate::model::MacSignResponse::protection_level].
     pub fn set_protection_level<T: std::convert::Into<crate::model::ProtectionLevel>>(
         mut self,
         v: T,
@@ -7246,37 +7259,37 @@ pub struct MacVerifyResponse {
 }
 
 impl MacVerifyResponse {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::MacVerifyResponse::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `success`.
+    /// Sets the value of [success][crate::model::MacVerifyResponse::success].
     pub fn set_success<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.success = v.into();
         self
     }
 
-    /// Sets the value of `verified_data_crc32c`.
+    /// Sets the value of [verified_data_crc32c][crate::model::MacVerifyResponse::verified_data_crc32c].
     pub fn set_verified_data_crc32c<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.verified_data_crc32c = v.into();
         self
     }
 
-    /// Sets the value of `verified_mac_crc32c`.
+    /// Sets the value of [verified_mac_crc32c][crate::model::MacVerifyResponse::verified_mac_crc32c].
     pub fn set_verified_mac_crc32c<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.verified_mac_crc32c = v.into();
         self
     }
 
-    /// Sets the value of `verified_success_integrity`.
+    /// Sets the value of [verified_success_integrity][crate::model::MacVerifyResponse::verified_success_integrity].
     pub fn set_verified_success_integrity<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.verified_success_integrity = v.into();
         self
     }
 
-    /// Sets the value of `protection_level`.
+    /// Sets the value of [protection_level][crate::model::MacVerifyResponse::protection_level].
     pub fn set_protection_level<T: std::convert::Into<crate::model::ProtectionLevel>>(
         mut self,
         v: T,
@@ -7328,13 +7341,13 @@ pub struct GenerateRandomBytesResponse {
 }
 
 impl GenerateRandomBytesResponse {
-    /// Sets the value of `data`.
+    /// Sets the value of [data][crate::model::GenerateRandomBytesResponse::data].
     pub fn set_data<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.data = v.into();
         self
     }
 
-    /// Sets the value of `data_crc32c`.
+    /// Sets the value of [data_crc32c][crate::model::GenerateRandomBytesResponse::data_crc32c].
     pub fn set_data_crc32c<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(
         mut self,
         v: T,
@@ -7430,13 +7443,13 @@ pub struct LocationMetadata {
 }
 
 impl LocationMetadata {
-    /// Sets the value of `hsm_available`.
+    /// Sets the value of [hsm_available][crate::model::LocationMetadata::hsm_available].
     pub fn set_hsm_available<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.hsm_available = v.into();
         self
     }
 
-    /// Sets the value of `ekm_available`.
+    /// Sets the value of [ekm_available][crate::model::LocationMetadata::ekm_available].
     pub fn set_ekm_available<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.ekm_available = v.into();
         self

--- a/src/generated/cloud/language/v2/src/builders.rs
+++ b/src/generated/cloud/language/v2/src/builders.rs
@@ -70,7 +70,7 @@ pub mod language_service {
                 .await
         }
 
-        /// Sets the value of `document`.
+        /// Sets the value of [document][crate::model::AnalyzeSentimentRequest::document].
         pub fn set_document<T: Into<std::option::Option<crate::model::Document>>>(
             mut self,
             v: T,
@@ -79,7 +79,7 @@ pub mod language_service {
             self
         }
 
-        /// Sets the value of `encoding_type`.
+        /// Sets the value of [encoding_type][crate::model::AnalyzeSentimentRequest::encoding_type].
         pub fn set_encoding_type<T: Into<crate::model::EncodingType>>(mut self, v: T) -> Self {
             self.0.request.encoding_type = v.into();
             self
@@ -120,7 +120,7 @@ pub mod language_service {
                 .await
         }
 
-        /// Sets the value of `document`.
+        /// Sets the value of [document][crate::model::AnalyzeEntitiesRequest::document].
         pub fn set_document<T: Into<std::option::Option<crate::model::Document>>>(
             mut self,
             v: T,
@@ -129,7 +129,7 @@ pub mod language_service {
             self
         }
 
-        /// Sets the value of `encoding_type`.
+        /// Sets the value of [encoding_type][crate::model::AnalyzeEntitiesRequest::encoding_type].
         pub fn set_encoding_type<T: Into<crate::model::EncodingType>>(mut self, v: T) -> Self {
             self.0.request.encoding_type = v.into();
             self
@@ -170,7 +170,7 @@ pub mod language_service {
                 .await
         }
 
-        /// Sets the value of `document`.
+        /// Sets the value of [document][crate::model::ClassifyTextRequest::document].
         pub fn set_document<T: Into<std::option::Option<crate::model::Document>>>(
             mut self,
             v: T,
@@ -214,7 +214,7 @@ pub mod language_service {
                 .await
         }
 
-        /// Sets the value of `document`.
+        /// Sets the value of [document][crate::model::ModerateTextRequest::document].
         pub fn set_document<T: Into<std::option::Option<crate::model::Document>>>(
             mut self,
             v: T,
@@ -223,7 +223,7 @@ pub mod language_service {
             self
         }
 
-        /// Sets the value of `model_version`.
+        /// Sets the value of [model_version][crate::model::ModerateTextRequest::model_version].
         pub fn set_model_version<T: Into<crate::model::moderate_text_request::ModelVersion>>(
             mut self,
             v: T,
@@ -267,7 +267,7 @@ pub mod language_service {
                 .await
         }
 
-        /// Sets the value of `document`.
+        /// Sets the value of [document][crate::model::AnnotateTextRequest::document].
         pub fn set_document<T: Into<std::option::Option<crate::model::Document>>>(
             mut self,
             v: T,
@@ -276,7 +276,7 @@ pub mod language_service {
             self
         }
 
-        /// Sets the value of `features`.
+        /// Sets the value of [features][crate::model::AnnotateTextRequest::features].
         pub fn set_features<
             T: Into<std::option::Option<crate::model::annotate_text_request::Features>>,
         >(
@@ -287,7 +287,7 @@ pub mod language_service {
             self
         }
 
-        /// Sets the value of `encoding_type`.
+        /// Sets the value of [encoding_type][crate::model::AnnotateTextRequest::encoding_type].
         pub fn set_encoding_type<T: Into<crate::model::EncodingType>>(mut self, v: T) -> Self {
             self.0.request.encoding_type = v.into();
             self

--- a/src/generated/cloud/language/v2/src/model.rs
+++ b/src/generated/cloud/language/v2/src/model.rs
@@ -59,13 +59,13 @@ pub struct Document {
 }
 
 impl Document {
-    /// Sets the value of `r#type`.
+    /// Sets the value of [r#type][crate::model::Document::type].
     pub fn set_type<T: std::convert::Into<crate::model::document::Type>>(mut self, v: T) -> Self {
         self.r#type = v.into();
         self
     }
 
-    /// Sets the value of `language_code`.
+    /// Sets the value of [language_code][crate::model::Document::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
         self
@@ -161,7 +161,7 @@ pub struct Sentence {
 }
 
 impl Sentence {
-    /// Sets the value of `text`.
+    /// Sets the value of [text][crate::model::Sentence::text].
     pub fn set_text<T: std::convert::Into<std::option::Option<crate::model::TextSpan>>>(
         mut self,
         v: T,
@@ -170,7 +170,7 @@ impl Sentence {
         self
     }
 
-    /// Sets the value of `sentiment`.
+    /// Sets the value of [sentiment][crate::model::Sentence::sentiment].
     pub fn set_sentiment<T: std::convert::Into<std::option::Option<crate::model::Sentiment>>>(
         mut self,
         v: T,
@@ -223,44 +223,47 @@ pub struct Entity {
 }
 
 impl Entity {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Entity::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `r#type`.
+    /// Sets the value of [r#type][crate::model::Entity::type].
     pub fn set_type<T: std::convert::Into<crate::model::entity::Type>>(mut self, v: T) -> Self {
         self.r#type = v.into();
         self
     }
 
-    /// Sets the value of `metadata`.
-    pub fn set_metadata<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metadata = v.into();
-        self
-    }
-
-    /// Sets the value of `mentions`.
-    pub fn set_mentions<T: std::convert::Into<std::vec::Vec<crate::model::EntityMention>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.mentions = v.into();
-        self
-    }
-
-    /// Sets the value of `sentiment`.
+    /// Sets the value of [sentiment][crate::model::Entity::sentiment].
     pub fn set_sentiment<T: std::convert::Into<std::option::Option<crate::model::Sentiment>>>(
         mut self,
         v: T,
     ) -> Self {
         self.sentiment = v.into();
+        self
+    }
+
+    /// Sets the value of [mentions][crate::model::Entity::mentions].
+    pub fn set_mentions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EntityMention>,
+    {
+        use std::iter::Iterator;
+        self.mentions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [metadata][crate::model::Entity::metadata].
+    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -391,13 +394,13 @@ pub struct Sentiment {
 }
 
 impl Sentiment {
-    /// Sets the value of `magnitude`.
+    /// Sets the value of [magnitude][crate::model::Sentiment::magnitude].
     pub fn set_magnitude<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
         self.magnitude = v.into();
         self
     }
 
-    /// Sets the value of `score`.
+    /// Sets the value of [score][crate::model::Sentiment::score].
     pub fn set_score<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
         self.score = v.into();
         self
@@ -440,7 +443,7 @@ pub struct EntityMention {
 }
 
 impl EntityMention {
-    /// Sets the value of `text`.
+    /// Sets the value of [text][crate::model::EntityMention::text].
     pub fn set_text<T: std::convert::Into<std::option::Option<crate::model::TextSpan>>>(
         mut self,
         v: T,
@@ -449,7 +452,7 @@ impl EntityMention {
         self
     }
 
-    /// Sets the value of `r#type`.
+    /// Sets the value of [r#type][crate::model::EntityMention::type].
     pub fn set_type<T: std::convert::Into<crate::model::entity_mention::Type>>(
         mut self,
         v: T,
@@ -458,7 +461,7 @@ impl EntityMention {
         self
     }
 
-    /// Sets the value of `sentiment`.
+    /// Sets the value of [sentiment][crate::model::EntityMention::sentiment].
     pub fn set_sentiment<T: std::convert::Into<std::option::Option<crate::model::Sentiment>>>(
         mut self,
         v: T,
@@ -467,7 +470,7 @@ impl EntityMention {
         self
     }
 
-    /// Sets the value of `probability`.
+    /// Sets the value of [probability][crate::model::EntityMention::probability].
     pub fn set_probability<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
         self.probability = v.into();
         self
@@ -536,13 +539,13 @@ pub struct TextSpan {
 }
 
 impl TextSpan {
-    /// Sets the value of `content`.
+    /// Sets the value of [content][crate::model::TextSpan::content].
     pub fn set_content<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.content = v.into();
         self
     }
 
-    /// Sets the value of `begin_offset`.
+    /// Sets the value of [begin_offset][crate::model::TextSpan::begin_offset].
     pub fn set_begin_offset<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.begin_offset = v.into();
         self
@@ -576,19 +579,19 @@ pub struct ClassificationCategory {
 }
 
 impl ClassificationCategory {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::ClassificationCategory::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `confidence`.
+    /// Sets the value of [confidence][crate::model::ClassificationCategory::confidence].
     pub fn set_confidence<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
         self.confidence = v.into();
         self
     }
 
-    /// Sets the value of `severity`.
+    /// Sets the value of [severity][crate::model::ClassificationCategory::severity].
     pub fn set_severity<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
         self.severity = v.into();
         self
@@ -616,7 +619,7 @@ pub struct AnalyzeSentimentRequest {
 }
 
 impl AnalyzeSentimentRequest {
-    /// Sets the value of `document`.
+    /// Sets the value of [document][crate::model::AnalyzeSentimentRequest::document].
     pub fn set_document<T: std::convert::Into<std::option::Option<crate::model::Document>>>(
         mut self,
         v: T,
@@ -625,7 +628,7 @@ impl AnalyzeSentimentRequest {
         self
     }
 
-    /// Sets the value of `encoding_type`.
+    /// Sets the value of [encoding_type][crate::model::AnalyzeSentimentRequest::encoding_type].
     pub fn set_encoding_type<T: std::convert::Into<crate::model::EncodingType>>(
         mut self,
         v: T,
@@ -668,7 +671,7 @@ pub struct AnalyzeSentimentResponse {
 }
 
 impl AnalyzeSentimentResponse {
-    /// Sets the value of `document_sentiment`.
+    /// Sets the value of [document_sentiment][crate::model::AnalyzeSentimentResponse::document_sentiment].
     pub fn set_document_sentiment<
         T: std::convert::Into<std::option::Option<crate::model::Sentiment>>,
     >(
@@ -679,24 +682,26 @@ impl AnalyzeSentimentResponse {
         self
     }
 
-    /// Sets the value of `language_code`.
+    /// Sets the value of [language_code][crate::model::AnalyzeSentimentResponse::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
         self
     }
 
-    /// Sets the value of `sentences`.
-    pub fn set_sentences<T: std::convert::Into<std::vec::Vec<crate::model::Sentence>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.sentences = v.into();
+    /// Sets the value of [language_supported][crate::model::AnalyzeSentimentResponse::language_supported].
+    pub fn set_language_supported<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.language_supported = v.into();
         self
     }
 
-    /// Sets the value of `language_supported`.
-    pub fn set_language_supported<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.language_supported = v.into();
+    /// Sets the value of [sentences][crate::model::AnalyzeSentimentResponse::sentences].
+    pub fn set_sentences<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Sentence>,
+    {
+        use std::iter::Iterator;
+        self.sentences = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -722,7 +727,7 @@ pub struct AnalyzeEntitiesRequest {
 }
 
 impl AnalyzeEntitiesRequest {
-    /// Sets the value of `document`.
+    /// Sets the value of [document][crate::model::AnalyzeEntitiesRequest::document].
     pub fn set_document<T: std::convert::Into<std::option::Option<crate::model::Document>>>(
         mut self,
         v: T,
@@ -731,7 +736,7 @@ impl AnalyzeEntitiesRequest {
         self
     }
 
-    /// Sets the value of `encoding_type`.
+    /// Sets the value of [encoding_type][crate::model::AnalyzeEntitiesRequest::encoding_type].
     pub fn set_encoding_type<T: std::convert::Into<crate::model::EncodingType>>(
         mut self,
         v: T,
@@ -770,24 +775,26 @@ pub struct AnalyzeEntitiesResponse {
 }
 
 impl AnalyzeEntitiesResponse {
-    /// Sets the value of `entities`.
-    pub fn set_entities<T: std::convert::Into<std::vec::Vec<crate::model::Entity>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.entities = v.into();
-        self
-    }
-
-    /// Sets the value of `language_code`.
+    /// Sets the value of [language_code][crate::model::AnalyzeEntitiesResponse::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
         self
     }
 
-    /// Sets the value of `language_supported`.
+    /// Sets the value of [language_supported][crate::model::AnalyzeEntitiesResponse::language_supported].
     pub fn set_language_supported<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.language_supported = v.into();
+        self
+    }
+
+    /// Sets the value of [entities][crate::model::AnalyzeEntitiesResponse::entities].
+    pub fn set_entities<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Entity>,
+    {
+        use std::iter::Iterator;
+        self.entities = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -810,7 +817,7 @@ pub struct ClassifyTextRequest {
 }
 
 impl ClassifyTextRequest {
-    /// Sets the value of `document`.
+    /// Sets the value of [document][crate::model::ClassifyTextRequest::document].
     pub fn set_document<T: std::convert::Into<std::option::Option<crate::model::Document>>>(
         mut self,
         v: T,
@@ -849,26 +856,26 @@ pub struct ClassifyTextResponse {
 }
 
 impl ClassifyTextResponse {
-    /// Sets the value of `categories`.
-    pub fn set_categories<
-        T: std::convert::Into<std::vec::Vec<crate::model::ClassificationCategory>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.categories = v.into();
-        self
-    }
-
-    /// Sets the value of `language_code`.
+    /// Sets the value of [language_code][crate::model::ClassifyTextResponse::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
         self
     }
 
-    /// Sets the value of `language_supported`.
+    /// Sets the value of [language_supported][crate::model::ClassifyTextResponse::language_supported].
     pub fn set_language_supported<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.language_supported = v.into();
+        self
+    }
+
+    /// Sets the value of [categories][crate::model::ClassifyTextResponse::categories].
+    pub fn set_categories<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ClassificationCategory>,
+    {
+        use std::iter::Iterator;
+        self.categories = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -894,7 +901,7 @@ pub struct ModerateTextRequest {
 }
 
 impl ModerateTextRequest {
-    /// Sets the value of `document`.
+    /// Sets the value of [document][crate::model::ModerateTextRequest::document].
     pub fn set_document<T: std::convert::Into<std::option::Option<crate::model::Document>>>(
         mut self,
         v: T,
@@ -903,7 +910,7 @@ impl ModerateTextRequest {
         self
     }
 
-    /// Sets the value of `model_version`.
+    /// Sets the value of [model_version][crate::model::ModerateTextRequest::model_version].
     pub fn set_model_version<
         T: std::convert::Into<crate::model::moderate_text_request::ModelVersion>,
     >(
@@ -984,26 +991,26 @@ pub struct ModerateTextResponse {
 }
 
 impl ModerateTextResponse {
-    /// Sets the value of `moderation_categories`.
-    pub fn set_moderation_categories<
-        T: std::convert::Into<std::vec::Vec<crate::model::ClassificationCategory>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.moderation_categories = v.into();
-        self
-    }
-
-    /// Sets the value of `language_code`.
+    /// Sets the value of [language_code][crate::model::ModerateTextResponse::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
         self
     }
 
-    /// Sets the value of `language_supported`.
+    /// Sets the value of [language_supported][crate::model::ModerateTextResponse::language_supported].
     pub fn set_language_supported<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.language_supported = v.into();
+        self
+    }
+
+    /// Sets the value of [moderation_categories][crate::model::ModerateTextResponse::moderation_categories].
+    pub fn set_moderation_categories<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ClassificationCategory>,
+    {
+        use std::iter::Iterator;
+        self.moderation_categories = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1034,7 +1041,7 @@ pub struct AnnotateTextRequest {
 }
 
 impl AnnotateTextRequest {
-    /// Sets the value of `document`.
+    /// Sets the value of [document][crate::model::AnnotateTextRequest::document].
     pub fn set_document<T: std::convert::Into<std::option::Option<crate::model::Document>>>(
         mut self,
         v: T,
@@ -1043,7 +1050,7 @@ impl AnnotateTextRequest {
         self
     }
 
-    /// Sets the value of `features`.
+    /// Sets the value of [features][crate::model::AnnotateTextRequest::features].
     pub fn set_features<
         T: std::convert::Into<std::option::Option<crate::model::annotate_text_request::Features>>,
     >(
@@ -1054,7 +1061,7 @@ impl AnnotateTextRequest {
         self
     }
 
-    /// Sets the value of `encoding_type`.
+    /// Sets the value of [encoding_type][crate::model::AnnotateTextRequest::encoding_type].
     pub fn set_encoding_type<T: std::convert::Into<crate::model::EncodingType>>(
         mut self,
         v: T,
@@ -1096,25 +1103,25 @@ pub mod annotate_text_request {
     }
 
     impl Features {
-        /// Sets the value of `extract_entities`.
+        /// Sets the value of [extract_entities][crate::model::annotate_text_request::Features::extract_entities].
         pub fn set_extract_entities<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.extract_entities = v.into();
             self
         }
 
-        /// Sets the value of `extract_document_sentiment`.
+        /// Sets the value of [extract_document_sentiment][crate::model::annotate_text_request::Features::extract_document_sentiment].
         pub fn set_extract_document_sentiment<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.extract_document_sentiment = v.into();
             self
         }
 
-        /// Sets the value of `classify_text`.
+        /// Sets the value of [classify_text][crate::model::annotate_text_request::Features::classify_text].
         pub fn set_classify_text<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.classify_text = v.into();
             self
         }
 
-        /// Sets the value of `moderate_text`.
+        /// Sets the value of [moderate_text][crate::model::annotate_text_request::Features::moderate_text].
         pub fn set_moderate_text<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.moderate_text = v.into();
             self
@@ -1179,25 +1186,7 @@ pub struct AnnotateTextResponse {
 }
 
 impl AnnotateTextResponse {
-    /// Sets the value of `sentences`.
-    pub fn set_sentences<T: std::convert::Into<std::vec::Vec<crate::model::Sentence>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.sentences = v.into();
-        self
-    }
-
-    /// Sets the value of `entities`.
-    pub fn set_entities<T: std::convert::Into<std::vec::Vec<crate::model::Entity>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.entities = v.into();
-        self
-    }
-
-    /// Sets the value of `document_sentiment`.
+    /// Sets the value of [document_sentiment][crate::model::AnnotateTextResponse::document_sentiment].
     pub fn set_document_sentiment<
         T: std::convert::Into<std::option::Option<crate::model::Sentiment>>,
     >(
@@ -1208,37 +1197,59 @@ impl AnnotateTextResponse {
         self
     }
 
-    /// Sets the value of `language_code`.
+    /// Sets the value of [language_code][crate::model::AnnotateTextResponse::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
         self
     }
 
-    /// Sets the value of `categories`.
-    pub fn set_categories<
-        T: std::convert::Into<std::vec::Vec<crate::model::ClassificationCategory>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.categories = v.into();
-        self
-    }
-
-    /// Sets the value of `moderation_categories`.
-    pub fn set_moderation_categories<
-        T: std::convert::Into<std::vec::Vec<crate::model::ClassificationCategory>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.moderation_categories = v.into();
-        self
-    }
-
-    /// Sets the value of `language_supported`.
+    /// Sets the value of [language_supported][crate::model::AnnotateTextResponse::language_supported].
     pub fn set_language_supported<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.language_supported = v.into();
+        self
+    }
+
+    /// Sets the value of [sentences][crate::model::AnnotateTextResponse::sentences].
+    pub fn set_sentences<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Sentence>,
+    {
+        use std::iter::Iterator;
+        self.sentences = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [entities][crate::model::AnnotateTextResponse::entities].
+    pub fn set_entities<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Entity>,
+    {
+        use std::iter::Iterator;
+        self.entities = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [categories][crate::model::AnnotateTextResponse::categories].
+    pub fn set_categories<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ClassificationCategory>,
+    {
+        use std::iter::Iterator;
+        self.categories = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [moderation_categories][crate::model::AnnotateTextResponse::moderation_categories].
+    pub fn set_moderation_categories<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ClassificationCategory>,
+    {
+        use std::iter::Iterator;
+        self.moderation_categories = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/cloud/location/src/builders.rs
+++ b/src/generated/cloud/location/src/builders.rs
@@ -82,25 +82,25 @@ pub mod locations {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::ListLocationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListLocationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListLocationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListLocationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -141,7 +141,7 @@ pub mod locations {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetLocationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self

--- a/src/generated/cloud/location/src/model.rs
+++ b/src/generated/cloud/location/src/model.rs
@@ -55,25 +55,25 @@ pub struct ListLocationsRequest {
 }
 
 impl ListLocationsRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::ListLocationsRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListLocationsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListLocationsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListLocationsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -104,18 +104,20 @@ pub struct ListLocationsResponse {
 }
 
 impl ListLocationsResponse {
-    /// Sets the value of `locations`.
-    pub fn set_locations<T: std::convert::Into<std::vec::Vec<crate::model::Location>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.locations = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListLocationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [locations][crate::model::ListLocationsResponse::locations].
+    pub fn set_locations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Location>,
+    {
+        use std::iter::Iterator;
+        self.locations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -153,7 +155,7 @@ pub struct GetLocationRequest {
 }
 
 impl GetLocationRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetLocationRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -201,41 +203,42 @@ pub struct Location {
 }
 
 impl Location {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Location::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `location_id`.
+    /// Sets the value of [location_id][crate::model::Location::location_id].
     pub fn set_location_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location_id = v.into();
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::Location::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `metadata`.
+    /// Sets the value of [metadata][crate::model::Location::metadata].
     pub fn set_metadata<T: std::convert::Into<std::option::Option<wkt::Any>>>(
         mut self,
         v: T,
     ) -> Self {
         self.metadata = v.into();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Location::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }

--- a/src/generated/cloud/run/v2/src/builders.rs
+++ b/src/generated/cloud/run/v2/src/builders.rs
@@ -67,33 +67,38 @@ pub mod builds {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::SubmitBuildRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `image_uri`.
+        /// Sets the value of [image_uri][crate::model::SubmitBuildRequest::image_uri].
         pub fn set_image_uri<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.image_uri = v.into();
             self
         }
 
-        /// Sets the value of `service_account`.
+        /// Sets the value of [service_account][crate::model::SubmitBuildRequest::service_account].
         pub fn set_service_account<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.service_account = v.into();
             self
         }
 
-        /// Sets the value of `worker_pool`.
+        /// Sets the value of [worker_pool][crate::model::SubmitBuildRequest::worker_pool].
         pub fn set_worker_pool<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.worker_pool = v.into();
             self
         }
 
-        /// Sets the value of `tags`.
-        pub fn set_tags<T: Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-            self.0.request.tags = v.into();
+        /// Sets the value of [tags][crate::model::SubmitBuildRequest::tags].
+        pub fn set_tags<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.tags = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -168,25 +173,25 @@ pub mod builds {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::ListOperationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][longrunning::model::ListOperationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][longrunning::model::ListOperationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][longrunning::model::ListOperationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -230,7 +235,7 @@ pub mod builds {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::GetOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -274,7 +279,7 @@ pub mod builds {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::DeleteOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -318,13 +323,13 @@ pub mod builds {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::WaitOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `timeout`.
+        /// Sets the value of [timeout][longrunning::model::WaitOperationRequest::timeout].
         pub fn set_timeout<T: Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
             self.0.request.timeout = v.into();
             self
@@ -391,7 +396,7 @@ pub mod executions {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetExecutionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -447,25 +452,25 @@ pub mod executions {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListExecutionsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListExecutionsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListExecutionsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `show_deleted`.
+        /// Sets the value of [show_deleted][crate::model::ListExecutionsRequest::show_deleted].
         pub fn set_show_deleted<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.show_deleted = v.into();
             self
@@ -541,19 +546,19 @@ pub mod executions {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteExecutionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `validate_only`.
+        /// Sets the value of [validate_only][crate::model::DeleteExecutionRequest::validate_only].
         pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.validate_only = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DeleteExecutionRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -629,19 +634,19 @@ pub mod executions {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::CancelExecutionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `validate_only`.
+        /// Sets the value of [validate_only][crate::model::CancelExecutionRequest::validate_only].
         pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.validate_only = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::CancelExecutionRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -700,25 +705,25 @@ pub mod executions {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::ListOperationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][longrunning::model::ListOperationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][longrunning::model::ListOperationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][longrunning::model::ListOperationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -762,7 +767,7 @@ pub mod executions {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::GetOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -806,7 +811,7 @@ pub mod executions {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::DeleteOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -850,13 +855,13 @@ pub mod executions {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::WaitOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `timeout`.
+        /// Sets the value of [timeout][longrunning::model::WaitOperationRequest::timeout].
         pub fn set_timeout<T: Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
             self.0.request.timeout = v.into();
             self
@@ -958,25 +963,25 @@ pub mod jobs {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateJobRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `job`.
+        /// Sets the value of [job][crate::model::CreateJobRequest::job].
         pub fn set_job<T: Into<std::option::Option<crate::model::Job>>>(mut self, v: T) -> Self {
             self.0.request.job = v.into();
             self
         }
 
-        /// Sets the value of `job_id`.
+        /// Sets the value of [job_id][crate::model::CreateJobRequest::job_id].
         pub fn set_job_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.job_id = v.into();
             self
         }
 
-        /// Sets the value of `validate_only`.
+        /// Sets the value of [validate_only][crate::model::CreateJobRequest::validate_only].
         pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.validate_only = v.into();
             self
@@ -1015,7 +1020,7 @@ pub mod jobs {
             (*self.0.stub).get_job(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetJobRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1070,25 +1075,25 @@ pub mod jobs {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListJobsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListJobsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListJobsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `show_deleted`.
+        /// Sets the value of [show_deleted][crate::model::ListJobsRequest::show_deleted].
         pub fn set_show_deleted<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.show_deleted = v.into();
             self
@@ -1164,19 +1169,19 @@ pub mod jobs {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `job`.
+        /// Sets the value of [job][crate::model::UpdateJobRequest::job].
         pub fn set_job<T: Into<std::option::Option<crate::model::Job>>>(mut self, v: T) -> Self {
             self.0.request.job = v.into();
             self
         }
 
-        /// Sets the value of `validate_only`.
+        /// Sets the value of [validate_only][crate::model::UpdateJobRequest::validate_only].
         pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.validate_only = v.into();
             self
         }
 
-        /// Sets the value of `allow_missing`.
+        /// Sets the value of [allow_missing][crate::model::UpdateJobRequest::allow_missing].
         pub fn set_allow_missing<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.allow_missing = v.into();
             self
@@ -1252,19 +1257,19 @@ pub mod jobs {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteJobRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `validate_only`.
+        /// Sets the value of [validate_only][crate::model::DeleteJobRequest::validate_only].
         pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.validate_only = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DeleteJobRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -1338,25 +1343,25 @@ pub mod jobs {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::RunJobRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `validate_only`.
+        /// Sets the value of [validate_only][crate::model::RunJobRequest::validate_only].
         pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.validate_only = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::RunJobRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
         }
 
-        /// Sets the value of `overrides`.
+        /// Sets the value of [overrides][crate::model::RunJobRequest::overrides].
         pub fn set_overrides<
             T: Into<std::option::Option<crate::model::run_job_request::Overrides>>,
         >(
@@ -1402,13 +1407,13 @@ pub mod jobs {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::GetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `options`.
+        /// Sets the value of [options][iam_v1::model::GetIamPolicyRequest::options].
         pub fn set_options<T: Into<std::option::Option<iam_v1::model::GetPolicyOptions>>>(
             mut self,
             v: T,
@@ -1452,13 +1457,13 @@ pub mod jobs {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::SetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][iam_v1::model::SetIamPolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<iam_v1::model::Policy>>>(
             mut self,
             v: T,
@@ -1467,7 +1472,7 @@ pub mod jobs {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][iam_v1::model::SetIamPolicyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -1514,18 +1519,20 @@ pub mod jobs {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::TestIamPermissionsRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `permissions`.
-        pub fn set_permissions<T: Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.permissions = v.into();
+        /// Sets the value of [permissions][iam_v1::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1582,25 +1589,25 @@ pub mod jobs {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::ListOperationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][longrunning::model::ListOperationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][longrunning::model::ListOperationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][longrunning::model::ListOperationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -1644,7 +1651,7 @@ pub mod jobs {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::GetOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1688,7 +1695,7 @@ pub mod jobs {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::DeleteOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1732,13 +1739,13 @@ pub mod jobs {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::WaitOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `timeout`.
+        /// Sets the value of [timeout][longrunning::model::WaitOperationRequest::timeout].
         pub fn set_timeout<T: Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
             self.0.request.timeout = v.into();
             self
@@ -1805,7 +1812,7 @@ pub mod revisions {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetRevisionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1861,25 +1868,25 @@ pub mod revisions {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListRevisionsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListRevisionsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListRevisionsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `show_deleted`.
+        /// Sets the value of [show_deleted][crate::model::ListRevisionsRequest::show_deleted].
         pub fn set_show_deleted<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.show_deleted = v.into();
             self
@@ -1955,19 +1962,19 @@ pub mod revisions {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteRevisionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `validate_only`.
+        /// Sets the value of [validate_only][crate::model::DeleteRevisionRequest::validate_only].
         pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.validate_only = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DeleteRevisionRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -2026,25 +2033,25 @@ pub mod revisions {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::ListOperationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][longrunning::model::ListOperationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][longrunning::model::ListOperationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][longrunning::model::ListOperationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -2088,7 +2095,7 @@ pub mod revisions {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::GetOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2132,7 +2139,7 @@ pub mod revisions {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::DeleteOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2176,13 +2183,13 @@ pub mod revisions {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::WaitOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `timeout`.
+        /// Sets the value of [timeout][longrunning::model::WaitOperationRequest::timeout].
         pub fn set_timeout<T: Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
             self.0.request.timeout = v.into();
             self
@@ -2284,13 +2291,13 @@ pub mod services {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateServiceRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `service`.
+        /// Sets the value of [service][crate::model::CreateServiceRequest::service].
         pub fn set_service<T: Into<std::option::Option<crate::model::Service>>>(
             mut self,
             v: T,
@@ -2299,13 +2306,13 @@ pub mod services {
             self
         }
 
-        /// Sets the value of `service_id`.
+        /// Sets the value of [service_id][crate::model::CreateServiceRequest::service_id].
         pub fn set_service_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.service_id = v.into();
             self
         }
 
-        /// Sets the value of `validate_only`.
+        /// Sets the value of [validate_only][crate::model::CreateServiceRequest::validate_only].
         pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.validate_only = v.into();
             self
@@ -2346,7 +2353,7 @@ pub mod services {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetServiceRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2402,25 +2409,25 @@ pub mod services {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListServicesRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListServicesRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListServicesRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `show_deleted`.
+        /// Sets the value of [show_deleted][crate::model::ListServicesRequest::show_deleted].
         pub fn set_show_deleted<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.show_deleted = v.into();
             self
@@ -2496,7 +2503,7 @@ pub mod services {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateServiceRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -2505,7 +2512,7 @@ pub mod services {
             self
         }
 
-        /// Sets the value of `service`.
+        /// Sets the value of [service][crate::model::UpdateServiceRequest::service].
         pub fn set_service<T: Into<std::option::Option<crate::model::Service>>>(
             mut self,
             v: T,
@@ -2514,13 +2521,13 @@ pub mod services {
             self
         }
 
-        /// Sets the value of `validate_only`.
+        /// Sets the value of [validate_only][crate::model::UpdateServiceRequest::validate_only].
         pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.validate_only = v.into();
             self
         }
 
-        /// Sets the value of `allow_missing`.
+        /// Sets the value of [allow_missing][crate::model::UpdateServiceRequest::allow_missing].
         pub fn set_allow_missing<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.allow_missing = v.into();
             self
@@ -2596,19 +2603,19 @@ pub mod services {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteServiceRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `validate_only`.
+        /// Sets the value of [validate_only][crate::model::DeleteServiceRequest::validate_only].
         pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.validate_only = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DeleteServiceRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -2649,13 +2656,13 @@ pub mod services {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::GetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `options`.
+        /// Sets the value of [options][iam_v1::model::GetIamPolicyRequest::options].
         pub fn set_options<T: Into<std::option::Option<iam_v1::model::GetPolicyOptions>>>(
             mut self,
             v: T,
@@ -2699,13 +2706,13 @@ pub mod services {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::SetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][iam_v1::model::SetIamPolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<iam_v1::model::Policy>>>(
             mut self,
             v: T,
@@ -2714,7 +2721,7 @@ pub mod services {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][iam_v1::model::SetIamPolicyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -2761,18 +2768,20 @@ pub mod services {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::TestIamPermissionsRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `permissions`.
-        pub fn set_permissions<T: Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.permissions = v.into();
+        /// Sets the value of [permissions][iam_v1::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -2829,25 +2838,25 @@ pub mod services {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::ListOperationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][longrunning::model::ListOperationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][longrunning::model::ListOperationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][longrunning::model::ListOperationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -2891,7 +2900,7 @@ pub mod services {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::GetOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2935,7 +2944,7 @@ pub mod services {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::DeleteOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2979,13 +2988,13 @@ pub mod services {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::WaitOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `timeout`.
+        /// Sets the value of [timeout][longrunning::model::WaitOperationRequest::timeout].
         pub fn set_timeout<T: Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
             self.0.request.timeout = v.into();
             self
@@ -3052,7 +3061,7 @@ pub mod tasks {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetTaskRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -3107,25 +3116,25 @@ pub mod tasks {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListTasksRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListTasksRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListTasksRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `show_deleted`.
+        /// Sets the value of [show_deleted][crate::model::ListTasksRequest::show_deleted].
         pub fn set_show_deleted<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.show_deleted = v.into();
             self
@@ -3184,25 +3193,25 @@ pub mod tasks {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::ListOperationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][longrunning::model::ListOperationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][longrunning::model::ListOperationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][longrunning::model::ListOperationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -3246,7 +3255,7 @@ pub mod tasks {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::GetOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -3290,7 +3299,7 @@ pub mod tasks {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::DeleteOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -3334,13 +3343,13 @@ pub mod tasks {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::WaitOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `timeout`.
+        /// Sets the value of [timeout][longrunning::model::WaitOperationRequest::timeout].
         pub fn set_timeout<T: Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
             self.0.request.timeout = v.into();
             self

--- a/src/generated/cloud/run/v2/src/model.rs
+++ b/src/generated/cloud/run/v2/src/model.rs
@@ -80,36 +80,38 @@ pub struct SubmitBuildRequest {
 }
 
 impl SubmitBuildRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::SubmitBuildRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `image_uri`.
+    /// Sets the value of [image_uri][crate::model::SubmitBuildRequest::image_uri].
     pub fn set_image_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.image_uri = v.into();
         self
     }
 
-    /// Sets the value of `service_account`.
+    /// Sets the value of [service_account][crate::model::SubmitBuildRequest::service_account].
     pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_account = v.into();
         self
     }
 
-    /// Sets the value of `worker_pool`.
+    /// Sets the value of [worker_pool][crate::model::SubmitBuildRequest::worker_pool].
     pub fn set_worker_pool<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.worker_pool = v.into();
         self
     }
 
-    /// Sets the value of `tags`.
-    pub fn set_tags<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.tags = v.into();
+    /// Sets the value of [tags][crate::model::SubmitBuildRequest::tags].
+    pub fn set_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.tags = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -201,13 +203,13 @@ pub mod submit_build_request {
     }
 
     impl BuildpacksBuild {
-        /// Sets the value of `runtime`.
+        /// Sets the value of [runtime][crate::model::submit_build_request::BuildpacksBuild::runtime].
         pub fn set_runtime<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.runtime = v.into();
             self
         }
 
-        /// Sets the value of `function_target`.
+        /// Sets the value of [function_target][crate::model::submit_build_request::BuildpacksBuild::function_target].
         pub fn set_function_target<T: std::convert::Into<std::string::String>>(
             mut self,
             v: T,
@@ -216,7 +218,7 @@ pub mod submit_build_request {
             self
         }
 
-        /// Sets the value of `cache_image_uri`.
+        /// Sets the value of [cache_image_uri][crate::model::submit_build_request::BuildpacksBuild::cache_image_uri].
         pub fn set_cache_image_uri<T: std::convert::Into<std::string::String>>(
             mut self,
             v: T,
@@ -225,26 +227,27 @@ pub mod submit_build_request {
             self
         }
 
-        /// Sets the value of `base_image`.
+        /// Sets the value of [base_image][crate::model::submit_build_request::BuildpacksBuild::base_image].
         pub fn set_base_image<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.base_image = v.into();
             self
         }
 
-        /// Sets the value of `environment_variables`.
-        pub fn set_environment_variables<
-            T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.environment_variables = v.into();
+        /// Sets the value of [enable_automatic_updates][crate::model::submit_build_request::BuildpacksBuild::enable_automatic_updates].
+        pub fn set_enable_automatic_updates<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.enable_automatic_updates = v.into();
             self
         }
 
-        /// Sets the value of `enable_automatic_updates`.
-        pub fn set_enable_automatic_updates<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.enable_automatic_updates = v.into();
+        /// Sets the value of [environment_variables][crate::model::submit_build_request::BuildpacksBuild::environment_variables].
+        pub fn set_environment_variables<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.environment_variables = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -297,7 +300,7 @@ pub struct SubmitBuildResponse {
 }
 
 impl SubmitBuildResponse {
-    /// Sets the value of `build_operation`.
+    /// Sets the value of [build_operation][crate::model::SubmitBuildResponse::build_operation].
     pub fn set_build_operation<
         T: std::convert::Into<std::option::Option<longrunning::model::Operation>>,
     >(
@@ -308,13 +311,13 @@ impl SubmitBuildResponse {
         self
     }
 
-    /// Sets the value of `base_image_uri`.
+    /// Sets the value of [base_image_uri][crate::model::SubmitBuildResponse::base_image_uri].
     pub fn set_base_image_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.base_image_uri = v.into();
         self
     }
 
-    /// Sets the value of `base_image_warning`.
+    /// Sets the value of [base_image_warning][crate::model::SubmitBuildResponse::base_image_warning].
     pub fn set_base_image_warning<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -356,19 +359,19 @@ pub struct StorageSource {
 }
 
 impl StorageSource {
-    /// Sets the value of `bucket`.
+    /// Sets the value of [bucket][crate::model::StorageSource::bucket].
     pub fn set_bucket<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.bucket = v.into();
         self
     }
 
-    /// Sets the value of `object`.
+    /// Sets the value of [object][crate::model::StorageSource::object].
     pub fn set_object<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.object = v.into();
         self
     }
 
-    /// Sets the value of `generation`.
+    /// Sets the value of [generation][crate::model::StorageSource::generation].
     pub fn set_generation<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.generation = v.into();
         self
@@ -419,13 +422,13 @@ pub struct Condition {
 }
 
 impl Condition {
-    /// Sets the value of `r#type`.
+    /// Sets the value of [r#type][crate::model::Condition::type].
     pub fn set_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.r#type = v.into();
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::Condition::state].
     pub fn set_state<T: std::convert::Into<crate::model::condition::State>>(
         mut self,
         v: T,
@@ -434,13 +437,13 @@ impl Condition {
         self
     }
 
-    /// Sets the value of `message`.
+    /// Sets the value of [message][crate::model::Condition::message].
     pub fn set_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.message = v.into();
         self
     }
 
-    /// Sets the value of `last_transition_time`.
+    /// Sets the value of [last_transition_time][crate::model::Condition::last_transition_time].
     pub fn set_last_transition_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -449,7 +452,7 @@ impl Condition {
         self
     }
 
-    /// Sets the value of `severity`.
+    /// Sets the value of [severity][crate::model::Condition::severity].
     pub fn set_severity<T: std::convert::Into<crate::model::condition::Severity>>(
         mut self,
         v: T,
@@ -755,7 +758,7 @@ pub struct GetExecutionRequest {
 }
 
 impl GetExecutionRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetExecutionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -794,25 +797,25 @@ pub struct ListExecutionsRequest {
 }
 
 impl ListExecutionsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListExecutionsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListExecutionsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListExecutionsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `show_deleted`.
+    /// Sets the value of [show_deleted][crate::model::ListExecutionsRequest::show_deleted].
     pub fn set_show_deleted<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.show_deleted = v.into();
         self
@@ -842,18 +845,20 @@ pub struct ListExecutionsResponse {
 }
 
 impl ListExecutionsResponse {
-    /// Sets the value of `executions`.
-    pub fn set_executions<T: std::convert::Into<std::vec::Vec<crate::model::Execution>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.executions = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListExecutionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [executions][crate::model::ListExecutionsResponse::executions].
+    pub fn set_executions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Execution>,
+    {
+        use std::iter::Iterator;
+        self.executions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -901,19 +906,19 @@ pub struct DeleteExecutionRequest {
 }
 
 impl DeleteExecutionRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteExecutionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `validate_only`.
+    /// Sets the value of [validate_only][crate::model::DeleteExecutionRequest::validate_only].
     pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.validate_only = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DeleteExecutionRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
@@ -950,19 +955,19 @@ pub struct CancelExecutionRequest {
 }
 
 impl CancelExecutionRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::CancelExecutionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `validate_only`.
+    /// Sets the value of [validate_only][crate::model::CancelExecutionRequest::validate_only].
     pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.validate_only = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::CancelExecutionRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
@@ -1119,47 +1124,25 @@ pub struct Execution {
 }
 
 impl Execution {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Execution::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `uid`.
+    /// Sets the value of [uid][crate::model::Execution::uid].
     pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.uid = v.into();
         self
     }
 
-    /// Sets the value of `generation`.
+    /// Sets the value of [generation][crate::model::Execution::generation].
     pub fn set_generation<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.generation = v.into();
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `annotations`.
-    pub fn set_annotations<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.annotations = v.into();
-        self
-    }
-
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::Execution::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1168,7 +1151,7 @@ impl Execution {
         self
     }
 
-    /// Sets the value of `start_time`.
+    /// Sets the value of [start_time][crate::model::Execution::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1177,7 +1160,7 @@ impl Execution {
         self
     }
 
-    /// Sets the value of `completion_time`.
+    /// Sets the value of [completion_time][crate::model::Execution::completion_time].
     pub fn set_completion_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1186,7 +1169,7 @@ impl Execution {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::Execution::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1195,7 +1178,7 @@ impl Execution {
         self
     }
 
-    /// Sets the value of `delete_time`.
+    /// Sets the value of [delete_time][crate::model::Execution::delete_time].
     pub fn set_delete_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1204,7 +1187,7 @@ impl Execution {
         self
     }
 
-    /// Sets the value of `expire_time`.
+    /// Sets the value of [expire_time][crate::model::Execution::expire_time].
     pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1213,7 +1196,7 @@ impl Execution {
         self
     }
 
-    /// Sets the value of `launch_stage`.
+    /// Sets the value of [launch_stage][crate::model::Execution::launch_stage].
     pub fn set_launch_stage<T: std::convert::Into<api::model::LaunchStage>>(
         mut self,
         v: T,
@@ -1222,25 +1205,25 @@ impl Execution {
         self
     }
 
-    /// Sets the value of `job`.
+    /// Sets the value of [job][crate::model::Execution::job].
     pub fn set_job<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.job = v.into();
         self
     }
 
-    /// Sets the value of `parallelism`.
+    /// Sets the value of [parallelism][crate::model::Execution::parallelism].
     pub fn set_parallelism<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.parallelism = v.into();
         self
     }
 
-    /// Sets the value of `task_count`.
+    /// Sets the value of [task_count][crate::model::Execution::task_count].
     pub fn set_task_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.task_count = v.into();
         self
     }
 
-    /// Sets the value of `template`.
+    /// Sets the value of [template][crate::model::Execution::template].
     pub fn set_template<T: std::convert::Into<std::option::Option<crate::model::TaskTemplate>>>(
         mut self,
         v: T,
@@ -1249,72 +1232,98 @@ impl Execution {
         self
     }
 
-    /// Sets the value of `reconciling`.
+    /// Sets the value of [reconciling][crate::model::Execution::reconciling].
     pub fn set_reconciling<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.reconciling = v.into();
         self
     }
 
-    /// Sets the value of `conditions`.
-    pub fn set_conditions<T: std::convert::Into<std::vec::Vec<crate::model::Condition>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.conditions = v.into();
-        self
-    }
-
-    /// Sets the value of `observed_generation`.
+    /// Sets the value of [observed_generation][crate::model::Execution::observed_generation].
     pub fn set_observed_generation<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.observed_generation = v.into();
         self
     }
 
-    /// Sets the value of `running_count`.
+    /// Sets the value of [running_count][crate::model::Execution::running_count].
     pub fn set_running_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.running_count = v.into();
         self
     }
 
-    /// Sets the value of `succeeded_count`.
+    /// Sets the value of [succeeded_count][crate::model::Execution::succeeded_count].
     pub fn set_succeeded_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.succeeded_count = v.into();
         self
     }
 
-    /// Sets the value of `failed_count`.
+    /// Sets the value of [failed_count][crate::model::Execution::failed_count].
     pub fn set_failed_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.failed_count = v.into();
         self
     }
 
-    /// Sets the value of `cancelled_count`.
+    /// Sets the value of [cancelled_count][crate::model::Execution::cancelled_count].
     pub fn set_cancelled_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.cancelled_count = v.into();
         self
     }
 
-    /// Sets the value of `retried_count`.
+    /// Sets the value of [retried_count][crate::model::Execution::retried_count].
     pub fn set_retried_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.retried_count = v.into();
         self
     }
 
-    /// Sets the value of `log_uri`.
+    /// Sets the value of [log_uri][crate::model::Execution::log_uri].
     pub fn set_log_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.log_uri = v.into();
         self
     }
 
-    /// Sets the value of `satisfies_pzs`.
+    /// Sets the value of [satisfies_pzs][crate::model::Execution::satisfies_pzs].
     pub fn set_satisfies_pzs<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzs = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::Execution::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [conditions][crate::model::Execution::conditions].
+    pub fn set_conditions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Condition>,
+    {
+        use std::iter::Iterator;
+        self.conditions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Execution::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::Execution::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1369,46 +1378,48 @@ pub struct ExecutionTemplate {
 }
 
 impl ExecutionTemplate {
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `annotations`.
-    pub fn set_annotations<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.annotations = v.into();
-        self
-    }
-
-    /// Sets the value of `parallelism`.
+    /// Sets the value of [parallelism][crate::model::ExecutionTemplate::parallelism].
     pub fn set_parallelism<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.parallelism = v.into();
         self
     }
 
-    /// Sets the value of `task_count`.
+    /// Sets the value of [task_count][crate::model::ExecutionTemplate::task_count].
     pub fn set_task_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.task_count = v.into();
         self
     }
 
-    /// Sets the value of `template`.
+    /// Sets the value of [template][crate::model::ExecutionTemplate::template].
     pub fn set_template<T: std::convert::Into<std::option::Option<crate::model::TaskTemplate>>>(
         mut self,
         v: T,
     ) -> Self {
         self.template = v.into();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::ExecutionTemplate::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::ExecutionTemplate::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1446,13 +1457,13 @@ pub struct CreateJobRequest {
 }
 
 impl CreateJobRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateJobRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `job`.
+    /// Sets the value of [job][crate::model::CreateJobRequest::job].
     pub fn set_job<T: std::convert::Into<std::option::Option<crate::model::Job>>>(
         mut self,
         v: T,
@@ -1461,13 +1472,13 @@ impl CreateJobRequest {
         self
     }
 
-    /// Sets the value of `job_id`.
+    /// Sets the value of [job_id][crate::model::CreateJobRequest::job_id].
     pub fn set_job_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.job_id = v.into();
         self
     }
 
-    /// Sets the value of `validate_only`.
+    /// Sets the value of [validate_only][crate::model::CreateJobRequest::validate_only].
     pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.validate_only = v.into();
         self
@@ -1494,7 +1505,7 @@ pub struct GetJobRequest {
 }
 
 impl GetJobRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetJobRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1528,7 +1539,7 @@ pub struct UpdateJobRequest {
 }
 
 impl UpdateJobRequest {
-    /// Sets the value of `job`.
+    /// Sets the value of [job][crate::model::UpdateJobRequest::job].
     pub fn set_job<T: std::convert::Into<std::option::Option<crate::model::Job>>>(
         mut self,
         v: T,
@@ -1537,13 +1548,13 @@ impl UpdateJobRequest {
         self
     }
 
-    /// Sets the value of `validate_only`.
+    /// Sets the value of [validate_only][crate::model::UpdateJobRequest::validate_only].
     pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.validate_only = v.into();
         self
     }
 
-    /// Sets the value of `allow_missing`.
+    /// Sets the value of [allow_missing][crate::model::UpdateJobRequest::allow_missing].
     pub fn set_allow_missing<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.allow_missing = v.into();
         self
@@ -1581,25 +1592,25 @@ pub struct ListJobsRequest {
 }
 
 impl ListJobsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListJobsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListJobsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListJobsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `show_deleted`.
+    /// Sets the value of [show_deleted][crate::model::ListJobsRequest::show_deleted].
     pub fn set_show_deleted<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.show_deleted = v.into();
         self
@@ -1629,18 +1640,20 @@ pub struct ListJobsResponse {
 }
 
 impl ListJobsResponse {
-    /// Sets the value of `jobs`.
-    pub fn set_jobs<T: std::convert::Into<std::vec::Vec<crate::model::Job>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.jobs = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [jobs][crate::model::ListJobsResponse::jobs].
+    pub fn set_jobs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Job>,
+    {
+        use std::iter::Iterator;
+        self.jobs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1687,19 +1700,19 @@ pub struct DeleteJobRequest {
 }
 
 impl DeleteJobRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteJobRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `validate_only`.
+    /// Sets the value of [validate_only][crate::model::DeleteJobRequest::validate_only].
     pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.validate_only = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DeleteJobRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
@@ -1740,25 +1753,25 @@ pub struct RunJobRequest {
 }
 
 impl RunJobRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::RunJobRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `validate_only`.
+    /// Sets the value of [validate_only][crate::model::RunJobRequest::validate_only].
     pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.validate_only = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::RunJobRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `overrides`.
+    /// Sets the value of [overrides][crate::model::RunJobRequest::overrides].
     pub fn set_overrides<
         T: std::convert::Into<std::option::Option<crate::model::run_job_request::Overrides>>,
     >(
@@ -1804,31 +1817,29 @@ pub mod run_job_request {
     }
 
     impl Overrides {
-        /// Sets the value of `container_overrides`.
-        pub fn set_container_overrides<
-            T: std::convert::Into<
-                std::vec::Vec<crate::model::run_job_request::overrides::ContainerOverride>,
-            >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.container_overrides = v.into();
-            self
-        }
-
-        /// Sets the value of `task_count`.
+        /// Sets the value of [task_count][crate::model::run_job_request::Overrides::task_count].
         pub fn set_task_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
             self.task_count = v.into();
             self
         }
 
-        /// Sets the value of `timeout`.
+        /// Sets the value of [timeout][crate::model::run_job_request::Overrides::timeout].
         pub fn set_timeout<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
             mut self,
             v: T,
         ) -> Self {
             self.timeout = v.into();
+            self
+        }
+
+        /// Sets the value of [container_overrides][crate::model::run_job_request::Overrides::container_overrides].
+        pub fn set_container_overrides<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::run_job_request::overrides::ContainerOverride>,
+        {
+            use std::iter::Iterator;
+            self.container_overrides = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1869,33 +1880,37 @@ pub mod run_job_request {
         }
 
         impl ContainerOverride {
-            /// Sets the value of `name`.
+            /// Sets the value of [name][crate::model::run_job_request::overrides::ContainerOverride::name].
             pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
                 self.name = v.into();
                 self
             }
 
-            /// Sets the value of `args`.
-            pub fn set_args<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.args = v.into();
-                self
-            }
-
-            /// Sets the value of `env`.
-            pub fn set_env<T: std::convert::Into<std::vec::Vec<crate::model::EnvVar>>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.env = v.into();
-                self
-            }
-
-            /// Sets the value of `clear_args`.
+            /// Sets the value of [clear_args][crate::model::run_job_request::overrides::ContainerOverride::clear_args].
             pub fn set_clear_args<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
                 self.clear_args = v.into();
+                self
+            }
+
+            /// Sets the value of [args][crate::model::run_job_request::overrides::ContainerOverride::args].
+            pub fn set_args<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<std::string::String>,
+            {
+                use std::iter::Iterator;
+                self.args = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [env][crate::model::run_job_request::overrides::ContainerOverride::env].
+            pub fn set_env<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<crate::model::EnvVar>,
+            {
+                use std::iter::Iterator;
+                self.env = v.into_iter().map(|i| i.into()).collect();
                 self
             }
         }
@@ -2061,47 +2076,25 @@ pub struct Job {
 }
 
 impl Job {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Job::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `uid`.
+    /// Sets the value of [uid][crate::model::Job::uid].
     pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.uid = v.into();
         self
     }
 
-    /// Sets the value of `generation`.
+    /// Sets the value of [generation][crate::model::Job::generation].
     pub fn set_generation<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.generation = v.into();
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `annotations`.
-    pub fn set_annotations<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.annotations = v.into();
-        self
-    }
-
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::Job::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2110,7 +2103,7 @@ impl Job {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::Job::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2119,7 +2112,7 @@ impl Job {
         self
     }
 
-    /// Sets the value of `delete_time`.
+    /// Sets the value of [delete_time][crate::model::Job::delete_time].
     pub fn set_delete_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2128,7 +2121,7 @@ impl Job {
         self
     }
 
-    /// Sets the value of `expire_time`.
+    /// Sets the value of [expire_time][crate::model::Job::expire_time].
     pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2137,31 +2130,31 @@ impl Job {
         self
     }
 
-    /// Sets the value of `creator`.
+    /// Sets the value of [creator][crate::model::Job::creator].
     pub fn set_creator<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.creator = v.into();
         self
     }
 
-    /// Sets the value of `last_modifier`.
+    /// Sets the value of [last_modifier][crate::model::Job::last_modifier].
     pub fn set_last_modifier<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.last_modifier = v.into();
         self
     }
 
-    /// Sets the value of `client`.
+    /// Sets the value of [client][crate::model::Job::client].
     pub fn set_client<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.client = v.into();
         self
     }
 
-    /// Sets the value of `client_version`.
+    /// Sets the value of [client_version][crate::model::Job::client_version].
     pub fn set_client_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.client_version = v.into();
         self
     }
 
-    /// Sets the value of `launch_stage`.
+    /// Sets the value of [launch_stage][crate::model::Job::launch_stage].
     pub fn set_launch_stage<T: std::convert::Into<api::model::LaunchStage>>(
         mut self,
         v: T,
@@ -2170,7 +2163,7 @@ impl Job {
         self
     }
 
-    /// Sets the value of `binary_authorization`.
+    /// Sets the value of [binary_authorization][crate::model::Job::binary_authorization].
     pub fn set_binary_authorization<
         T: std::convert::Into<std::option::Option<crate::model::BinaryAuthorization>>,
     >(
@@ -2181,7 +2174,7 @@ impl Job {
         self
     }
 
-    /// Sets the value of `template`.
+    /// Sets the value of [template][crate::model::Job::template].
     pub fn set_template<
         T: std::convert::Into<std::option::Option<crate::model::ExecutionTemplate>>,
     >(
@@ -2192,13 +2185,13 @@ impl Job {
         self
     }
 
-    /// Sets the value of `observed_generation`.
+    /// Sets the value of [observed_generation][crate::model::Job::observed_generation].
     pub fn set_observed_generation<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.observed_generation = v.into();
         self
     }
 
-    /// Sets the value of `terminal_condition`.
+    /// Sets the value of [terminal_condition][crate::model::Job::terminal_condition].
     pub fn set_terminal_condition<
         T: std::convert::Into<std::option::Option<crate::model::Condition>>,
     >(
@@ -2209,22 +2202,13 @@ impl Job {
         self
     }
 
-    /// Sets the value of `conditions`.
-    pub fn set_conditions<T: std::convert::Into<std::vec::Vec<crate::model::Condition>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.conditions = v.into();
-        self
-    }
-
-    /// Sets the value of `execution_count`.
+    /// Sets the value of [execution_count][crate::model::Job::execution_count].
     pub fn set_execution_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.execution_count = v.into();
         self
     }
 
-    /// Sets the value of `latest_created_execution`.
+    /// Sets the value of [latest_created_execution][crate::model::Job::latest_created_execution].
     pub fn set_latest_created_execution<
         T: std::convert::Into<std::option::Option<crate::model::ExecutionReference>>,
     >(
@@ -2235,21 +2219,56 @@ impl Job {
         self
     }
 
-    /// Sets the value of `reconciling`.
+    /// Sets the value of [reconciling][crate::model::Job::reconciling].
     pub fn set_reconciling<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.reconciling = v.into();
         self
     }
 
-    /// Sets the value of `satisfies_pzs`.
+    /// Sets the value of [satisfies_pzs][crate::model::Job::satisfies_pzs].
     pub fn set_satisfies_pzs<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzs = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::Job::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [conditions][crate::model::Job::conditions].
+    pub fn set_conditions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Condition>,
+    {
+        use std::iter::Iterator;
+        self.conditions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Job::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::Job::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -2320,13 +2339,13 @@ pub struct ExecutionReference {
 }
 
 impl ExecutionReference {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::ExecutionReference::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::ExecutionReference::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2335,7 +2354,7 @@ impl ExecutionReference {
         self
     }
 
-    /// Sets the value of `completion_time`.
+    /// Sets the value of [completion_time][crate::model::ExecutionReference::completion_time].
     pub fn set_completion_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2344,7 +2363,7 @@ impl ExecutionReference {
         self
     }
 
-    /// Sets the value of `delete_time`.
+    /// Sets the value of [delete_time][crate::model::ExecutionReference::delete_time].
     pub fn set_delete_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2353,7 +2372,7 @@ impl ExecutionReference {
         self
     }
 
-    /// Sets the value of `completion_status`.
+    /// Sets the value of [completion_status][crate::model::ExecutionReference::completion_status].
     pub fn set_completion_status<
         T: std::convert::Into<crate::model::execution_reference::CompletionStatus>,
     >(
@@ -2491,46 +2510,19 @@ pub struct Container {
 }
 
 impl Container {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Container::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `image`.
+    /// Sets the value of [image][crate::model::Container::image].
     pub fn set_image<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.image = v.into();
         self
     }
 
-    /// Sets the value of `command`.
-    pub fn set_command<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.command = v.into();
-        self
-    }
-
-    /// Sets the value of `args`.
-    pub fn set_args<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.args = v.into();
-        self
-    }
-
-    /// Sets the value of `env`.
-    pub fn set_env<T: std::convert::Into<std::vec::Vec<crate::model::EnvVar>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.env = v.into();
-        self
-    }
-
-    /// Sets the value of `resources`.
+    /// Sets the value of [resources][crate::model::Container::resources].
     pub fn set_resources<
         T: std::convert::Into<std::option::Option<crate::model::ResourceRequirements>>,
     >(
@@ -2541,31 +2533,13 @@ impl Container {
         self
     }
 
-    /// Sets the value of `ports`.
-    pub fn set_ports<T: std::convert::Into<std::vec::Vec<crate::model::ContainerPort>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.ports = v.into();
-        self
-    }
-
-    /// Sets the value of `volume_mounts`.
-    pub fn set_volume_mounts<T: std::convert::Into<std::vec::Vec<crate::model::VolumeMount>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.volume_mounts = v.into();
-        self
-    }
-
-    /// Sets the value of `working_dir`.
+    /// Sets the value of [working_dir][crate::model::Container::working_dir].
     pub fn set_working_dir<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.working_dir = v.into();
         self
     }
 
-    /// Sets the value of `liveness_probe`.
+    /// Sets the value of [liveness_probe][crate::model::Container::liveness_probe].
     pub fn set_liveness_probe<T: std::convert::Into<std::option::Option<crate::model::Probe>>>(
         mut self,
         v: T,
@@ -2574,7 +2548,7 @@ impl Container {
         self
     }
 
-    /// Sets the value of `startup_probe`.
+    /// Sets the value of [startup_probe][crate::model::Container::startup_probe].
     pub fn set_startup_probe<T: std::convert::Into<std::option::Option<crate::model::Probe>>>(
         mut self,
         v: T,
@@ -2583,12 +2557,69 @@ impl Container {
         self
     }
 
-    /// Sets the value of `depends_on`.
-    pub fn set_depends_on<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.depends_on = v.into();
+    /// Sets the value of [command][crate::model::Container::command].
+    pub fn set_command<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.command = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [args][crate::model::Container::args].
+    pub fn set_args<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.args = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [env][crate::model::Container::env].
+    pub fn set_env<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EnvVar>,
+    {
+        use std::iter::Iterator;
+        self.env = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [ports][crate::model::Container::ports].
+    pub fn set_ports<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ContainerPort>,
+    {
+        use std::iter::Iterator;
+        self.ports = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [volume_mounts][crate::model::Container::volume_mounts].
+    pub fn set_volume_mounts<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::VolumeMount>,
+    {
+        use std::iter::Iterator;
+        self.volume_mounts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [depends_on][crate::model::Container::depends_on].
+    pub fn set_depends_on<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.depends_on = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2621,26 +2652,27 @@ pub struct ResourceRequirements {
 }
 
 impl ResourceRequirements {
-    /// Sets the value of `limits`.
-    pub fn set_limits<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.limits = v.into();
-        self
-    }
-
-    /// Sets the value of `cpu_idle`.
+    /// Sets the value of [cpu_idle][crate::model::ResourceRequirements::cpu_idle].
     pub fn set_cpu_idle<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.cpu_idle = v.into();
         self
     }
 
-    /// Sets the value of `startup_cpu_boost`.
+    /// Sets the value of [startup_cpu_boost][crate::model::ResourceRequirements::startup_cpu_boost].
     pub fn set_startup_cpu_boost<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.startup_cpu_boost = v.into();
+        self
+    }
+
+    /// Sets the value of [limits][crate::model::ResourceRequirements::limits].
+    pub fn set_limits<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.limits = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2667,7 +2699,7 @@ pub struct EnvVar {
 }
 
 impl EnvVar {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::EnvVar::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -2719,7 +2751,7 @@ pub struct EnvVarSource {
 }
 
 impl EnvVarSource {
-    /// Sets the value of `secret_key_ref`.
+    /// Sets the value of [secret_key_ref][crate::model::EnvVarSource::secret_key_ref].
     pub fn set_secret_key_ref<
         T: std::convert::Into<std::option::Option<crate::model::SecretKeySelector>>,
     >(
@@ -2758,13 +2790,13 @@ pub struct SecretKeySelector {
 }
 
 impl SecretKeySelector {
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::SecretKeySelector::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::SecretKeySelector::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
@@ -2794,13 +2826,13 @@ pub struct ContainerPort {
 }
 
 impl ContainerPort {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::ContainerPort::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `container_port`.
+    /// Sets the value of [container_port][crate::model::ContainerPort::container_port].
     pub fn set_container_port<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.container_port = v.into();
         self
@@ -2833,13 +2865,13 @@ pub struct VolumeMount {
 }
 
 impl VolumeMount {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::VolumeMount::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `mount_path`.
+    /// Sets the value of [mount_path][crate::model::VolumeMount::mount_path].
     pub fn set_mount_path<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.mount_path = v.into();
         self
@@ -2867,7 +2899,7 @@ pub struct Volume {
 }
 
 impl Volume {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Volume::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -2959,24 +2991,26 @@ pub struct SecretVolumeSource {
 }
 
 impl SecretVolumeSource {
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::SecretVolumeSource::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `items`.
-    pub fn set_items<T: std::convert::Into<std::vec::Vec<crate::model::VersionToPath>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.items = v.into();
+    /// Sets the value of [default_mode][crate::model::SecretVolumeSource::default_mode].
+    pub fn set_default_mode<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.default_mode = v.into();
         self
     }
 
-    /// Sets the value of `default_mode`.
-    pub fn set_default_mode<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.default_mode = v.into();
+    /// Sets the value of [items][crate::model::SecretVolumeSource::items].
+    pub fn set_items<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::VersionToPath>,
+    {
+        use std::iter::Iterator;
+        self.items = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3022,19 +3056,19 @@ pub struct VersionToPath {
 }
 
 impl VersionToPath {
-    /// Sets the value of `path`.
+    /// Sets the value of [path][crate::model::VersionToPath::path].
     pub fn set_path<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.path = v.into();
         self
     }
 
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::VersionToPath::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
     }
 
-    /// Sets the value of `mode`.
+    /// Sets the value of [mode][crate::model::VersionToPath::mode].
     pub fn set_mode<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.mode = v.into();
         self
@@ -3066,12 +3100,14 @@ pub struct CloudSqlInstance {
 }
 
 impl CloudSqlInstance {
-    /// Sets the value of `instances`.
-    pub fn set_instances<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.instances = v.into();
+    /// Sets the value of [instances][crate::model::CloudSqlInstance::instances].
+    pub fn set_instances<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.instances = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3109,7 +3145,7 @@ pub struct EmptyDirVolumeSource {
 }
 
 impl EmptyDirVolumeSource {
-    /// Sets the value of `medium`.
+    /// Sets the value of [medium][crate::model::EmptyDirVolumeSource::medium].
     pub fn set_medium<T: std::convert::Into<crate::model::empty_dir_volume_source::Medium>>(
         mut self,
         v: T,
@@ -3118,7 +3154,7 @@ impl EmptyDirVolumeSource {
         self
     }
 
-    /// Sets the value of `size_limit`.
+    /// Sets the value of [size_limit][crate::model::EmptyDirVolumeSource::size_limit].
     pub fn set_size_limit<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.size_limit = v.into();
         self
@@ -3184,19 +3220,19 @@ pub struct NFSVolumeSource {
 }
 
 impl NFSVolumeSource {
-    /// Sets the value of `server`.
+    /// Sets the value of [server][crate::model::NFSVolumeSource::server].
     pub fn set_server<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.server = v.into();
         self
     }
 
-    /// Sets the value of `path`.
+    /// Sets the value of [path][crate::model::NFSVolumeSource::path].
     pub fn set_path<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.path = v.into();
         self
     }
 
-    /// Sets the value of `read_only`.
+    /// Sets the value of [read_only][crate::model::NFSVolumeSource::read_only].
     pub fn set_read_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.read_only = v.into();
         self
@@ -3230,24 +3266,26 @@ pub struct GCSVolumeSource {
 }
 
 impl GCSVolumeSource {
-    /// Sets the value of `bucket`.
+    /// Sets the value of [bucket][crate::model::GCSVolumeSource::bucket].
     pub fn set_bucket<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.bucket = v.into();
         self
     }
 
-    /// Sets the value of `read_only`.
+    /// Sets the value of [read_only][crate::model::GCSVolumeSource::read_only].
     pub fn set_read_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.read_only = v.into();
         self
     }
 
-    /// Sets the value of `mount_options`.
-    pub fn set_mount_options<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.mount_options = v.into();
+    /// Sets the value of [mount_options][crate::model::GCSVolumeSource::mount_options].
+    pub fn set_mount_options<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.mount_options = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3290,25 +3328,25 @@ pub struct Probe {
 }
 
 impl Probe {
-    /// Sets the value of `initial_delay_seconds`.
+    /// Sets the value of [initial_delay_seconds][crate::model::Probe::initial_delay_seconds].
     pub fn set_initial_delay_seconds<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.initial_delay_seconds = v.into();
         self
     }
 
-    /// Sets the value of `timeout_seconds`.
+    /// Sets the value of [timeout_seconds][crate::model::Probe::timeout_seconds].
     pub fn set_timeout_seconds<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.timeout_seconds = v.into();
         self
     }
 
-    /// Sets the value of `period_seconds`.
+    /// Sets the value of [period_seconds][crate::model::Probe::period_seconds].
     pub fn set_period_seconds<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.period_seconds = v.into();
         self
     }
 
-    /// Sets the value of `failure_threshold`.
+    /// Sets the value of [failure_threshold][crate::model::Probe::failure_threshold].
     pub fn set_failure_threshold<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.failure_threshold = v.into();
         self
@@ -3375,24 +3413,26 @@ pub struct HTTPGetAction {
 }
 
 impl HTTPGetAction {
-    /// Sets the value of `path`.
+    /// Sets the value of [path][crate::model::HTTPGetAction::path].
     pub fn set_path<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.path = v.into();
         self
     }
 
-    /// Sets the value of `http_headers`.
-    pub fn set_http_headers<T: std::convert::Into<std::vec::Vec<crate::model::HTTPHeader>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.http_headers = v.into();
+    /// Sets the value of [port][crate::model::HTTPGetAction::port].
+    pub fn set_port<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.port = v.into();
         self
     }
 
-    /// Sets the value of `port`.
-    pub fn set_port<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.port = v.into();
+    /// Sets the value of [http_headers][crate::model::HTTPGetAction::http_headers].
+    pub fn set_http_headers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::HTTPHeader>,
+    {
+        use std::iter::Iterator;
+        self.http_headers = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3419,13 +3459,13 @@ pub struct HTTPHeader {
 }
 
 impl HTTPHeader {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::HTTPHeader::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `value`.
+    /// Sets the value of [value][crate::model::HTTPHeader::value].
     pub fn set_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.value = v.into();
         self
@@ -3451,7 +3491,7 @@ pub struct TCPSocketAction {
 }
 
 impl TCPSocketAction {
-    /// Sets the value of `port`.
+    /// Sets the value of [port][crate::model::TCPSocketAction::port].
     pub fn set_port<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.port = v.into();
         self
@@ -3484,13 +3524,13 @@ pub struct GRPCAction {
 }
 
 impl GRPCAction {
-    /// Sets the value of `port`.
+    /// Sets the value of [port][crate::model::GRPCAction::port].
     pub fn set_port<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.port = v.into();
         self
     }
 
-    /// Sets the value of `service`.
+    /// Sets the value of [service][crate::model::GRPCAction::service].
     pub fn set_service<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service = v.into();
         self
@@ -3517,7 +3557,7 @@ pub struct GetRevisionRequest {
 }
 
 impl GetRevisionRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetRevisionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -3556,25 +3596,25 @@ pub struct ListRevisionsRequest {
 }
 
 impl ListRevisionsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListRevisionsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListRevisionsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListRevisionsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `show_deleted`.
+    /// Sets the value of [show_deleted][crate::model::ListRevisionsRequest::show_deleted].
     pub fn set_show_deleted<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.show_deleted = v.into();
         self
@@ -3604,18 +3644,20 @@ pub struct ListRevisionsResponse {
 }
 
 impl ListRevisionsResponse {
-    /// Sets the value of `revisions`.
-    pub fn set_revisions<T: std::convert::Into<std::vec::Vec<crate::model::Revision>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.revisions = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListRevisionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [revisions][crate::model::ListRevisionsResponse::revisions].
+    pub fn set_revisions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Revision>,
+    {
+        use std::iter::Iterator;
+        self.revisions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3664,19 +3706,19 @@ pub struct DeleteRevisionRequest {
 }
 
 impl DeleteRevisionRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteRevisionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `validate_only`.
+    /// Sets the value of [validate_only][crate::model::DeleteRevisionRequest::validate_only].
     pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.validate_only = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DeleteRevisionRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
@@ -3851,47 +3893,25 @@ pub struct Revision {
 }
 
 impl Revision {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Revision::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `uid`.
+    /// Sets the value of [uid][crate::model::Revision::uid].
     pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.uid = v.into();
         self
     }
 
-    /// Sets the value of `generation`.
+    /// Sets the value of [generation][crate::model::Revision::generation].
     pub fn set_generation<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.generation = v.into();
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `annotations`.
-    pub fn set_annotations<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.annotations = v.into();
-        self
-    }
-
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::Revision::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3900,7 +3920,7 @@ impl Revision {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::Revision::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3909,7 +3929,7 @@ impl Revision {
         self
     }
 
-    /// Sets the value of `delete_time`.
+    /// Sets the value of [delete_time][crate::model::Revision::delete_time].
     pub fn set_delete_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3918,7 +3938,7 @@ impl Revision {
         self
     }
 
-    /// Sets the value of `expire_time`.
+    /// Sets the value of [expire_time][crate::model::Revision::expire_time].
     pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3927,7 +3947,7 @@ impl Revision {
         self
     }
 
-    /// Sets the value of `launch_stage`.
+    /// Sets the value of [launch_stage][crate::model::Revision::launch_stage].
     pub fn set_launch_stage<T: std::convert::Into<api::model::LaunchStage>>(
         mut self,
         v: T,
@@ -3936,13 +3956,13 @@ impl Revision {
         self
     }
 
-    /// Sets the value of `service`.
+    /// Sets the value of [service][crate::model::Revision::service].
     pub fn set_service<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service = v.into();
         self
     }
 
-    /// Sets the value of `scaling`.
+    /// Sets the value of [scaling][crate::model::Revision::scaling].
     pub fn set_scaling<
         T: std::convert::Into<std::option::Option<crate::model::RevisionScaling>>,
     >(
@@ -3953,7 +3973,7 @@ impl Revision {
         self
     }
 
-    /// Sets the value of `vpc_access`.
+    /// Sets the value of [vpc_access][crate::model::Revision::vpc_access].
     pub fn set_vpc_access<T: std::convert::Into<std::option::Option<crate::model::VpcAccess>>>(
         mut self,
         v: T,
@@ -3962,7 +3982,7 @@ impl Revision {
         self
     }
 
-    /// Sets the value of `max_instance_request_concurrency`.
+    /// Sets the value of [max_instance_request_concurrency][crate::model::Revision::max_instance_request_concurrency].
     pub fn set_max_instance_request_concurrency<T: std::convert::Into<i32>>(
         mut self,
         v: T,
@@ -3971,7 +3991,7 @@ impl Revision {
         self
     }
 
-    /// Sets the value of `timeout`.
+    /// Sets the value of [timeout][crate::model::Revision::timeout].
     pub fn set_timeout<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
@@ -3980,31 +4000,13 @@ impl Revision {
         self
     }
 
-    /// Sets the value of `service_account`.
+    /// Sets the value of [service_account][crate::model::Revision::service_account].
     pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_account = v.into();
         self
     }
 
-    /// Sets the value of `containers`.
-    pub fn set_containers<T: std::convert::Into<std::vec::Vec<crate::model::Container>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.containers = v.into();
-        self
-    }
-
-    /// Sets the value of `volumes`.
-    pub fn set_volumes<T: std::convert::Into<std::vec::Vec<crate::model::Volume>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.volumes = v.into();
-        self
-    }
-
-    /// Sets the value of `execution_environment`.
+    /// Sets the value of [execution_environment][crate::model::Revision::execution_environment].
     pub fn set_execution_environment<T: std::convert::Into<crate::model::ExecutionEnvironment>>(
         mut self,
         v: T,
@@ -4013,13 +4015,13 @@ impl Revision {
         self
     }
 
-    /// Sets the value of `encryption_key`.
+    /// Sets the value of [encryption_key][crate::model::Revision::encryption_key].
     pub fn set_encryption_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.encryption_key = v.into();
         self
     }
 
-    /// Sets the value of `service_mesh`.
+    /// Sets the value of [service_mesh][crate::model::Revision::service_mesh].
     pub fn set_service_mesh<
         T: std::convert::Into<std::option::Option<crate::model::ServiceMesh>>,
     >(
@@ -4030,7 +4032,7 @@ impl Revision {
         self
     }
 
-    /// Sets the value of `encryption_key_revocation_action`.
+    /// Sets the value of [encryption_key_revocation_action][crate::model::Revision::encryption_key_revocation_action].
     pub fn set_encryption_key_revocation_action<
         T: std::convert::Into<crate::model::EncryptionKeyRevocationAction>,
     >(
@@ -4041,7 +4043,7 @@ impl Revision {
         self
     }
 
-    /// Sets the value of `encryption_key_shutdown_duration`.
+    /// Sets the value of [encryption_key_shutdown_duration][crate::model::Revision::encryption_key_shutdown_duration].
     pub fn set_encryption_key_shutdown_duration<
         T: std::convert::Into<std::option::Option<wkt::Duration>>,
     >(
@@ -4052,46 +4054,37 @@ impl Revision {
         self
     }
 
-    /// Sets the value of `reconciling`.
+    /// Sets the value of [reconciling][crate::model::Revision::reconciling].
     pub fn set_reconciling<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.reconciling = v.into();
         self
     }
 
-    /// Sets the value of `conditions`.
-    pub fn set_conditions<T: std::convert::Into<std::vec::Vec<crate::model::Condition>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.conditions = v.into();
-        self
-    }
-
-    /// Sets the value of `observed_generation`.
+    /// Sets the value of [observed_generation][crate::model::Revision::observed_generation].
     pub fn set_observed_generation<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.observed_generation = v.into();
         self
     }
 
-    /// Sets the value of `log_uri`.
+    /// Sets the value of [log_uri][crate::model::Revision::log_uri].
     pub fn set_log_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.log_uri = v.into();
         self
     }
 
-    /// Sets the value of `satisfies_pzs`.
+    /// Sets the value of [satisfies_pzs][crate::model::Revision::satisfies_pzs].
     pub fn set_satisfies_pzs<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzs = v.into();
         self
     }
 
-    /// Sets the value of `session_affinity`.
+    /// Sets the value of [session_affinity][crate::model::Revision::session_affinity].
     pub fn set_session_affinity<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.session_affinity = v.into();
         self
     }
 
-    /// Sets the value of `scaling_status`.
+    /// Sets the value of [scaling_status][crate::model::Revision::scaling_status].
     pub fn set_scaling_status<
         T: std::convert::Into<std::option::Option<crate::model::RevisionScalingStatus>>,
     >(
@@ -4102,7 +4095,7 @@ impl Revision {
         self
     }
 
-    /// Sets the value of `node_selector`.
+    /// Sets the value of [node_selector][crate::model::Revision::node_selector].
     pub fn set_node_selector<
         T: std::convert::Into<std::option::Option<crate::model::NodeSelector>>,
     >(
@@ -4113,9 +4106,66 @@ impl Revision {
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::Revision::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [containers][crate::model::Revision::containers].
+    pub fn set_containers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Container>,
+    {
+        use std::iter::Iterator;
+        self.containers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [volumes][crate::model::Revision::volumes].
+    pub fn set_volumes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Volume>,
+    {
+        use std::iter::Iterator;
+        self.volumes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [conditions][crate::model::Revision::conditions].
+    pub fn set_conditions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Condition>,
+    {
+        use std::iter::Iterator;
+        self.conditions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Revision::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::Revision::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4221,35 +4271,13 @@ pub struct RevisionTemplate {
 }
 
 impl RevisionTemplate {
-    /// Sets the value of `revision`.
+    /// Sets the value of [revision][crate::model::RevisionTemplate::revision].
     pub fn set_revision<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.revision = v.into();
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `annotations`.
-    pub fn set_annotations<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.annotations = v.into();
-        self
-    }
-
-    /// Sets the value of `scaling`.
+    /// Sets the value of [scaling][crate::model::RevisionTemplate::scaling].
     pub fn set_scaling<
         T: std::convert::Into<std::option::Option<crate::model::RevisionScaling>>,
     >(
@@ -4260,7 +4288,7 @@ impl RevisionTemplate {
         self
     }
 
-    /// Sets the value of `vpc_access`.
+    /// Sets the value of [vpc_access][crate::model::RevisionTemplate::vpc_access].
     pub fn set_vpc_access<T: std::convert::Into<std::option::Option<crate::model::VpcAccess>>>(
         mut self,
         v: T,
@@ -4269,7 +4297,7 @@ impl RevisionTemplate {
         self
     }
 
-    /// Sets the value of `timeout`.
+    /// Sets the value of [timeout][crate::model::RevisionTemplate::timeout].
     pub fn set_timeout<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
@@ -4278,31 +4306,13 @@ impl RevisionTemplate {
         self
     }
 
-    /// Sets the value of `service_account`.
+    /// Sets the value of [service_account][crate::model::RevisionTemplate::service_account].
     pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_account = v.into();
         self
     }
 
-    /// Sets the value of `containers`.
-    pub fn set_containers<T: std::convert::Into<std::vec::Vec<crate::model::Container>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.containers = v.into();
-        self
-    }
-
-    /// Sets the value of `volumes`.
-    pub fn set_volumes<T: std::convert::Into<std::vec::Vec<crate::model::Volume>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.volumes = v.into();
-        self
-    }
-
-    /// Sets the value of `execution_environment`.
+    /// Sets the value of [execution_environment][crate::model::RevisionTemplate::execution_environment].
     pub fn set_execution_environment<T: std::convert::Into<crate::model::ExecutionEnvironment>>(
         mut self,
         v: T,
@@ -4311,13 +4321,13 @@ impl RevisionTemplate {
         self
     }
 
-    /// Sets the value of `encryption_key`.
+    /// Sets the value of [encryption_key][crate::model::RevisionTemplate::encryption_key].
     pub fn set_encryption_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.encryption_key = v.into();
         self
     }
 
-    /// Sets the value of `max_instance_request_concurrency`.
+    /// Sets the value of [max_instance_request_concurrency][crate::model::RevisionTemplate::max_instance_request_concurrency].
     pub fn set_max_instance_request_concurrency<T: std::convert::Into<i32>>(
         mut self,
         v: T,
@@ -4326,7 +4336,7 @@ impl RevisionTemplate {
         self
     }
 
-    /// Sets the value of `service_mesh`.
+    /// Sets the value of [service_mesh][crate::model::RevisionTemplate::service_mesh].
     pub fn set_service_mesh<
         T: std::convert::Into<std::option::Option<crate::model::ServiceMesh>>,
     >(
@@ -4337,7 +4347,7 @@ impl RevisionTemplate {
         self
     }
 
-    /// Sets the value of `encryption_key_revocation_action`.
+    /// Sets the value of [encryption_key_revocation_action][crate::model::RevisionTemplate::encryption_key_revocation_action].
     pub fn set_encryption_key_revocation_action<
         T: std::convert::Into<crate::model::EncryptionKeyRevocationAction>,
     >(
@@ -4348,7 +4358,7 @@ impl RevisionTemplate {
         self
     }
 
-    /// Sets the value of `encryption_key_shutdown_duration`.
+    /// Sets the value of [encryption_key_shutdown_duration][crate::model::RevisionTemplate::encryption_key_shutdown_duration].
     pub fn set_encryption_key_shutdown_duration<
         T: std::convert::Into<std::option::Option<wkt::Duration>>,
     >(
@@ -4359,19 +4369,19 @@ impl RevisionTemplate {
         self
     }
 
-    /// Sets the value of `session_affinity`.
+    /// Sets the value of [session_affinity][crate::model::RevisionTemplate::session_affinity].
     pub fn set_session_affinity<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.session_affinity = v.into();
         self
     }
 
-    /// Sets the value of `health_check_disabled`.
+    /// Sets the value of [health_check_disabled][crate::model::RevisionTemplate::health_check_disabled].
     pub fn set_health_check_disabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.health_check_disabled = v.into();
         self
     }
 
-    /// Sets the value of `node_selector`.
+    /// Sets the value of [node_selector][crate::model::RevisionTemplate::node_selector].
     pub fn set_node_selector<
         T: std::convert::Into<std::option::Option<crate::model::NodeSelector>>,
     >(
@@ -4379,6 +4389,52 @@ impl RevisionTemplate {
         v: T,
     ) -> Self {
         self.node_selector = v.into();
+        self
+    }
+
+    /// Sets the value of [containers][crate::model::RevisionTemplate::containers].
+    pub fn set_containers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Container>,
+    {
+        use std::iter::Iterator;
+        self.containers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [volumes][crate::model::RevisionTemplate::volumes].
+    pub fn set_volumes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Volume>,
+    {
+        use std::iter::Iterator;
+        self.volumes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::RevisionTemplate::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::RevisionTemplate::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4417,13 +4473,13 @@ pub struct CreateServiceRequest {
 }
 
 impl CreateServiceRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateServiceRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `service`.
+    /// Sets the value of [service][crate::model::CreateServiceRequest::service].
     pub fn set_service<T: std::convert::Into<std::option::Option<crate::model::Service>>>(
         mut self,
         v: T,
@@ -4432,13 +4488,13 @@ impl CreateServiceRequest {
         self
     }
 
-    /// Sets the value of `service_id`.
+    /// Sets the value of [service_id][crate::model::CreateServiceRequest::service_id].
     pub fn set_service_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_id = v.into();
         self
     }
 
-    /// Sets the value of `validate_only`.
+    /// Sets the value of [validate_only][crate::model::CreateServiceRequest::validate_only].
     pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.validate_only = v.into();
         self
@@ -4476,7 +4532,7 @@ pub struct UpdateServiceRequest {
 }
 
 impl UpdateServiceRequest {
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateServiceRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -4485,7 +4541,7 @@ impl UpdateServiceRequest {
         self
     }
 
-    /// Sets the value of `service`.
+    /// Sets the value of [service][crate::model::UpdateServiceRequest::service].
     pub fn set_service<T: std::convert::Into<std::option::Option<crate::model::Service>>>(
         mut self,
         v: T,
@@ -4494,13 +4550,13 @@ impl UpdateServiceRequest {
         self
     }
 
-    /// Sets the value of `validate_only`.
+    /// Sets the value of [validate_only][crate::model::UpdateServiceRequest::validate_only].
     pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.validate_only = v.into();
         self
     }
 
-    /// Sets the value of `allow_missing`.
+    /// Sets the value of [allow_missing][crate::model::UpdateServiceRequest::allow_missing].
     pub fn set_allow_missing<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.allow_missing = v.into();
         self
@@ -4539,25 +4595,25 @@ pub struct ListServicesRequest {
 }
 
 impl ListServicesRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListServicesRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListServicesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListServicesRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `show_deleted`.
+    /// Sets the value of [show_deleted][crate::model::ListServicesRequest::show_deleted].
     pub fn set_show_deleted<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.show_deleted = v.into();
         self
@@ -4587,18 +4643,20 @@ pub struct ListServicesResponse {
 }
 
 impl ListServicesResponse {
-    /// Sets the value of `services`.
-    pub fn set_services<T: std::convert::Into<std::vec::Vec<crate::model::Service>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.services = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListServicesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [services][crate::model::ListServicesResponse::services].
+    pub fn set_services<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Service>,
+    {
+        use std::iter::Iterator;
+        self.services = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4636,7 +4694,7 @@ pub struct GetServiceRequest {
 }
 
 impl GetServiceRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetServiceRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -4672,19 +4730,19 @@ pub struct DeleteServiceRequest {
 }
 
 impl DeleteServiceRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteServiceRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `validate_only`.
+    /// Sets the value of [validate_only][crate::model::DeleteServiceRequest::validate_only].
     pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.validate_only = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DeleteServiceRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
@@ -4914,53 +4972,31 @@ pub struct Service {
 }
 
 impl Service {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Service::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::Service::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
     }
 
-    /// Sets the value of `uid`.
+    /// Sets the value of [uid][crate::model::Service::uid].
     pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.uid = v.into();
         self
     }
 
-    /// Sets the value of `generation`.
+    /// Sets the value of [generation][crate::model::Service::generation].
     pub fn set_generation<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.generation = v.into();
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `annotations`.
-    pub fn set_annotations<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.annotations = v.into();
-        self
-    }
-
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::Service::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -4969,7 +5005,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::Service::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -4978,7 +5014,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `delete_time`.
+    /// Sets the value of [delete_time][crate::model::Service::delete_time].
     pub fn set_delete_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -4987,7 +5023,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `expire_time`.
+    /// Sets the value of [expire_time][crate::model::Service::expire_time].
     pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -4996,31 +5032,31 @@ impl Service {
         self
     }
 
-    /// Sets the value of `creator`.
+    /// Sets the value of [creator][crate::model::Service::creator].
     pub fn set_creator<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.creator = v.into();
         self
     }
 
-    /// Sets the value of `last_modifier`.
+    /// Sets the value of [last_modifier][crate::model::Service::last_modifier].
     pub fn set_last_modifier<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.last_modifier = v.into();
         self
     }
 
-    /// Sets the value of `client`.
+    /// Sets the value of [client][crate::model::Service::client].
     pub fn set_client<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.client = v.into();
         self
     }
 
-    /// Sets the value of `client_version`.
+    /// Sets the value of [client_version][crate::model::Service::client_version].
     pub fn set_client_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.client_version = v.into();
         self
     }
 
-    /// Sets the value of `ingress`.
+    /// Sets the value of [ingress][crate::model::Service::ingress].
     pub fn set_ingress<T: std::convert::Into<crate::model::IngressTraffic>>(
         mut self,
         v: T,
@@ -5029,7 +5065,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `launch_stage`.
+    /// Sets the value of [launch_stage][crate::model::Service::launch_stage].
     pub fn set_launch_stage<T: std::convert::Into<api::model::LaunchStage>>(
         mut self,
         v: T,
@@ -5038,7 +5074,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `binary_authorization`.
+    /// Sets the value of [binary_authorization][crate::model::Service::binary_authorization].
     pub fn set_binary_authorization<
         T: std::convert::Into<std::option::Option<crate::model::BinaryAuthorization>>,
     >(
@@ -5049,7 +5085,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `template`.
+    /// Sets the value of [template][crate::model::Service::template].
     pub fn set_template<
         T: std::convert::Into<std::option::Option<crate::model::RevisionTemplate>>,
     >(
@@ -5060,16 +5096,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `traffic`.
-    pub fn set_traffic<T: std::convert::Into<std::vec::Vec<crate::model::TrafficTarget>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.traffic = v.into();
-        self
-    }
-
-    /// Sets the value of `scaling`.
+    /// Sets the value of [scaling][crate::model::Service::scaling].
     pub fn set_scaling<T: std::convert::Into<std::option::Option<crate::model::ServiceScaling>>>(
         mut self,
         v: T,
@@ -5078,43 +5105,25 @@ impl Service {
         self
     }
 
-    /// Sets the value of `invoker_iam_disabled`.
+    /// Sets the value of [invoker_iam_disabled][crate::model::Service::invoker_iam_disabled].
     pub fn set_invoker_iam_disabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.invoker_iam_disabled = v.into();
         self
     }
 
-    /// Sets the value of `default_uri_disabled`.
+    /// Sets the value of [default_uri_disabled][crate::model::Service::default_uri_disabled].
     pub fn set_default_uri_disabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.default_uri_disabled = v.into();
         self
     }
 
-    /// Sets the value of `urls`.
-    pub fn set_urls<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.urls = v.into();
-        self
-    }
-
-    /// Sets the value of `custom_audiences`.
-    pub fn set_custom_audiences<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.custom_audiences = v.into();
-        self
-    }
-
-    /// Sets the value of `observed_generation`.
+    /// Sets the value of [observed_generation][crate::model::Service::observed_generation].
     pub fn set_observed_generation<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.observed_generation = v.into();
         self
     }
 
-    /// Sets the value of `terminal_condition`.
+    /// Sets the value of [terminal_condition][crate::model::Service::terminal_condition].
     pub fn set_terminal_condition<
         T: std::convert::Into<std::option::Option<crate::model::Condition>>,
     >(
@@ -5125,16 +5134,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `conditions`.
-    pub fn set_conditions<T: std::convert::Into<std::vec::Vec<crate::model::Condition>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.conditions = v.into();
-        self
-    }
-
-    /// Sets the value of `latest_ready_revision`.
+    /// Sets the value of [latest_ready_revision][crate::model::Service::latest_ready_revision].
     pub fn set_latest_ready_revision<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -5143,7 +5143,7 @@ impl Service {
         self
     }
 
-    /// Sets the value of `latest_created_revision`.
+    /// Sets the value of [latest_created_revision][crate::model::Service::latest_created_revision].
     pub fn set_latest_created_revision<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -5152,38 +5152,106 @@ impl Service {
         self
     }
 
-    /// Sets the value of `traffic_statuses`.
-    pub fn set_traffic_statuses<
-        T: std::convert::Into<std::vec::Vec<crate::model::TrafficTargetStatus>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.traffic_statuses = v.into();
-        self
-    }
-
-    /// Sets the value of `uri`.
+    /// Sets the value of [uri][crate::model::Service::uri].
     pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.uri = v.into();
         self
     }
 
-    /// Sets the value of `satisfies_pzs`.
+    /// Sets the value of [satisfies_pzs][crate::model::Service::satisfies_pzs].
     pub fn set_satisfies_pzs<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzs = v.into();
         self
     }
 
-    /// Sets the value of `reconciling`.
+    /// Sets the value of [reconciling][crate::model::Service::reconciling].
     pub fn set_reconciling<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.reconciling = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::Service::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [traffic][crate::model::Service::traffic].
+    pub fn set_traffic<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::TrafficTarget>,
+    {
+        use std::iter::Iterator;
+        self.traffic = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [urls][crate::model::Service::urls].
+    pub fn set_urls<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.urls = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [custom_audiences][crate::model::Service::custom_audiences].
+    pub fn set_custom_audiences<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.custom_audiences = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [conditions][crate::model::Service::conditions].
+    pub fn set_conditions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Condition>,
+    {
+        use std::iter::Iterator;
+        self.conditions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [traffic_statuses][crate::model::Service::traffic_statuses].
+    pub fn set_traffic_statuses<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::TrafficTargetStatus>,
+    {
+        use std::iter::Iterator;
+        self.traffic_statuses = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Service::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::Service::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -5205,7 +5273,7 @@ pub struct RevisionScalingStatus {
 }
 
 impl RevisionScalingStatus {
-    /// Sets the value of `desired_min_instance_count`.
+    /// Sets the value of [desired_min_instance_count][crate::model::RevisionScalingStatus::desired_min_instance_count].
     pub fn set_desired_min_instance_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.desired_min_instance_count = v.into();
         self
@@ -5232,7 +5300,7 @@ pub struct GetTaskRequest {
 }
 
 impl GetTaskRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetTaskRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -5271,25 +5339,25 @@ pub struct ListTasksRequest {
 }
 
 impl ListTasksRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListTasksRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListTasksRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListTasksRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `show_deleted`.
+    /// Sets the value of [show_deleted][crate::model::ListTasksRequest::show_deleted].
     pub fn set_show_deleted<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.show_deleted = v.into();
         self
@@ -5319,18 +5387,20 @@ pub struct ListTasksResponse {
 }
 
 impl ListTasksResponse {
-    /// Sets the value of `tasks`.
-    pub fn set_tasks<T: std::convert::Into<std::vec::Vec<crate::model::Task>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.tasks = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListTasksResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [tasks][crate::model::ListTasksResponse::tasks].
+    pub fn set_tasks<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Task>,
+    {
+        use std::iter::Iterator;
+        self.tasks = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5518,47 +5588,25 @@ pub struct Task {
 }
 
 impl Task {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Task::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `uid`.
+    /// Sets the value of [uid][crate::model::Task::uid].
     pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.uid = v.into();
         self
     }
 
-    /// Sets the value of `generation`.
+    /// Sets the value of [generation][crate::model::Task::generation].
     pub fn set_generation<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.generation = v.into();
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `annotations`.
-    pub fn set_annotations<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.annotations = v.into();
-        self
-    }
-
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::Task::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -5567,7 +5615,7 @@ impl Task {
         self
     }
 
-    /// Sets the value of `scheduled_time`.
+    /// Sets the value of [scheduled_time][crate::model::Task::scheduled_time].
     pub fn set_scheduled_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -5576,7 +5624,7 @@ impl Task {
         self
     }
 
-    /// Sets the value of `start_time`.
+    /// Sets the value of [start_time][crate::model::Task::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -5585,7 +5633,7 @@ impl Task {
         self
     }
 
-    /// Sets the value of `completion_time`.
+    /// Sets the value of [completion_time][crate::model::Task::completion_time].
     pub fn set_completion_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -5594,7 +5642,7 @@ impl Task {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::Task::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -5603,7 +5651,7 @@ impl Task {
         self
     }
 
-    /// Sets the value of `delete_time`.
+    /// Sets the value of [delete_time][crate::model::Task::delete_time].
     pub fn set_delete_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -5612,7 +5660,7 @@ impl Task {
         self
     }
 
-    /// Sets the value of `expire_time`.
+    /// Sets the value of [expire_time][crate::model::Task::expire_time].
     pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -5621,43 +5669,25 @@ impl Task {
         self
     }
 
-    /// Sets the value of `job`.
+    /// Sets the value of [job][crate::model::Task::job].
     pub fn set_job<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.job = v.into();
         self
     }
 
-    /// Sets the value of `execution`.
+    /// Sets the value of [execution][crate::model::Task::execution].
     pub fn set_execution<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.execution = v.into();
         self
     }
 
-    /// Sets the value of `containers`.
-    pub fn set_containers<T: std::convert::Into<std::vec::Vec<crate::model::Container>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.containers = v.into();
-        self
-    }
-
-    /// Sets the value of `volumes`.
-    pub fn set_volumes<T: std::convert::Into<std::vec::Vec<crate::model::Volume>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.volumes = v.into();
-        self
-    }
-
-    /// Sets the value of `max_retries`.
+    /// Sets the value of [max_retries][crate::model::Task::max_retries].
     pub fn set_max_retries<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.max_retries = v.into();
         self
     }
 
-    /// Sets the value of `timeout`.
+    /// Sets the value of [timeout][crate::model::Task::timeout].
     pub fn set_timeout<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
@@ -5666,13 +5696,13 @@ impl Task {
         self
     }
 
-    /// Sets the value of `service_account`.
+    /// Sets the value of [service_account][crate::model::Task::service_account].
     pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_account = v.into();
         self
     }
 
-    /// Sets the value of `execution_environment`.
+    /// Sets the value of [execution_environment][crate::model::Task::execution_environment].
     pub fn set_execution_environment<T: std::convert::Into<crate::model::ExecutionEnvironment>>(
         mut self,
         v: T,
@@ -5681,40 +5711,31 @@ impl Task {
         self
     }
 
-    /// Sets the value of `reconciling`.
+    /// Sets the value of [reconciling][crate::model::Task::reconciling].
     pub fn set_reconciling<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.reconciling = v.into();
         self
     }
 
-    /// Sets the value of `conditions`.
-    pub fn set_conditions<T: std::convert::Into<std::vec::Vec<crate::model::Condition>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.conditions = v.into();
-        self
-    }
-
-    /// Sets the value of `observed_generation`.
+    /// Sets the value of [observed_generation][crate::model::Task::observed_generation].
     pub fn set_observed_generation<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.observed_generation = v.into();
         self
     }
 
-    /// Sets the value of `index`.
+    /// Sets the value of [index][crate::model::Task::index].
     pub fn set_index<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.index = v.into();
         self
     }
 
-    /// Sets the value of `retried`.
+    /// Sets the value of [retried][crate::model::Task::retried].
     pub fn set_retried<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.retried = v.into();
         self
     }
 
-    /// Sets the value of `last_attempt_result`.
+    /// Sets the value of [last_attempt_result][crate::model::Task::last_attempt_result].
     pub fn set_last_attempt_result<
         T: std::convert::Into<std::option::Option<crate::model::TaskAttemptResult>>,
     >(
@@ -5725,13 +5746,13 @@ impl Task {
         self
     }
 
-    /// Sets the value of `encryption_key`.
+    /// Sets the value of [encryption_key][crate::model::Task::encryption_key].
     pub fn set_encryption_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.encryption_key = v.into();
         self
     }
 
-    /// Sets the value of `vpc_access`.
+    /// Sets the value of [vpc_access][crate::model::Task::vpc_access].
     pub fn set_vpc_access<T: std::convert::Into<std::option::Option<crate::model::VpcAccess>>>(
         mut self,
         v: T,
@@ -5740,21 +5761,78 @@ impl Task {
         self
     }
 
-    /// Sets the value of `log_uri`.
+    /// Sets the value of [log_uri][crate::model::Task::log_uri].
     pub fn set_log_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.log_uri = v.into();
         self
     }
 
-    /// Sets the value of `satisfies_pzs`.
+    /// Sets the value of [satisfies_pzs][crate::model::Task::satisfies_pzs].
     pub fn set_satisfies_pzs<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzs = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::Task::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [containers][crate::model::Task::containers].
+    pub fn set_containers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Container>,
+    {
+        use std::iter::Iterator;
+        self.containers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [volumes][crate::model::Task::volumes].
+    pub fn set_volumes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Volume>,
+    {
+        use std::iter::Iterator;
+        self.volumes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [conditions][crate::model::Task::conditions].
+    pub fn set_conditions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Condition>,
+    {
+        use std::iter::Iterator;
+        self.conditions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Task::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::Task::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -5784,7 +5862,7 @@ pub struct TaskAttemptResult {
 }
 
 impl TaskAttemptResult {
-    /// Sets the value of `status`.
+    /// Sets the value of [status][crate::model::TaskAttemptResult::status].
     pub fn set_status<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
         mut self,
         v: T,
@@ -5793,7 +5871,7 @@ impl TaskAttemptResult {
         self
     }
 
-    /// Sets the value of `exit_code`.
+    /// Sets the value of [exit_code][crate::model::TaskAttemptResult::exit_code].
     pub fn set_exit_code<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.exit_code = v.into();
         self
@@ -5856,25 +5934,7 @@ pub struct TaskTemplate {
 }
 
 impl TaskTemplate {
-    /// Sets the value of `containers`.
-    pub fn set_containers<T: std::convert::Into<std::vec::Vec<crate::model::Container>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.containers = v.into();
-        self
-    }
-
-    /// Sets the value of `volumes`.
-    pub fn set_volumes<T: std::convert::Into<std::vec::Vec<crate::model::Volume>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.volumes = v.into();
-        self
-    }
-
-    /// Sets the value of `timeout`.
+    /// Sets the value of [timeout][crate::model::TaskTemplate::timeout].
     pub fn set_timeout<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
@@ -5883,13 +5943,13 @@ impl TaskTemplate {
         self
     }
 
-    /// Sets the value of `service_account`.
+    /// Sets the value of [service_account][crate::model::TaskTemplate::service_account].
     pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_account = v.into();
         self
     }
 
-    /// Sets the value of `execution_environment`.
+    /// Sets the value of [execution_environment][crate::model::TaskTemplate::execution_environment].
     pub fn set_execution_environment<T: std::convert::Into<crate::model::ExecutionEnvironment>>(
         mut self,
         v: T,
@@ -5898,18 +5958,40 @@ impl TaskTemplate {
         self
     }
 
-    /// Sets the value of `encryption_key`.
+    /// Sets the value of [encryption_key][crate::model::TaskTemplate::encryption_key].
     pub fn set_encryption_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.encryption_key = v.into();
         self
     }
 
-    /// Sets the value of `vpc_access`.
+    /// Sets the value of [vpc_access][crate::model::TaskTemplate::vpc_access].
     pub fn set_vpc_access<T: std::convert::Into<std::option::Option<crate::model::VpcAccess>>>(
         mut self,
         v: T,
     ) -> Self {
         self.vpc_access = v.into();
+        self
+    }
+
+    /// Sets the value of [containers][crate::model::TaskTemplate::containers].
+    pub fn set_containers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Container>,
+    {
+        use std::iter::Iterator;
+        self.containers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [volumes][crate::model::TaskTemplate::volumes].
+    pub fn set_volumes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Volume>,
+    {
+        use std::iter::Iterator;
+        self.volumes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -5973,7 +6055,7 @@ pub struct TrafficTarget {
 }
 
 impl TrafficTarget {
-    /// Sets the value of `r#type`.
+    /// Sets the value of [r#type][crate::model::TrafficTarget::type].
     pub fn set_type<T: std::convert::Into<crate::model::TrafficTargetAllocationType>>(
         mut self,
         v: T,
@@ -5982,19 +6064,19 @@ impl TrafficTarget {
         self
     }
 
-    /// Sets the value of `revision`.
+    /// Sets the value of [revision][crate::model::TrafficTarget::revision].
     pub fn set_revision<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.revision = v.into();
         self
     }
 
-    /// Sets the value of `percent`.
+    /// Sets the value of [percent][crate::model::TrafficTarget::percent].
     pub fn set_percent<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.percent = v.into();
         self
     }
 
-    /// Sets the value of `tag`.
+    /// Sets the value of [tag][crate::model::TrafficTarget::tag].
     pub fn set_tag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.tag = v.into();
         self
@@ -6034,7 +6116,7 @@ pub struct TrafficTargetStatus {
 }
 
 impl TrafficTargetStatus {
-    /// Sets the value of `r#type`.
+    /// Sets the value of [r#type][crate::model::TrafficTargetStatus::type].
     pub fn set_type<T: std::convert::Into<crate::model::TrafficTargetAllocationType>>(
         mut self,
         v: T,
@@ -6043,25 +6125,25 @@ impl TrafficTargetStatus {
         self
     }
 
-    /// Sets the value of `revision`.
+    /// Sets the value of [revision][crate::model::TrafficTargetStatus::revision].
     pub fn set_revision<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.revision = v.into();
         self
     }
 
-    /// Sets the value of `percent`.
+    /// Sets the value of [percent][crate::model::TrafficTargetStatus::percent].
     pub fn set_percent<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.percent = v.into();
         self
     }
 
-    /// Sets the value of `tag`.
+    /// Sets the value of [tag][crate::model::TrafficTargetStatus::tag].
     pub fn set_tag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.tag = v.into();
         self
     }
 
-    /// Sets the value of `uri`.
+    /// Sets the value of [uri][crate::model::TrafficTargetStatus::uri].
     pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.uri = v.into();
         self
@@ -6100,13 +6182,13 @@ pub struct VpcAccess {
 }
 
 impl VpcAccess {
-    /// Sets the value of `connector`.
+    /// Sets the value of [connector][crate::model::VpcAccess::connector].
     pub fn set_connector<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.connector = v.into();
         self
     }
 
-    /// Sets the value of `egress`.
+    /// Sets the value of [egress][crate::model::VpcAccess::egress].
     pub fn set_egress<T: std::convert::Into<crate::model::vpc_access::VpcEgress>>(
         mut self,
         v: T,
@@ -6115,14 +6197,14 @@ impl VpcAccess {
         self
     }
 
-    /// Sets the value of `network_interfaces`.
-    pub fn set_network_interfaces<
-        T: std::convert::Into<std::vec::Vec<crate::model::vpc_access::NetworkInterface>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.network_interfaces = v.into();
+    /// Sets the value of [network_interfaces][crate::model::VpcAccess::network_interfaces].
+    pub fn set_network_interfaces<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::vpc_access::NetworkInterface>,
+    {
+        use std::iter::Iterator;
+        self.network_interfaces = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -6166,24 +6248,26 @@ pub mod vpc_access {
     }
 
     impl NetworkInterface {
-        /// Sets the value of `network`.
+        /// Sets the value of [network][crate::model::vpc_access::NetworkInterface::network].
         pub fn set_network<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.network = v.into();
             self
         }
 
-        /// Sets the value of `subnetwork`.
+        /// Sets the value of [subnetwork][crate::model::vpc_access::NetworkInterface::subnetwork].
         pub fn set_subnetwork<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.subnetwork = v.into();
             self
         }
 
-        /// Sets the value of `tags`.
-        pub fn set_tags<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.tags = v.into();
+        /// Sets the value of [tags][crate::model::vpc_access::NetworkInterface::tags].
+        pub fn set_tags<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.tags = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -6243,7 +6327,7 @@ pub struct BinaryAuthorization {
 }
 
 impl BinaryAuthorization {
-    /// Sets the value of `breakglass_justification`.
+    /// Sets the value of [breakglass_justification][crate::model::BinaryAuthorization::breakglass_justification].
     pub fn set_breakglass_justification<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -6306,13 +6390,13 @@ pub struct RevisionScaling {
 }
 
 impl RevisionScaling {
-    /// Sets the value of `min_instance_count`.
+    /// Sets the value of [min_instance_count][crate::model::RevisionScaling::min_instance_count].
     pub fn set_min_instance_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.min_instance_count = v.into();
         self
     }
 
-    /// Sets the value of `max_instance_count`.
+    /// Sets the value of [max_instance_count][crate::model::RevisionScaling::max_instance_count].
     pub fn set_max_instance_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.max_instance_count = v.into();
         self
@@ -6340,7 +6424,7 @@ pub struct ServiceMesh {
 }
 
 impl ServiceMesh {
-    /// Sets the value of `mesh`.
+    /// Sets the value of [mesh][crate::model::ServiceMesh::mesh].
     pub fn set_mesh<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.mesh = v.into();
         self
@@ -6376,13 +6460,13 @@ pub struct ServiceScaling {
 }
 
 impl ServiceScaling {
-    /// Sets the value of `min_instance_count`.
+    /// Sets the value of [min_instance_count][crate::model::ServiceScaling::min_instance_count].
     pub fn set_min_instance_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.min_instance_count = v.into();
         self
     }
 
-    /// Sets the value of `scaling_mode`.
+    /// Sets the value of [scaling_mode][crate::model::ServiceScaling::scaling_mode].
     pub fn set_scaling_mode<T: std::convert::Into<crate::model::service_scaling::ScalingMode>>(
         mut self,
         v: T,
@@ -6391,7 +6475,7 @@ impl ServiceScaling {
         self
     }
 
-    /// Sets the value of `manual_instance_count`.
+    /// Sets the value of [manual_instance_count][crate::model::ServiceScaling::manual_instance_count].
     pub fn set_manual_instance_count<T: std::convert::Into<std::option::Option<i32>>>(
         mut self,
         v: T,
@@ -6456,7 +6540,7 @@ pub struct NodeSelector {
 }
 
 impl NodeSelector {
-    /// Sets the value of `accelerator`.
+    /// Sets the value of [accelerator][crate::model::NodeSelector::accelerator].
     pub fn set_accelerator<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.accelerator = v.into();
         self

--- a/src/generated/cloud/scheduler/v1/src/builders.rs
+++ b/src/generated/cloud/scheduler/v1/src/builders.rs
@@ -81,19 +81,19 @@ pub mod cloud_scheduler {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListJobsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListJobsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListJobsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -132,7 +132,7 @@ pub mod cloud_scheduler {
             (*self.0.stub).get_job(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetJobRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -173,13 +173,13 @@ pub mod cloud_scheduler {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateJobRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `job`.
+        /// Sets the value of [job][crate::model::CreateJobRequest::job].
         pub fn set_job<T: Into<std::option::Option<crate::model::Job>>>(mut self, v: T) -> Self {
             self.0.request.job = v.into();
             self
@@ -220,13 +220,13 @@ pub mod cloud_scheduler {
                 .await
         }
 
-        /// Sets the value of `job`.
+        /// Sets the value of [job][crate::model::UpdateJobRequest::job].
         pub fn set_job<T: Into<std::option::Option<crate::model::Job>>>(mut self, v: T) -> Self {
             self.0.request.job = v.into();
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateJobRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -270,7 +270,7 @@ pub mod cloud_scheduler {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteJobRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -311,7 +311,7 @@ pub mod cloud_scheduler {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::PauseJobRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -352,7 +352,7 @@ pub mod cloud_scheduler {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::ResumeJobRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -391,7 +391,7 @@ pub mod cloud_scheduler {
             (*self.0.stub).run_job(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::RunJobRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -450,25 +450,25 @@ pub mod cloud_scheduler {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][location::model::ListLocationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][location::model::ListLocationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][location::model::ListLocationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][location::model::ListLocationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -509,7 +509,7 @@ pub mod cloud_scheduler {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][location::model::GetLocationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self

--- a/src/generated/cloud/scheduler/v1/src/model.rs
+++ b/src/generated/cloud/scheduler/v1/src/model.rs
@@ -68,19 +68,19 @@ pub struct ListJobsRequest {
 }
 
 impl ListJobsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListJobsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListJobsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListJobsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -122,18 +122,20 @@ pub struct ListJobsResponse {
 }
 
 impl ListJobsResponse {
-    /// Sets the value of `jobs`.
-    pub fn set_jobs<T: std::convert::Into<std::vec::Vec<crate::model::Job>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.jobs = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [jobs][crate::model::ListJobsResponse::jobs].
+    pub fn set_jobs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Job>,
+    {
+        use std::iter::Iterator;
+        self.jobs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -173,7 +175,7 @@ pub struct GetJobRequest {
 }
 
 impl GetJobRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetJobRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -213,13 +215,13 @@ pub struct CreateJobRequest {
 }
 
 impl CreateJobRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateJobRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `job`.
+    /// Sets the value of [job][crate::model::CreateJobRequest::job].
     pub fn set_job<T: std::convert::Into<std::option::Option<crate::model::Job>>>(
         mut self,
         v: T,
@@ -260,7 +262,7 @@ pub struct UpdateJobRequest {
 }
 
 impl UpdateJobRequest {
-    /// Sets the value of `job`.
+    /// Sets the value of [job][crate::model::UpdateJobRequest::job].
     pub fn set_job<T: std::convert::Into<std::option::Option<crate::model::Job>>>(
         mut self,
         v: T,
@@ -269,7 +271,7 @@ impl UpdateJobRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateJobRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -301,7 +303,7 @@ pub struct DeleteJobRequest {
 }
 
 impl DeleteJobRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteJobRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -330,7 +332,7 @@ pub struct PauseJobRequest {
 }
 
 impl PauseJobRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::PauseJobRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -359,7 +361,7 @@ pub struct ResumeJobRequest {
 }
 
 impl ResumeJobRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::ResumeJobRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -388,7 +390,7 @@ pub struct RunJobRequest {
 }
 
 impl RunJobRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::RunJobRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -556,31 +558,31 @@ pub struct Job {
 }
 
 impl Job {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Job::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::Job::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
     }
 
-    /// Sets the value of `schedule`.
+    /// Sets the value of [schedule][crate::model::Job::schedule].
     pub fn set_schedule<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.schedule = v.into();
         self
     }
 
-    /// Sets the value of `time_zone`.
+    /// Sets the value of [time_zone][crate::model::Job::time_zone].
     pub fn set_time_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.time_zone = v.into();
         self
     }
 
-    /// Sets the value of `user_update_time`.
+    /// Sets the value of [user_update_time][crate::model::Job::user_update_time].
     pub fn set_user_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -589,13 +591,13 @@ impl Job {
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::Job::state].
     pub fn set_state<T: std::convert::Into<crate::model::job::State>>(mut self, v: T) -> Self {
         self.state = v.into();
         self
     }
 
-    /// Sets the value of `status`.
+    /// Sets the value of [status][crate::model::Job::status].
     pub fn set_status<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
         mut self,
         v: T,
@@ -604,7 +606,7 @@ impl Job {
         self
     }
 
-    /// Sets the value of `schedule_time`.
+    /// Sets the value of [schedule_time][crate::model::Job::schedule_time].
     pub fn set_schedule_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -613,7 +615,7 @@ impl Job {
         self
     }
 
-    /// Sets the value of `last_attempt_time`.
+    /// Sets the value of [last_attempt_time][crate::model::Job::last_attempt_time].
     pub fn set_last_attempt_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -622,7 +624,7 @@ impl Job {
         self
     }
 
-    /// Sets the value of `retry_config`.
+    /// Sets the value of [retry_config][crate::model::Job::retry_config].
     pub fn set_retry_config<
         T: std::convert::Into<std::option::Option<crate::model::RetryConfig>>,
     >(
@@ -633,7 +635,7 @@ impl Job {
         self
     }
 
-    /// Sets the value of `attempt_deadline`.
+    /// Sets the value of [attempt_deadline][crate::model::Job::attempt_deadline].
     pub fn set_attempt_deadline<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
@@ -818,13 +820,13 @@ pub struct RetryConfig {
 }
 
 impl RetryConfig {
-    /// Sets the value of `retry_count`.
+    /// Sets the value of [retry_count][crate::model::RetryConfig::retry_count].
     pub fn set_retry_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.retry_count = v.into();
         self
     }
 
-    /// Sets the value of `max_retry_duration`.
+    /// Sets the value of [max_retry_duration][crate::model::RetryConfig::max_retry_duration].
     pub fn set_max_retry_duration<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
@@ -833,7 +835,7 @@ impl RetryConfig {
         self
     }
 
-    /// Sets the value of `min_backoff_duration`.
+    /// Sets the value of [min_backoff_duration][crate::model::RetryConfig::min_backoff_duration].
     pub fn set_min_backoff_duration<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
@@ -842,7 +844,7 @@ impl RetryConfig {
         self
     }
 
-    /// Sets the value of `max_backoff_duration`.
+    /// Sets the value of [max_backoff_duration][crate::model::RetryConfig::max_backoff_duration].
     pub fn set_max_backoff_duration<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
@@ -851,7 +853,7 @@ impl RetryConfig {
         self
     }
 
-    /// Sets the value of `max_doublings`.
+    /// Sets the value of [max_doublings][crate::model::RetryConfig::max_doublings].
     pub fn set_max_doublings<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.max_doublings = v.into();
         self
@@ -954,13 +956,13 @@ pub struct HttpTarget {
 }
 
 impl HttpTarget {
-    /// Sets the value of `uri`.
+    /// Sets the value of [uri][crate::model::HttpTarget::uri].
     pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.uri = v.into();
         self
     }
 
-    /// Sets the value of `http_method`.
+    /// Sets the value of [http_method][crate::model::HttpTarget::http_method].
     pub fn set_http_method<T: std::convert::Into<crate::model::HttpMethod>>(
         mut self,
         v: T,
@@ -969,20 +971,21 @@ impl HttpTarget {
         self
     }
 
-    /// Sets the value of `headers`.
-    pub fn set_headers<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.headers = v.into();
+    /// Sets the value of [body][crate::model::HttpTarget::body].
+    pub fn set_body<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
+        self.body = v.into();
         self
     }
 
-    /// Sets the value of `body`.
-    pub fn set_body<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
-        self.body = v.into();
+    /// Sets the value of [headers][crate::model::HttpTarget::headers].
+    pub fn set_headers<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.headers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -1128,7 +1131,7 @@ pub struct AppEngineHttpTarget {
 }
 
 impl AppEngineHttpTarget {
-    /// Sets the value of `http_method`.
+    /// Sets the value of [http_method][crate::model::AppEngineHttpTarget::http_method].
     pub fn set_http_method<T: std::convert::Into<crate::model::HttpMethod>>(
         mut self,
         v: T,
@@ -1137,7 +1140,7 @@ impl AppEngineHttpTarget {
         self
     }
 
-    /// Sets the value of `app_engine_routing`.
+    /// Sets the value of [app_engine_routing][crate::model::AppEngineHttpTarget::app_engine_routing].
     pub fn set_app_engine_routing<
         T: std::convert::Into<std::option::Option<crate::model::AppEngineRouting>>,
     >(
@@ -1148,26 +1151,27 @@ impl AppEngineHttpTarget {
         self
     }
 
-    /// Sets the value of `relative_uri`.
+    /// Sets the value of [relative_uri][crate::model::AppEngineHttpTarget::relative_uri].
     pub fn set_relative_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.relative_uri = v.into();
         self
     }
 
-    /// Sets the value of `headers`.
-    pub fn set_headers<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.headers = v.into();
+    /// Sets the value of [body][crate::model::AppEngineHttpTarget::body].
+    pub fn set_body<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
+        self.body = v.into();
         self
     }
 
-    /// Sets the value of `body`.
-    pub fn set_body<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
-        self.body = v.into();
+    /// Sets the value of [headers][crate::model::AppEngineHttpTarget::headers].
+    pub fn set_headers<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.headers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1212,26 +1216,27 @@ pub struct PubsubTarget {
 }
 
 impl PubsubTarget {
-    /// Sets the value of `topic_name`.
+    /// Sets the value of [topic_name][crate::model::PubsubTarget::topic_name].
     pub fn set_topic_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.topic_name = v.into();
         self
     }
 
-    /// Sets the value of `data`.
+    /// Sets the value of [data][crate::model::PubsubTarget::data].
     pub fn set_data<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.data = v.into();
         self
     }
 
-    /// Sets the value of `attributes`.
-    pub fn set_attributes<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.attributes = v.into();
+    /// Sets the value of [attributes][crate::model::PubsubTarget::attributes].
+    pub fn set_attributes<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1359,25 +1364,25 @@ pub struct AppEngineRouting {
 }
 
 impl AppEngineRouting {
-    /// Sets the value of `service`.
+    /// Sets the value of [service][crate::model::AppEngineRouting::service].
     pub fn set_service<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service = v.into();
         self
     }
 
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::AppEngineRouting::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
     }
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::AppEngineRouting::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `host`.
+    /// Sets the value of [host][crate::model::AppEngineRouting::host].
     pub fn set_host<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.host = v.into();
         self
@@ -1414,7 +1419,7 @@ pub struct OAuthToken {
 }
 
 impl OAuthToken {
-    /// Sets the value of `service_account_email`.
+    /// Sets the value of [service_account_email][crate::model::OAuthToken::service_account_email].
     pub fn set_service_account_email<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -1423,7 +1428,7 @@ impl OAuthToken {
         self
     }
 
-    /// Sets the value of `scope`.
+    /// Sets the value of [scope][crate::model::OAuthToken::scope].
     pub fn set_scope<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.scope = v.into();
         self
@@ -1461,7 +1466,7 @@ pub struct OidcToken {
 }
 
 impl OidcToken {
-    /// Sets the value of `service_account_email`.
+    /// Sets the value of [service_account_email][crate::model::OidcToken::service_account_email].
     pub fn set_service_account_email<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -1470,7 +1475,7 @@ impl OidcToken {
         self
     }
 
-    /// Sets the value of `audience`.
+    /// Sets the value of [audience][crate::model::OidcToken::audience].
     pub fn set_audience<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.audience = v.into();
         self

--- a/src/generated/cloud/secretmanager/v1/src/builders.rs
+++ b/src/generated/cloud/secretmanager/v1/src/builders.rs
@@ -82,25 +82,25 @@ pub mod secret_manager_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListSecretsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListSecretsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListSecretsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListSecretsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
@@ -141,19 +141,19 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateSecretRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `secret_id`.
+        /// Sets the value of [secret_id][crate::model::CreateSecretRequest::secret_id].
         pub fn set_secret_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret_id = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::CreateSecretRequest::secret].
         pub fn set_secret<T: Into<std::option::Option<crate::model::Secret>>>(
             mut self,
             v: T,
@@ -200,13 +200,13 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::AddSecretVersionRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `payload`.
+        /// Sets the value of [payload][crate::model::AddSecretVersionRequest::payload].
         pub fn set_payload<T: Into<std::option::Option<crate::model::SecretPayload>>>(
             mut self,
             v: T,
@@ -250,7 +250,7 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetSecretRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -291,7 +291,7 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::UpdateSecretRequest::secret].
         pub fn set_secret<T: Into<std::option::Option<crate::model::Secret>>>(
             mut self,
             v: T,
@@ -300,7 +300,7 @@ pub mod secret_manager_service {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateSecretRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -344,13 +344,13 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteSecretRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DeleteSecretRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -409,25 +409,25 @@ pub mod secret_manager_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListSecretVersionsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListSecretVersionsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListSecretVersionsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListSecretVersionsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
@@ -471,7 +471,7 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetSecretVersionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -515,7 +515,7 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::AccessSecretVersionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -559,13 +559,13 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DisableSecretVersionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DisableSecretVersionRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -609,13 +609,13 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::EnableSecretVersionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::EnableSecretVersionRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -659,13 +659,13 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DestroySecretVersionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DestroySecretVersionRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -706,13 +706,13 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::SetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][iam_v1::model::SetIamPolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<iam_v1::model::Policy>>>(
             mut self,
             v: T,
@@ -721,7 +721,7 @@ pub mod secret_manager_service {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][iam_v1::model::SetIamPolicyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -765,13 +765,13 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::GetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `options`.
+        /// Sets the value of [options][iam_v1::model::GetIamPolicyRequest::options].
         pub fn set_options<T: Into<std::option::Option<iam_v1::model::GetPolicyOptions>>>(
             mut self,
             v: T,
@@ -818,18 +818,20 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::TestIamPermissionsRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `permissions`.
-        pub fn set_permissions<T: Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.permissions = v.into();
+        /// Sets the value of [permissions][iam_v1::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -886,25 +888,25 @@ pub mod secret_manager_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][location::model::ListLocationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][location::model::ListLocationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][location::model::ListLocationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][location::model::ListLocationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -945,7 +947,7 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][location::model::GetLocationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self

--- a/src/generated/cloud/secretmanager/v1/src/model.rs
+++ b/src/generated/cloud/secretmanager/v1/src/model.rs
@@ -177,13 +177,13 @@ pub struct Secret {
 }
 
 impl Secret {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Secret::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `replication`.
+    /// Sets the value of [replication][crate::model::Secret::replication].
     pub fn set_replication<
         T: std::convert::Into<std::option::Option<crate::model::Replication>>,
     >(
@@ -194,7 +194,7 @@ impl Secret {
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::Secret::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -203,33 +203,13 @@ impl Secret {
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `topics`.
-    pub fn set_topics<T: std::convert::Into<std::vec::Vec<crate::model::Topic>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.topics = v.into();
-        self
-    }
-
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::Secret::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `rotation`.
+    /// Sets the value of [rotation][crate::model::Secret::rotation].
     pub fn set_rotation<T: std::convert::Into<std::option::Option<crate::model::Rotation>>>(
         mut self,
         v: T,
@@ -238,29 +218,7 @@ impl Secret {
         self
     }
 
-    /// Sets the value of `version_aliases`.
-    pub fn set_version_aliases<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, i64>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.version_aliases = v.into();
-        self
-    }
-
-    /// Sets the value of `annotations`.
-    pub fn set_annotations<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.annotations = v.into();
-        self
-    }
-
-    /// Sets the value of `version_destroy_ttl`.
+    /// Sets the value of [version_destroy_ttl][crate::model::Secret::version_destroy_ttl].
     pub fn set_version_destroy_ttl<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
@@ -269,7 +227,7 @@ impl Secret {
         self
     }
 
-    /// Sets the value of `customer_managed_encryption`.
+    /// Sets the value of [customer_managed_encryption][crate::model::Secret::customer_managed_encryption].
     pub fn set_customer_managed_encryption<
         T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryption>>,
     >(
@@ -277,6 +235,53 @@ impl Secret {
         v: T,
     ) -> Self {
         self.customer_managed_encryption = v.into();
+        self
+    }
+
+    /// Sets the value of [topics][crate::model::Secret::topics].
+    pub fn set_topics<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Topic>,
+    {
+        use std::iter::Iterator;
+        self.topics = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Secret::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [version_aliases][crate::model::Secret::version_aliases].
+    pub fn set_version_aliases<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<i64>,
+    {
+        use std::iter::Iterator;
+        self.version_aliases = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::Secret::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -426,13 +431,13 @@ pub struct SecretVersion {
 }
 
 impl SecretVersion {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::SecretVersion::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::SecretVersion::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -441,7 +446,7 @@ impl SecretVersion {
         self
     }
 
-    /// Sets the value of `destroy_time`.
+    /// Sets the value of [destroy_time][crate::model::SecretVersion::destroy_time].
     pub fn set_destroy_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -450,7 +455,7 @@ impl SecretVersion {
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::SecretVersion::state].
     pub fn set_state<T: std::convert::Into<crate::model::secret_version::State>>(
         mut self,
         v: T,
@@ -459,7 +464,7 @@ impl SecretVersion {
         self
     }
 
-    /// Sets the value of `replication_status`.
+    /// Sets the value of [replication_status][crate::model::SecretVersion::replication_status].
     pub fn set_replication_status<
         T: std::convert::Into<std::option::Option<crate::model::ReplicationStatus>>,
     >(
@@ -470,13 +475,13 @@ impl SecretVersion {
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::SecretVersion::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `client_specified_payload_checksum`.
+    /// Sets the value of [client_specified_payload_checksum][crate::model::SecretVersion::client_specified_payload_checksum].
     pub fn set_client_specified_payload_checksum<T: std::convert::Into<bool>>(
         mut self,
         v: T,
@@ -485,7 +490,7 @@ impl SecretVersion {
         self
     }
 
-    /// Sets the value of `scheduled_destroy_time`.
+    /// Sets the value of [scheduled_destroy_time][crate::model::SecretVersion::scheduled_destroy_time].
     pub fn set_scheduled_destroy_time<
         T: std::convert::Into<std::option::Option<wkt::Timestamp>>,
     >(
@@ -496,7 +501,7 @@ impl SecretVersion {
         self
     }
 
-    /// Sets the value of `customer_managed_encryption`.
+    /// Sets the value of [customer_managed_encryption][crate::model::SecretVersion::customer_managed_encryption].
     pub fn set_customer_managed_encryption<
         T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryptionStatus>>,
     >(
@@ -634,7 +639,7 @@ pub mod replication {
     }
 
     impl Automatic {
-        /// Sets the value of `customer_managed_encryption`.
+        /// Sets the value of [customer_managed_encryption][crate::model::replication::Automatic::customer_managed_encryption].
         pub fn set_customer_managed_encryption<
             T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryption>>,
         >(
@@ -675,14 +680,14 @@ pub mod replication {
     }
 
     impl UserManaged {
-        /// Sets the value of `replicas`.
-        pub fn set_replicas<
-            T: std::convert::Into<std::vec::Vec<crate::model::replication::user_managed::Replica>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.replicas = v.into();
+        /// Sets the value of [replicas][crate::model::replication::UserManaged::replicas].
+        pub fn set_replicas<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::replication::user_managed::Replica>,
+        {
+            use std::iter::Iterator;
+            self.replicas = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -730,7 +735,7 @@ pub mod replication {
         }
 
         impl Replica {
-            /// Sets the value of `location`.
+            /// Sets the value of [location][crate::model::replication::user_managed::Replica::location].
             pub fn set_location<T: std::convert::Into<std::string::String>>(
                 mut self,
                 v: T,
@@ -739,7 +744,7 @@ pub mod replication {
                 self
             }
 
-            /// Sets the value of `customer_managed_encryption`.
+            /// Sets the value of [customer_managed_encryption][crate::model::replication::user_managed::Replica::customer_managed_encryption].
             pub fn set_customer_managed_encryption<
                 T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryption>>,
             >(
@@ -804,7 +809,7 @@ pub struct CustomerManagedEncryption {
 }
 
 impl CustomerManagedEncryption {
-    /// Sets the value of `kms_key_name`.
+    /// Sets the value of [kms_key_name][crate::model::CustomerManagedEncryption::kms_key_name].
     pub fn set_kms_key_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kms_key_name = v.into();
         self
@@ -886,7 +891,7 @@ pub mod replication_status {
     }
 
     impl AutomaticStatus {
-        /// Sets the value of `customer_managed_encryption`.
+        /// Sets the value of [customer_managed_encryption][crate::model::replication_status::AutomaticStatus::customer_managed_encryption].
         pub fn set_customer_managed_encryption<
             T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryptionStatus>>,
         >(
@@ -928,16 +933,16 @@ pub mod replication_status {
     }
 
     impl UserManagedStatus {
-        /// Sets the value of `replicas`.
-        pub fn set_replicas<
-            T: std::convert::Into<
-                std::vec::Vec<crate::model::replication_status::user_managed_status::ReplicaStatus>,
+        /// Sets the value of [replicas][crate::model::replication_status::UserManagedStatus::replicas].
+        pub fn set_replicas<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<
+                crate::model::replication_status::user_managed_status::ReplicaStatus,
             >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.replicas = v.into();
+        {
+            use std::iter::Iterator;
+            self.replicas = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -978,7 +983,7 @@ pub mod replication_status {
         }
 
         impl ReplicaStatus {
-            /// Sets the value of `location`.
+            /// Sets the value of [location][crate::model::replication_status::user_managed_status::ReplicaStatus::location].
             pub fn set_location<T: std::convert::Into<std::string::String>>(
                 mut self,
                 v: T,
@@ -987,7 +992,7 @@ pub mod replication_status {
                 self
             }
 
-            /// Sets the value of `customer_managed_encryption`.
+            /// Sets the value of [customer_managed_encryption][crate::model::replication_status::user_managed_status::ReplicaStatus::customer_managed_encryption].
             pub fn set_customer_managed_encryption<
                 T: std::convert::Into<
                     std::option::Option<crate::model::CustomerManagedEncryptionStatus>,
@@ -1055,7 +1060,7 @@ pub struct CustomerManagedEncryptionStatus {
 }
 
 impl CustomerManagedEncryptionStatus {
-    /// Sets the value of `kms_key_version_name`.
+    /// Sets the value of [kms_key_version_name][crate::model::CustomerManagedEncryptionStatus::kms_key_version_name].
     pub fn set_kms_key_version_name<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -1088,7 +1093,7 @@ pub struct Topic {
 }
 
 impl Topic {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Topic::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1149,7 +1154,7 @@ pub struct Rotation {
 }
 
 impl Rotation {
-    /// Sets the value of `next_rotation_time`.
+    /// Sets the value of [next_rotation_time][crate::model::Rotation::next_rotation_time].
     pub fn set_next_rotation_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1158,7 +1163,7 @@ impl Rotation {
         self
     }
 
-    /// Sets the value of `rotation_period`.
+    /// Sets the value of [rotation_period][crate::model::Rotation::rotation_period].
     pub fn set_rotation_period<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
@@ -1217,13 +1222,13 @@ pub struct SecretPayload {
 }
 
 impl SecretPayload {
-    /// Sets the value of `data`.
+    /// Sets the value of [data][crate::model::SecretPayload::data].
     pub fn set_data<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.data = v.into();
         self
     }
 
-    /// Sets the value of `data_crc32c`.
+    /// Sets the value of [data_crc32c][crate::model::SecretPayload::data_crc32c].
     pub fn set_data_crc32c<T: std::convert::Into<std::option::Option<i64>>>(
         mut self,
         v: T,
@@ -1278,25 +1283,25 @@ pub struct ListSecretsRequest {
 }
 
 impl ListSecretsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListSecretsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListSecretsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListSecretsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListSecretsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
@@ -1344,24 +1349,26 @@ pub struct ListSecretsResponse {
 }
 
 impl ListSecretsResponse {
-    /// Sets the value of `secrets`.
-    pub fn set_secrets<T: std::convert::Into<std::vec::Vec<crate::model::Secret>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.secrets = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListSecretsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `total_size`.
+    /// Sets the value of [total_size][crate::model::ListSecretsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
+        self
+    }
+
+    /// Sets the value of [secrets][crate::model::ListSecretsResponse::secrets].
+    pub fn set_secrets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Secret>,
+    {
+        use std::iter::Iterator;
+        self.secrets = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1419,19 +1426,19 @@ pub struct CreateSecretRequest {
 }
 
 impl CreateSecretRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateSecretRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `secret_id`.
+    /// Sets the value of [secret_id][crate::model::CreateSecretRequest::secret_id].
     pub fn set_secret_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret_id = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::CreateSecretRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::option::Option<crate::model::Secret>>>(
         mut self,
         v: T,
@@ -1475,13 +1482,13 @@ pub struct AddSecretVersionRequest {
 }
 
 impl AddSecretVersionRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::AddSecretVersionRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `payload`.
+    /// Sets the value of [payload][crate::model::AddSecretVersionRequest::payload].
     pub fn set_payload<T: std::convert::Into<std::option::Option<crate::model::SecretPayload>>>(
         mut self,
         v: T,
@@ -1516,7 +1523,7 @@ pub struct GetSecretRequest {
 }
 
 impl GetSecretRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetSecretRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1568,25 +1575,25 @@ pub struct ListSecretVersionsRequest {
 }
 
 impl ListSecretVersionsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListSecretVersionsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListSecretVersionsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListSecretVersionsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListSecretVersionsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
@@ -1635,24 +1642,26 @@ pub struct ListSecretVersionsResponse {
 }
 
 impl ListSecretVersionsResponse {
-    /// Sets the value of `versions`.
-    pub fn set_versions<T: std::convert::Into<std::vec::Vec<crate::model::SecretVersion>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.versions = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListSecretVersionsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `total_size`.
+    /// Sets the value of [total_size][crate::model::ListSecretVersionsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
+        self
+    }
+
+    /// Sets the value of [versions][crate::model::ListSecretVersionsResponse::versions].
+    pub fn set_versions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SecretVersion>,
+    {
+        use std::iter::Iterator;
+        self.versions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1701,7 +1710,7 @@ pub struct GetSecretVersionRequest {
 }
 
 impl GetSecretVersionRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetSecretVersionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1736,7 +1745,7 @@ pub struct UpdateSecretRequest {
 }
 
 impl UpdateSecretRequest {
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::UpdateSecretRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::option::Option<crate::model::Secret>>>(
         mut self,
         v: T,
@@ -1745,7 +1754,7 @@ impl UpdateSecretRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateSecretRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -1786,7 +1795,7 @@ pub struct AccessSecretVersionRequest {
 }
 
 impl AccessSecretVersionRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::AccessSecretVersionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1823,13 +1832,13 @@ pub struct AccessSecretVersionResponse {
 }
 
 impl AccessSecretVersionResponse {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::AccessSecretVersionResponse::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `payload`.
+    /// Sets the value of [payload][crate::model::AccessSecretVersionResponse::payload].
     pub fn set_payload<T: std::convert::Into<std::option::Option<crate::model::SecretPayload>>>(
         mut self,
         v: T,
@@ -1872,13 +1881,13 @@ pub struct DeleteSecretRequest {
 }
 
 impl DeleteSecretRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteSecretRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DeleteSecretRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
@@ -1920,13 +1929,13 @@ pub struct DisableSecretVersionRequest {
 }
 
 impl DisableSecretVersionRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DisableSecretVersionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DisableSecretVersionRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
@@ -1968,13 +1977,13 @@ pub struct EnableSecretVersionRequest {
 }
 
 impl EnableSecretVersionRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::EnableSecretVersionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::EnableSecretVersionRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
@@ -2016,13 +2025,13 @@ pub struct DestroySecretVersionRequest {
 }
 
 impl DestroySecretVersionRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DestroySecretVersionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DestroySecretVersionRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self

--- a/src/generated/cloud/sql/v1/src/builders.rs
+++ b/src/generated/cloud/sql/v1/src/builders.rs
@@ -65,19 +65,19 @@ pub mod sql_backup_runs_service {
             (*self.0.stub).delete(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `id`.
+        /// Sets the value of [id][crate::model::SqlBackupRunsDeleteRequest::id].
         pub fn set_id<T: Into<i64>>(mut self, v: T) -> Self {
             self.0.request.id = v.into();
             self
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlBackupRunsDeleteRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlBackupRunsDeleteRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -118,19 +118,19 @@ pub mod sql_backup_runs_service {
             (*self.0.stub).get(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `id`.
+        /// Sets the value of [id][crate::model::SqlBackupRunsGetRequest::id].
         pub fn set_id<T: Into<i64>>(mut self, v: T) -> Self {
             self.0.request.id = v.into();
             self
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlBackupRunsGetRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlBackupRunsGetRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -171,19 +171,19 @@ pub mod sql_backup_runs_service {
             (*self.0.stub).insert(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlBackupRunsInsertRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlBackupRunsInsertRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlBackupRunsInsertRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::BackupRun>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -224,25 +224,25 @@ pub mod sql_backup_runs_service {
             (*self.0.stub).list(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlBackupRunsListRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `max_results`.
+        /// Sets the value of [max_results][crate::model::SqlBackupRunsListRequest::max_results].
         pub fn set_max_results<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.max_results = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::SqlBackupRunsListRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlBackupRunsListRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -308,19 +308,19 @@ pub mod sql_connect_service {
             (*self.0.stub).get_connect_settings(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::GetConnectSettingsRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::GetConnectSettingsRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `read_time`.
+        /// Sets the value of [read_time][crate::model::GetConnectSettingsRequest::read_time].
         pub fn set_read_time<T: Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
             self.0.request.read_time = v.into();
             self
@@ -361,37 +361,37 @@ pub mod sql_connect_service {
             (*self.0.stub).generate_ephemeral_cert(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::GenerateEphemeralCertRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::GenerateEphemeralCertRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `public_key`.
+        /// Sets the value of [public_key][crate::model::GenerateEphemeralCertRequest::public_key].
         pub fn set_public_key<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.public_key = v.into();
             self
         }
 
-        /// Sets the value of `access_token`.
+        /// Sets the value of [access_token][crate::model::GenerateEphemeralCertRequest::access_token].
         pub fn set_access_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.access_token = v.into();
             self
         }
 
-        /// Sets the value of `read_time`.
+        /// Sets the value of [read_time][crate::model::GenerateEphemeralCertRequest::read_time].
         pub fn set_read_time<T: Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
             self.0.request.read_time = v.into();
             self
         }
 
-        /// Sets the value of `valid_duration`.
+        /// Sets the value of [valid_duration][crate::model::GenerateEphemeralCertRequest::valid_duration].
         pub fn set_valid_duration<T: Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
             self.0.request.valid_duration = v.into();
             self
@@ -457,19 +457,19 @@ pub mod sql_databases_service {
             (*self.0.stub).delete(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `database`.
+        /// Sets the value of [database][crate::model::SqlDatabasesDeleteRequest::database].
         pub fn set_database<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.database = v.into();
             self
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlDatabasesDeleteRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlDatabasesDeleteRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -510,19 +510,19 @@ pub mod sql_databases_service {
             (*self.0.stub).get(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `database`.
+        /// Sets the value of [database][crate::model::SqlDatabasesGetRequest::database].
         pub fn set_database<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.database = v.into();
             self
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlDatabasesGetRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlDatabasesGetRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -563,19 +563,19 @@ pub mod sql_databases_service {
             (*self.0.stub).insert(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlDatabasesInsertRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlDatabasesInsertRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlDatabasesInsertRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::Database>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -616,13 +616,13 @@ pub mod sql_databases_service {
             (*self.0.stub).list(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlDatabasesListRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlDatabasesListRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -663,25 +663,25 @@ pub mod sql_databases_service {
             (*self.0.stub).patch(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `database`.
+        /// Sets the value of [database][crate::model::SqlDatabasesUpdateRequest::database].
         pub fn set_database<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.database = v.into();
             self
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlDatabasesUpdateRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlDatabasesUpdateRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlDatabasesUpdateRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::Database>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -722,25 +722,25 @@ pub mod sql_databases_service {
             (*self.0.stub).update(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `database`.
+        /// Sets the value of [database][crate::model::SqlDatabasesUpdateRequest::database].
         pub fn set_database<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.database = v.into();
             self
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlDatabasesUpdateRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlDatabasesUpdateRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlDatabasesUpdateRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::Database>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -806,7 +806,7 @@ pub mod sql_flags_service {
             (*self.0.stub).list(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `database_version`.
+        /// Sets the value of [database_version][crate::model::SqlFlagsListRequest::database_version].
         pub fn set_database_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.database_version = v.into();
             self
@@ -872,13 +872,13 @@ pub mod sql_instances_service {
             (*self.0.stub).add_server_ca(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesAddServerCaRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesAddServerCaRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -919,19 +919,19 @@ pub mod sql_instances_service {
             (*self.0.stub).clone(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesCloneRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesCloneRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlInstancesCloneRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::InstancesCloneRequest>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -972,13 +972,13 @@ pub mod sql_instances_service {
             (*self.0.stub).delete(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesDeleteRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesDeleteRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -1019,19 +1019,19 @@ pub mod sql_instances_service {
             (*self.0.stub).demote_master(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesDemoteMasterRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesDemoteMasterRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlInstancesDemoteMasterRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::InstancesDemoteMasterRequest>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -1072,19 +1072,19 @@ pub mod sql_instances_service {
             (*self.0.stub).demote(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesDemoteRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesDemoteRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlInstancesDemoteRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::InstancesDemoteRequest>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -1125,19 +1125,19 @@ pub mod sql_instances_service {
             (*self.0.stub).export(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesExportRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesExportRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlInstancesExportRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::InstancesExportRequest>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -1178,19 +1178,19 @@ pub mod sql_instances_service {
             (*self.0.stub).failover(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesFailoverRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesFailoverRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlInstancesFailoverRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::InstancesFailoverRequest>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -1231,19 +1231,19 @@ pub mod sql_instances_service {
             (*self.0.stub).reencrypt(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesReencryptRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesReencryptRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlInstancesReencryptRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::InstancesReencryptRequest>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -1284,13 +1284,13 @@ pub mod sql_instances_service {
             (*self.0.stub).get(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesGetRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesGetRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -1331,19 +1331,19 @@ pub mod sql_instances_service {
             (*self.0.stub).import(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesImportRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesImportRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlInstancesImportRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::InstancesImportRequest>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -1384,13 +1384,13 @@ pub mod sql_instances_service {
             (*self.0.stub).insert(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesInsertRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlInstancesInsertRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::DatabaseInstance>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -1431,25 +1431,25 @@ pub mod sql_instances_service {
             (*self.0.stub).list(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::SqlInstancesListRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `max_results`.
+        /// Sets the value of [max_results][crate::model::SqlInstancesListRequest::max_results].
         pub fn set_max_results<T: Into<u32>>(mut self, v: T) -> Self {
             self.0.request.max_results = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::SqlInstancesListRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesListRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -1490,13 +1490,13 @@ pub mod sql_instances_service {
             (*self.0.stub).list_server_cas(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesListServerCasRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesListServerCasRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -1537,19 +1537,19 @@ pub mod sql_instances_service {
             (*self.0.stub).patch(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesPatchRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesPatchRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlInstancesPatchRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::DatabaseInstance>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -1590,19 +1590,19 @@ pub mod sql_instances_service {
             (*self.0.stub).promote_replica(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesPromoteReplicaRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesPromoteReplicaRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `failover`.
+        /// Sets the value of [failover][crate::model::SqlInstancesPromoteReplicaRequest::failover].
         pub fn set_failover<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.failover = v.into();
             self
@@ -1643,19 +1643,19 @@ pub mod sql_instances_service {
             (*self.0.stub).switchover(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesSwitchoverRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesSwitchoverRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `db_timeout`.
+        /// Sets the value of [db_timeout][crate::model::SqlInstancesSwitchoverRequest::db_timeout].
         pub fn set_db_timeout<T: Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
             self.0.request.db_timeout = v.into();
             self
@@ -1696,13 +1696,13 @@ pub mod sql_instances_service {
             (*self.0.stub).reset_ssl_config(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesResetSslConfigRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesResetSslConfigRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -1743,13 +1743,13 @@ pub mod sql_instances_service {
             (*self.0.stub).restart(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesRestartRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesRestartRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -1790,19 +1790,19 @@ pub mod sql_instances_service {
             (*self.0.stub).restore_backup(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesRestoreBackupRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesRestoreBackupRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlInstancesRestoreBackupRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::InstancesRestoreBackupRequest>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -1843,19 +1843,19 @@ pub mod sql_instances_service {
             (*self.0.stub).rotate_server_ca(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesRotateServerCaRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesRotateServerCaRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlInstancesRotateServerCaRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::InstancesRotateServerCaRequest>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -1896,13 +1896,13 @@ pub mod sql_instances_service {
             (*self.0.stub).start_replica(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesStartReplicaRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesStartReplicaRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -1943,13 +1943,13 @@ pub mod sql_instances_service {
             (*self.0.stub).stop_replica(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesStopReplicaRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesStopReplicaRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -1990,19 +1990,19 @@ pub mod sql_instances_service {
             (*self.0.stub).truncate_log(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesTruncateLogRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesTruncateLogRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlInstancesTruncateLogRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::InstancesTruncateLogRequest>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -2043,19 +2043,19 @@ pub mod sql_instances_service {
             (*self.0.stub).update(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesUpdateRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesUpdateRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlInstancesUpdateRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::DatabaseInstance>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -2096,19 +2096,19 @@ pub mod sql_instances_service {
             (*self.0.stub).create_ephemeral(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesCreateEphemeralCertRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesCreateEphemeralCertRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlInstancesCreateEphemeralCertRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::SslCertsCreateEphemeralRequest>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -2149,19 +2149,19 @@ pub mod sql_instances_service {
             (*self.0.stub).reschedule_maintenance(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesRescheduleMaintenanceRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesRescheduleMaintenanceRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlInstancesRescheduleMaintenanceRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::SqlInstancesRescheduleMaintenanceRequestBody>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -2202,43 +2202,43 @@ pub mod sql_instances_service {
             (*self.0.stub).verify_external_sync_settings(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesVerifyExternalSyncSettingsRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesVerifyExternalSyncSettingsRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `verify_connection_only`.
+        /// Sets the value of [verify_connection_only][crate::model::SqlInstancesVerifyExternalSyncSettingsRequest::verify_connection_only].
         pub fn set_verify_connection_only<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.verify_connection_only = v.into();
             self
         }
 
-        /// Sets the value of `sync_mode`.
+        /// Sets the value of [sync_mode][crate::model::SqlInstancesVerifyExternalSyncSettingsRequest::sync_mode].
         pub fn set_sync_mode<T: Into<crate::model::sql_instances_verify_external_sync_settings_request::ExternalSyncMode>>(mut self, v: T) -> Self {
             self.0.request.sync_mode = v.into();
             self
         }
 
-        /// Sets the value of `verify_replication_only`.
+        /// Sets the value of [verify_replication_only][crate::model::SqlInstancesVerifyExternalSyncSettingsRequest::verify_replication_only].
         pub fn set_verify_replication_only<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.verify_replication_only = v.into();
             self
         }
 
-        /// Sets the value of `migration_type`.
+        /// Sets the value of [migration_type][crate::model::SqlInstancesVerifyExternalSyncSettingsRequest::migration_type].
         pub fn set_migration_type<T: Into<crate::model::sql_instances_verify_external_sync_settings_request::MigrationType>>(mut self, v: T) -> Self {
             self.0.request.migration_type = v.into();
             self
         }
 
-        /// Sets the value of `sync_parallel_level`.
+        /// Sets the value of [sync_parallel_level][crate::model::SqlInstancesVerifyExternalSyncSettingsRequest::sync_parallel_level].
         pub fn set_sync_parallel_level<T: Into<crate::model::ExternalSyncParallelLevel>>(mut self, v: T) -> Self {
             self.0.request.sync_parallel_level = v.into();
             self
@@ -2285,37 +2285,37 @@ pub mod sql_instances_service {
             (*self.0.stub).start_external_sync(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesStartExternalSyncRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesStartExternalSyncRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `sync_mode`.
+        /// Sets the value of [sync_mode][crate::model::SqlInstancesStartExternalSyncRequest::sync_mode].
         pub fn set_sync_mode<T: Into<crate::model::sql_instances_verify_external_sync_settings_request::ExternalSyncMode>>(mut self, v: T) -> Self {
             self.0.request.sync_mode = v.into();
             self
         }
 
-        /// Sets the value of `skip_verification`.
+        /// Sets the value of [skip_verification][crate::model::SqlInstancesStartExternalSyncRequest::skip_verification].
         pub fn set_skip_verification<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.skip_verification = v.into();
             self
         }
 
-        /// Sets the value of `sync_parallel_level`.
+        /// Sets the value of [sync_parallel_level][crate::model::SqlInstancesStartExternalSyncRequest::sync_parallel_level].
         pub fn set_sync_parallel_level<T: Into<crate::model::ExternalSyncParallelLevel>>(mut self, v: T) -> Self {
             self.0.request.sync_parallel_level = v.into();
             self
         }
 
-        /// Sets the value of `migration_type`.
+        /// Sets the value of [migration_type][crate::model::SqlInstancesStartExternalSyncRequest::migration_type].
         pub fn set_migration_type<T: Into<crate::model::sql_instances_verify_external_sync_settings_request::MigrationType>>(mut self, v: T) -> Self {
             self.0.request.migration_type = v.into();
             self
@@ -2362,19 +2362,19 @@ pub mod sql_instances_service {
             (*self.0.stub).perform_disk_shrink(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesPerformDiskShrinkRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesPerformDiskShrinkRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlInstancesPerformDiskShrinkRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::PerformDiskShrinkContext>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -2415,13 +2415,13 @@ pub mod sql_instances_service {
             (*self.0.stub).get_disk_shrink_config(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesGetDiskShrinkConfigRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesGetDiskShrinkConfigRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -2462,13 +2462,13 @@ pub mod sql_instances_service {
             (*self.0.stub).reset_replica_size(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesResetReplicaSizeRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesResetReplicaSizeRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -2509,13 +2509,13 @@ pub mod sql_instances_service {
             (*self.0.stub).get_latest_recovery_time(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesGetLatestRecoveryTimeRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesGetLatestRecoveryTimeRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -2556,19 +2556,19 @@ pub mod sql_instances_service {
             (*self.0.stub).acquire_ssrs_lease(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesAcquireSsrsLeaseRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesAcquireSsrsLeaseRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlInstancesAcquireSsrsLeaseRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::InstancesAcquireSsrsLeaseRequest>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -2609,13 +2609,13 @@ pub mod sql_instances_service {
             (*self.0.stub).release_ssrs_lease(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlInstancesReleaseSsrsLeaseRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlInstancesReleaseSsrsLeaseRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -2681,13 +2681,13 @@ pub mod sql_operations_service {
             (*self.0.stub).get(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `operation`.
+        /// Sets the value of [operation][crate::model::SqlOperationsGetRequest::operation].
         pub fn set_operation<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.operation = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlOperationsGetRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -2728,25 +2728,25 @@ pub mod sql_operations_service {
             (*self.0.stub).list(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlOperationsListRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `max_results`.
+        /// Sets the value of [max_results][crate::model::SqlOperationsListRequest::max_results].
         pub fn set_max_results<T: Into<u32>>(mut self, v: T) -> Self {
             self.0.request.max_results = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::SqlOperationsListRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlOperationsListRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -2787,13 +2787,13 @@ pub mod sql_operations_service {
             (*self.0.stub).cancel(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `operation`.
+        /// Sets the value of [operation][crate::model::SqlOperationsCancelRequest::operation].
         pub fn set_operation<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.operation = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlOperationsCancelRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -2859,19 +2859,19 @@ pub mod sql_ssl_certs_service {
             (*self.0.stub).delete(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlSslCertsDeleteRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlSslCertsDeleteRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `sha1_fingerprint`.
+        /// Sets the value of [sha1_fingerprint][crate::model::SqlSslCertsDeleteRequest::sha1_fingerprint].
         pub fn set_sha1_fingerprint<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.sha1_fingerprint = v.into();
             self
@@ -2912,19 +2912,19 @@ pub mod sql_ssl_certs_service {
             (*self.0.stub).get(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlSslCertsGetRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlSslCertsGetRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `sha1_fingerprint`.
+        /// Sets the value of [sha1_fingerprint][crate::model::SqlSslCertsGetRequest::sha1_fingerprint].
         pub fn set_sha1_fingerprint<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.sha1_fingerprint = v.into();
             self
@@ -2965,19 +2965,19 @@ pub mod sql_ssl_certs_service {
             (*self.0.stub).insert(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlSslCertsInsertRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlSslCertsInsertRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlSslCertsInsertRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::SslCertsInsertRequest>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -3018,13 +3018,13 @@ pub mod sql_ssl_certs_service {
             (*self.0.stub).list(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlSslCertsListRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlSslCertsListRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -3090,7 +3090,7 @@ pub mod sql_tiers_service {
             (*self.0.stub).list(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlTiersListRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -3156,25 +3156,25 @@ pub mod sql_users_service {
             (*self.0.stub).delete(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `host`.
+        /// Sets the value of [host][crate::model::SqlUsersDeleteRequest::host].
         pub fn set_host<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.host = v.into();
             self
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlUsersDeleteRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::SqlUsersDeleteRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlUsersDeleteRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -3215,25 +3215,25 @@ pub mod sql_users_service {
             (*self.0.stub).get(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlUsersGetRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::SqlUsersGetRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlUsersGetRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `host`.
+        /// Sets the value of [host][crate::model::SqlUsersGetRequest::host].
         pub fn set_host<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.host = v.into();
             self
@@ -3274,19 +3274,19 @@ pub mod sql_users_service {
             (*self.0.stub).insert(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlUsersInsertRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlUsersInsertRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlUsersInsertRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::User>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self
@@ -3327,13 +3327,13 @@ pub mod sql_users_service {
             (*self.0.stub).list(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlUsersListRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlUsersListRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
@@ -3374,31 +3374,31 @@ pub mod sql_users_service {
             (*self.0.stub).update(self.0.request, self.0.options).await
         }
 
-        /// Sets the value of `host`.
+        /// Sets the value of [host][crate::model::SqlUsersUpdateRequest::host].
         pub fn set_host<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.host = v.into();
             self
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::SqlUsersUpdateRequest::instance].
         pub fn set_instance<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance = v.into();
             self
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::SqlUsersUpdateRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SqlUsersUpdateRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `body`.
+        /// Sets the value of [body][crate::model::SqlUsersUpdateRequest::body].
         pub fn set_body<T: Into<std::option::Option<crate::model::User>>>(mut self, v: T) -> Self {
             self.0.request.body = v.into();
             self

--- a/src/generated/cloud/sql/v1/src/model.rs
+++ b/src/generated/cloud/sql/v1/src/model.rs
@@ -54,19 +54,19 @@ pub struct SqlBackupRunsDeleteRequest {
 
 impl SqlBackupRunsDeleteRequest {
 
-    /// Sets the value of `id`.
+    /// Sets the value of [id][crate::model::SqlBackupRunsDeleteRequest::id].
     pub fn set_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.id = v.into();
         self
     }
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlBackupRunsDeleteRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlBackupRunsDeleteRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -101,19 +101,19 @@ pub struct SqlBackupRunsGetRequest {
 
 impl SqlBackupRunsGetRequest {
 
-    /// Sets the value of `id`.
+    /// Sets the value of [id][crate::model::SqlBackupRunsGetRequest::id].
     pub fn set_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.id = v.into();
         self
     }
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlBackupRunsGetRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlBackupRunsGetRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -147,19 +147,19 @@ pub struct SqlBackupRunsInsertRequest {
 
 impl SqlBackupRunsInsertRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlBackupRunsInsertRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlBackupRunsInsertRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlBackupRunsInsertRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::BackupRun>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -199,25 +199,25 @@ pub struct SqlBackupRunsListRequest {
 
 impl SqlBackupRunsListRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlBackupRunsListRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `max_results`.
+    /// Sets the value of [max_results][crate::model::SqlBackupRunsListRequest::max_results].
     pub fn set_max_results<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.max_results = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::SqlBackupRunsListRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlBackupRunsListRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -324,109 +324,109 @@ pub struct BackupRun {
 
 impl BackupRun {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::BackupRun::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `status`.
+    /// Sets the value of [status][crate::model::BackupRun::status].
     pub fn set_status<T: std::convert::Into<crate::model::SqlBackupRunStatus>>(mut self, v: T) -> Self {
         self.status = v.into();
         self
     }
 
-    /// Sets the value of `enqueued_time`.
+    /// Sets the value of [enqueued_time][crate::model::BackupRun::enqueued_time].
     pub fn set_enqueued_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.enqueued_time = v.into();
         self
     }
 
-    /// Sets the value of `id`.
+    /// Sets the value of [id][crate::model::BackupRun::id].
     pub fn set_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.id = v.into();
         self
     }
 
-    /// Sets the value of `start_time`.
+    /// Sets the value of [start_time][crate::model::BackupRun::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.start_time = v.into();
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::BackupRun::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.end_time = v.into();
         self
     }
 
-    /// Sets the value of `error`.
+    /// Sets the value of [error][crate::model::BackupRun::error].
     pub fn set_error<T: std::convert::Into<std::option::Option<crate::model::OperationError>>>(mut self, v: T) -> Self {
         self.error = v.into();
         self
     }
 
-    /// Sets the value of `r#type`.
+    /// Sets the value of [r#type][crate::model::BackupRun::type].
     pub fn set_type<T: std::convert::Into<crate::model::SqlBackupRunType>>(mut self, v: T) -> Self {
         self.r#type = v.into();
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::BackupRun::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
     }
 
-    /// Sets the value of `window_start_time`.
+    /// Sets the value of [window_start_time][crate::model::BackupRun::window_start_time].
     pub fn set_window_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.window_start_time = v.into();
         self
     }
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::BackupRun::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `self_link`.
+    /// Sets the value of [self_link][crate::model::BackupRun::self_link].
     pub fn set_self_link<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.self_link = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::BackupRun::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `disk_encryption_configuration`.
+    /// Sets the value of [disk_encryption_configuration][crate::model::BackupRun::disk_encryption_configuration].
     pub fn set_disk_encryption_configuration<T: std::convert::Into<std::option::Option<crate::model::DiskEncryptionConfiguration>>>(mut self, v: T) -> Self {
         self.disk_encryption_configuration = v.into();
         self
     }
 
-    /// Sets the value of `disk_encryption_status`.
+    /// Sets the value of [disk_encryption_status][crate::model::BackupRun::disk_encryption_status].
     pub fn set_disk_encryption_status<T: std::convert::Into<std::option::Option<crate::model::DiskEncryptionStatus>>>(mut self, v: T) -> Self {
         self.disk_encryption_status = v.into();
         self
     }
 
-    /// Sets the value of `backup_kind`.
+    /// Sets the value of [backup_kind][crate::model::BackupRun::backup_kind].
     pub fn set_backup_kind<T: std::convert::Into<crate::model::SqlBackupKind>>(mut self, v: T) -> Self {
         self.backup_kind = v.into();
         self
     }
 
-    /// Sets the value of `time_zone`.
+    /// Sets the value of [time_zone][crate::model::BackupRun::time_zone].
     pub fn set_time_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.time_zone = v.into();
         self
     }
 
-    /// Sets the value of `max_chargeable_bytes`.
+    /// Sets the value of [max_chargeable_bytes][crate::model::BackupRun::max_chargeable_bytes].
     pub fn set_max_chargeable_bytes<T: std::convert::Into<std::option::Option<i64>>>(mut self, v: T) -> Self {
         self.max_chargeable_bytes = v.into();
         self
@@ -462,21 +462,26 @@ pub struct BackupRunsListResponse {
 
 impl BackupRunsListResponse {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::BackupRunsListResponse::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `items`.
-    pub fn set_items<T: std::convert::Into<std::vec::Vec<crate::model::BackupRun>>>(mut self, v: T) -> Self {
-        self.items = v.into();
+    /// Sets the value of [next_page_token][crate::model::BackupRunsListResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [items][crate::model::BackupRunsListResponse::items].
+    pub fn set_items<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::BackupRun>
+    {
+        use std::iter::Iterator;
+        self.items = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -510,19 +515,19 @@ pub struct GetConnectSettingsRequest {
 
 impl GetConnectSettingsRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::GetConnectSettingsRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::GetConnectSettingsRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `read_time`.
+    /// Sets the value of [read_time][crate::model::GetConnectSettingsRequest::read_time].
     pub fn set_read_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.read_time = v.into();
         self
@@ -591,57 +596,62 @@ pub struct ConnectSettings {
 
 impl ConnectSettings {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::ConnectSettings::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `server_ca_cert`.
+    /// Sets the value of [server_ca_cert][crate::model::ConnectSettings::server_ca_cert].
     pub fn set_server_ca_cert<T: std::convert::Into<std::option::Option<crate::model::SslCert>>>(mut self, v: T) -> Self {
         self.server_ca_cert = v.into();
         self
     }
 
-    /// Sets the value of `ip_addresses`.
-    pub fn set_ip_addresses<T: std::convert::Into<std::vec::Vec<crate::model::IpMapping>>>(mut self, v: T) -> Self {
-        self.ip_addresses = v.into();
-        self
-    }
-
-    /// Sets the value of `region`.
+    /// Sets the value of [region][crate::model::ConnectSettings::region].
     pub fn set_region<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.region = v.into();
         self
     }
 
-    /// Sets the value of `database_version`.
+    /// Sets the value of [database_version][crate::model::ConnectSettings::database_version].
     pub fn set_database_version<T: std::convert::Into<crate::model::SqlDatabaseVersion>>(mut self, v: T) -> Self {
         self.database_version = v.into();
         self
     }
 
-    /// Sets the value of `backend_type`.
+    /// Sets the value of [backend_type][crate::model::ConnectSettings::backend_type].
     pub fn set_backend_type<T: std::convert::Into<crate::model::SqlBackendType>>(mut self, v: T) -> Self {
         self.backend_type = v.into();
         self
     }
 
-    /// Sets the value of `psc_enabled`.
+    /// Sets the value of [psc_enabled][crate::model::ConnectSettings::psc_enabled].
     pub fn set_psc_enabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.psc_enabled = v.into();
         self
     }
 
-    /// Sets the value of `dns_name`.
+    /// Sets the value of [dns_name][crate::model::ConnectSettings::dns_name].
     pub fn set_dns_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.dns_name = v.into();
         self
     }
 
-    /// Sets the value of `server_ca_mode`.
+    /// Sets the value of [server_ca_mode][crate::model::ConnectSettings::server_ca_mode].
     pub fn set_server_ca_mode<T: std::convert::Into<crate::model::connect_settings::CaMode>>(mut self, v: T) -> Self {
         self.server_ca_mode = v.into();
+        self
+    }
+
+    /// Sets the value of [ip_addresses][crate::model::ConnectSettings::ip_addresses].
+    pub fn set_ip_addresses<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::IpMapping>
+    {
+        use std::iter::Iterator;
+        self.ip_addresses = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -725,37 +735,37 @@ pub struct GenerateEphemeralCertRequest {
 
 impl GenerateEphemeralCertRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::GenerateEphemeralCertRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::GenerateEphemeralCertRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `public_key`.
+    /// Sets the value of [public_key][crate::model::GenerateEphemeralCertRequest::public_key].
     pub fn set_public_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.public_key = v.into();
         self
     }
 
-    /// Sets the value of `access_token`.
+    /// Sets the value of [access_token][crate::model::GenerateEphemeralCertRequest::access_token].
     pub fn set_access_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.access_token = v.into();
         self
     }
 
-    /// Sets the value of `read_time`.
+    /// Sets the value of [read_time][crate::model::GenerateEphemeralCertRequest::read_time].
     pub fn set_read_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.read_time = v.into();
         self
     }
 
-    /// Sets the value of `valid_duration`.
+    /// Sets the value of [valid_duration][crate::model::GenerateEphemeralCertRequest::valid_duration].
     pub fn set_valid_duration<T: std::convert::Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
         self.valid_duration = v.into();
         self
@@ -782,7 +792,7 @@ pub struct GenerateEphemeralCertResponse {
 
 impl GenerateEphemeralCertResponse {
 
-    /// Sets the value of `ephemeral_cert`.
+    /// Sets the value of [ephemeral_cert][crate::model::GenerateEphemeralCertResponse::ephemeral_cert].
     pub fn set_ephemeral_cert<T: std::convert::Into<std::option::Option<crate::model::SslCert>>>(mut self, v: T) -> Self {
         self.ephemeral_cert = v.into();
         self
@@ -817,19 +827,19 @@ pub struct SqlDatabasesDeleteRequest {
 
 impl SqlDatabasesDeleteRequest {
 
-    /// Sets the value of `database`.
+    /// Sets the value of [database][crate::model::SqlDatabasesDeleteRequest::database].
     pub fn set_database<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.database = v.into();
         self
     }
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlDatabasesDeleteRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlDatabasesDeleteRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -864,19 +874,19 @@ pub struct SqlDatabasesGetRequest {
 
 impl SqlDatabasesGetRequest {
 
-    /// Sets the value of `database`.
+    /// Sets the value of [database][crate::model::SqlDatabasesGetRequest::database].
     pub fn set_database<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.database = v.into();
         self
     }
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlDatabasesGetRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlDatabasesGetRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -910,19 +920,19 @@ pub struct SqlDatabasesInsertRequest {
 
 impl SqlDatabasesInsertRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlDatabasesInsertRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlDatabasesInsertRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlDatabasesInsertRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::Database>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -953,13 +963,13 @@ pub struct SqlDatabasesListRequest {
 
 impl SqlDatabasesListRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlDatabasesListRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlDatabasesListRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -997,25 +1007,25 @@ pub struct SqlDatabasesUpdateRequest {
 
 impl SqlDatabasesUpdateRequest {
 
-    /// Sets the value of `database`.
+    /// Sets the value of [database][crate::model::SqlDatabasesUpdateRequest::database].
     pub fn set_database<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.database = v.into();
         self
     }
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlDatabasesUpdateRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlDatabasesUpdateRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlDatabasesUpdateRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::Database>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -1046,15 +1056,20 @@ pub struct DatabasesListResponse {
 
 impl DatabasesListResponse {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::DatabasesListResponse::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `items`.
-    pub fn set_items<T: std::convert::Into<std::vec::Vec<crate::model::Database>>>(mut self, v: T) -> Self {
-        self.items = v.into();
+    /// Sets the value of [items][crate::model::DatabasesListResponse::items].
+    pub fn set_items<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Database>
+    {
+        use std::iter::Iterator;
+        self.items = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1080,7 +1095,7 @@ pub struct SqlFlagsListRequest {
 
 impl SqlFlagsListRequest {
 
-    /// Sets the value of `database_version`.
+    /// Sets the value of [database_version][crate::model::SqlFlagsListRequest::database_version].
     pub fn set_database_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.database_version = v.into();
         self
@@ -1111,15 +1126,20 @@ pub struct FlagsListResponse {
 
 impl FlagsListResponse {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::FlagsListResponse::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `items`.
-    pub fn set_items<T: std::convert::Into<std::vec::Vec<crate::model::Flag>>>(mut self, v: T) -> Self {
-        self.items = v.into();
+    /// Sets the value of [items][crate::model::FlagsListResponse::items].
+    pub fn set_items<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Flag>
+    {
+        use std::iter::Iterator;
+        self.items = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1197,63 +1217,78 @@ pub struct Flag {
 
 impl Flag {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Flag::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `r#type`.
+    /// Sets the value of [r#type][crate::model::Flag::type].
     pub fn set_type<T: std::convert::Into<crate::model::SqlFlagType>>(mut self, v: T) -> Self {
         self.r#type = v.into();
         self
     }
 
-    /// Sets the value of `applies_to`.
-    pub fn set_applies_to<T: std::convert::Into<std::vec::Vec<crate::model::SqlDatabaseVersion>>>(mut self, v: T) -> Self {
-        self.applies_to = v.into();
-        self
-    }
-
-    /// Sets the value of `allowed_string_values`.
-    pub fn set_allowed_string_values<T: std::convert::Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-        self.allowed_string_values = v.into();
-        self
-    }
-
-    /// Sets the value of `min_value`.
+    /// Sets the value of [min_value][crate::model::Flag::min_value].
     pub fn set_min_value<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(mut self, v: T) -> Self {
         self.min_value = v.into();
         self
     }
 
-    /// Sets the value of `max_value`.
+    /// Sets the value of [max_value][crate::model::Flag::max_value].
     pub fn set_max_value<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(mut self, v: T) -> Self {
         self.max_value = v.into();
         self
     }
 
-    /// Sets the value of `requires_restart`.
+    /// Sets the value of [requires_restart][crate::model::Flag::requires_restart].
     pub fn set_requires_restart<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.requires_restart = v.into();
         self
     }
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::Flag::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `in_beta`.
+    /// Sets the value of [in_beta][crate::model::Flag::in_beta].
     pub fn set_in_beta<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.in_beta = v.into();
         self
     }
 
-    /// Sets the value of `allowed_int_values`.
-    pub fn set_allowed_int_values<T: std::convert::Into<std::vec::Vec<i64>>>(mut self, v: T) -> Self {
-        self.allowed_int_values = v.into();
+    /// Sets the value of [applies_to][crate::model::Flag::applies_to].
+    pub fn set_applies_to<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SqlDatabaseVersion>
+    {
+        use std::iter::Iterator;
+        self.applies_to = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [allowed_string_values][crate::model::Flag::allowed_string_values].
+    pub fn set_allowed_string_values<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.allowed_string_values = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [allowed_int_values][crate::model::Flag::allowed_int_values].
+    pub fn set_allowed_int_values<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<i64>
+    {
+        use std::iter::Iterator;
+        self.allowed_int_values = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1282,13 +1317,13 @@ pub struct SqlInstancesAddServerCaRequest {
 
 impl SqlInstancesAddServerCaRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesAddServerCaRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesAddServerCaRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -1323,19 +1358,19 @@ pub struct SqlInstancesCloneRequest {
 
 impl SqlInstancesCloneRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesCloneRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesCloneRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlInstancesCloneRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::InstancesCloneRequest>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -1366,13 +1401,13 @@ pub struct SqlInstancesDeleteRequest {
 
 impl SqlInstancesDeleteRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesDeleteRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesDeleteRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -1406,19 +1441,19 @@ pub struct SqlInstancesDemoteMasterRequest {
 
 impl SqlInstancesDemoteMasterRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesDemoteMasterRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesDemoteMasterRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlInstancesDemoteMasterRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::InstancesDemoteMasterRequest>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -1453,19 +1488,19 @@ pub struct SqlInstancesDemoteRequest {
 
 impl SqlInstancesDemoteRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesDemoteRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesDemoteRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlInstancesDemoteRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::InstancesDemoteRequest>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -1499,19 +1534,19 @@ pub struct SqlInstancesExportRequest {
 
 impl SqlInstancesExportRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesExportRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesExportRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlInstancesExportRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::InstancesExportRequest>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -1545,19 +1580,19 @@ pub struct SqlInstancesFailoverRequest {
 
 impl SqlInstancesFailoverRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesFailoverRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesFailoverRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlInstancesFailoverRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::InstancesFailoverRequest>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -1588,13 +1623,13 @@ pub struct SqlInstancesGetRequest {
 
 impl SqlInstancesGetRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesGetRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesGetRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -1628,19 +1663,19 @@ pub struct SqlInstancesImportRequest {
 
 impl SqlInstancesImportRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesImportRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesImportRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlInstancesImportRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::InstancesImportRequest>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -1671,13 +1706,13 @@ pub struct SqlInstancesInsertRequest {
 
 impl SqlInstancesInsertRequest {
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesInsertRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlInstancesInsertRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::DatabaseInstance>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -1727,25 +1762,25 @@ pub struct SqlInstancesListRequest {
 
 impl SqlInstancesListRequest {
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::SqlInstancesListRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
     }
 
-    /// Sets the value of `max_results`.
+    /// Sets the value of [max_results][crate::model::SqlInstancesListRequest::max_results].
     pub fn set_max_results<T: std::convert::Into<u32>>(mut self, v: T) -> Self {
         self.max_results = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::SqlInstancesListRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesListRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -1776,13 +1811,13 @@ pub struct SqlInstancesListServerCasRequest {
 
 impl SqlInstancesListServerCasRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesListServerCasRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesListServerCasRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -1816,19 +1851,19 @@ pub struct SqlInstancesPatchRequest {
 
 impl SqlInstancesPatchRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesPatchRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesPatchRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlInstancesPatchRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::DatabaseInstance>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -1868,19 +1903,19 @@ pub struct SqlInstancesPromoteReplicaRequest {
 
 impl SqlInstancesPromoteReplicaRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesPromoteReplicaRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesPromoteReplicaRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `failover`.
+    /// Sets the value of [failover][crate::model::SqlInstancesPromoteReplicaRequest::failover].
     pub fn set_failover<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.failover = v.into();
         self
@@ -1917,19 +1952,19 @@ pub struct SqlInstancesSwitchoverRequest {
 
 impl SqlInstancesSwitchoverRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesSwitchoverRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesSwitchoverRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `db_timeout`.
+    /// Sets the value of [db_timeout][crate::model::SqlInstancesSwitchoverRequest::db_timeout].
     pub fn set_db_timeout<T: std::convert::Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
         self.db_timeout = v.into();
         self
@@ -1960,13 +1995,13 @@ pub struct SqlInstancesResetSslConfigRequest {
 
 impl SqlInstancesResetSslConfigRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesResetSslConfigRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesResetSslConfigRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -1997,13 +2032,13 @@ pub struct SqlInstancesRestartRequest {
 
 impl SqlInstancesRestartRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesRestartRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesRestartRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -2037,19 +2072,19 @@ pub struct SqlInstancesRestoreBackupRequest {
 
 impl SqlInstancesRestoreBackupRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesRestoreBackupRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesRestoreBackupRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlInstancesRestoreBackupRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::InstancesRestoreBackupRequest>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -2083,19 +2118,19 @@ pub struct SqlInstancesRotateServerCaRequest {
 
 impl SqlInstancesRotateServerCaRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesRotateServerCaRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesRotateServerCaRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlInstancesRotateServerCaRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::InstancesRotateServerCaRequest>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -2126,13 +2161,13 @@ pub struct SqlInstancesStartReplicaRequest {
 
 impl SqlInstancesStartReplicaRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesStartReplicaRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesStartReplicaRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -2163,13 +2198,13 @@ pub struct SqlInstancesStopReplicaRequest {
 
 impl SqlInstancesStopReplicaRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesStopReplicaRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesStopReplicaRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -2203,19 +2238,19 @@ pub struct SqlInstancesTruncateLogRequest {
 
 impl SqlInstancesTruncateLogRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesTruncateLogRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesTruncateLogRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlInstancesTruncateLogRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::InstancesTruncateLogRequest>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -2250,19 +2285,19 @@ pub struct SqlInstancesPerformDiskShrinkRequest {
 
 impl SqlInstancesPerformDiskShrinkRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesPerformDiskShrinkRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesPerformDiskShrinkRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlInstancesPerformDiskShrinkRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::PerformDiskShrinkContext>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -2296,19 +2331,19 @@ pub struct SqlInstancesUpdateRequest {
 
 impl SqlInstancesUpdateRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesUpdateRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesUpdateRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlInstancesUpdateRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::DatabaseInstance>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -2342,19 +2377,19 @@ pub struct SqlInstancesRescheduleMaintenanceRequest {
 
 impl SqlInstancesRescheduleMaintenanceRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesRescheduleMaintenanceRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesRescheduleMaintenanceRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlInstancesRescheduleMaintenanceRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::SqlInstancesRescheduleMaintenanceRequestBody>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -2389,19 +2424,19 @@ pub struct SqlInstancesReencryptRequest {
 
 impl SqlInstancesReencryptRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesReencryptRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesReencryptRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlInstancesReencryptRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::InstancesReencryptRequest>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -2428,7 +2463,7 @@ pub struct InstancesReencryptRequest {
 
 impl InstancesReencryptRequest {
 
-    /// Sets the value of `backup_reencryption_config`.
+    /// Sets the value of [backup_reencryption_config][crate::model::InstancesReencryptRequest::backup_reencryption_config].
     pub fn set_backup_reencryption_config<T: std::convert::Into<std::option::Option<crate::model::BackupReencryptionConfig>>>(mut self, v: T) -> Self {
         self.backup_reencryption_config = v.into();
         self
@@ -2459,13 +2494,13 @@ pub struct BackupReencryptionConfig {
 
 impl BackupReencryptionConfig {
 
-    /// Sets the value of `backup_limit`.
+    /// Sets the value of [backup_limit][crate::model::BackupReencryptionConfig::backup_limit].
     pub fn set_backup_limit<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
         self.backup_limit = v.into();
         self
     }
 
-    /// Sets the value of `backup_type`.
+    /// Sets the value of [backup_type][crate::model::BackupReencryptionConfig::backup_type].
     pub fn set_backup_type<T: std::convert::Into<std::option::Option<crate::model::backup_reencryption_config::BackupType>>>(mut self, v: T) -> Self {
         self.backup_type = v.into();
         self
@@ -2533,13 +2568,13 @@ pub struct SqlInstancesGetDiskShrinkConfigRequest {
 
 impl SqlInstancesGetDiskShrinkConfigRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesGetDiskShrinkConfigRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesGetDiskShrinkConfigRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -2591,43 +2626,43 @@ pub struct SqlInstancesVerifyExternalSyncSettingsRequest {
 
 impl SqlInstancesVerifyExternalSyncSettingsRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesVerifyExternalSyncSettingsRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesVerifyExternalSyncSettingsRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `verify_connection_only`.
+    /// Sets the value of [verify_connection_only][crate::model::SqlInstancesVerifyExternalSyncSettingsRequest::verify_connection_only].
     pub fn set_verify_connection_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.verify_connection_only = v.into();
         self
     }
 
-    /// Sets the value of `sync_mode`.
+    /// Sets the value of [sync_mode][crate::model::SqlInstancesVerifyExternalSyncSettingsRequest::sync_mode].
     pub fn set_sync_mode<T: std::convert::Into<crate::model::sql_instances_verify_external_sync_settings_request::ExternalSyncMode>>(mut self, v: T) -> Self {
         self.sync_mode = v.into();
         self
     }
 
-    /// Sets the value of `verify_replication_only`.
+    /// Sets the value of [verify_replication_only][crate::model::SqlInstancesVerifyExternalSyncSettingsRequest::verify_replication_only].
     pub fn set_verify_replication_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.verify_replication_only = v.into();
         self
     }
 
-    /// Sets the value of `migration_type`.
+    /// Sets the value of [migration_type][crate::model::SqlInstancesVerifyExternalSyncSettingsRequest::migration_type].
     pub fn set_migration_type<T: std::convert::Into<crate::model::sql_instances_verify_external_sync_settings_request::MigrationType>>(mut self, v: T) -> Self {
         self.migration_type = v.into();
         self
     }
 
-    /// Sets the value of `sync_parallel_level`.
+    /// Sets the value of [sync_parallel_level][crate::model::SqlInstancesVerifyExternalSyncSettingsRequest::sync_parallel_level].
     pub fn set_sync_parallel_level<T: std::convert::Into<crate::model::ExternalSyncParallelLevel>>(mut self, v: T) -> Self {
         self.sync_parallel_level = v.into();
         self
@@ -2759,37 +2794,37 @@ pub struct SqlInstancesStartExternalSyncRequest {
 
 impl SqlInstancesStartExternalSyncRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesStartExternalSyncRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesStartExternalSyncRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `sync_mode`.
+    /// Sets the value of [sync_mode][crate::model::SqlInstancesStartExternalSyncRequest::sync_mode].
     pub fn set_sync_mode<T: std::convert::Into<crate::model::sql_instances_verify_external_sync_settings_request::ExternalSyncMode>>(mut self, v: T) -> Self {
         self.sync_mode = v.into();
         self
     }
 
-    /// Sets the value of `skip_verification`.
+    /// Sets the value of [skip_verification][crate::model::SqlInstancesStartExternalSyncRequest::skip_verification].
     pub fn set_skip_verification<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.skip_verification = v.into();
         self
     }
 
-    /// Sets the value of `sync_parallel_level`.
+    /// Sets the value of [sync_parallel_level][crate::model::SqlInstancesStartExternalSyncRequest::sync_parallel_level].
     pub fn set_sync_parallel_level<T: std::convert::Into<crate::model::ExternalSyncParallelLevel>>(mut self, v: T) -> Self {
         self.sync_parallel_level = v.into();
         self
     }
 
-    /// Sets the value of `migration_type`.
+    /// Sets the value of [migration_type][crate::model::SqlInstancesStartExternalSyncRequest::migration_type].
     pub fn set_migration_type<T: std::convert::Into<crate::model::sql_instances_verify_external_sync_settings_request::MigrationType>>(mut self, v: T) -> Self {
         self.migration_type = v.into();
         self
@@ -2841,13 +2876,13 @@ pub struct SqlInstancesResetReplicaSizeRequest {
 
 impl SqlInstancesResetReplicaSizeRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesResetReplicaSizeRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesResetReplicaSizeRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -2881,19 +2916,19 @@ pub struct SqlInstancesCreateEphemeralCertRequest {
 
 impl SqlInstancesCreateEphemeralCertRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesCreateEphemeralCertRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesCreateEphemeralCertRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlInstancesCreateEphemeralCertRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::SslCertsCreateEphemeralRequest>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -2920,7 +2955,7 @@ pub struct InstancesCloneRequest {
 
 impl InstancesCloneRequest {
 
-    /// Sets the value of `clone_context`.
+    /// Sets the value of [clone_context][crate::model::InstancesCloneRequest::clone_context].
     pub fn set_clone_context<T: std::convert::Into<std::option::Option<crate::model::CloneContext>>>(mut self, v: T) -> Self {
         self.clone_context = v.into();
         self
@@ -2947,7 +2982,7 @@ pub struct InstancesDemoteMasterRequest {
 
 impl InstancesDemoteMasterRequest {
 
-    /// Sets the value of `demote_master_context`.
+    /// Sets the value of [demote_master_context][crate::model::InstancesDemoteMasterRequest::demote_master_context].
     pub fn set_demote_master_context<T: std::convert::Into<std::option::Option<crate::model::DemoteMasterContext>>>(mut self, v: T) -> Self {
         self.demote_master_context = v.into();
         self
@@ -2975,7 +3010,7 @@ pub struct InstancesDemoteRequest {
 
 impl InstancesDemoteRequest {
 
-    /// Sets the value of `demote_context`.
+    /// Sets the value of [demote_context][crate::model::InstancesDemoteRequest::demote_context].
     pub fn set_demote_context<T: std::convert::Into<std::option::Option<crate::model::DemoteContext>>>(mut self, v: T) -> Self {
         self.demote_context = v.into();
         self
@@ -3002,7 +3037,7 @@ pub struct InstancesExportRequest {
 
 impl InstancesExportRequest {
 
-    /// Sets the value of `export_context`.
+    /// Sets the value of [export_context][crate::model::InstancesExportRequest::export_context].
     pub fn set_export_context<T: std::convert::Into<std::option::Option<crate::model::ExportContext>>>(mut self, v: T) -> Self {
         self.export_context = v.into();
         self
@@ -3029,7 +3064,7 @@ pub struct InstancesFailoverRequest {
 
 impl InstancesFailoverRequest {
 
-    /// Sets the value of `failover_context`.
+    /// Sets the value of [failover_context][crate::model::InstancesFailoverRequest::failover_context].
     pub fn set_failover_context<T: std::convert::Into<std::option::Option<crate::model::FailoverContext>>>(mut self, v: T) -> Self {
         self.failover_context = v.into();
         self
@@ -3060,13 +3095,13 @@ pub struct SslCertsCreateEphemeralRequest {
 
 impl SslCertsCreateEphemeralRequest {
 
-    /// Sets the value of `public_key`.
+    /// Sets the value of [public_key][crate::model::SslCertsCreateEphemeralRequest::public_key].
     pub fn set_public_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.public_key = v.into();
         self
     }
 
-    /// Sets the value of `access_token`.
+    /// Sets the value of [access_token][crate::model::SslCertsCreateEphemeralRequest::access_token].
     pub fn set_access_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.access_token = v.into();
         self
@@ -3093,7 +3128,7 @@ pub struct InstancesImportRequest {
 
 impl InstancesImportRequest {
 
-    /// Sets the value of `import_context`.
+    /// Sets the value of [import_context][crate::model::InstancesImportRequest::import_context].
     pub fn set_import_context<T: std::convert::Into<std::option::Option<crate::model::ImportContext>>>(mut self, v: T) -> Self {
         self.import_context = v.into();
         self
@@ -3133,27 +3168,37 @@ pub struct InstancesListResponse {
 
 impl InstancesListResponse {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::InstancesListResponse::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `warnings`.
-    pub fn set_warnings<T: std::convert::Into<std::vec::Vec<crate::model::ApiWarning>>>(mut self, v: T) -> Self {
-        self.warnings = v.into();
-        self
-    }
-
-    /// Sets the value of `items`.
-    pub fn set_items<T: std::convert::Into<std::vec::Vec<crate::model::DatabaseInstance>>>(mut self, v: T) -> Self {
-        self.items = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::InstancesListResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
+        self
+    }
+
+    /// Sets the value of [warnings][crate::model::InstancesListResponse::warnings].
+    pub fn set_warnings<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ApiWarning>
+    {
+        use std::iter::Iterator;
+        self.warnings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [items][crate::model::InstancesListResponse::items].
+    pub fn set_items<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DatabaseInstance>
+    {
+        use std::iter::Iterator;
+        self.items = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3185,21 +3230,26 @@ pub struct InstancesListServerCasResponse {
 
 impl InstancesListServerCasResponse {
 
-    /// Sets the value of `certs`.
-    pub fn set_certs<T: std::convert::Into<std::vec::Vec<crate::model::SslCert>>>(mut self, v: T) -> Self {
-        self.certs = v.into();
-        self
-    }
-
-    /// Sets the value of `active_version`.
+    /// Sets the value of [active_version][crate::model::InstancesListServerCasResponse::active_version].
     pub fn set_active_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.active_version = v.into();
         self
     }
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::InstancesListServerCasResponse::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
+        self
+    }
+
+    /// Sets the value of [certs][crate::model::InstancesListServerCasResponse::certs].
+    pub fn set_certs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SslCert>
+    {
+        use std::iter::Iterator;
+        self.certs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3224,7 +3274,7 @@ pub struct InstancesRestoreBackupRequest {
 
 impl InstancesRestoreBackupRequest {
 
-    /// Sets the value of `restore_backup_context`.
+    /// Sets the value of [restore_backup_context][crate::model::InstancesRestoreBackupRequest::restore_backup_context].
     pub fn set_restore_backup_context<T: std::convert::Into<std::option::Option<crate::model::RestoreBackupContext>>>(mut self, v: T) -> Self {
         self.restore_backup_context = v.into();
         self
@@ -3251,7 +3301,7 @@ pub struct InstancesRotateServerCaRequest {
 
 impl InstancesRotateServerCaRequest {
 
-    /// Sets the value of `rotate_server_ca_context`.
+    /// Sets the value of [rotate_server_ca_context][crate::model::InstancesRotateServerCaRequest::rotate_server_ca_context].
     pub fn set_rotate_server_ca_context<T: std::convert::Into<std::option::Option<crate::model::RotateServerCaContext>>>(mut self, v: T) -> Self {
         self.rotate_server_ca_context = v.into();
         self
@@ -3278,7 +3328,7 @@ pub struct InstancesTruncateLogRequest {
 
 impl InstancesTruncateLogRequest {
 
-    /// Sets the value of `truncate_log_context`.
+    /// Sets the value of [truncate_log_context][crate::model::InstancesTruncateLogRequest::truncate_log_context].
     pub fn set_truncate_log_context<T: std::convert::Into<std::option::Option<crate::model::TruncateLogContext>>>(mut self, v: T) -> Self {
         self.truncate_log_context = v.into();
         self
@@ -3305,7 +3355,7 @@ pub struct InstancesAcquireSsrsLeaseRequest {
 
 impl InstancesAcquireSsrsLeaseRequest {
 
-    /// Sets the value of `acquire_ssrs_lease_context`.
+    /// Sets the value of [acquire_ssrs_lease_context][crate::model::InstancesAcquireSsrsLeaseRequest::acquire_ssrs_lease_context].
     pub fn set_acquire_ssrs_lease_context<T: std::convert::Into<std::option::Option<crate::model::AcquireSsrsLeaseContext>>>(mut self, v: T) -> Self {
         self.acquire_ssrs_lease_context = v.into();
         self
@@ -3340,21 +3390,31 @@ pub struct SqlInstancesVerifyExternalSyncSettingsResponse {
 
 impl SqlInstancesVerifyExternalSyncSettingsResponse {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::SqlInstancesVerifyExternalSyncSettingsResponse::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `errors`.
-    pub fn set_errors<T: std::convert::Into<std::vec::Vec<crate::model::SqlExternalSyncSettingError>>>(mut self, v: T) -> Self {
-        self.errors = v.into();
+    /// Sets the value of [errors][crate::model::SqlInstancesVerifyExternalSyncSettingsResponse::errors].
+    pub fn set_errors<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SqlExternalSyncSettingError>
+    {
+        use std::iter::Iterator;
+        self.errors = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
-    /// Sets the value of `warnings`.
-    pub fn set_warnings<T: std::convert::Into<std::vec::Vec<crate::model::SqlExternalSyncSettingError>>>(mut self, v: T) -> Self {
-        self.warnings = v.into();
+    /// Sets the value of [warnings][crate::model::SqlInstancesVerifyExternalSyncSettingsResponse::warnings].
+    pub fn set_warnings<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SqlExternalSyncSettingError>
+    {
+        use std::iter::Iterator;
+        self.warnings = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3387,19 +3447,19 @@ pub struct SqlInstancesGetDiskShrinkConfigResponse {
 
 impl SqlInstancesGetDiskShrinkConfigResponse {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::SqlInstancesGetDiskShrinkConfigResponse::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `minimal_target_size_gb`.
+    /// Sets the value of [minimal_target_size_gb][crate::model::SqlInstancesGetDiskShrinkConfigResponse::minimal_target_size_gb].
     pub fn set_minimal_target_size_gb<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.minimal_target_size_gb = v.into();
         self
     }
 
-    /// Sets the value of `message`.
+    /// Sets the value of [message][crate::model::SqlInstancesGetDiskShrinkConfigResponse::message].
     pub fn set_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.message = v.into();
         self
@@ -3430,13 +3490,13 @@ pub struct SqlInstancesGetLatestRecoveryTimeRequest {
 
 impl SqlInstancesGetLatestRecoveryTimeRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesGetLatestRecoveryTimeRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesGetLatestRecoveryTimeRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -3467,13 +3527,13 @@ pub struct SqlInstancesGetLatestRecoveryTimeResponse {
 
 impl SqlInstancesGetLatestRecoveryTimeResponse {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::SqlInstancesGetLatestRecoveryTimeResponse::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `latest_recovery_time`.
+    /// Sets the value of [latest_recovery_time][crate::model::SqlInstancesGetLatestRecoveryTimeResponse::latest_recovery_time].
     pub fn set_latest_recovery_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.latest_recovery_time = v.into();
         self
@@ -3540,51 +3600,56 @@ pub struct CloneContext {
 
 impl CloneContext {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::CloneContext::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `pitr_timestamp_ms`.
+    /// Sets the value of [pitr_timestamp_ms][crate::model::CloneContext::pitr_timestamp_ms].
     pub fn set_pitr_timestamp_ms<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.pitr_timestamp_ms = v.into();
         self
     }
 
-    /// Sets the value of `destination_instance_name`.
+    /// Sets the value of [destination_instance_name][crate::model::CloneContext::destination_instance_name].
     pub fn set_destination_instance_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.destination_instance_name = v.into();
         self
     }
 
-    /// Sets the value of `bin_log_coordinates`.
+    /// Sets the value of [bin_log_coordinates][crate::model::CloneContext::bin_log_coordinates].
     pub fn set_bin_log_coordinates<T: std::convert::Into<std::option::Option<crate::model::BinLogCoordinates>>>(mut self, v: T) -> Self {
         self.bin_log_coordinates = v.into();
         self
     }
 
-    /// Sets the value of `point_in_time`.
+    /// Sets the value of [point_in_time][crate::model::CloneContext::point_in_time].
     pub fn set_point_in_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.point_in_time = v.into();
         self
     }
 
-    /// Sets the value of `allocated_ip_range`.
+    /// Sets the value of [allocated_ip_range][crate::model::CloneContext::allocated_ip_range].
     pub fn set_allocated_ip_range<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.allocated_ip_range = v.into();
         self
     }
 
-    /// Sets the value of `database_names`.
-    pub fn set_database_names<T: std::convert::Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-        self.database_names = v.into();
+    /// Sets the value of [preferred_zone][crate::model::CloneContext::preferred_zone].
+    pub fn set_preferred_zone<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
+        self.preferred_zone = v.into();
         self
     }
 
-    /// Sets the value of `preferred_zone`.
-    pub fn set_preferred_zone<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
-        self.preferred_zone = v.into();
+    /// Sets the value of [database_names][crate::model::CloneContext::database_names].
+    pub fn set_database_names<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.database_names = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3617,19 +3682,19 @@ pub struct BinLogCoordinates {
 
 impl BinLogCoordinates {
 
-    /// Sets the value of `bin_log_file_name`.
+    /// Sets the value of [bin_log_file_name][crate::model::BinLogCoordinates::bin_log_file_name].
     pub fn set_bin_log_file_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.bin_log_file_name = v.into();
         self
     }
 
-    /// Sets the value of `bin_log_position`.
+    /// Sets the value of [bin_log_position][crate::model::BinLogCoordinates::bin_log_position].
     pub fn set_bin_log_position<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.bin_log_position = v.into();
         self
     }
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::BinLogCoordinates::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
@@ -3881,279 +3946,304 @@ pub struct DatabaseInstance {
 
 impl DatabaseInstance {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::DatabaseInstance::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::DatabaseInstance::state].
     pub fn set_state<T: std::convert::Into<crate::model::database_instance::SqlInstanceState>>(mut self, v: T) -> Self {
         self.state = v.into();
         self
     }
 
-    /// Sets the value of `database_version`.
+    /// Sets the value of [database_version][crate::model::DatabaseInstance::database_version].
     pub fn set_database_version<T: std::convert::Into<crate::model::SqlDatabaseVersion>>(mut self, v: T) -> Self {
         self.database_version = v.into();
         self
     }
 
-    /// Sets the value of `settings`.
+    /// Sets the value of [settings][crate::model::DatabaseInstance::settings].
     pub fn set_settings<T: std::convert::Into<std::option::Option<crate::model::Settings>>>(mut self, v: T) -> Self {
         self.settings = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DatabaseInstance::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `failover_replica`.
+    /// Sets the value of [failover_replica][crate::model::DatabaseInstance::failover_replica].
     pub fn set_failover_replica<T: std::convert::Into<std::option::Option<crate::model::database_instance::SqlFailoverReplica>>>(mut self, v: T) -> Self {
         self.failover_replica = v.into();
         self
     }
 
-    /// Sets the value of `master_instance_name`.
+    /// Sets the value of [master_instance_name][crate::model::DatabaseInstance::master_instance_name].
     pub fn set_master_instance_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.master_instance_name = v.into();
         self
     }
 
-    /// Sets the value of `replica_names`.
-    pub fn set_replica_names<T: std::convert::Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-        self.replica_names = v.into();
-        self
-    }
-
-    /// Sets the value of `max_disk_size`.
+    /// Sets the value of [max_disk_size][crate::model::DatabaseInstance::max_disk_size].
     pub fn set_max_disk_size<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(mut self, v: T) -> Self {
         self.max_disk_size = v.into();
         self
     }
 
-    /// Sets the value of `current_disk_size`.
+    /// Sets the value of [current_disk_size][crate::model::DatabaseInstance::current_disk_size].
     pub fn set_current_disk_size<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(mut self, v: T) -> Self {
         self.current_disk_size = v.into();
         self
     }
 
-    /// Sets the value of `ip_addresses`.
-    pub fn set_ip_addresses<T: std::convert::Into<std::vec::Vec<crate::model::IpMapping>>>(mut self, v: T) -> Self {
-        self.ip_addresses = v.into();
-        self
-    }
-
-    /// Sets the value of `server_ca_cert`.
+    /// Sets the value of [server_ca_cert][crate::model::DatabaseInstance::server_ca_cert].
     pub fn set_server_ca_cert<T: std::convert::Into<std::option::Option<crate::model::SslCert>>>(mut self, v: T) -> Self {
         self.server_ca_cert = v.into();
         self
     }
 
-    /// Sets the value of `instance_type`.
+    /// Sets the value of [instance_type][crate::model::DatabaseInstance::instance_type].
     pub fn set_instance_type<T: std::convert::Into<crate::model::SqlInstanceType>>(mut self, v: T) -> Self {
         self.instance_type = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::DatabaseInstance::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `ipv6_address`.
+    /// Sets the value of [ipv6_address][crate::model::DatabaseInstance::ipv6_address].
     pub fn set_ipv6_address<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.ipv6_address = v.into();
         self
     }
 
-    /// Sets the value of `service_account_email_address`.
+    /// Sets the value of [service_account_email_address][crate::model::DatabaseInstance::service_account_email_address].
     pub fn set_service_account_email_address<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_account_email_address = v.into();
         self
     }
 
-    /// Sets the value of `on_premises_configuration`.
+    /// Sets the value of [on_premises_configuration][crate::model::DatabaseInstance::on_premises_configuration].
     pub fn set_on_premises_configuration<T: std::convert::Into<std::option::Option<crate::model::OnPremisesConfiguration>>>(mut self, v: T) -> Self {
         self.on_premises_configuration = v.into();
         self
     }
 
-    /// Sets the value of `replica_configuration`.
+    /// Sets the value of [replica_configuration][crate::model::DatabaseInstance::replica_configuration].
     pub fn set_replica_configuration<T: std::convert::Into<std::option::Option<crate::model::ReplicaConfiguration>>>(mut self, v: T) -> Self {
         self.replica_configuration = v.into();
         self
     }
 
-    /// Sets the value of `backend_type`.
+    /// Sets the value of [backend_type][crate::model::DatabaseInstance::backend_type].
     pub fn set_backend_type<T: std::convert::Into<crate::model::SqlBackendType>>(mut self, v: T) -> Self {
         self.backend_type = v.into();
         self
     }
 
-    /// Sets the value of `self_link`.
+    /// Sets the value of [self_link][crate::model::DatabaseInstance::self_link].
     pub fn set_self_link<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.self_link = v.into();
         self
     }
 
-    /// Sets the value of `suspension_reason`.
-    pub fn set_suspension_reason<T: std::convert::Into<std::vec::Vec<crate::model::SqlSuspensionReason>>>(mut self, v: T) -> Self {
-        self.suspension_reason = v.into();
-        self
-    }
-
-    /// Sets the value of `connection_name`.
+    /// Sets the value of [connection_name][crate::model::DatabaseInstance::connection_name].
     pub fn set_connection_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.connection_name = v.into();
         self
     }
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DatabaseInstance::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `region`.
+    /// Sets the value of [region][crate::model::DatabaseInstance::region].
     pub fn set_region<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.region = v.into();
         self
     }
 
-    /// Sets the value of `gce_zone`.
+    /// Sets the value of [gce_zone][crate::model::DatabaseInstance::gce_zone].
     pub fn set_gce_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.gce_zone = v.into();
         self
     }
 
-    /// Sets the value of `secondary_gce_zone`.
+    /// Sets the value of [secondary_gce_zone][crate::model::DatabaseInstance::secondary_gce_zone].
     pub fn set_secondary_gce_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secondary_gce_zone = v.into();
         self
     }
 
-    /// Sets the value of `disk_encryption_configuration`.
+    /// Sets the value of [disk_encryption_configuration][crate::model::DatabaseInstance::disk_encryption_configuration].
     pub fn set_disk_encryption_configuration<T: std::convert::Into<std::option::Option<crate::model::DiskEncryptionConfiguration>>>(mut self, v: T) -> Self {
         self.disk_encryption_configuration = v.into();
         self
     }
 
-    /// Sets the value of `disk_encryption_status`.
+    /// Sets the value of [disk_encryption_status][crate::model::DatabaseInstance::disk_encryption_status].
     pub fn set_disk_encryption_status<T: std::convert::Into<std::option::Option<crate::model::DiskEncryptionStatus>>>(mut self, v: T) -> Self {
         self.disk_encryption_status = v.into();
         self
     }
 
-    /// Sets the value of `root_password`.
+    /// Sets the value of [root_password][crate::model::DatabaseInstance::root_password].
     pub fn set_root_password<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.root_password = v.into();
         self
     }
 
-    /// Sets the value of `scheduled_maintenance`.
+    /// Sets the value of [scheduled_maintenance][crate::model::DatabaseInstance::scheduled_maintenance].
     pub fn set_scheduled_maintenance<T: std::convert::Into<std::option::Option<crate::model::database_instance::SqlScheduledMaintenance>>>(mut self, v: T) -> Self {
         self.scheduled_maintenance = v.into();
         self
     }
 
-    /// Sets the value of `satisfies_pzs`.
+    /// Sets the value of [satisfies_pzs][crate::model::DatabaseInstance::satisfies_pzs].
     pub fn set_satisfies_pzs<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.satisfies_pzs = v.into();
         self
     }
 
-    /// Sets the value of `database_installed_version`.
+    /// Sets the value of [database_installed_version][crate::model::DatabaseInstance::database_installed_version].
     pub fn set_database_installed_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.database_installed_version = v.into();
         self
     }
 
-    /// Sets the value of `out_of_disk_report`.
+    /// Sets the value of [out_of_disk_report][crate::model::DatabaseInstance::out_of_disk_report].
     pub fn set_out_of_disk_report<T: std::convert::Into<std::option::Option<crate::model::database_instance::SqlOutOfDiskReport>>>(mut self, v: T) -> Self {
         self.out_of_disk_report = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::DatabaseInstance::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.create_time = v.into();
         self
     }
 
-    /// Sets the value of `available_maintenance_versions`.
-    pub fn set_available_maintenance_versions<T: std::convert::Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-        self.available_maintenance_versions = v.into();
-        self
-    }
-
-    /// Sets the value of `maintenance_version`.
+    /// Sets the value of [maintenance_version][crate::model::DatabaseInstance::maintenance_version].
     pub fn set_maintenance_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.maintenance_version = v.into();
         self
     }
 
-    /// Sets the value of `upgradable_database_versions`.
-    pub fn set_upgradable_database_versions<T: std::convert::Into<std::vec::Vec<crate::model::AvailableDatabaseVersion>>>(mut self, v: T) -> Self {
-        self.upgradable_database_versions = v.into();
-        self
-    }
-
-    /// Sets the value of `sql_network_architecture`.
+    /// Sets the value of [sql_network_architecture][crate::model::DatabaseInstance::sql_network_architecture].
     pub fn set_sql_network_architecture<T: std::convert::Into<std::option::Option<crate::model::database_instance::SqlNetworkArchitecture>>>(mut self, v: T) -> Self {
         self.sql_network_architecture = v.into();
         self
     }
 
-    /// Sets the value of `psc_service_attachment_link`.
+    /// Sets the value of [psc_service_attachment_link][crate::model::DatabaseInstance::psc_service_attachment_link].
     pub fn set_psc_service_attachment_link<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.psc_service_attachment_link = v.into();
         self
     }
 
-    /// Sets the value of `dns_name`.
+    /// Sets the value of [dns_name][crate::model::DatabaseInstance::dns_name].
     pub fn set_dns_name<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.dns_name = v.into();
         self
     }
 
-    /// Sets the value of `primary_dns_name`.
+    /// Sets the value of [primary_dns_name][crate::model::DatabaseInstance::primary_dns_name].
     pub fn set_primary_dns_name<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.primary_dns_name = v.into();
         self
     }
 
-    /// Sets the value of `write_endpoint`.
+    /// Sets the value of [write_endpoint][crate::model::DatabaseInstance::write_endpoint].
     pub fn set_write_endpoint<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.write_endpoint = v.into();
         self
     }
 
-    /// Sets the value of `replication_cluster`.
+    /// Sets the value of [replication_cluster][crate::model::DatabaseInstance::replication_cluster].
     pub fn set_replication_cluster<T: std::convert::Into<std::option::Option<crate::model::ReplicationCluster>>>(mut self, v: T) -> Self {
         self.replication_cluster = v.into();
         self
     }
 
-    /// Sets the value of `gemini_config`.
+    /// Sets the value of [gemini_config][crate::model::DatabaseInstance::gemini_config].
     pub fn set_gemini_config<T: std::convert::Into<std::option::Option<crate::model::GeminiInstanceConfig>>>(mut self, v: T) -> Self {
         self.gemini_config = v.into();
         self
     }
 
-    /// Sets the value of `satisfies_pzi`.
+    /// Sets the value of [satisfies_pzi][crate::model::DatabaseInstance::satisfies_pzi].
     pub fn set_satisfies_pzi<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.satisfies_pzi = v.into();
         self
     }
 
-    /// Sets the value of `switch_transaction_logs_to_cloud_storage_enabled`.
+    /// Sets the value of [switch_transaction_logs_to_cloud_storage_enabled][crate::model::DatabaseInstance::switch_transaction_logs_to_cloud_storage_enabled].
     pub fn set_switch_transaction_logs_to_cloud_storage_enabled<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.switch_transaction_logs_to_cloud_storage_enabled = v.into();
+        self
+    }
+
+    /// Sets the value of [replica_names][crate::model::DatabaseInstance::replica_names].
+    pub fn set_replica_names<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.replica_names = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [ip_addresses][crate::model::DatabaseInstance::ip_addresses].
+    pub fn set_ip_addresses<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::IpMapping>
+    {
+        use std::iter::Iterator;
+        self.ip_addresses = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [suspension_reason][crate::model::DatabaseInstance::suspension_reason].
+    pub fn set_suspension_reason<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SqlSuspensionReason>
+    {
+        use std::iter::Iterator;
+        self.suspension_reason = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [available_maintenance_versions][crate::model::DatabaseInstance::available_maintenance_versions].
+    pub fn set_available_maintenance_versions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.available_maintenance_versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [upgradable_database_versions][crate::model::DatabaseInstance::upgradable_database_versions].
+    pub fn set_upgradable_database_versions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AvailableDatabaseVersion>
+    {
+        use std::iter::Iterator;
+        self.upgradable_database_versions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4191,13 +4281,13 @@ pub mod database_instance {
 
     impl SqlFailoverReplica {
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::database_instance::SqlFailoverReplica::name].
         pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.name = v.into();
             self
         }
 
-        /// Sets the value of `available`.
+        /// Sets the value of [available][crate::model::database_instance::SqlFailoverReplica::available].
         pub fn set_available<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
             self.available = v.into();
             self
@@ -4233,25 +4323,25 @@ pub mod database_instance {
 
     impl SqlScheduledMaintenance {
 
-        /// Sets the value of `start_time`.
+        /// Sets the value of [start_time][crate::model::database_instance::SqlScheduledMaintenance::start_time].
         pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
             self.start_time = v.into();
             self
         }
 
-        /// Sets the value of `can_defer`.
+        /// Sets the value of [can_defer][crate::model::database_instance::SqlScheduledMaintenance::can_defer].
         pub fn set_can_defer<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.can_defer = v.into();
             self
         }
 
-        /// Sets the value of `can_reschedule`.
+        /// Sets the value of [can_reschedule][crate::model::database_instance::SqlScheduledMaintenance::can_reschedule].
         pub fn set_can_reschedule<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.can_reschedule = v.into();
             self
         }
 
-        /// Sets the value of `schedule_deadline_time`.
+        /// Sets the value of [schedule_deadline_time][crate::model::database_instance::SqlScheduledMaintenance::schedule_deadline_time].
         pub fn set_schedule_deadline_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
             self.schedule_deadline_time = v.into();
             self
@@ -4293,13 +4383,13 @@ pub mod database_instance {
 
     impl SqlOutOfDiskReport {
 
-        /// Sets the value of `sql_out_of_disk_state`.
+        /// Sets the value of [sql_out_of_disk_state][crate::model::database_instance::SqlOutOfDiskReport::sql_out_of_disk_state].
         pub fn set_sql_out_of_disk_state<T: std::convert::Into<std::option::Option<crate::model::database_instance::sql_out_of_disk_report::SqlOutOfDiskState>>>(mut self, v: T) -> Self {
             self.sql_out_of_disk_state = v.into();
             self
         }
 
-        /// Sets the value of `sql_min_recommended_increase_size_gb`.
+        /// Sets the value of [sql_min_recommended_increase_size_gb][crate::model::database_instance::SqlOutOfDiskReport::sql_min_recommended_increase_size_gb].
         pub fn set_sql_min_recommended_increase_size_gb<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
             self.sql_min_recommended_increase_size_gb = v.into();
             self
@@ -4460,37 +4550,37 @@ pub struct GeminiInstanceConfig {
 
 impl GeminiInstanceConfig {
 
-    /// Sets the value of `entitled`.
+    /// Sets the value of [entitled][crate::model::GeminiInstanceConfig::entitled].
     pub fn set_entitled<T: std::convert::Into<std::option::Option<bool>>>(mut self, v: T) -> Self {
         self.entitled = v.into();
         self
     }
 
-    /// Sets the value of `google_vacuum_mgmt_enabled`.
+    /// Sets the value of [google_vacuum_mgmt_enabled][crate::model::GeminiInstanceConfig::google_vacuum_mgmt_enabled].
     pub fn set_google_vacuum_mgmt_enabled<T: std::convert::Into<std::option::Option<bool>>>(mut self, v: T) -> Self {
         self.google_vacuum_mgmt_enabled = v.into();
         self
     }
 
-    /// Sets the value of `oom_session_cancel_enabled`.
+    /// Sets the value of [oom_session_cancel_enabled][crate::model::GeminiInstanceConfig::oom_session_cancel_enabled].
     pub fn set_oom_session_cancel_enabled<T: std::convert::Into<std::option::Option<bool>>>(mut self, v: T) -> Self {
         self.oom_session_cancel_enabled = v.into();
         self
     }
 
-    /// Sets the value of `active_query_enabled`.
+    /// Sets the value of [active_query_enabled][crate::model::GeminiInstanceConfig::active_query_enabled].
     pub fn set_active_query_enabled<T: std::convert::Into<std::option::Option<bool>>>(mut self, v: T) -> Self {
         self.active_query_enabled = v.into();
         self
     }
 
-    /// Sets the value of `index_advisor_enabled`.
+    /// Sets the value of [index_advisor_enabled][crate::model::GeminiInstanceConfig::index_advisor_enabled].
     pub fn set_index_advisor_enabled<T: std::convert::Into<std::option::Option<bool>>>(mut self, v: T) -> Self {
         self.index_advisor_enabled = v.into();
         self
     }
 
-    /// Sets the value of `flag_recommender_enabled`.
+    /// Sets the value of [flag_recommender_enabled][crate::model::GeminiInstanceConfig::flag_recommender_enabled].
     pub fn set_flag_recommender_enabled<T: std::convert::Into<std::option::Option<bool>>>(mut self, v: T) -> Self {
         self.flag_recommender_enabled = v.into();
         self
@@ -4539,19 +4629,19 @@ pub struct ReplicationCluster {
 
 impl ReplicationCluster {
 
-    /// Sets the value of `psa_write_endpoint`.
+    /// Sets the value of [psa_write_endpoint][crate::model::ReplicationCluster::psa_write_endpoint].
     pub fn set_psa_write_endpoint<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.psa_write_endpoint = v.into();
         self
     }
 
-    /// Sets the value of `failover_dr_replica_name`.
+    /// Sets the value of [failover_dr_replica_name][crate::model::ReplicationCluster::failover_dr_replica_name].
     pub fn set_failover_dr_replica_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.failover_dr_replica_name = v.into();
         self
     }
 
-    /// Sets the value of `dr_replica`.
+    /// Sets the value of [dr_replica][crate::model::ReplicationCluster::dr_replica].
     pub fn set_dr_replica<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.dr_replica = v.into();
         self
@@ -4587,19 +4677,19 @@ pub struct AvailableDatabaseVersion {
 
 impl AvailableDatabaseVersion {
 
-    /// Sets the value of `major_version`.
+    /// Sets the value of [major_version][crate::model::AvailableDatabaseVersion::major_version].
     pub fn set_major_version<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.major_version = v.into();
         self
     }
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::AvailableDatabaseVersion::name].
     pub fn set_name<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::AvailableDatabaseVersion::display_name].
     pub fn set_display_name<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.display_name = v.into();
         self
@@ -4626,7 +4716,7 @@ pub struct SqlInstancesRescheduleMaintenanceRequestBody {
 
 impl SqlInstancesRescheduleMaintenanceRequestBody {
 
-    /// Sets the value of `reschedule`.
+    /// Sets the value of [reschedule][crate::model::SqlInstancesRescheduleMaintenanceRequestBody::reschedule].
     pub fn set_reschedule<T: std::convert::Into<std::option::Option<crate::model::sql_instances_reschedule_maintenance_request_body::Reschedule>>>(mut self, v: T) -> Self {
         self.reschedule = v.into();
         self
@@ -4664,13 +4754,13 @@ pub mod sql_instances_reschedule_maintenance_request_body {
 
     impl Reschedule {
 
-        /// Sets the value of `reschedule_type`.
+        /// Sets the value of [reschedule_type][crate::model::sql_instances_reschedule_maintenance_request_body::Reschedule::reschedule_type].
         pub fn set_reschedule_type<T: std::convert::Into<crate::model::sql_instances_reschedule_maintenance_request_body::RescheduleType>>(mut self, v: T) -> Self {
             self.reschedule_type = v.into();
             self
         }
 
-        /// Sets the value of `schedule_time`.
+        /// Sets the value of [schedule_time][crate::model::sql_instances_reschedule_maintenance_request_body::Reschedule::schedule_time].
         pub fn set_schedule_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
             self.schedule_time = v.into();
             self
@@ -4753,31 +4843,31 @@ pub struct DemoteMasterContext {
 
 impl DemoteMasterContext {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::DemoteMasterContext::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `verify_gtid_consistency`.
+    /// Sets the value of [verify_gtid_consistency][crate::model::DemoteMasterContext::verify_gtid_consistency].
     pub fn set_verify_gtid_consistency<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.verify_gtid_consistency = v.into();
         self
     }
 
-    /// Sets the value of `master_instance_name`.
+    /// Sets the value of [master_instance_name][crate::model::DemoteMasterContext::master_instance_name].
     pub fn set_master_instance_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.master_instance_name = v.into();
         self
     }
 
-    /// Sets the value of `replica_configuration`.
+    /// Sets the value of [replica_configuration][crate::model::DemoteMasterContext::replica_configuration].
     pub fn set_replica_configuration<T: std::convert::Into<std::option::Option<crate::model::DemoteMasterConfiguration>>>(mut self, v: T) -> Self {
         self.replica_configuration = v.into();
         self
     }
 
-    /// Sets the value of `skip_replication_setup`.
+    /// Sets the value of [skip_replication_setup][crate::model::DemoteMasterContext::skip_replication_setup].
     pub fn set_skip_replication_setup<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.skip_replication_setup = v.into();
         self
@@ -4810,13 +4900,13 @@ pub struct DemoteContext {
 
 impl DemoteContext {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::DemoteContext::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `source_representative_instance_name`.
+    /// Sets the value of [source_representative_instance_name][crate::model::DemoteContext::source_representative_instance_name].
     pub fn set_source_representative_instance_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.source_representative_instance_name = v.into();
         self
@@ -4848,13 +4938,13 @@ pub struct FailoverContext {
 
 impl FailoverContext {
 
-    /// Sets the value of `settings_version`.
+    /// Sets the value of [settings_version][crate::model::FailoverContext::settings_version].
     pub fn set_settings_version<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.settings_version = v.into();
         self
     }
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::FailoverContext::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
@@ -4894,25 +4984,25 @@ pub struct RestoreBackupContext {
 
 impl RestoreBackupContext {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::RestoreBackupContext::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `backup_run_id`.
+    /// Sets the value of [backup_run_id][crate::model::RestoreBackupContext::backup_run_id].
     pub fn set_backup_run_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.backup_run_id = v.into();
         self
     }
 
-    /// Sets the value of `instance_id`.
+    /// Sets the value of [instance_id][crate::model::RestoreBackupContext::instance_id].
     pub fn set_instance_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance_id = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::RestoreBackupContext::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -4944,13 +5034,13 @@ pub struct RotateServerCaContext {
 
 impl RotateServerCaContext {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::RotateServerCaContext::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `next_version`.
+    /// Sets the value of [next_version][crate::model::RotateServerCaContext::next_version].
     pub fn set_next_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_version = v.into();
         self
@@ -4982,13 +5072,13 @@ pub struct TruncateLogContext {
 
 impl TruncateLogContext {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::TruncateLogContext::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `log_type`.
+    /// Sets the value of [log_type][crate::model::TruncateLogContext::log_type].
     pub fn set_log_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.log_type = v.into();
         self
@@ -5024,19 +5114,19 @@ pub struct SqlExternalSyncSettingError {
 
 impl SqlExternalSyncSettingError {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::SqlExternalSyncSettingError::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `r#type`.
+    /// Sets the value of [r#type][crate::model::SqlExternalSyncSettingError::type].
     pub fn set_type<T: std::convert::Into<crate::model::sql_external_sync_setting_error::SqlExternalSyncSettingErrorType>>(mut self, v: T) -> Self {
         self.r#type = v.into();
         self
     }
 
-    /// Sets the value of `detail`.
+    /// Sets the value of [detail][crate::model::SqlExternalSyncSettingError::detail].
     pub fn set_detail<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.detail = v.into();
         self
@@ -5289,55 +5379,55 @@ pub struct OnPremisesConfiguration {
 
 impl OnPremisesConfiguration {
 
-    /// Sets the value of `host_port`.
+    /// Sets the value of [host_port][crate::model::OnPremisesConfiguration::host_port].
     pub fn set_host_port<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.host_port = v.into();
         self
     }
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::OnPremisesConfiguration::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `username`.
+    /// Sets the value of [username][crate::model::OnPremisesConfiguration::username].
     pub fn set_username<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.username = v.into();
         self
     }
 
-    /// Sets the value of `password`.
+    /// Sets the value of [password][crate::model::OnPremisesConfiguration::password].
     pub fn set_password<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.password = v.into();
         self
     }
 
-    /// Sets the value of `ca_certificate`.
+    /// Sets the value of [ca_certificate][crate::model::OnPremisesConfiguration::ca_certificate].
     pub fn set_ca_certificate<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.ca_certificate = v.into();
         self
     }
 
-    /// Sets the value of `client_certificate`.
+    /// Sets the value of [client_certificate][crate::model::OnPremisesConfiguration::client_certificate].
     pub fn set_client_certificate<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.client_certificate = v.into();
         self
     }
 
-    /// Sets the value of `client_key`.
+    /// Sets the value of [client_key][crate::model::OnPremisesConfiguration::client_key].
     pub fn set_client_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.client_key = v.into();
         self
     }
 
-    /// Sets the value of `dump_file_path`.
+    /// Sets the value of [dump_file_path][crate::model::OnPremisesConfiguration::dump_file_path].
     pub fn set_dump_file_path<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.dump_file_path = v.into();
         self
     }
 
-    /// Sets the value of `source_instance`.
+    /// Sets the value of [source_instance][crate::model::OnPremisesConfiguration::source_instance].
     pub fn set_source_instance<T: std::convert::Into<std::option::Option<crate::model::InstanceReference>>>(mut self, v: T) -> Self {
         self.source_instance = v.into();
         self
@@ -5387,25 +5477,25 @@ pub struct ReplicaConfiguration {
 
 impl ReplicaConfiguration {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::ReplicaConfiguration::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `mysql_replica_configuration`.
+    /// Sets the value of [mysql_replica_configuration][crate::model::ReplicaConfiguration::mysql_replica_configuration].
     pub fn set_mysql_replica_configuration<T: std::convert::Into<std::option::Option<crate::model::MySqlReplicaConfiguration>>>(mut self, v: T) -> Self {
         self.mysql_replica_configuration = v.into();
         self
     }
 
-    /// Sets the value of `failover_target`.
+    /// Sets the value of [failover_target][crate::model::ReplicaConfiguration::failover_target].
     pub fn set_failover_target<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.failover_target = v.into();
         self
     }
 
-    /// Sets the value of `cascadable_replica`.
+    /// Sets the value of [cascadable_replica][crate::model::ReplicaConfiguration::cascadable_replica].
     pub fn set_cascadable_replica<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.cascadable_replica = v.into();
         self
@@ -5444,19 +5534,19 @@ pub struct SqlInstancesAcquireSsrsLeaseRequest {
 
 impl SqlInstancesAcquireSsrsLeaseRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesAcquireSsrsLeaseRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesAcquireSsrsLeaseRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlInstancesAcquireSsrsLeaseRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::InstancesAcquireSsrsLeaseRequest>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -5483,7 +5573,7 @@ pub struct SqlInstancesAcquireSsrsLeaseResponse {
 
 impl SqlInstancesAcquireSsrsLeaseResponse {
 
-    /// Sets the value of `operation_id`.
+    /// Sets the value of [operation_id][crate::model::SqlInstancesAcquireSsrsLeaseResponse::operation_id].
     pub fn set_operation_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.operation_id = v.into();
         self
@@ -5517,13 +5607,13 @@ pub struct SqlInstancesReleaseSsrsLeaseRequest {
 
 impl SqlInstancesReleaseSsrsLeaseRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlInstancesReleaseSsrsLeaseRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlInstancesReleaseSsrsLeaseRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -5550,7 +5640,7 @@ pub struct SqlInstancesReleaseSsrsLeaseResponse {
 
 impl SqlInstancesReleaseSsrsLeaseResponse {
 
-    /// Sets the value of `operation_id`.
+    /// Sets the value of [operation_id][crate::model::SqlInstancesReleaseSsrsLeaseResponse::operation_id].
     pub fn set_operation_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.operation_id = v.into();
         self
@@ -5581,13 +5671,13 @@ pub struct SqlOperationsGetRequest {
 
 impl SqlOperationsGetRequest {
 
-    /// Sets the value of `operation`.
+    /// Sets the value of [operation][crate::model::SqlOperationsGetRequest::operation].
     pub fn set_operation<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.operation = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlOperationsGetRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -5626,25 +5716,25 @@ pub struct SqlOperationsListRequest {
 
 impl SqlOperationsListRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlOperationsListRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `max_results`.
+    /// Sets the value of [max_results][crate::model::SqlOperationsListRequest::max_results].
     pub fn set_max_results<T: std::convert::Into<u32>>(mut self, v: T) -> Self {
         self.max_results = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::SqlOperationsListRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlOperationsListRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -5680,21 +5770,26 @@ pub struct OperationsListResponse {
 
 impl OperationsListResponse {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::OperationsListResponse::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `items`.
-    pub fn set_items<T: std::convert::Into<std::vec::Vec<crate::model::Operation>>>(mut self, v: T) -> Self {
-        self.items = v.into();
+    /// Sets the value of [next_page_token][crate::model::OperationsListResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [items][crate::model::OperationsListResponse::items].
+    pub fn set_items<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Operation>
+    {
+        use std::iter::Iterator;
+        self.items = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5723,13 +5818,13 @@ pub struct SqlOperationsCancelRequest {
 
 impl SqlOperationsCancelRequest {
 
-    /// Sets the value of `operation`.
+    /// Sets the value of [operation][crate::model::SqlOperationsCancelRequest::operation].
     pub fn set_operation<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.operation = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlOperationsCancelRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -5770,25 +5865,25 @@ pub struct AclEntry {
 
 impl AclEntry {
 
-    /// Sets the value of `value`.
+    /// Sets the value of [value][crate::model::AclEntry::value].
     pub fn set_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.value = v.into();
         self
     }
 
-    /// Sets the value of `expiration_time`.
+    /// Sets the value of [expiration_time][crate::model::AclEntry::expiration_time].
     pub fn set_expiration_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.expiration_time = v.into();
         self
     }
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::AclEntry::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::AclEntry::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
@@ -5822,19 +5917,19 @@ pub struct ApiWarning {
 
 impl ApiWarning {
 
-    /// Sets the value of `code`.
+    /// Sets the value of [code][crate::model::ApiWarning::code].
     pub fn set_code<T: std::convert::Into<crate::model::api_warning::SqlApiWarningCode>>(mut self, v: T) -> Self {
         self.code = v.into();
         self
     }
 
-    /// Sets the value of `message`.
+    /// Sets the value of [message][crate::model::ApiWarning::message].
     pub fn set_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.message = v.into();
         self
     }
 
-    /// Sets the value of `region`.
+    /// Sets the value of [region][crate::model::ApiWarning::region].
     pub fn set_region<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.region = v.into();
         self
@@ -5913,13 +6008,13 @@ pub struct BackupRetentionSettings {
 
 impl BackupRetentionSettings {
 
-    /// Sets the value of `retention_unit`.
+    /// Sets the value of [retention_unit][crate::model::BackupRetentionSettings::retention_unit].
     pub fn set_retention_unit<T: std::convert::Into<crate::model::backup_retention_settings::RetentionUnit>>(mut self, v: T) -> Self {
         self.retention_unit = v.into();
         self
     }
 
-    /// Sets the value of `retained_backups`.
+    /// Sets the value of [retained_backups][crate::model::BackupRetentionSettings::retained_backups].
     pub fn set_retained_backups<T: std::convert::Into<std::option::Option<wkt::Int32Value>>>(mut self, v: T) -> Self {
         self.retained_backups = v.into();
         self
@@ -6020,61 +6115,61 @@ pub struct BackupConfiguration {
 
 impl BackupConfiguration {
 
-    /// Sets the value of `start_time`.
+    /// Sets the value of [start_time][crate::model::BackupConfiguration::start_time].
     pub fn set_start_time<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.start_time = v.into();
         self
     }
 
-    /// Sets the value of `enabled`.
+    /// Sets the value of [enabled][crate::model::BackupConfiguration::enabled].
     pub fn set_enabled<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.enabled = v.into();
         self
     }
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::BackupConfiguration::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `binary_log_enabled`.
+    /// Sets the value of [binary_log_enabled][crate::model::BackupConfiguration::binary_log_enabled].
     pub fn set_binary_log_enabled<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.binary_log_enabled = v.into();
         self
     }
 
-    /// Sets the value of `replication_log_archiving_enabled`.
+    /// Sets the value of [replication_log_archiving_enabled][crate::model::BackupConfiguration::replication_log_archiving_enabled].
     pub fn set_replication_log_archiving_enabled<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.replication_log_archiving_enabled = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::BackupConfiguration::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `point_in_time_recovery_enabled`.
+    /// Sets the value of [point_in_time_recovery_enabled][crate::model::BackupConfiguration::point_in_time_recovery_enabled].
     pub fn set_point_in_time_recovery_enabled<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.point_in_time_recovery_enabled = v.into();
         self
     }
 
-    /// Sets the value of `backup_retention_settings`.
+    /// Sets the value of [backup_retention_settings][crate::model::BackupConfiguration::backup_retention_settings].
     pub fn set_backup_retention_settings<T: std::convert::Into<std::option::Option<crate::model::BackupRetentionSettings>>>(mut self, v: T) -> Self {
         self.backup_retention_settings = v.into();
         self
     }
 
-    /// Sets the value of `transaction_log_retention_days`.
+    /// Sets the value of [transaction_log_retention_days][crate::model::BackupConfiguration::transaction_log_retention_days].
     pub fn set_transaction_log_retention_days<T: std::convert::Into<std::option::Option<wkt::Int32Value>>>(mut self, v: T) -> Self {
         self.transaction_log_retention_days = v.into();
         self
     }
 
-    /// Sets the value of `transactional_log_storage_state`.
+    /// Sets the value of [transactional_log_storage_state][crate::model::BackupConfiguration::transactional_log_storage_state].
     pub fn set_transactional_log_storage_state<T: std::convert::Into<std::option::Option<crate::model::backup_configuration::TransactionalLogStorageState>>>(mut self, v: T) -> Self {
         self.transactional_log_storage_state = v.into();
         self
@@ -6151,7 +6246,7 @@ pub struct PerformDiskShrinkContext {
 
 impl PerformDiskShrinkContext {
 
-    /// Sets the value of `target_size_gb`.
+    /// Sets the value of [target_size_gb][crate::model::PerformDiskShrinkContext::target_size_gb].
     pub fn set_target_size_gb<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.target_size_gb = v.into();
         self
@@ -6182,13 +6277,13 @@ pub struct BackupContext {
 
 impl BackupContext {
 
-    /// Sets the value of `backup_id`.
+    /// Sets the value of [backup_id][crate::model::BackupContext::backup_id].
     pub fn set_backup_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.backup_id = v.into();
         self
     }
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::BackupContext::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
@@ -6249,49 +6344,49 @@ pub struct Database {
 
 impl Database {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::Database::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `charset`.
+    /// Sets the value of [charset][crate::model::Database::charset].
     pub fn set_charset<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.charset = v.into();
         self
     }
 
-    /// Sets the value of `collation`.
+    /// Sets the value of [collation][crate::model::Database::collation].
     pub fn set_collation<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.collation = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::Database::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Database::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::Database::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `self_link`.
+    /// Sets the value of [self_link][crate::model::Database::self_link].
     pub fn set_self_link<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.self_link = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::Database::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -6341,13 +6436,13 @@ pub struct SqlServerDatabaseDetails {
 
 impl SqlServerDatabaseDetails {
 
-    /// Sets the value of `compatibility_level`.
+    /// Sets the value of [compatibility_level][crate::model::SqlServerDatabaseDetails::compatibility_level].
     pub fn set_compatibility_level<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.compatibility_level = v.into();
         self
     }
 
-    /// Sets the value of `recovery_model`.
+    /// Sets the value of [recovery_model][crate::model::SqlServerDatabaseDetails::recovery_model].
     pub fn set_recovery_model<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.recovery_model = v.into();
         self
@@ -6384,13 +6479,13 @@ pub struct DatabaseFlags {
 
 impl DatabaseFlags {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DatabaseFlags::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `value`.
+    /// Sets the value of [value][crate::model::DatabaseFlags::value].
     pub fn set_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.value = v.into();
         self
@@ -6417,9 +6512,14 @@ pub struct MySqlSyncConfig {
 
 impl MySqlSyncConfig {
 
-    /// Sets the value of `initial_sync_flags`.
-    pub fn set_initial_sync_flags<T: std::convert::Into<std::vec::Vec<crate::model::SyncFlags>>>(mut self, v: T) -> Self {
-        self.initial_sync_flags = v.into();
+    /// Sets the value of [initial_sync_flags][crate::model::MySqlSyncConfig::initial_sync_flags].
+    pub fn set_initial_sync_flags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SyncFlags>
+    {
+        use std::iter::Iterator;
+        self.initial_sync_flags = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -6450,13 +6550,13 @@ pub struct SyncFlags {
 
 impl SyncFlags {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::SyncFlags::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `value`.
+    /// Sets the value of [value][crate::model::SyncFlags::value].
     pub fn set_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.value = v.into();
         self
@@ -6493,19 +6593,19 @@ pub struct InstanceReference {
 
 impl InstanceReference {
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::InstanceReference::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `region`.
+    /// Sets the value of [region][crate::model::InstanceReference::region].
     pub fn set_region<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.region = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::InstanceReference::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -6542,13 +6642,13 @@ pub struct DemoteMasterConfiguration {
 
 impl DemoteMasterConfiguration {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::DemoteMasterConfiguration::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `mysql_replica_configuration`.
+    /// Sets the value of [mysql_replica_configuration][crate::model::DemoteMasterConfiguration::mysql_replica_configuration].
     pub fn set_mysql_replica_configuration<T: std::convert::Into<std::option::Option<crate::model::DemoteMasterMySqlReplicaConfiguration>>>(mut self, v: T) -> Self {
         self.mysql_replica_configuration = v.into();
         self
@@ -6597,37 +6697,37 @@ pub struct DemoteMasterMySqlReplicaConfiguration {
 
 impl DemoteMasterMySqlReplicaConfiguration {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::DemoteMasterMySqlReplicaConfiguration::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `username`.
+    /// Sets the value of [username][crate::model::DemoteMasterMySqlReplicaConfiguration::username].
     pub fn set_username<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.username = v.into();
         self
     }
 
-    /// Sets the value of `password`.
+    /// Sets the value of [password][crate::model::DemoteMasterMySqlReplicaConfiguration::password].
     pub fn set_password<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.password = v.into();
         self
     }
 
-    /// Sets the value of `client_key`.
+    /// Sets the value of [client_key][crate::model::DemoteMasterMySqlReplicaConfiguration::client_key].
     pub fn set_client_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.client_key = v.into();
         self
     }
 
-    /// Sets the value of `client_certificate`.
+    /// Sets the value of [client_certificate][crate::model::DemoteMasterMySqlReplicaConfiguration::client_certificate].
     pub fn set_client_certificate<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.client_certificate = v.into();
         self
     }
 
-    /// Sets the value of `ca_certificate`.
+    /// Sets the value of [ca_certificate][crate::model::DemoteMasterMySqlReplicaConfiguration::ca_certificate].
     pub fn set_ca_certificate<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.ca_certificate = v.into();
         self
@@ -6697,51 +6797,56 @@ pub struct ExportContext {
 
 impl ExportContext {
 
-    /// Sets the value of `uri`.
+    /// Sets the value of [uri][crate::model::ExportContext::uri].
     pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.uri = v.into();
         self
     }
 
-    /// Sets the value of `databases`.
-    pub fn set_databases<T: std::convert::Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-        self.databases = v.into();
-        self
-    }
-
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::ExportContext::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `sql_export_options`.
+    /// Sets the value of [sql_export_options][crate::model::ExportContext::sql_export_options].
     pub fn set_sql_export_options<T: std::convert::Into<std::option::Option<crate::model::export_context::SqlExportOptions>>>(mut self, v: T) -> Self {
         self.sql_export_options = v.into();
         self
     }
 
-    /// Sets the value of `csv_export_options`.
+    /// Sets the value of [csv_export_options][crate::model::ExportContext::csv_export_options].
     pub fn set_csv_export_options<T: std::convert::Into<std::option::Option<crate::model::export_context::SqlCsvExportOptions>>>(mut self, v: T) -> Self {
         self.csv_export_options = v.into();
         self
     }
 
-    /// Sets the value of `file_type`.
+    /// Sets the value of [file_type][crate::model::ExportContext::file_type].
     pub fn set_file_type<T: std::convert::Into<crate::model::SqlFileType>>(mut self, v: T) -> Self {
         self.file_type = v.into();
         self
     }
 
-    /// Sets the value of `offload`.
+    /// Sets the value of [offload][crate::model::ExportContext::offload].
     pub fn set_offload<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.offload = v.into();
         self
     }
 
-    /// Sets the value of `bak_export_options`.
+    /// Sets the value of [bak_export_options][crate::model::ExportContext::bak_export_options].
     pub fn set_bak_export_options<T: std::convert::Into<std::option::Option<crate::model::export_context::SqlBakExportOptions>>>(mut self, v: T) -> Self {
         self.bak_export_options = v.into();
+        self
+    }
+
+    /// Sets the value of [databases][crate::model::ExportContext::databases].
+    pub fn set_databases<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.databases = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -6790,31 +6895,31 @@ pub mod export_context {
 
     impl SqlCsvExportOptions {
 
-        /// Sets the value of `select_query`.
+        /// Sets the value of [select_query][crate::model::export_context::SqlCsvExportOptions::select_query].
         pub fn set_select_query<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.select_query = v.into();
             self
         }
 
-        /// Sets the value of `escape_character`.
+        /// Sets the value of [escape_character][crate::model::export_context::SqlCsvExportOptions::escape_character].
         pub fn set_escape_character<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.escape_character = v.into();
             self
         }
 
-        /// Sets the value of `quote_character`.
+        /// Sets the value of [quote_character][crate::model::export_context::SqlCsvExportOptions::quote_character].
         pub fn set_quote_character<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.quote_character = v.into();
             self
         }
 
-        /// Sets the value of `fields_terminated_by`.
+        /// Sets the value of [fields_terminated_by][crate::model::export_context::SqlCsvExportOptions::fields_terminated_by].
         pub fn set_fields_terminated_by<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.fields_terminated_by = v.into();
             self
         }
 
-        /// Sets the value of `lines_terminated_by`.
+        /// Sets the value of [lines_terminated_by][crate::model::export_context::SqlCsvExportOptions::lines_terminated_by].
         pub fn set_lines_terminated_by<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.lines_terminated_by = v.into();
             self
@@ -6861,39 +6966,44 @@ pub mod export_context {
 
     impl SqlExportOptions {
 
-        /// Sets the value of `tables`.
-        pub fn set_tables<T: std::convert::Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-            self.tables = v.into();
-            self
-        }
-
-        /// Sets the value of `schema_only`.
+        /// Sets the value of [schema_only][crate::model::export_context::SqlExportOptions::schema_only].
         pub fn set_schema_only<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
             self.schema_only = v.into();
             self
         }
 
-        /// Sets the value of `mysql_export_options`.
+        /// Sets the value of [mysql_export_options][crate::model::export_context::SqlExportOptions::mysql_export_options].
         pub fn set_mysql_export_options<T: std::convert::Into<std::option::Option<crate::model::export_context::sql_export_options::MysqlExportOptions>>>(mut self, v: T) -> Self {
             self.mysql_export_options = v.into();
             self
         }
 
-        /// Sets the value of `threads`.
+        /// Sets the value of [threads][crate::model::export_context::SqlExportOptions::threads].
         pub fn set_threads<T: std::convert::Into<std::option::Option<wkt::Int32Value>>>(mut self, v: T) -> Self {
             self.threads = v.into();
             self
         }
 
-        /// Sets the value of `parallel`.
+        /// Sets the value of [parallel][crate::model::export_context::SqlExportOptions::parallel].
         pub fn set_parallel<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
             self.parallel = v.into();
             self
         }
 
-        /// Sets the value of `postgres_export_options`.
+        /// Sets the value of [postgres_export_options][crate::model::export_context::SqlExportOptions::postgres_export_options].
         pub fn set_postgres_export_options<T: std::convert::Into<std::option::Option<crate::model::export_context::sql_export_options::PostgresExportOptions>>>(mut self, v: T) -> Self {
             self.postgres_export_options = v.into();
+            self
+        }
+
+        /// Sets the value of [tables][crate::model::export_context::SqlExportOptions::tables].
+        pub fn set_tables<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>
+        {
+            use std::iter::Iterator;
+            self.tables = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -6929,7 +7039,7 @@ pub mod export_context {
 
         impl MysqlExportOptions {
 
-            /// Sets the value of `master_data`.
+            /// Sets the value of [master_data][crate::model::export_context::sql_export_options::MysqlExportOptions::master_data].
             pub fn set_master_data<T: std::convert::Into<std::option::Option<wkt::Int32Value>>>(mut self, v: T) -> Self {
                 self.master_data = v.into();
                 self
@@ -6963,13 +7073,13 @@ pub mod export_context {
 
         impl PostgresExportOptions {
 
-            /// Sets the value of `clean`.
+            /// Sets the value of [clean][crate::model::export_context::sql_export_options::PostgresExportOptions::clean].
             pub fn set_clean<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
                 self.clean = v.into();
                 self
             }
 
-            /// Sets the value of `if_exists`.
+            /// Sets the value of [if_exists][crate::model::export_context::sql_export_options::PostgresExportOptions::if_exists].
             pub fn set_if_exists<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
                 self.if_exists = v.into();
                 self
@@ -7015,31 +7125,31 @@ pub mod export_context {
 
     impl SqlBakExportOptions {
 
-        /// Sets the value of `striped`.
+        /// Sets the value of [striped][crate::model::export_context::SqlBakExportOptions::striped].
         pub fn set_striped<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
             self.striped = v.into();
             self
         }
 
-        /// Sets the value of `stripe_count`.
+        /// Sets the value of [stripe_count][crate::model::export_context::SqlBakExportOptions::stripe_count].
         pub fn set_stripe_count<T: std::convert::Into<std::option::Option<wkt::Int32Value>>>(mut self, v: T) -> Self {
             self.stripe_count = v.into();
             self
         }
 
-        /// Sets the value of `bak_type`.
+        /// Sets the value of [bak_type][crate::model::export_context::SqlBakExportOptions::bak_type].
         pub fn set_bak_type<T: std::convert::Into<crate::model::BakType>>(mut self, v: T) -> Self {
             self.bak_type = v.into();
             self
         }
 
-        /// Sets the value of `copy_only`.
+        /// Sets the value of [copy_only][crate::model::export_context::SqlBakExportOptions::copy_only].
         pub fn set_copy_only<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
             self.copy_only = v.into();
             self
         }
 
-        /// Sets the value of `differential_base`.
+        /// Sets the value of [differential_base][crate::model::export_context::SqlBakExportOptions::differential_base].
         pub fn set_differential_base<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
             self.differential_base = v.into();
             self
@@ -7101,49 +7211,49 @@ pub struct ImportContext {
 
 impl ImportContext {
 
-    /// Sets the value of `uri`.
+    /// Sets the value of [uri][crate::model::ImportContext::uri].
     pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.uri = v.into();
         self
     }
 
-    /// Sets the value of `database`.
+    /// Sets the value of [database][crate::model::ImportContext::database].
     pub fn set_database<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.database = v.into();
         self
     }
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::ImportContext::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `file_type`.
+    /// Sets the value of [file_type][crate::model::ImportContext::file_type].
     pub fn set_file_type<T: std::convert::Into<crate::model::SqlFileType>>(mut self, v: T) -> Self {
         self.file_type = v.into();
         self
     }
 
-    /// Sets the value of `csv_import_options`.
+    /// Sets the value of [csv_import_options][crate::model::ImportContext::csv_import_options].
     pub fn set_csv_import_options<T: std::convert::Into<std::option::Option<crate::model::import_context::SqlCsvImportOptions>>>(mut self, v: T) -> Self {
         self.csv_import_options = v.into();
         self
     }
 
-    /// Sets the value of `import_user`.
+    /// Sets the value of [import_user][crate::model::ImportContext::import_user].
     pub fn set_import_user<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.import_user = v.into();
         self
     }
 
-    /// Sets the value of `bak_import_options`.
+    /// Sets the value of [bak_import_options][crate::model::ImportContext::bak_import_options].
     pub fn set_bak_import_options<T: std::convert::Into<std::option::Option<crate::model::import_context::SqlBakImportOptions>>>(mut self, v: T) -> Self {
         self.bak_import_options = v.into();
         self
     }
 
-    /// Sets the value of `sql_import_options`.
+    /// Sets the value of [sql_import_options][crate::model::ImportContext::sql_import_options].
     pub fn set_sql_import_options<T: std::convert::Into<std::option::Option<crate::model::import_context::SqlImportOptions>>>(mut self, v: T) -> Self {
         self.sql_import_options = v.into();
         self
@@ -7183,19 +7293,19 @@ pub mod import_context {
 
     impl SqlImportOptions {
 
-        /// Sets the value of `threads`.
+        /// Sets the value of [threads][crate::model::import_context::SqlImportOptions::threads].
         pub fn set_threads<T: std::convert::Into<std::option::Option<wkt::Int32Value>>>(mut self, v: T) -> Self {
             self.threads = v.into();
             self
         }
 
-        /// Sets the value of `parallel`.
+        /// Sets the value of [parallel][crate::model::import_context::SqlImportOptions::parallel].
         pub fn set_parallel<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
             self.parallel = v.into();
             self
         }
 
-        /// Sets the value of `postgres_import_options`.
+        /// Sets the value of [postgres_import_options][crate::model::import_context::SqlImportOptions::postgres_import_options].
         pub fn set_postgres_import_options<T: std::convert::Into<std::option::Option<crate::model::import_context::sql_import_options::PostgresImportOptions>>>(mut self, v: T) -> Self {
             self.postgres_import_options = v.into();
             self
@@ -7233,13 +7343,13 @@ pub mod import_context {
 
         impl PostgresImportOptions {
 
-            /// Sets the value of `clean`.
+            /// Sets the value of [clean][crate::model::import_context::sql_import_options::PostgresImportOptions::clean].
             pub fn set_clean<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
                 self.clean = v.into();
                 self
             }
 
-            /// Sets the value of `if_exists`.
+            /// Sets the value of [if_exists][crate::model::import_context::sql_import_options::PostgresImportOptions::if_exists].
             pub fn set_if_exists<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
                 self.if_exists = v.into();
                 self
@@ -7290,39 +7400,44 @@ pub mod import_context {
 
     impl SqlCsvImportOptions {
 
-        /// Sets the value of `table`.
+        /// Sets the value of [table][crate::model::import_context::SqlCsvImportOptions::table].
         pub fn set_table<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.table = v.into();
             self
         }
 
-        /// Sets the value of `columns`.
-        pub fn set_columns<T: std::convert::Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-            self.columns = v.into();
-            self
-        }
-
-        /// Sets the value of `escape_character`.
+        /// Sets the value of [escape_character][crate::model::import_context::SqlCsvImportOptions::escape_character].
         pub fn set_escape_character<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.escape_character = v.into();
             self
         }
 
-        /// Sets the value of `quote_character`.
+        /// Sets the value of [quote_character][crate::model::import_context::SqlCsvImportOptions::quote_character].
         pub fn set_quote_character<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.quote_character = v.into();
             self
         }
 
-        /// Sets the value of `fields_terminated_by`.
+        /// Sets the value of [fields_terminated_by][crate::model::import_context::SqlCsvImportOptions::fields_terminated_by].
         pub fn set_fields_terminated_by<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.fields_terminated_by = v.into();
             self
         }
 
-        /// Sets the value of `lines_terminated_by`.
+        /// Sets the value of [lines_terminated_by][crate::model::import_context::SqlCsvImportOptions::lines_terminated_by].
         pub fn set_lines_terminated_by<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.lines_terminated_by = v.into();
+            self
+        }
+
+        /// Sets the value of [columns][crate::model::import_context::SqlCsvImportOptions::columns].
+        pub fn set_columns<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>
+        {
+            use std::iter::Iterator;
+            self.columns = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -7379,43 +7494,43 @@ pub mod import_context {
 
     impl SqlBakImportOptions {
 
-        /// Sets the value of `encryption_options`.
+        /// Sets the value of [encryption_options][crate::model::import_context::SqlBakImportOptions::encryption_options].
         pub fn set_encryption_options<T: std::convert::Into<std::option::Option<crate::model::import_context::sql_bak_import_options::EncryptionOptions>>>(mut self, v: T) -> Self {
             self.encryption_options = v.into();
             self
         }
 
-        /// Sets the value of `striped`.
+        /// Sets the value of [striped][crate::model::import_context::SqlBakImportOptions::striped].
         pub fn set_striped<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
             self.striped = v.into();
             self
         }
 
-        /// Sets the value of `no_recovery`.
+        /// Sets the value of [no_recovery][crate::model::import_context::SqlBakImportOptions::no_recovery].
         pub fn set_no_recovery<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
             self.no_recovery = v.into();
             self
         }
 
-        /// Sets the value of `recovery_only`.
+        /// Sets the value of [recovery_only][crate::model::import_context::SqlBakImportOptions::recovery_only].
         pub fn set_recovery_only<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
             self.recovery_only = v.into();
             self
         }
 
-        /// Sets the value of `bak_type`.
+        /// Sets the value of [bak_type][crate::model::import_context::SqlBakImportOptions::bak_type].
         pub fn set_bak_type<T: std::convert::Into<crate::model::BakType>>(mut self, v: T) -> Self {
             self.bak_type = v.into();
             self
         }
 
-        /// Sets the value of `stop_at`.
+        /// Sets the value of [stop_at][crate::model::import_context::SqlBakImportOptions::stop_at].
         pub fn set_stop_at<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
             self.stop_at = v.into();
             self
         }
 
-        /// Sets the value of `stop_at_mark`.
+        /// Sets the value of [stop_at_mark][crate::model::import_context::SqlBakImportOptions::stop_at_mark].
         pub fn set_stop_at_mark<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.stop_at_mark = v.into();
             self
@@ -7459,19 +7574,19 @@ pub mod import_context {
 
         impl EncryptionOptions {
 
-            /// Sets the value of `cert_path`.
+            /// Sets the value of [cert_path][crate::model::import_context::sql_bak_import_options::EncryptionOptions::cert_path].
             pub fn set_cert_path<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
                 self.cert_path = v.into();
                 self
             }
 
-            /// Sets the value of `pvk_path`.
+            /// Sets the value of [pvk_path][crate::model::import_context::sql_bak_import_options::EncryptionOptions::pvk_path].
             pub fn set_pvk_path<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
                 self.pvk_path = v.into();
                 self
             }
 
-            /// Sets the value of `pvk_password`.
+            /// Sets the value of [pvk_password][crate::model::import_context::sql_bak_import_options::EncryptionOptions::pvk_password].
             pub fn set_pvk_password<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
                 self.pvk_password = v.into();
                 self
@@ -7571,57 +7686,62 @@ pub struct IpConfiguration {
 
 impl IpConfiguration {
 
-    /// Sets the value of `ipv4_enabled`.
+    /// Sets the value of [ipv4_enabled][crate::model::IpConfiguration::ipv4_enabled].
     pub fn set_ipv4_enabled<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.ipv4_enabled = v.into();
         self
     }
 
-    /// Sets the value of `private_network`.
+    /// Sets the value of [private_network][crate::model::IpConfiguration::private_network].
     pub fn set_private_network<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.private_network = v.into();
         self
     }
 
-    /// Sets the value of `require_ssl`.
+    /// Sets the value of [require_ssl][crate::model::IpConfiguration::require_ssl].
     pub fn set_require_ssl<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.require_ssl = v.into();
         self
     }
 
-    /// Sets the value of `authorized_networks`.
-    pub fn set_authorized_networks<T: std::convert::Into<std::vec::Vec<crate::model::AclEntry>>>(mut self, v: T) -> Self {
-        self.authorized_networks = v.into();
-        self
-    }
-
-    /// Sets the value of `allocated_ip_range`.
+    /// Sets the value of [allocated_ip_range][crate::model::IpConfiguration::allocated_ip_range].
     pub fn set_allocated_ip_range<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.allocated_ip_range = v.into();
         self
     }
 
-    /// Sets the value of `enable_private_path_for_google_cloud_services`.
+    /// Sets the value of [enable_private_path_for_google_cloud_services][crate::model::IpConfiguration::enable_private_path_for_google_cloud_services].
     pub fn set_enable_private_path_for_google_cloud_services<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.enable_private_path_for_google_cloud_services = v.into();
         self
     }
 
-    /// Sets the value of `ssl_mode`.
+    /// Sets the value of [ssl_mode][crate::model::IpConfiguration::ssl_mode].
     pub fn set_ssl_mode<T: std::convert::Into<crate::model::ip_configuration::SslMode>>(mut self, v: T) -> Self {
         self.ssl_mode = v.into();
         self
     }
 
-    /// Sets the value of `psc_config`.
+    /// Sets the value of [psc_config][crate::model::IpConfiguration::psc_config].
     pub fn set_psc_config<T: std::convert::Into<std::option::Option<crate::model::PscConfig>>>(mut self, v: T) -> Self {
         self.psc_config = v.into();
         self
     }
 
-    /// Sets the value of `server_ca_mode`.
+    /// Sets the value of [server_ca_mode][crate::model::IpConfiguration::server_ca_mode].
     pub fn set_server_ca_mode<T: std::convert::Into<std::option::Option<crate::model::ip_configuration::CaMode>>>(mut self, v: T) -> Self {
         self.server_ca_mode = v.into();
+        self
+    }
+
+    /// Sets the value of [authorized_networks][crate::model::IpConfiguration::authorized_networks].
+    pub fn set_authorized_networks<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AclEntry>
+    {
+        use std::iter::Iterator;
+        self.authorized_networks = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -7749,15 +7869,20 @@ pub struct PscConfig {
 
 impl PscConfig {
 
-    /// Sets the value of `psc_enabled`.
+    /// Sets the value of [psc_enabled][crate::model::PscConfig::psc_enabled].
     pub fn set_psc_enabled<T: std::convert::Into<std::option::Option<bool>>>(mut self, v: T) -> Self {
         self.psc_enabled = v.into();
         self
     }
 
-    /// Sets the value of `allowed_consumer_projects`.
-    pub fn set_allowed_consumer_projects<T: std::convert::Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-        self.allowed_consumer_projects = v.into();
+    /// Sets the value of [allowed_consumer_projects][crate::model::PscConfig::allowed_consumer_projects].
+    pub fn set_allowed_consumer_projects<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.allowed_consumer_projects = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -7801,25 +7926,25 @@ pub struct LocationPreference {
 
 impl LocationPreference {
 
-    /// Sets the value of `follow_gae_application`.
+    /// Sets the value of [follow_gae_application][crate::model::LocationPreference::follow_gae_application].
     pub fn set_follow_gae_application<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.follow_gae_application = v.into();
         self
     }
 
-    /// Sets the value of `zone`.
+    /// Sets the value of [zone][crate::model::LocationPreference::zone].
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
-    /// Sets the value of `secondary_zone`.
+    /// Sets the value of [secondary_zone][crate::model::LocationPreference::secondary_zone].
     pub fn set_secondary_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secondary_zone = v.into();
         self
     }
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::LocationPreference::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
@@ -7862,25 +7987,25 @@ pub struct MaintenanceWindow {
 
 impl MaintenanceWindow {
 
-    /// Sets the value of `hour`.
+    /// Sets the value of [hour][crate::model::MaintenanceWindow::hour].
     pub fn set_hour<T: std::convert::Into<std::option::Option<wkt::Int32Value>>>(mut self, v: T) -> Self {
         self.hour = v.into();
         self
     }
 
-    /// Sets the value of `day`.
+    /// Sets the value of [day][crate::model::MaintenanceWindow::day].
     pub fn set_day<T: std::convert::Into<std::option::Option<wkt::Int32Value>>>(mut self, v: T) -> Self {
         self.day = v.into();
         self
     }
 
-    /// Sets the value of `update_track`.
+    /// Sets the value of [update_track][crate::model::MaintenanceWindow::update_track].
     pub fn set_update_track<T: std::convert::Into<crate::model::SqlUpdateTrack>>(mut self, v: T) -> Self {
         self.update_track = v.into();
         self
     }
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::MaintenanceWindow::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
@@ -7923,19 +8048,19 @@ pub struct DenyMaintenancePeriod {
 
 impl DenyMaintenancePeriod {
 
-    /// Sets the value of `start_date`.
+    /// Sets the value of [start_date][crate::model::DenyMaintenancePeriod::start_date].
     pub fn set_start_date<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.start_date = v.into();
         self
     }
 
-    /// Sets the value of `end_date`.
+    /// Sets the value of [end_date][crate::model::DenyMaintenancePeriod::end_date].
     pub fn set_end_date<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.end_date = v.into();
         self
     }
 
-    /// Sets the value of `time`.
+    /// Sets the value of [time][crate::model::DenyMaintenancePeriod::time].
     pub fn set_time<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.time = v.into();
         self
@@ -7981,31 +8106,31 @@ pub struct InsightsConfig {
 
 impl InsightsConfig {
 
-    /// Sets the value of `query_insights_enabled`.
+    /// Sets the value of [query_insights_enabled][crate::model::InsightsConfig::query_insights_enabled].
     pub fn set_query_insights_enabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.query_insights_enabled = v.into();
         self
     }
 
-    /// Sets the value of `record_client_address`.
+    /// Sets the value of [record_client_address][crate::model::InsightsConfig::record_client_address].
     pub fn set_record_client_address<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.record_client_address = v.into();
         self
     }
 
-    /// Sets the value of `record_application_tags`.
+    /// Sets the value of [record_application_tags][crate::model::InsightsConfig::record_application_tags].
     pub fn set_record_application_tags<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.record_application_tags = v.into();
         self
     }
 
-    /// Sets the value of `query_string_length`.
+    /// Sets the value of [query_string_length][crate::model::InsightsConfig::query_string_length].
     pub fn set_query_string_length<T: std::convert::Into<std::option::Option<wkt::Int32Value>>>(mut self, v: T) -> Self {
         self.query_string_length = v.into();
         self
     }
 
-    /// Sets the value of `query_plans_per_minute`.
+    /// Sets the value of [query_plans_per_minute][crate::model::InsightsConfig::query_plans_per_minute].
     pub fn set_query_plans_per_minute<T: std::convert::Into<std::option::Option<wkt::Int32Value>>>(mut self, v: T) -> Self {
         self.query_plans_per_minute = v.into();
         self
@@ -8080,67 +8205,67 @@ pub struct MySqlReplicaConfiguration {
 
 impl MySqlReplicaConfiguration {
 
-    /// Sets the value of `dump_file_path`.
+    /// Sets the value of [dump_file_path][crate::model::MySqlReplicaConfiguration::dump_file_path].
     pub fn set_dump_file_path<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.dump_file_path = v.into();
         self
     }
 
-    /// Sets the value of `username`.
+    /// Sets the value of [username][crate::model::MySqlReplicaConfiguration::username].
     pub fn set_username<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.username = v.into();
         self
     }
 
-    /// Sets the value of `password`.
+    /// Sets the value of [password][crate::model::MySqlReplicaConfiguration::password].
     pub fn set_password<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.password = v.into();
         self
     }
 
-    /// Sets the value of `connect_retry_interval`.
+    /// Sets the value of [connect_retry_interval][crate::model::MySqlReplicaConfiguration::connect_retry_interval].
     pub fn set_connect_retry_interval<T: std::convert::Into<std::option::Option<wkt::Int32Value>>>(mut self, v: T) -> Self {
         self.connect_retry_interval = v.into();
         self
     }
 
-    /// Sets the value of `master_heartbeat_period`.
+    /// Sets the value of [master_heartbeat_period][crate::model::MySqlReplicaConfiguration::master_heartbeat_period].
     pub fn set_master_heartbeat_period<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(mut self, v: T) -> Self {
         self.master_heartbeat_period = v.into();
         self
     }
 
-    /// Sets the value of `ca_certificate`.
+    /// Sets the value of [ca_certificate][crate::model::MySqlReplicaConfiguration::ca_certificate].
     pub fn set_ca_certificate<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.ca_certificate = v.into();
         self
     }
 
-    /// Sets the value of `client_certificate`.
+    /// Sets the value of [client_certificate][crate::model::MySqlReplicaConfiguration::client_certificate].
     pub fn set_client_certificate<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.client_certificate = v.into();
         self
     }
 
-    /// Sets the value of `client_key`.
+    /// Sets the value of [client_key][crate::model::MySqlReplicaConfiguration::client_key].
     pub fn set_client_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.client_key = v.into();
         self
     }
 
-    /// Sets the value of `ssl_cipher`.
+    /// Sets the value of [ssl_cipher][crate::model::MySqlReplicaConfiguration::ssl_cipher].
     pub fn set_ssl_cipher<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.ssl_cipher = v.into();
         self
     }
 
-    /// Sets the value of `verify_server_certificate`.
+    /// Sets the value of [verify_server_certificate][crate::model::MySqlReplicaConfiguration::verify_server_certificate].
     pub fn set_verify_server_certificate<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.verify_server_certificate = v.into();
         self
     }
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::MySqlReplicaConfiguration::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
@@ -8171,13 +8296,13 @@ pub struct DiskEncryptionConfiguration {
 
 impl DiskEncryptionConfiguration {
 
-    /// Sets the value of `kms_key_name`.
+    /// Sets the value of [kms_key_name][crate::model::DiskEncryptionConfiguration::kms_key_name].
     pub fn set_kms_key_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kms_key_name = v.into();
         self
     }
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::DiskEncryptionConfiguration::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
@@ -8208,13 +8333,13 @@ pub struct DiskEncryptionStatus {
 
 impl DiskEncryptionStatus {
 
-    /// Sets the value of `kms_key_version_name`.
+    /// Sets the value of [kms_key_version_name][crate::model::DiskEncryptionStatus::kms_key_version_name].
     pub fn set_kms_key_version_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kms_key_version_name = v.into();
         self
     }
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::DiskEncryptionStatus::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
@@ -8255,19 +8380,19 @@ pub struct IpMapping {
 
 impl IpMapping {
 
-    /// Sets the value of `r#type`.
+    /// Sets the value of [r#type][crate::model::IpMapping::type].
     pub fn set_type<T: std::convert::Into<crate::model::SqlIpAddressType>>(mut self, v: T) -> Self {
         self.r#type = v.into();
         self
     }
 
-    /// Sets the value of `ip_address`.
+    /// Sets the value of [ip_address][crate::model::IpMapping::ip_address].
     pub fn set_ip_address<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.ip_address = v.into();
         self
     }
 
-    /// Sets the value of `time_to_retire`.
+    /// Sets the value of [time_to_retire][crate::model::IpMapping::time_to_retire].
     pub fn set_time_to_retire<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.time_to_retire = v.into();
         self
@@ -8383,109 +8508,109 @@ pub struct Operation {
 
 impl Operation {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::Operation::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `target_link`.
+    /// Sets the value of [target_link][crate::model::Operation::target_link].
     pub fn set_target_link<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.target_link = v.into();
         self
     }
 
-    /// Sets the value of `status`.
+    /// Sets the value of [status][crate::model::Operation::status].
     pub fn set_status<T: std::convert::Into<crate::model::operation::SqlOperationStatus>>(mut self, v: T) -> Self {
         self.status = v.into();
         self
     }
 
-    /// Sets the value of `user`.
+    /// Sets the value of [user][crate::model::Operation::user].
     pub fn set_user<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.user = v.into();
         self
     }
 
-    /// Sets the value of `insert_time`.
+    /// Sets the value of [insert_time][crate::model::Operation::insert_time].
     pub fn set_insert_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.insert_time = v.into();
         self
     }
 
-    /// Sets the value of `start_time`.
+    /// Sets the value of [start_time][crate::model::Operation::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.start_time = v.into();
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::Operation::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.end_time = v.into();
         self
     }
 
-    /// Sets the value of `error`.
+    /// Sets the value of [error][crate::model::Operation::error].
     pub fn set_error<T: std::convert::Into<std::option::Option<crate::model::OperationErrors>>>(mut self, v: T) -> Self {
         self.error = v.into();
         self
     }
 
-    /// Sets the value of `api_warning`.
+    /// Sets the value of [api_warning][crate::model::Operation::api_warning].
     pub fn set_api_warning<T: std::convert::Into<std::option::Option<crate::model::ApiWarning>>>(mut self, v: T) -> Self {
         self.api_warning = v.into();
         self
     }
 
-    /// Sets the value of `operation_type`.
+    /// Sets the value of [operation_type][crate::model::Operation::operation_type].
     pub fn set_operation_type<T: std::convert::Into<crate::model::operation::SqlOperationType>>(mut self, v: T) -> Self {
         self.operation_type = v.into();
         self
     }
 
-    /// Sets the value of `import_context`.
+    /// Sets the value of [import_context][crate::model::Operation::import_context].
     pub fn set_import_context<T: std::convert::Into<std::option::Option<crate::model::ImportContext>>>(mut self, v: T) -> Self {
         self.import_context = v.into();
         self
     }
 
-    /// Sets the value of `export_context`.
+    /// Sets the value of [export_context][crate::model::Operation::export_context].
     pub fn set_export_context<T: std::convert::Into<std::option::Option<crate::model::ExportContext>>>(mut self, v: T) -> Self {
         self.export_context = v.into();
         self
     }
 
-    /// Sets the value of `backup_context`.
+    /// Sets the value of [backup_context][crate::model::Operation::backup_context].
     pub fn set_backup_context<T: std::convert::Into<std::option::Option<crate::model::BackupContext>>>(mut self, v: T) -> Self {
         self.backup_context = v.into();
         self
     }
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Operation::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `target_id`.
+    /// Sets the value of [target_id][crate::model::Operation::target_id].
     pub fn set_target_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.target_id = v.into();
         self
     }
 
-    /// Sets the value of `self_link`.
+    /// Sets the value of [self_link][crate::model::Operation::self_link].
     pub fn set_self_link<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.self_link = v.into();
         self
     }
 
-    /// Sets the value of `target_project`.
+    /// Sets the value of [target_project][crate::model::Operation::target_project].
     pub fn set_target_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.target_project = v.into();
         self
     }
 
-    /// Sets the value of `acquire_ssrs_lease_context`.
+    /// Sets the value of [acquire_ssrs_lease_context][crate::model::Operation::acquire_ssrs_lease_context].
     pub fn set_acquire_ssrs_lease_context<T: std::convert::Into<std::option::Option<crate::model::AcquireSsrsLeaseContext>>>(mut self, v: T) -> Self {
         self.acquire_ssrs_lease_context = v.into();
         self
@@ -8733,19 +8858,19 @@ pub struct OperationError {
 
 impl OperationError {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::OperationError::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `code`.
+    /// Sets the value of [code][crate::model::OperationError::code].
     pub fn set_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.code = v.into();
         self
     }
 
-    /// Sets the value of `message`.
+    /// Sets the value of [message][crate::model::OperationError::message].
     pub fn set_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.message = v.into();
         self
@@ -8776,15 +8901,20 @@ pub struct OperationErrors {
 
 impl OperationErrors {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::OperationErrors::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `errors`.
-    pub fn set_errors<T: std::convert::Into<std::vec::Vec<crate::model::OperationError>>>(mut self, v: T) -> Self {
-        self.errors = v.into();
+    /// Sets the value of [errors][crate::model::OperationErrors::errors].
+    pub fn set_errors<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::OperationError>
+    {
+        use std::iter::Iterator;
+        self.errors = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -8834,43 +8964,43 @@ pub struct PasswordValidationPolicy {
 
 impl PasswordValidationPolicy {
 
-    /// Sets the value of `min_length`.
+    /// Sets the value of [min_length][crate::model::PasswordValidationPolicy::min_length].
     pub fn set_min_length<T: std::convert::Into<std::option::Option<wkt::Int32Value>>>(mut self, v: T) -> Self {
         self.min_length = v.into();
         self
     }
 
-    /// Sets the value of `complexity`.
+    /// Sets the value of [complexity][crate::model::PasswordValidationPolicy::complexity].
     pub fn set_complexity<T: std::convert::Into<crate::model::password_validation_policy::Complexity>>(mut self, v: T) -> Self {
         self.complexity = v.into();
         self
     }
 
-    /// Sets the value of `reuse_interval`.
+    /// Sets the value of [reuse_interval][crate::model::PasswordValidationPolicy::reuse_interval].
     pub fn set_reuse_interval<T: std::convert::Into<std::option::Option<wkt::Int32Value>>>(mut self, v: T) -> Self {
         self.reuse_interval = v.into();
         self
     }
 
-    /// Sets the value of `disallow_username_substring`.
+    /// Sets the value of [disallow_username_substring][crate::model::PasswordValidationPolicy::disallow_username_substring].
     pub fn set_disallow_username_substring<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.disallow_username_substring = v.into();
         self
     }
 
-    /// Sets the value of `password_change_interval`.
+    /// Sets the value of [password_change_interval][crate::model::PasswordValidationPolicy::password_change_interval].
     pub fn set_password_change_interval<T: std::convert::Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
         self.password_change_interval = v.into();
         self
     }
 
-    /// Sets the value of `enable_password_policy`.
+    /// Sets the value of [enable_password_policy][crate::model::PasswordValidationPolicy::enable_password_policy].
     pub fn set_enable_password_policy<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.enable_password_policy = v.into();
         self
     }
 
-    /// Sets the value of `disallow_compromised_credentials`.
+    /// Sets the value of [disallow_compromised_credentials][crate::model::PasswordValidationPolicy::disallow_compromised_credentials].
     pub fn set_disallow_compromised_credentials<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.disallow_compromised_credentials = v.into();
         self
@@ -8931,7 +9061,7 @@ pub struct DataCacheConfig {
 
 impl DataCacheConfig {
 
-    /// Sets the value of `data_cache_enabled`.
+    /// Sets the value of [data_cache_enabled][crate::model::DataCacheConfig::data_cache_enabled].
     pub fn set_data_cache_enabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.data_cache_enabled = v.into();
         self
@@ -9137,207 +9267,228 @@ pub struct Settings {
 
 impl Settings {
 
-    /// Sets the value of `settings_version`.
+    /// Sets the value of [settings_version][crate::model::Settings::settings_version].
     pub fn set_settings_version<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(mut self, v: T) -> Self {
         self.settings_version = v.into();
         self
     }
 
-    /// Sets the value of `authorized_gae_applications`.
-    pub fn set_authorized_gae_applications<T: std::convert::Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-        self.authorized_gae_applications = v.into();
-        self
-    }
-
-    /// Sets the value of `tier`.
+    /// Sets the value of [tier][crate::model::Settings::tier].
     pub fn set_tier<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.tier = v.into();
         self
     }
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::Settings::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `user_labels`.
-    pub fn set_user_labels<T: std::convert::Into<std::collections::HashMap<std::string::String,std::string::String>>>(mut self, v: T) -> Self {
-        self.user_labels = v.into();
-        self
-    }
-
-    /// Sets the value of `availability_type`.
+    /// Sets the value of [availability_type][crate::model::Settings::availability_type].
     pub fn set_availability_type<T: std::convert::Into<crate::model::SqlAvailabilityType>>(mut self, v: T) -> Self {
         self.availability_type = v.into();
         self
     }
 
-    /// Sets the value of `pricing_plan`.
+    /// Sets the value of [pricing_plan][crate::model::Settings::pricing_plan].
     pub fn set_pricing_plan<T: std::convert::Into<crate::model::SqlPricingPlan>>(mut self, v: T) -> Self {
         self.pricing_plan = v.into();
         self
     }
 
-    /// Sets the value of `replication_type`.
+    /// Sets the value of [replication_type][crate::model::Settings::replication_type].
     pub fn set_replication_type<T: std::convert::Into<crate::model::SqlReplicationType>>(mut self, v: T) -> Self {
         self.replication_type = v.into();
         self
     }
 
-    /// Sets the value of `storage_auto_resize_limit`.
+    /// Sets the value of [storage_auto_resize_limit][crate::model::Settings::storage_auto_resize_limit].
     pub fn set_storage_auto_resize_limit<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(mut self, v: T) -> Self {
         self.storage_auto_resize_limit = v.into();
         self
     }
 
-    /// Sets the value of `activation_policy`.
+    /// Sets the value of [activation_policy][crate::model::Settings::activation_policy].
     pub fn set_activation_policy<T: std::convert::Into<crate::model::settings::SqlActivationPolicy>>(mut self, v: T) -> Self {
         self.activation_policy = v.into();
         self
     }
 
-    /// Sets the value of `ip_configuration`.
+    /// Sets the value of [ip_configuration][crate::model::Settings::ip_configuration].
     pub fn set_ip_configuration<T: std::convert::Into<std::option::Option<crate::model::IpConfiguration>>>(mut self, v: T) -> Self {
         self.ip_configuration = v.into();
         self
     }
 
-    /// Sets the value of `storage_auto_resize`.
+    /// Sets the value of [storage_auto_resize][crate::model::Settings::storage_auto_resize].
     pub fn set_storage_auto_resize<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.storage_auto_resize = v.into();
         self
     }
 
-    /// Sets the value of `location_preference`.
+    /// Sets the value of [location_preference][crate::model::Settings::location_preference].
     pub fn set_location_preference<T: std::convert::Into<std::option::Option<crate::model::LocationPreference>>>(mut self, v: T) -> Self {
         self.location_preference = v.into();
         self
     }
 
-    /// Sets the value of `database_flags`.
-    pub fn set_database_flags<T: std::convert::Into<std::vec::Vec<crate::model::DatabaseFlags>>>(mut self, v: T) -> Self {
-        self.database_flags = v.into();
-        self
-    }
-
-    /// Sets the value of `data_disk_type`.
+    /// Sets the value of [data_disk_type][crate::model::Settings::data_disk_type].
     pub fn set_data_disk_type<T: std::convert::Into<crate::model::SqlDataDiskType>>(mut self, v: T) -> Self {
         self.data_disk_type = v.into();
         self
     }
 
-    /// Sets the value of `maintenance_window`.
+    /// Sets the value of [maintenance_window][crate::model::Settings::maintenance_window].
     pub fn set_maintenance_window<T: std::convert::Into<std::option::Option<crate::model::MaintenanceWindow>>>(mut self, v: T) -> Self {
         self.maintenance_window = v.into();
         self
     }
 
-    /// Sets the value of `backup_configuration`.
+    /// Sets the value of [backup_configuration][crate::model::Settings::backup_configuration].
     pub fn set_backup_configuration<T: std::convert::Into<std::option::Option<crate::model::BackupConfiguration>>>(mut self, v: T) -> Self {
         self.backup_configuration = v.into();
         self
     }
 
-    /// Sets the value of `database_replication_enabled`.
+    /// Sets the value of [database_replication_enabled][crate::model::Settings::database_replication_enabled].
     pub fn set_database_replication_enabled<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.database_replication_enabled = v.into();
         self
     }
 
-    /// Sets the value of `crash_safe_replication_enabled`.
+    /// Sets the value of [crash_safe_replication_enabled][crate::model::Settings::crash_safe_replication_enabled].
     pub fn set_crash_safe_replication_enabled<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.crash_safe_replication_enabled = v.into();
         self
     }
 
-    /// Sets the value of `data_disk_size_gb`.
+    /// Sets the value of [data_disk_size_gb][crate::model::Settings::data_disk_size_gb].
     pub fn set_data_disk_size_gb<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(mut self, v: T) -> Self {
         self.data_disk_size_gb = v.into();
         self
     }
 
-    /// Sets the value of `active_directory_config`.
+    /// Sets the value of [active_directory_config][crate::model::Settings::active_directory_config].
     pub fn set_active_directory_config<T: std::convert::Into<std::option::Option<crate::model::SqlActiveDirectoryConfig>>>(mut self, v: T) -> Self {
         self.active_directory_config = v.into();
         self
     }
 
-    /// Sets the value of `collation`.
+    /// Sets the value of [collation][crate::model::Settings::collation].
     pub fn set_collation<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.collation = v.into();
         self
     }
 
-    /// Sets the value of `deny_maintenance_periods`.
-    pub fn set_deny_maintenance_periods<T: std::convert::Into<std::vec::Vec<crate::model::DenyMaintenancePeriod>>>(mut self, v: T) -> Self {
-        self.deny_maintenance_periods = v.into();
-        self
-    }
-
-    /// Sets the value of `insights_config`.
+    /// Sets the value of [insights_config][crate::model::Settings::insights_config].
     pub fn set_insights_config<T: std::convert::Into<std::option::Option<crate::model::InsightsConfig>>>(mut self, v: T) -> Self {
         self.insights_config = v.into();
         self
     }
 
-    /// Sets the value of `password_validation_policy`.
+    /// Sets the value of [password_validation_policy][crate::model::Settings::password_validation_policy].
     pub fn set_password_validation_policy<T: std::convert::Into<std::option::Option<crate::model::PasswordValidationPolicy>>>(mut self, v: T) -> Self {
         self.password_validation_policy = v.into();
         self
     }
 
-    /// Sets the value of `sql_server_audit_config`.
+    /// Sets the value of [sql_server_audit_config][crate::model::Settings::sql_server_audit_config].
     pub fn set_sql_server_audit_config<T: std::convert::Into<std::option::Option<crate::model::SqlServerAuditConfig>>>(mut self, v: T) -> Self {
         self.sql_server_audit_config = v.into();
         self
     }
 
-    /// Sets the value of `edition`.
+    /// Sets the value of [edition][crate::model::Settings::edition].
     pub fn set_edition<T: std::convert::Into<crate::model::settings::Edition>>(mut self, v: T) -> Self {
         self.edition = v.into();
         self
     }
 
-    /// Sets the value of `connector_enforcement`.
+    /// Sets the value of [connector_enforcement][crate::model::Settings::connector_enforcement].
     pub fn set_connector_enforcement<T: std::convert::Into<crate::model::settings::ConnectorEnforcement>>(mut self, v: T) -> Self {
         self.connector_enforcement = v.into();
         self
     }
 
-    /// Sets the value of `deletion_protection_enabled`.
+    /// Sets the value of [deletion_protection_enabled][crate::model::Settings::deletion_protection_enabled].
     pub fn set_deletion_protection_enabled<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.deletion_protection_enabled = v.into();
         self
     }
 
-    /// Sets the value of `time_zone`.
+    /// Sets the value of [time_zone][crate::model::Settings::time_zone].
     pub fn set_time_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.time_zone = v.into();
         self
     }
 
-    /// Sets the value of `advanced_machine_features`.
+    /// Sets the value of [advanced_machine_features][crate::model::Settings::advanced_machine_features].
     pub fn set_advanced_machine_features<T: std::convert::Into<std::option::Option<crate::model::AdvancedMachineFeatures>>>(mut self, v: T) -> Self {
         self.advanced_machine_features = v.into();
         self
     }
 
-    /// Sets the value of `data_cache_config`.
+    /// Sets the value of [data_cache_config][crate::model::Settings::data_cache_config].
     pub fn set_data_cache_config<T: std::convert::Into<std::option::Option<crate::model::DataCacheConfig>>>(mut self, v: T) -> Self {
         self.data_cache_config = v.into();
         self
     }
 
-    /// Sets the value of `enable_google_ml_integration`.
+    /// Sets the value of [enable_google_ml_integration][crate::model::Settings::enable_google_ml_integration].
     pub fn set_enable_google_ml_integration<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.enable_google_ml_integration = v.into();
         self
     }
 
-    /// Sets the value of `enable_dataplex_integration`.
+    /// Sets the value of [enable_dataplex_integration][crate::model::Settings::enable_dataplex_integration].
     pub fn set_enable_dataplex_integration<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.enable_dataplex_integration = v.into();
+        self
+    }
+
+    /// Sets the value of [authorized_gae_applications][crate::model::Settings::authorized_gae_applications].
+    pub fn set_authorized_gae_applications<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.authorized_gae_applications = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [database_flags][crate::model::Settings::database_flags].
+    pub fn set_database_flags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DatabaseFlags>
+    {
+        use std::iter::Iterator;
+        self.database_flags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [deny_maintenance_periods][crate::model::Settings::deny_maintenance_periods].
+    pub fn set_deny_maintenance_periods<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DenyMaintenancePeriod>
+    {
+        use std::iter::Iterator;
+        self.deny_maintenance_periods = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [user_labels][crate::model::Settings::user_labels].
+    pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -9463,7 +9614,7 @@ pub struct AdvancedMachineFeatures {
 
 impl AdvancedMachineFeatures {
 
-    /// Sets the value of `threads_per_core`.
+    /// Sets the value of [threads_per_core][crate::model::AdvancedMachineFeatures::threads_per_core].
     pub fn set_threads_per_core<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.threads_per_core = v.into();
         self
@@ -9526,55 +9677,55 @@ pub struct SslCert {
 
 impl SslCert {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::SslCert::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `cert_serial_number`.
+    /// Sets the value of [cert_serial_number][crate::model::SslCert::cert_serial_number].
     pub fn set_cert_serial_number<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cert_serial_number = v.into();
         self
     }
 
-    /// Sets the value of `cert`.
+    /// Sets the value of [cert][crate::model::SslCert::cert].
     pub fn set_cert<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cert = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::SslCert::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.create_time = v.into();
         self
     }
 
-    /// Sets the value of `common_name`.
+    /// Sets the value of [common_name][crate::model::SslCert::common_name].
     pub fn set_common_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.common_name = v.into();
         self
     }
 
-    /// Sets the value of `expiration_time`.
+    /// Sets the value of [expiration_time][crate::model::SslCert::expiration_time].
     pub fn set_expiration_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.expiration_time = v.into();
         self
     }
 
-    /// Sets the value of `sha1_fingerprint`.
+    /// Sets the value of [sha1_fingerprint][crate::model::SslCert::sha1_fingerprint].
     pub fn set_sha1_fingerprint<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.sha1_fingerprint = v.into();
         self
     }
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SslCert::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `self_link`.
+    /// Sets the value of [self_link][crate::model::SslCert::self_link].
     pub fn set_self_link<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.self_link = v.into();
         self
@@ -9606,13 +9757,13 @@ pub struct SslCertDetail {
 
 impl SslCertDetail {
 
-    /// Sets the value of `cert_info`.
+    /// Sets the value of [cert_info][crate::model::SslCertDetail::cert_info].
     pub fn set_cert_info<T: std::convert::Into<std::option::Option<crate::model::SslCert>>>(mut self, v: T) -> Self {
         self.cert_info = v.into();
         self
     }
 
-    /// Sets the value of `cert_private_key`.
+    /// Sets the value of [cert_private_key][crate::model::SslCertDetail::cert_private_key].
     pub fn set_cert_private_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cert_private_key = v.into();
         self
@@ -9643,13 +9794,13 @@ pub struct SqlActiveDirectoryConfig {
 
 impl SqlActiveDirectoryConfig {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::SqlActiveDirectoryConfig::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `domain`.
+    /// Sets the value of [domain][crate::model::SqlActiveDirectoryConfig::domain].
     pub fn set_domain<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.domain = v.into();
         self
@@ -9688,25 +9839,25 @@ pub struct SqlServerAuditConfig {
 
 impl SqlServerAuditConfig {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::SqlServerAuditConfig::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `bucket`.
+    /// Sets the value of [bucket][crate::model::SqlServerAuditConfig::bucket].
     pub fn set_bucket<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.bucket = v.into();
         self
     }
 
-    /// Sets the value of `retention_interval`.
+    /// Sets the value of [retention_interval][crate::model::SqlServerAuditConfig::retention_interval].
     pub fn set_retention_interval<T: std::convert::Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
         self.retention_interval = v.into();
         self
     }
 
-    /// Sets the value of `upload_interval`.
+    /// Sets the value of [upload_interval][crate::model::SqlServerAuditConfig::upload_interval].
     pub fn set_upload_interval<T: std::convert::Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
         self.upload_interval = v.into();
         self
@@ -9747,25 +9898,25 @@ pub struct AcquireSsrsLeaseContext {
 
 impl AcquireSsrsLeaseContext {
 
-    /// Sets the value of `setup_login`.
+    /// Sets the value of [setup_login][crate::model::AcquireSsrsLeaseContext::setup_login].
     pub fn set_setup_login<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.setup_login = v.into();
         self
     }
 
-    /// Sets the value of `service_login`.
+    /// Sets the value of [service_login][crate::model::AcquireSsrsLeaseContext::service_login].
     pub fn set_service_login<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.service_login = v.into();
         self
     }
 
-    /// Sets the value of `report_database`.
+    /// Sets the value of [report_database][crate::model::AcquireSsrsLeaseContext::report_database].
     pub fn set_report_database<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.report_database = v.into();
         self
     }
 
-    /// Sets the value of `duration`.
+    /// Sets the value of [duration][crate::model::AcquireSsrsLeaseContext::duration].
     pub fn set_duration<T: std::convert::Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
         self.duration = v.into();
         self
@@ -9799,19 +9950,19 @@ pub struct SqlSslCertsDeleteRequest {
 
 impl SqlSslCertsDeleteRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlSslCertsDeleteRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlSslCertsDeleteRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `sha1_fingerprint`.
+    /// Sets the value of [sha1_fingerprint][crate::model::SqlSslCertsDeleteRequest::sha1_fingerprint].
     pub fn set_sha1_fingerprint<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.sha1_fingerprint = v.into();
         self
@@ -9845,19 +9996,19 @@ pub struct SqlSslCertsGetRequest {
 
 impl SqlSslCertsGetRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlSslCertsGetRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlSslCertsGetRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `sha1_fingerprint`.
+    /// Sets the value of [sha1_fingerprint][crate::model::SqlSslCertsGetRequest::sha1_fingerprint].
     pub fn set_sha1_fingerprint<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.sha1_fingerprint = v.into();
         self
@@ -9890,19 +10041,19 @@ pub struct SqlSslCertsInsertRequest {
 
 impl SqlSslCertsInsertRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlSslCertsInsertRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlSslCertsInsertRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlSslCertsInsertRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::SslCertsInsertRequest>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -9932,13 +10083,13 @@ pub struct SqlSslCertsListRequest {
 
 impl SqlSslCertsListRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlSslCertsListRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlSslCertsListRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -9966,7 +10117,7 @@ pub struct SslCertsInsertRequest {
 
 impl SslCertsInsertRequest {
 
-    /// Sets the value of `common_name`.
+    /// Sets the value of [common_name][crate::model::SslCertsInsertRequest::common_name].
     pub fn set_common_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.common_name = v.into();
         self
@@ -10007,25 +10158,25 @@ pub struct SslCertsInsertResponse {
 
 impl SslCertsInsertResponse {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::SslCertsInsertResponse::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `operation`.
+    /// Sets the value of [operation][crate::model::SslCertsInsertResponse::operation].
     pub fn set_operation<T: std::convert::Into<std::option::Option<crate::model::Operation>>>(mut self, v: T) -> Self {
         self.operation = v.into();
         self
     }
 
-    /// Sets the value of `server_ca_cert`.
+    /// Sets the value of [server_ca_cert][crate::model::SslCertsInsertResponse::server_ca_cert].
     pub fn set_server_ca_cert<T: std::convert::Into<std::option::Option<crate::model::SslCert>>>(mut self, v: T) -> Self {
         self.server_ca_cert = v.into();
         self
     }
 
-    /// Sets the value of `client_cert`.
+    /// Sets the value of [client_cert][crate::model::SslCertsInsertResponse::client_cert].
     pub fn set_client_cert<T: std::convert::Into<std::option::Option<crate::model::SslCertDetail>>>(mut self, v: T) -> Self {
         self.client_cert = v.into();
         self
@@ -10056,15 +10207,20 @@ pub struct SslCertsListResponse {
 
 impl SslCertsListResponse {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::SslCertsListResponse::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `items`.
-    pub fn set_items<T: std::convert::Into<std::vec::Vec<crate::model::SslCert>>>(mut self, v: T) -> Self {
-        self.items = v.into();
+    /// Sets the value of [items][crate::model::SslCertsListResponse::items].
+    pub fn set_items<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SslCert>
+    {
+        use std::iter::Iterator;
+        self.items = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -10089,7 +10245,7 @@ pub struct SqlTiersListRequest {
 
 impl SqlTiersListRequest {
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlTiersListRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -10120,15 +10276,20 @@ pub struct TiersListResponse {
 
 impl TiersListResponse {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::TiersListResponse::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `items`.
-    pub fn set_items<T: std::convert::Into<std::vec::Vec<crate::model::Tier>>>(mut self, v: T) -> Self {
-        self.items = v.into();
+    /// Sets the value of [items][crate::model::TiersListResponse::items].
+    pub fn set_items<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Tier>
+    {
+        use std::iter::Iterator;
+        self.items = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -10172,33 +10333,38 @@ pub struct Tier {
 
 impl Tier {
 
-    /// Sets the value of `tier`.
+    /// Sets the value of [tier][crate::model::Tier::tier].
     pub fn set_tier<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.tier = v.into();
         self
     }
 
-    /// Sets the value of `ram`.
+    /// Sets the value of [ram][crate::model::Tier::ram].
     pub fn set_ram<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.ram = v.into();
         self
     }
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::Tier::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `disk_quota`.
+    /// Sets the value of [disk_quota][crate::model::Tier::disk_quota].
     pub fn set_disk_quota<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.disk_quota = v.into();
         self
     }
 
-    /// Sets the value of `region`.
-    pub fn set_region<T: std::convert::Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-        self.region = v.into();
+    /// Sets the value of [region][crate::model::Tier::region].
+    pub fn set_region<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.region = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -10234,25 +10400,25 @@ pub struct SqlUsersDeleteRequest {
 
 impl SqlUsersDeleteRequest {
 
-    /// Sets the value of `host`.
+    /// Sets the value of [host][crate::model::SqlUsersDeleteRequest::host].
     pub fn set_host<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.host = v.into();
         self
     }
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlUsersDeleteRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::SqlUsersDeleteRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlUsersDeleteRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -10291,25 +10457,25 @@ pub struct SqlUsersGetRequest {
 
 impl SqlUsersGetRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlUsersGetRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::SqlUsersGetRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlUsersGetRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `host`.
+    /// Sets the value of [host][crate::model::SqlUsersGetRequest::host].
     pub fn set_host<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.host = v.into();
         self
@@ -10342,19 +10508,19 @@ pub struct SqlUsersInsertRequest {
 
 impl SqlUsersInsertRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlUsersInsertRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlUsersInsertRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlUsersInsertRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::User>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -10384,13 +10550,13 @@ pub struct SqlUsersListRequest {
 
 impl SqlUsersListRequest {
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlUsersListRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlUsersListRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
@@ -10431,31 +10597,31 @@ pub struct SqlUsersUpdateRequest {
 
 impl SqlUsersUpdateRequest {
 
-    /// Sets the value of `host`.
+    /// Sets the value of [host][crate::model::SqlUsersUpdateRequest::host].
     pub fn set_host<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.host = v.into();
         self
     }
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::SqlUsersUpdateRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::SqlUsersUpdateRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SqlUsersUpdateRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::SqlUsersUpdateRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<crate::model::User>>>(mut self, v: T) -> Self {
         self.body = v.into();
         self
@@ -10496,31 +10662,31 @@ pub struct UserPasswordValidationPolicy {
 
 impl UserPasswordValidationPolicy {
 
-    /// Sets the value of `allowed_failed_attempts`.
+    /// Sets the value of [allowed_failed_attempts][crate::model::UserPasswordValidationPolicy::allowed_failed_attempts].
     pub fn set_allowed_failed_attempts<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.allowed_failed_attempts = v.into();
         self
     }
 
-    /// Sets the value of `password_expiration_duration`.
+    /// Sets the value of [password_expiration_duration][crate::model::UserPasswordValidationPolicy::password_expiration_duration].
     pub fn set_password_expiration_duration<T: std::convert::Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
         self.password_expiration_duration = v.into();
         self
     }
 
-    /// Sets the value of `enable_failed_attempts_check`.
+    /// Sets the value of [enable_failed_attempts_check][crate::model::UserPasswordValidationPolicy::enable_failed_attempts_check].
     pub fn set_enable_failed_attempts_check<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enable_failed_attempts_check = v.into();
         self
     }
 
-    /// Sets the value of `status`.
+    /// Sets the value of [status][crate::model::UserPasswordValidationPolicy::status].
     pub fn set_status<T: std::convert::Into<std::option::Option<crate::model::PasswordStatus>>>(mut self, v: T) -> Self {
         self.status = v.into();
         self
     }
 
-    /// Sets the value of `enable_password_verification`.
+    /// Sets the value of [enable_password_verification][crate::model::UserPasswordValidationPolicy::enable_password_verification].
     pub fn set_enable_password_verification<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enable_password_verification = v.into();
         self
@@ -10550,13 +10716,13 @@ pub struct PasswordStatus {
 
 impl PasswordStatus {
 
-    /// Sets the value of `locked`.
+    /// Sets the value of [locked][crate::model::PasswordStatus::locked].
     pub fn set_locked<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.locked = v.into();
         self
     }
 
-    /// Sets the value of `password_expiration_time`.
+    /// Sets the value of [password_expiration_time][crate::model::PasswordStatus::password_expiration_time].
     pub fn set_password_expiration_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
         self.password_expiration_time = v.into();
         self
@@ -10634,61 +10800,61 @@ pub struct User {
 
 impl User {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::User::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `password`.
+    /// Sets the value of [password][crate::model::User::password].
     pub fn set_password<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.password = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::User::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::User::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `host`.
+    /// Sets the value of [host][crate::model::User::host].
     pub fn set_host<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.host = v.into();
         self
     }
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::User::instance].
     pub fn set_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance = v.into();
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::User::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `r#type`.
+    /// Sets the value of [r#type][crate::model::User::type].
     pub fn set_type<T: std::convert::Into<crate::model::user::SqlUserType>>(mut self, v: T) -> Self {
         self.r#type = v.into();
         self
     }
 
-    /// Sets the value of `password_policy`.
+    /// Sets the value of [password_policy][crate::model::User::password_policy].
     pub fn set_password_policy<T: std::convert::Into<std::option::Option<crate::model::UserPasswordValidationPolicy>>>(mut self, v: T) -> Self {
         self.password_policy = v.into();
         self
     }
 
-    /// Sets the value of `dual_password_type`.
+    /// Sets the value of [dual_password_type][crate::model::User::dual_password_type].
     pub fn set_dual_password_type<T: std::convert::Into<std::option::Option<crate::model::user::DualPasswordType>>>(mut self, v: T) -> Self {
         self.dual_password_type = v.into();
         self
@@ -10811,15 +10977,20 @@ pub struct SqlServerUserDetails {
 
 impl SqlServerUserDetails {
 
-    /// Sets the value of `disabled`.
+    /// Sets the value of [disabled][crate::model::SqlServerUserDetails::disabled].
     pub fn set_disabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.disabled = v.into();
         self
     }
 
-    /// Sets the value of `server_roles`.
-    pub fn set_server_roles<T: std::convert::Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-        self.server_roles = v.into();
+    /// Sets the value of [server_roles][crate::model::SqlServerUserDetails::server_roles].
+    pub fn set_server_roles<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.server_roles = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -10852,21 +11023,26 @@ pub struct UsersListResponse {
 
 impl UsersListResponse {
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::UsersListResponse::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `items`.
-    pub fn set_items<T: std::convert::Into<std::vec::Vec<crate::model::User>>>(mut self, v: T) -> Self {
-        self.items = v.into();
+    /// Sets the value of [next_page_token][crate::model::UsersListResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [items][crate::model::UsersListResponse::items].
+    pub fn set_items<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::User>
+    {
+        use std::iter::Iterator;
+        self.items = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/cloud/translate/v3/src/builders.rs
+++ b/src/generated/cloud/translate/v3/src/builders.rs
@@ -67,43 +67,37 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `contents`.
-        pub fn set_contents<T: Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-            self.0.request.contents = v.into();
-            self
-        }
-
-        /// Sets the value of `mime_type`.
+        /// Sets the value of [mime_type][crate::model::TranslateTextRequest::mime_type].
         pub fn set_mime_type<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.mime_type = v.into();
             self
         }
 
-        /// Sets the value of `source_language_code`.
+        /// Sets the value of [source_language_code][crate::model::TranslateTextRequest::source_language_code].
         pub fn set_source_language_code<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.source_language_code = v.into();
             self
         }
 
-        /// Sets the value of `target_language_code`.
+        /// Sets the value of [target_language_code][crate::model::TranslateTextRequest::target_language_code].
         pub fn set_target_language_code<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.target_language_code = v.into();
             self
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::TranslateTextRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `model`.
+        /// Sets the value of [model][crate::model::TranslateTextRequest::model].
         pub fn set_model<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.model = v.into();
             self
         }
 
-        /// Sets the value of `glossary_config`.
+        /// Sets the value of [glossary_config][crate::model::TranslateTextRequest::glossary_config].
         pub fn set_glossary_config<
             T: Into<std::option::Option<crate::model::TranslateTextGlossaryConfig>>,
         >(
@@ -114,7 +108,7 @@ pub mod translation_service {
             self
         }
 
-        /// Sets the value of `transliteration_config`.
+        /// Sets the value of [transliteration_config][crate::model::TranslateTextRequest::transliteration_config].
         pub fn set_transliteration_config<
             T: Into<std::option::Option<crate::model::TransliterationConfig>>,
         >(
@@ -125,14 +119,25 @@ pub mod translation_service {
             self
         }
 
-        /// Sets the value of `labels`.
-        pub fn set_labels<
-            T: Into<std::collections::HashMap<std::string::String, std::string::String>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.labels = v.into();
+        /// Sets the value of [contents][crate::model::TranslateTextRequest::contents].
+        pub fn set_contents<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.contents = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [labels][crate::model::TranslateTextRequest::labels].
+        pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            self.0.request.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -171,21 +176,26 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::RomanizeTextRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `contents`.
-        pub fn set_contents<T: Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-            self.0.request.contents = v.into();
+        /// Sets the value of [source_language_code][crate::model::RomanizeTextRequest::source_language_code].
+        pub fn set_source_language_code<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.source_language_code = v.into();
             self
         }
 
-        /// Sets the value of `source_language_code`.
-        pub fn set_source_language_code<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.source_language_code = v.into();
+        /// Sets the value of [contents][crate::model::RomanizeTextRequest::contents].
+        pub fn set_contents<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.contents = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -224,32 +234,32 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::DetectLanguageRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `model`.
+        /// Sets the value of [model][crate::model::DetectLanguageRequest::model].
         pub fn set_model<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.model = v.into();
             self
         }
 
-        /// Sets the value of `mime_type`.
+        /// Sets the value of [mime_type][crate::model::DetectLanguageRequest::mime_type].
         pub fn set_mime_type<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.mime_type = v.into();
             self
         }
 
-        /// Sets the value of `labels`.
-        pub fn set_labels<
-            T: Into<std::collections::HashMap<std::string::String, std::string::String>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.labels = v.into();
+        /// Sets the value of [labels][crate::model::DetectLanguageRequest::labels].
+        pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            self.0.request.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
 
@@ -300,19 +310,19 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::GetSupportedLanguagesRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `display_language_code`.
+        /// Sets the value of [display_language_code][crate::model::GetSupportedLanguagesRequest::display_language_code].
         pub fn set_display_language_code<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.display_language_code = v.into();
             self
         }
 
-        /// Sets the value of `model`.
+        /// Sets the value of [model][crate::model::GetSupportedLanguagesRequest::model].
         pub fn set_model<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.model = v.into();
             self
@@ -356,25 +366,25 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::TranslateDocumentRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `source_language_code`.
+        /// Sets the value of [source_language_code][crate::model::TranslateDocumentRequest::source_language_code].
         pub fn set_source_language_code<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.source_language_code = v.into();
             self
         }
 
-        /// Sets the value of `target_language_code`.
+        /// Sets the value of [target_language_code][crate::model::TranslateDocumentRequest::target_language_code].
         pub fn set_target_language_code<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.target_language_code = v.into();
             self
         }
 
-        /// Sets the value of `document_input_config`.
+        /// Sets the value of [document_input_config][crate::model::TranslateDocumentRequest::document_input_config].
         pub fn set_document_input_config<
             T: Into<std::option::Option<crate::model::DocumentInputConfig>>,
         >(
@@ -385,7 +395,7 @@ pub mod translation_service {
             self
         }
 
-        /// Sets the value of `document_output_config`.
+        /// Sets the value of [document_output_config][crate::model::TranslateDocumentRequest::document_output_config].
         pub fn set_document_output_config<
             T: Into<std::option::Option<crate::model::DocumentOutputConfig>>,
         >(
@@ -396,13 +406,13 @@ pub mod translation_service {
             self
         }
 
-        /// Sets the value of `model`.
+        /// Sets the value of [model][crate::model::TranslateDocumentRequest::model].
         pub fn set_model<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.model = v.into();
             self
         }
 
-        /// Sets the value of `glossary_config`.
+        /// Sets the value of [glossary_config][crate::model::TranslateDocumentRequest::glossary_config].
         pub fn set_glossary_config<
             T: Into<std::option::Option<crate::model::TranslateTextGlossaryConfig>>,
         >(
@@ -413,38 +423,38 @@ pub mod translation_service {
             self
         }
 
-        /// Sets the value of `labels`.
-        pub fn set_labels<
-            T: Into<std::collections::HashMap<std::string::String, std::string::String>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.labels = v.into();
-            self
-        }
-
-        /// Sets the value of `customized_attribution`.
+        /// Sets the value of [customized_attribution][crate::model::TranslateDocumentRequest::customized_attribution].
         pub fn set_customized_attribution<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.customized_attribution = v.into();
             self
         }
 
-        /// Sets the value of `is_translate_native_pdf_only`.
+        /// Sets the value of [is_translate_native_pdf_only][crate::model::TranslateDocumentRequest::is_translate_native_pdf_only].
         pub fn set_is_translate_native_pdf_only<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.is_translate_native_pdf_only = v.into();
             self
         }
 
-        /// Sets the value of `enable_shadow_removal_native_pdf`.
+        /// Sets the value of [enable_shadow_removal_native_pdf][crate::model::TranslateDocumentRequest::enable_shadow_removal_native_pdf].
         pub fn set_enable_shadow_removal_native_pdf<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.enable_shadow_removal_native_pdf = v.into();
             self
         }
 
-        /// Sets the value of `enable_rotation_correction`.
+        /// Sets the value of [enable_rotation_correction][crate::model::TranslateDocumentRequest::enable_rotation_correction].
         pub fn set_enable_rotation_correction<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.enable_rotation_correction = v.into();
+            self
+        }
+
+        /// Sets the value of [labels][crate::model::TranslateDocumentRequest::labels].
+        pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            self.0.request.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -527,48 +537,19 @@ pub mod translation_service {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::BatchTranslateTextRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `source_language_code`.
+        /// Sets the value of [source_language_code][crate::model::BatchTranslateTextRequest::source_language_code].
         pub fn set_source_language_code<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.source_language_code = v.into();
             self
         }
 
-        /// Sets the value of `target_language_codes`.
-        pub fn set_target_language_codes<T: Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.target_language_codes = v.into();
-            self
-        }
-
-        /// Sets the value of `models`.
-        pub fn set_models<
-            T: Into<std::collections::HashMap<std::string::String, std::string::String>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.models = v.into();
-            self
-        }
-
-        /// Sets the value of `input_configs`.
-        pub fn set_input_configs<T: Into<std::vec::Vec<crate::model::InputConfig>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.input_configs = v.into();
-            self
-        }
-
-        /// Sets the value of `output_config`.
+        /// Sets the value of [output_config][crate::model::BatchTranslateTextRequest::output_config].
         pub fn set_output_config<T: Into<std::option::Option<crate::model::OutputConfig>>>(
             mut self,
             v: T,
@@ -577,30 +558,58 @@ pub mod translation_service {
             self
         }
 
-        /// Sets the value of `glossaries`.
-        pub fn set_glossaries<
-            T: Into<
-                std::collections::HashMap<
-                    std::string::String,
-                    crate::model::TranslateTextGlossaryConfig,
-                >,
-            >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.glossaries = v.into();
+        /// Sets the value of [target_language_codes][crate::model::BatchTranslateTextRequest::target_language_codes].
+        pub fn set_target_language_codes<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.target_language_codes = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
-        /// Sets the value of `labels`.
-        pub fn set_labels<
-            T: Into<std::collections::HashMap<std::string::String, std::string::String>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.labels = v.into();
+        /// Sets the value of [input_configs][crate::model::BatchTranslateTextRequest::input_configs].
+        pub fn set_input_configs<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::InputConfig>,
+        {
+            use std::iter::Iterator;
+            self.0.request.input_configs = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [models][crate::model::BatchTranslateTextRequest::models].
+        pub fn set_models<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            self.0.request.models = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [glossaries][crate::model::BatchTranslateTextRequest::glossaries].
+        pub fn set_glossaries<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<crate::model::TranslateTextGlossaryConfig>,
+        {
+            self.0.request.glossaries = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [labels][crate::model::BatchTranslateTextRequest::labels].
+        pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            self.0.request.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -685,37 +694,19 @@ pub mod translation_service {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::BatchTranslateDocumentRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `source_language_code`.
+        /// Sets the value of [source_language_code][crate::model::BatchTranslateDocumentRequest::source_language_code].
         pub fn set_source_language_code<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.source_language_code = v.into();
             self
         }
 
-        /// Sets the value of `target_language_codes`.
-        pub fn set_target_language_codes<T: Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.target_language_codes = v.into();
-            self
-        }
-
-        /// Sets the value of `input_configs`.
-        pub fn set_input_configs<T: Into<std::vec::Vec<crate::model::BatchDocumentInputConfig>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.input_configs = v.into();
-            self
-        }
-
-        /// Sets the value of `output_config`.
+        /// Sets the value of [output_config][crate::model::BatchTranslateDocumentRequest::output_config].
         pub fn set_output_config<
             T: Into<std::option::Option<crate::model::BatchDocumentOutputConfig>>,
         >(
@@ -726,59 +717,77 @@ pub mod translation_service {
             self
         }
 
-        /// Sets the value of `models`.
-        pub fn set_models<
-            T: Into<std::collections::HashMap<std::string::String, std::string::String>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.models = v.into();
-            self
-        }
-
-        /// Sets the value of `glossaries`.
-        pub fn set_glossaries<
-            T: Into<
-                std::collections::HashMap<
-                    std::string::String,
-                    crate::model::TranslateTextGlossaryConfig,
-                >,
-            >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.glossaries = v.into();
-            self
-        }
-
-        /// Sets the value of `format_conversions`.
-        pub fn set_format_conversions<
-            T: Into<std::collections::HashMap<std::string::String, std::string::String>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.format_conversions = v.into();
-            self
-        }
-
-        /// Sets the value of `customized_attribution`.
+        /// Sets the value of [customized_attribution][crate::model::BatchTranslateDocumentRequest::customized_attribution].
         pub fn set_customized_attribution<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.customized_attribution = v.into();
             self
         }
 
-        /// Sets the value of `enable_shadow_removal_native_pdf`.
+        /// Sets the value of [enable_shadow_removal_native_pdf][crate::model::BatchTranslateDocumentRequest::enable_shadow_removal_native_pdf].
         pub fn set_enable_shadow_removal_native_pdf<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.enable_shadow_removal_native_pdf = v.into();
             self
         }
 
-        /// Sets the value of `enable_rotation_correction`.
+        /// Sets the value of [enable_rotation_correction][crate::model::BatchTranslateDocumentRequest::enable_rotation_correction].
         pub fn set_enable_rotation_correction<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.enable_rotation_correction = v.into();
+            self
+        }
+
+        /// Sets the value of [target_language_codes][crate::model::BatchTranslateDocumentRequest::target_language_codes].
+        pub fn set_target_language_codes<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.target_language_codes = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [input_configs][crate::model::BatchTranslateDocumentRequest::input_configs].
+        pub fn set_input_configs<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::BatchDocumentInputConfig>,
+        {
+            use std::iter::Iterator;
+            self.0.request.input_configs = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [models][crate::model::BatchTranslateDocumentRequest::models].
+        pub fn set_models<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            self.0.request.models = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [glossaries][crate::model::BatchTranslateDocumentRequest::glossaries].
+        pub fn set_glossaries<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<crate::model::TranslateTextGlossaryConfig>,
+        {
+            self.0.request.glossaries = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [format_conversions][crate::model::BatchTranslateDocumentRequest::format_conversions].
+        pub fn set_format_conversions<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            self.0.request.format_conversions =
+                v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -856,13 +865,13 @@ pub mod translation_service {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateGlossaryRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `glossary`.
+        /// Sets the value of [glossary][crate::model::CreateGlossaryRequest::glossary].
         pub fn set_glossary<T: Into<std::option::Option<crate::model::Glossary>>>(
             mut self,
             v: T,
@@ -945,7 +954,7 @@ pub mod translation_service {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `glossary`.
+        /// Sets the value of [glossary][crate::model::UpdateGlossaryRequest::glossary].
         pub fn set_glossary<T: Into<std::option::Option<crate::model::Glossary>>>(
             mut self,
             v: T,
@@ -954,7 +963,7 @@ pub mod translation_service {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateGlossaryRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -1013,25 +1022,25 @@ pub mod translation_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListGlossariesRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListGlossariesRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListGlossariesRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListGlossariesRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
@@ -1072,7 +1081,7 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetGlossaryRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1154,7 +1163,7 @@ pub mod translation_service {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteGlossaryRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1198,7 +1207,7 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetGlossaryEntryRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1257,19 +1266,19 @@ pub mod translation_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListGlossaryEntriesRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListGlossaryEntriesRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListGlossaryEntriesRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -1313,13 +1322,13 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateGlossaryEntryRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `glossary_entry`.
+        /// Sets the value of [glossary_entry][crate::model::CreateGlossaryEntryRequest::glossary_entry].
         pub fn set_glossary_entry<T: Into<std::option::Option<crate::model::GlossaryEntry>>>(
             mut self,
             v: T,
@@ -1366,7 +1375,7 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `glossary_entry`.
+        /// Sets the value of [glossary_entry][crate::model::UpdateGlossaryEntryRequest::glossary_entry].
         pub fn set_glossary_entry<T: Into<std::option::Option<crate::model::GlossaryEntry>>>(
             mut self,
             v: T,
@@ -1413,7 +1422,7 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteGlossaryEntryRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1492,13 +1501,13 @@ pub mod translation_service {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateDatasetRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `dataset`.
+        /// Sets the value of [dataset][crate::model::CreateDatasetRequest::dataset].
         pub fn set_dataset<T: Into<std::option::Option<crate::model::Dataset>>>(
             mut self,
             v: T,
@@ -1542,7 +1551,7 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetDatasetRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1598,19 +1607,19 @@ pub mod translation_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListDatasetsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListDatasetsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListDatasetsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -1686,7 +1695,7 @@ pub mod translation_service {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteDatasetRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1732,13 +1741,13 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateAdaptiveMtDatasetRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `adaptive_mt_dataset`.
+        /// Sets the value of [adaptive_mt_dataset][crate::model::CreateAdaptiveMtDatasetRequest::adaptive_mt_dataset].
         pub fn set_adaptive_mt_dataset<
             T: Into<std::option::Option<crate::model::AdaptiveMtDataset>>,
         >(
@@ -1789,7 +1798,7 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteAdaptiveMtDatasetRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1833,7 +1842,7 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetAdaptiveMtDatasetRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1894,25 +1903,25 @@ pub mod translation_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListAdaptiveMtDatasetsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListAdaptiveMtDatasetsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListAdaptiveMtDatasetsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListAdaptiveMtDatasetsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
@@ -1956,25 +1965,19 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::AdaptiveMtTranslateRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `dataset`.
+        /// Sets the value of [dataset][crate::model::AdaptiveMtTranslateRequest::dataset].
         pub fn set_dataset<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.dataset = v.into();
             self
         }
 
-        /// Sets the value of `content`.
-        pub fn set_content<T: Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-            self.0.request.content = v.into();
-            self
-        }
-
-        /// Sets the value of `reference_sentence_config`.
+        /// Sets the value of [reference_sentence_config][crate::model::AdaptiveMtTranslateRequest::reference_sentence_config].
         pub fn set_reference_sentence_config<
             T: Into<
                 std::option::Option<
@@ -1989,7 +1992,7 @@ pub mod translation_service {
             self
         }
 
-        /// Sets the value of `glossary_config`.
+        /// Sets the value of [glossary_config][crate::model::AdaptiveMtTranslateRequest::glossary_config].
         pub fn set_glossary_config<
             T: Into<std::option::Option<crate::model::adaptive_mt_translate_request::GlossaryConfig>>,
         >(
@@ -1997,6 +2000,17 @@ pub mod translation_service {
             v: T,
         ) -> Self {
             self.0.request.glossary_config = v.into();
+            self
+        }
+
+        /// Sets the value of [content][crate::model::AdaptiveMtTranslateRequest::content].
+        pub fn set_content<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.content = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -2038,7 +2052,7 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetAdaptiveMtFileRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2082,7 +2096,7 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteAdaptiveMtFileRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2126,7 +2140,7 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ImportAdaptiveMtFileRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
@@ -2196,19 +2210,19 @@ pub mod translation_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListAdaptiveMtFilesRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListAdaptiveMtFilesRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListAdaptiveMtFilesRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -2271,19 +2285,19 @@ pub mod translation_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListAdaptiveMtSentencesRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListAdaptiveMtSentencesRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListAdaptiveMtSentencesRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -2359,13 +2373,13 @@ pub mod translation_service {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `dataset`.
+        /// Sets the value of [dataset][crate::model::ImportDataRequest::dataset].
         pub fn set_dataset<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.dataset = v.into();
             self
         }
 
-        /// Sets the value of `input_config`.
+        /// Sets the value of [input_config][crate::model::ImportDataRequest::input_config].
         pub fn set_input_config<T: Into<std::option::Option<crate::model::DatasetInputConfig>>>(
             mut self,
             v: T,
@@ -2444,13 +2458,13 @@ pub mod translation_service {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `dataset`.
+        /// Sets the value of [dataset][crate::model::ExportDataRequest::dataset].
         pub fn set_dataset<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.dataset = v.into();
             self
         }
 
-        /// Sets the value of `output_config`.
+        /// Sets the value of [output_config][crate::model::ExportDataRequest::output_config].
         pub fn set_output_config<
             T: Into<std::option::Option<crate::model::DatasetOutputConfig>>,
         >(
@@ -2511,25 +2525,25 @@ pub mod translation_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListExamplesRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListExamplesRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListExamplesRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListExamplesRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -2607,13 +2621,13 @@ pub mod translation_service {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateModelRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `model`.
+        /// Sets the value of [model][crate::model::CreateModelRequest::model].
         pub fn set_model<T: Into<std::option::Option<crate::model::Model>>>(
             mut self,
             v: T,
@@ -2672,25 +2686,25 @@ pub mod translation_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListModelsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListModelsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListModelsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListModelsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -2731,7 +2745,7 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetModelRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2807,7 +2821,7 @@ pub mod translation_service {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteModelRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2866,25 +2880,25 @@ pub mod translation_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][location::model::ListLocationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][location::model::ListLocationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][location::model::ListLocationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][location::model::ListLocationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -2925,7 +2939,7 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][location::model::GetLocationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -2984,25 +2998,25 @@ pub mod translation_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::ListOperationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][longrunning::model::ListOperationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][longrunning::model::ListOperationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][longrunning::model::ListOperationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -3046,7 +3060,7 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::GetOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -3090,7 +3104,7 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::DeleteOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -3134,7 +3148,7 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::CancelOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -3178,13 +3192,13 @@ pub mod translation_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::WaitOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `timeout`.
+        /// Sets the value of [timeout][longrunning::model::WaitOperationRequest::timeout].
         pub fn set_timeout<T: Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
             self.0.request.timeout = v.into();
             self

--- a/src/generated/cloud/translate/v3/src/model.rs
+++ b/src/generated/cloud/translate/v3/src/model.rs
@@ -72,19 +72,19 @@ pub struct AdaptiveMtDataset {
 }
 
 impl AdaptiveMtDataset {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::AdaptiveMtDataset::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::AdaptiveMtDataset::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
         self
     }
 
-    /// Sets the value of `source_language_code`.
+    /// Sets the value of [source_language_code][crate::model::AdaptiveMtDataset::source_language_code].
     pub fn set_source_language_code<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -93,7 +93,7 @@ impl AdaptiveMtDataset {
         self
     }
 
-    /// Sets the value of `target_language_code`.
+    /// Sets the value of [target_language_code][crate::model::AdaptiveMtDataset::target_language_code].
     pub fn set_target_language_code<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -102,13 +102,13 @@ impl AdaptiveMtDataset {
         self
     }
 
-    /// Sets the value of `example_count`.
+    /// Sets the value of [example_count][crate::model::AdaptiveMtDataset::example_count].
     pub fn set_example_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.example_count = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::AdaptiveMtDataset::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -117,7 +117,7 @@ impl AdaptiveMtDataset {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::AdaptiveMtDataset::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -150,13 +150,13 @@ pub struct CreateAdaptiveMtDatasetRequest {
 }
 
 impl CreateAdaptiveMtDatasetRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateAdaptiveMtDatasetRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `adaptive_mt_dataset`.
+    /// Sets the value of [adaptive_mt_dataset][crate::model::CreateAdaptiveMtDatasetRequest::adaptive_mt_dataset].
     pub fn set_adaptive_mt_dataset<
         T: std::convert::Into<std::option::Option<crate::model::AdaptiveMtDataset>>,
     >(
@@ -187,7 +187,7 @@ pub struct DeleteAdaptiveMtDatasetRequest {
 }
 
 impl DeleteAdaptiveMtDatasetRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteAdaptiveMtDatasetRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -213,7 +213,7 @@ pub struct GetAdaptiveMtDatasetRequest {
 }
 
 impl GetAdaptiveMtDatasetRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetAdaptiveMtDatasetRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -257,25 +257,25 @@ pub struct ListAdaptiveMtDatasetsRequest {
 }
 
 impl ListAdaptiveMtDatasetsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListAdaptiveMtDatasetsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListAdaptiveMtDatasetsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListAdaptiveMtDatasetsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListAdaptiveMtDatasetsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
@@ -306,20 +306,20 @@ pub struct ListAdaptiveMtDatasetsResponse {
 }
 
 impl ListAdaptiveMtDatasetsResponse {
-    /// Sets the value of `adaptive_mt_datasets`.
-    pub fn set_adaptive_mt_datasets<
-        T: std::convert::Into<std::vec::Vec<crate::model::AdaptiveMtDataset>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.adaptive_mt_datasets = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListAdaptiveMtDatasetsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [adaptive_mt_datasets][crate::model::ListAdaptiveMtDatasetsResponse::adaptive_mt_datasets].
+    pub fn set_adaptive_mt_datasets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AdaptiveMtDataset>,
+    {
+        use std::iter::Iterator;
+        self.adaptive_mt_datasets = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -378,28 +378,19 @@ pub struct AdaptiveMtTranslateRequest {
 }
 
 impl AdaptiveMtTranslateRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::AdaptiveMtTranslateRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `dataset`.
+    /// Sets the value of [dataset][crate::model::AdaptiveMtTranslateRequest::dataset].
     pub fn set_dataset<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.dataset = v.into();
         self
     }
 
-    /// Sets the value of `content`.
-    pub fn set_content<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.content = v.into();
-        self
-    }
-
-    /// Sets the value of `reference_sentence_config`.
+    /// Sets the value of [reference_sentence_config][crate::model::AdaptiveMtTranslateRequest::reference_sentence_config].
     pub fn set_reference_sentence_config<
         T: std::convert::Into<
             std::option::Option<
@@ -414,7 +405,7 @@ impl AdaptiveMtTranslateRequest {
         self
     }
 
-    /// Sets the value of `glossary_config`.
+    /// Sets the value of [glossary_config][crate::model::AdaptiveMtTranslateRequest::glossary_config].
     pub fn set_glossary_config<
         T: std::convert::Into<
             std::option::Option<crate::model::adaptive_mt_translate_request::GlossaryConfig>,
@@ -424,6 +415,17 @@ impl AdaptiveMtTranslateRequest {
         v: T,
     ) -> Self {
         self.glossary_config = v.into();
+        self
+    }
+
+    /// Sets the value of [content][crate::model::AdaptiveMtTranslateRequest::content].
+    pub fn set_content<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.content = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -455,7 +457,7 @@ pub mod adaptive_mt_translate_request {
     }
 
     impl ReferenceSentencePair {
-        /// Sets the value of `source_sentence`.
+        /// Sets the value of [source_sentence][crate::model::adaptive_mt_translate_request::ReferenceSentencePair::source_sentence].
         pub fn set_source_sentence<T: std::convert::Into<std::string::String>>(
             mut self,
             v: T,
@@ -464,7 +466,7 @@ pub mod adaptive_mt_translate_request {
             self
         }
 
-        /// Sets the value of `target_sentence`.
+        /// Sets the value of [target_sentence][crate::model::adaptive_mt_translate_request::ReferenceSentencePair::target_sentence].
         pub fn set_target_sentence<T: std::convert::Into<std::string::String>>(
             mut self,
             v: T,
@@ -493,16 +495,16 @@ pub mod adaptive_mt_translate_request {
     }
 
     impl ReferenceSentencePairList {
-        /// Sets the value of `reference_sentence_pairs`.
-        pub fn set_reference_sentence_pairs<
-            T: std::convert::Into<
-                std::vec::Vec<crate::model::adaptive_mt_translate_request::ReferenceSentencePair>,
+        /// Sets the value of [reference_sentence_pairs][crate::model::adaptive_mt_translate_request::ReferenceSentencePairList::reference_sentence_pairs].
+        pub fn set_reference_sentence_pairs<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<
+                crate::model::adaptive_mt_translate_request::ReferenceSentencePair,
             >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.reference_sentence_pairs = v.into();
+        {
+            use std::iter::Iterator;
+            self.reference_sentence_pairs = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -537,22 +539,7 @@ pub mod adaptive_mt_translate_request {
     }
 
     impl ReferenceSentenceConfig {
-        /// Sets the value of `reference_sentence_pair_lists`.
-        pub fn set_reference_sentence_pair_lists<
-            T: std::convert::Into<
-                std::vec::Vec<
-                    crate::model::adaptive_mt_translate_request::ReferenceSentencePairList,
-                >,
-            >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.reference_sentence_pair_lists = v.into();
-            self
-        }
-
-        /// Sets the value of `source_language_code`.
+        /// Sets the value of [source_language_code][crate::model::adaptive_mt_translate_request::ReferenceSentenceConfig::source_language_code].
         pub fn set_source_language_code<T: std::convert::Into<std::string::String>>(
             mut self,
             v: T,
@@ -561,12 +548,25 @@ pub mod adaptive_mt_translate_request {
             self
         }
 
-        /// Sets the value of `target_language_code`.
+        /// Sets the value of [target_language_code][crate::model::adaptive_mt_translate_request::ReferenceSentenceConfig::target_language_code].
         pub fn set_target_language_code<T: std::convert::Into<std::string::String>>(
             mut self,
             v: T,
         ) -> Self {
             self.target_language_code = v.into();
+            self
+        }
+
+        /// Sets the value of [reference_sentence_pair_lists][crate::model::adaptive_mt_translate_request::ReferenceSentenceConfig::reference_sentence_pair_lists].
+        pub fn set_reference_sentence_pair_lists<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<
+                crate::model::adaptive_mt_translate_request::ReferenceSentencePairList,
+            >,
+        {
+            use std::iter::Iterator;
+            self.reference_sentence_pair_lists = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -604,19 +604,19 @@ pub mod adaptive_mt_translate_request {
     }
 
     impl GlossaryConfig {
-        /// Sets the value of `glossary`.
+        /// Sets the value of [glossary][crate::model::adaptive_mt_translate_request::GlossaryConfig::glossary].
         pub fn set_glossary<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.glossary = v.into();
             self
         }
 
-        /// Sets the value of `ignore_case`.
+        /// Sets the value of [ignore_case][crate::model::adaptive_mt_translate_request::GlossaryConfig::ignore_case].
         pub fn set_ignore_case<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.ignore_case = v.into();
             self
         }
 
-        /// Sets the value of `contextual_translation_enabled`.
+        /// Sets the value of [contextual_translation_enabled][crate::model::adaptive_mt_translate_request::GlossaryConfig::contextual_translation_enabled].
         pub fn set_contextual_translation_enabled<T: std::convert::Into<bool>>(
             mut self,
             v: T,
@@ -645,7 +645,7 @@ pub struct AdaptiveMtTranslation {
 }
 
 impl AdaptiveMtTranslation {
-    /// Sets the value of `translated_text`.
+    /// Sets the value of [translated_text][crate::model::AdaptiveMtTranslation::translated_text].
     pub fn set_translated_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.translated_text = v.into();
         self
@@ -679,31 +679,31 @@ pub struct AdaptiveMtTranslateResponse {
 }
 
 impl AdaptiveMtTranslateResponse {
-    /// Sets the value of `translations`.
-    pub fn set_translations<
-        T: std::convert::Into<std::vec::Vec<crate::model::AdaptiveMtTranslation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.translations = v.into();
-        self
-    }
-
-    /// Sets the value of `language_code`.
+    /// Sets the value of [language_code][crate::model::AdaptiveMtTranslateResponse::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
         self
     }
 
-    /// Sets the value of `glossary_translations`.
-    pub fn set_glossary_translations<
-        T: std::convert::Into<std::vec::Vec<crate::model::AdaptiveMtTranslation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.glossary_translations = v.into();
+    /// Sets the value of [translations][crate::model::AdaptiveMtTranslateResponse::translations].
+    pub fn set_translations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AdaptiveMtTranslation>,
+    {
+        use std::iter::Iterator;
+        self.translations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [glossary_translations][crate::model::AdaptiveMtTranslateResponse::glossary_translations].
+    pub fn set_glossary_translations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AdaptiveMtTranslation>,
+    {
+        use std::iter::Iterator;
+        self.glossary_translations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -742,25 +742,25 @@ pub struct AdaptiveMtFile {
 }
 
 impl AdaptiveMtFile {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::AdaptiveMtFile::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::AdaptiveMtFile::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
         self
     }
 
-    /// Sets the value of `entry_count`.
+    /// Sets the value of [entry_count][crate::model::AdaptiveMtFile::entry_count].
     pub fn set_entry_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.entry_count = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::AdaptiveMtFile::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -769,7 +769,7 @@ impl AdaptiveMtFile {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::AdaptiveMtFile::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -798,7 +798,7 @@ pub struct GetAdaptiveMtFileRequest {
 }
 
 impl GetAdaptiveMtFileRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetAdaptiveMtFileRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -824,7 +824,7 @@ pub struct DeleteAdaptiveMtFileRequest {
 }
 
 impl DeleteAdaptiveMtFileRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteAdaptiveMtFileRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -854,7 +854,7 @@ pub struct ImportAdaptiveMtFileRequest {
 }
 
 impl ImportAdaptiveMtFileRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ImportAdaptiveMtFileRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
@@ -909,7 +909,7 @@ pub struct ImportAdaptiveMtFileResponse {
 }
 
 impl ImportAdaptiveMtFileResponse {
-    /// Sets the value of `adaptive_mt_file`.
+    /// Sets the value of [adaptive_mt_file][crate::model::ImportAdaptiveMtFileResponse::adaptive_mt_file].
     pub fn set_adaptive_mt_file<
         T: std::convert::Into<std::option::Option<crate::model::AdaptiveMtFile>>,
     >(
@@ -952,19 +952,19 @@ pub struct ListAdaptiveMtFilesRequest {
 }
 
 impl ListAdaptiveMtFilesRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListAdaptiveMtFilesRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListAdaptiveMtFilesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListAdaptiveMtFilesRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -995,20 +995,20 @@ pub struct ListAdaptiveMtFilesResponse {
 }
 
 impl ListAdaptiveMtFilesResponse {
-    /// Sets the value of `adaptive_mt_files`.
-    pub fn set_adaptive_mt_files<
-        T: std::convert::Into<std::vec::Vec<crate::model::AdaptiveMtFile>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.adaptive_mt_files = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListAdaptiveMtFilesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [adaptive_mt_files][crate::model::ListAdaptiveMtFilesResponse::adaptive_mt_files].
+    pub fn set_adaptive_mt_files<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AdaptiveMtFile>,
+    {
+        use std::iter::Iterator;
+        self.adaptive_mt_files = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1061,25 +1061,25 @@ pub struct AdaptiveMtSentence {
 }
 
 impl AdaptiveMtSentence {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::AdaptiveMtSentence::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `source_sentence`.
+    /// Sets the value of [source_sentence][crate::model::AdaptiveMtSentence::source_sentence].
     pub fn set_source_sentence<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.source_sentence = v.into();
         self
     }
 
-    /// Sets the value of `target_sentence`.
+    /// Sets the value of [target_sentence][crate::model::AdaptiveMtSentence::target_sentence].
     pub fn set_target_sentence<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.target_sentence = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::AdaptiveMtSentence::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1088,7 +1088,7 @@ impl AdaptiveMtSentence {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::AdaptiveMtSentence::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1130,19 +1130,19 @@ pub struct ListAdaptiveMtSentencesRequest {
 }
 
 impl ListAdaptiveMtSentencesRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListAdaptiveMtSentencesRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListAdaptiveMtSentencesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListAdaptiveMtSentencesRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -1171,20 +1171,20 @@ pub struct ListAdaptiveMtSentencesResponse {
 }
 
 impl ListAdaptiveMtSentencesResponse {
-    /// Sets the value of `adaptive_mt_sentences`.
-    pub fn set_adaptive_mt_sentences<
-        T: std::convert::Into<std::vec::Vec<crate::model::AdaptiveMtSentence>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.adaptive_mt_sentences = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListAdaptiveMtSentencesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [adaptive_mt_sentences][crate::model::ListAdaptiveMtSentencesResponse::adaptive_mt_sentences].
+    pub fn set_adaptive_mt_sentences<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AdaptiveMtSentence>,
+    {
+        use std::iter::Iterator;
+        self.adaptive_mt_sentences = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1225,13 +1225,13 @@ pub struct ImportDataRequest {
 }
 
 impl ImportDataRequest {
-    /// Sets the value of `dataset`.
+    /// Sets the value of [dataset][crate::model::ImportDataRequest::dataset].
     pub fn set_dataset<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.dataset = v.into();
         self
     }
 
-    /// Sets the value of `input_config`.
+    /// Sets the value of [input_config][crate::model::ImportDataRequest::input_config].
     pub fn set_input_config<
         T: std::convert::Into<std::option::Option<crate::model::DatasetInputConfig>>,
     >(
@@ -1261,14 +1261,14 @@ pub struct DatasetInputConfig {
 }
 
 impl DatasetInputConfig {
-    /// Sets the value of `input_files`.
-    pub fn set_input_files<
-        T: std::convert::Into<std::vec::Vec<crate::model::dataset_input_config::InputFile>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.input_files = v.into();
+    /// Sets the value of [input_files][crate::model::DatasetInputConfig::input_files].
+    pub fn set_input_files<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::dataset_input_config::InputFile>,
+    {
+        use std::iter::Iterator;
+        self.input_files = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1303,7 +1303,7 @@ pub mod dataset_input_config {
     }
 
     impl InputFile {
-        /// Sets the value of `usage`.
+        /// Sets the value of [usage][crate::model::dataset_input_config::InputFile::usage].
         pub fn set_usage<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.usage = v.into();
             self
@@ -1370,13 +1370,13 @@ pub struct ImportDataMetadata {
 }
 
 impl ImportDataMetadata {
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::ImportDataMetadata::state].
     pub fn set_state<T: std::convert::Into<crate::model::OperationState>>(mut self, v: T) -> Self {
         self.state = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::ImportDataMetadata::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1385,7 +1385,7 @@ impl ImportDataMetadata {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::ImportDataMetadata::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1394,7 +1394,7 @@ impl ImportDataMetadata {
         self
     }
 
-    /// Sets the value of `error`.
+    /// Sets the value of [error][crate::model::ImportDataMetadata::error].
     pub fn set_error<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
         mut self,
         v: T,
@@ -1427,13 +1427,13 @@ pub struct ExportDataRequest {
 }
 
 impl ExportDataRequest {
-    /// Sets the value of `dataset`.
+    /// Sets the value of [dataset][crate::model::ExportDataRequest::dataset].
     pub fn set_dataset<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.dataset = v.into();
         self
     }
 
-    /// Sets the value of `output_config`.
+    /// Sets the value of [output_config][crate::model::ExportDataRequest::output_config].
     pub fn set_output_config<
         T: std::convert::Into<std::option::Option<crate::model::DatasetOutputConfig>>,
     >(
@@ -1519,13 +1519,13 @@ pub struct ExportDataMetadata {
 }
 
 impl ExportDataMetadata {
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::ExportDataMetadata::state].
     pub fn set_state<T: std::convert::Into<crate::model::OperationState>>(mut self, v: T) -> Self {
         self.state = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::ExportDataMetadata::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1534,7 +1534,7 @@ impl ExportDataMetadata {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::ExportDataMetadata::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1543,7 +1543,7 @@ impl ExportDataMetadata {
         self
     }
 
-    /// Sets the value of `error`.
+    /// Sets the value of [error][crate::model::ExportDataMetadata::error].
     pub fn set_error<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
         mut self,
         v: T,
@@ -1571,7 +1571,7 @@ pub struct DeleteDatasetRequest {
 }
 
 impl DeleteDatasetRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteDatasetRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1607,13 +1607,13 @@ pub struct DeleteDatasetMetadata {
 }
 
 impl DeleteDatasetMetadata {
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::DeleteDatasetMetadata::state].
     pub fn set_state<T: std::convert::Into<crate::model::OperationState>>(mut self, v: T) -> Self {
         self.state = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::DeleteDatasetMetadata::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1622,7 +1622,7 @@ impl DeleteDatasetMetadata {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::DeleteDatasetMetadata::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1631,7 +1631,7 @@ impl DeleteDatasetMetadata {
         self
     }
 
-    /// Sets the value of `error`.
+    /// Sets the value of [error][crate::model::DeleteDatasetMetadata::error].
     pub fn set_error<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
         mut self,
         v: T,
@@ -1659,7 +1659,7 @@ pub struct GetDatasetRequest {
 }
 
 impl GetDatasetRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetDatasetRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1695,19 +1695,19 @@ pub struct ListDatasetsRequest {
 }
 
 impl ListDatasetsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListDatasetsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListDatasetsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListDatasetsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -1738,18 +1738,20 @@ pub struct ListDatasetsResponse {
 }
 
 impl ListDatasetsResponse {
-    /// Sets the value of `datasets`.
-    pub fn set_datasets<T: std::convert::Into<std::vec::Vec<crate::model::Dataset>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.datasets = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListDatasetsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [datasets][crate::model::ListDatasetsResponse::datasets].
+    pub fn set_datasets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Dataset>,
+    {
+        use std::iter::Iterator;
+        self.datasets = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1789,13 +1791,13 @@ pub struct CreateDatasetRequest {
 }
 
 impl CreateDatasetRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateDatasetRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `dataset`.
+    /// Sets the value of [dataset][crate::model::CreateDatasetRequest::dataset].
     pub fn set_dataset<T: std::convert::Into<std::option::Option<crate::model::Dataset>>>(
         mut self,
         v: T,
@@ -1834,13 +1836,13 @@ pub struct CreateDatasetMetadata {
 }
 
 impl CreateDatasetMetadata {
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::CreateDatasetMetadata::state].
     pub fn set_state<T: std::convert::Into<crate::model::OperationState>>(mut self, v: T) -> Self {
         self.state = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::CreateDatasetMetadata::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1849,7 +1851,7 @@ impl CreateDatasetMetadata {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::CreateDatasetMetadata::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1858,7 +1860,7 @@ impl CreateDatasetMetadata {
         self
     }
 
-    /// Sets the value of `error`.
+    /// Sets the value of [error][crate::model::CreateDatasetMetadata::error].
     pub fn set_error<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
         mut self,
         v: T,
@@ -1904,25 +1906,25 @@ pub struct ListExamplesRequest {
 }
 
 impl ListExamplesRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListExamplesRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListExamplesRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListExamplesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListExamplesRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -1953,18 +1955,20 @@ pub struct ListExamplesResponse {
 }
 
 impl ListExamplesResponse {
-    /// Sets the value of `examples`.
-    pub fn set_examples<T: std::convert::Into<std::vec::Vec<crate::model::Example>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.examples = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListExamplesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [examples][crate::model::ListExamplesResponse::examples].
+    pub fn set_examples<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Example>,
+    {
+        use std::iter::Iterator;
+        self.examples = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2013,25 +2017,25 @@ pub struct Example {
 }
 
 impl Example {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Example::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `source_text`.
+    /// Sets the value of [source_text][crate::model::Example::source_text].
     pub fn set_source_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.source_text = v.into();
         self
     }
 
-    /// Sets the value of `target_text`.
+    /// Sets the value of [target_text][crate::model::Example::target_text].
     pub fn set_target_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.target_text = v.into();
         self
     }
 
-    /// Sets the value of `usage`.
+    /// Sets the value of [usage][crate::model::Example::usage].
     pub fn set_usage<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.usage = v.into();
         self
@@ -2057,18 +2061,16 @@ pub struct BatchTransferResourcesResponse {
 }
 
 impl BatchTransferResourcesResponse {
-    /// Sets the value of `responses`.
-    pub fn set_responses<
-        T: std::convert::Into<
-            std::vec::Vec<
-                crate::model::batch_transfer_resources_response::TransferResourceResponse,
-            >,
+    /// Sets the value of [responses][crate::model::BatchTransferResourcesResponse::responses].
+    pub fn set_responses<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<
+            crate::model::batch_transfer_resources_response::TransferResourceResponse,
         >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.responses = v.into();
+    {
+        use std::iter::Iterator;
+        self.responses = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2105,19 +2107,19 @@ pub mod batch_transfer_resources_response {
     }
 
     impl TransferResourceResponse {
-        /// Sets the value of `source`.
+        /// Sets the value of [source][crate::model::batch_transfer_resources_response::TransferResourceResponse::source].
         pub fn set_source<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.source = v.into();
             self
         }
 
-        /// Sets the value of `target`.
+        /// Sets the value of [target][crate::model::batch_transfer_resources_response::TransferResourceResponse::target].
         pub fn set_target<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.target = v.into();
             self
         }
 
-        /// Sets the value of `error`.
+        /// Sets the value of [error][crate::model::batch_transfer_resources_response::TransferResourceResponse::error].
         pub fn set_error<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
             mut self,
             v: T,
@@ -2182,19 +2184,19 @@ pub struct Dataset {
 }
 
 impl Dataset {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Dataset::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::Dataset::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
         self
     }
 
-    /// Sets the value of `source_language_code`.
+    /// Sets the value of [source_language_code][crate::model::Dataset::source_language_code].
     pub fn set_source_language_code<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -2203,7 +2205,7 @@ impl Dataset {
         self
     }
 
-    /// Sets the value of `target_language_code`.
+    /// Sets the value of [target_language_code][crate::model::Dataset::target_language_code].
     pub fn set_target_language_code<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -2212,31 +2214,31 @@ impl Dataset {
         self
     }
 
-    /// Sets the value of `example_count`.
+    /// Sets the value of [example_count][crate::model::Dataset::example_count].
     pub fn set_example_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.example_count = v.into();
         self
     }
 
-    /// Sets the value of `train_example_count`.
+    /// Sets the value of [train_example_count][crate::model::Dataset::train_example_count].
     pub fn set_train_example_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.train_example_count = v.into();
         self
     }
 
-    /// Sets the value of `validate_example_count`.
+    /// Sets the value of [validate_example_count][crate::model::Dataset::validate_example_count].
     pub fn set_validate_example_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.validate_example_count = v.into();
         self
     }
 
-    /// Sets the value of `test_example_count`.
+    /// Sets the value of [test_example_count][crate::model::Dataset::test_example_count].
     pub fn set_test_example_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.test_example_count = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::Dataset::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2245,7 +2247,7 @@ impl Dataset {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::Dataset::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2278,13 +2280,13 @@ pub struct CreateModelRequest {
 }
 
 impl CreateModelRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateModelRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `model`.
+    /// Sets the value of [model][crate::model::CreateModelRequest::model].
     pub fn set_model<T: std::convert::Into<std::option::Option<crate::model::Model>>>(
         mut self,
         v: T,
@@ -2323,13 +2325,13 @@ pub struct CreateModelMetadata {
 }
 
 impl CreateModelMetadata {
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::CreateModelMetadata::state].
     pub fn set_state<T: std::convert::Into<crate::model::OperationState>>(mut self, v: T) -> Self {
         self.state = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::CreateModelMetadata::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2338,7 +2340,7 @@ impl CreateModelMetadata {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::CreateModelMetadata::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2347,7 +2349,7 @@ impl CreateModelMetadata {
         self
     }
 
-    /// Sets the value of `error`.
+    /// Sets the value of [error][crate::model::CreateModelMetadata::error].
     pub fn set_error<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
         mut self,
         v: T,
@@ -2392,25 +2394,25 @@ pub struct ListModelsRequest {
 }
 
 impl ListModelsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListModelsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListModelsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListModelsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListModelsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -2441,18 +2443,20 @@ pub struct ListModelsResponse {
 }
 
 impl ListModelsResponse {
-    /// Sets the value of `models`.
-    pub fn set_models<T: std::convert::Into<std::vec::Vec<crate::model::Model>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.models = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListModelsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [models][crate::model::ListModelsResponse::models].
+    pub fn set_models<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Model>,
+    {
+        use std::iter::Iterator;
+        self.models = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2488,7 +2492,7 @@ pub struct GetModelRequest {
 }
 
 impl GetModelRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetModelRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -2513,7 +2517,7 @@ pub struct DeleteModelRequest {
 }
 
 impl DeleteModelRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteModelRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -2549,13 +2553,13 @@ pub struct DeleteModelMetadata {
 }
 
 impl DeleteModelMetadata {
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::DeleteModelMetadata::state].
     pub fn set_state<T: std::convert::Into<crate::model::OperationState>>(mut self, v: T) -> Self {
         self.state = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::DeleteModelMetadata::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2564,7 +2568,7 @@ impl DeleteModelMetadata {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::DeleteModelMetadata::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2573,7 +2577,7 @@ impl DeleteModelMetadata {
         self
     }
 
-    /// Sets the value of `error`.
+    /// Sets the value of [error][crate::model::DeleteModelMetadata::error].
     pub fn set_error<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
         mut self,
         v: T,
@@ -2640,25 +2644,25 @@ pub struct Model {
 }
 
 impl Model {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Model::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::Model::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
         self
     }
 
-    /// Sets the value of `dataset`.
+    /// Sets the value of [dataset][crate::model::Model::dataset].
     pub fn set_dataset<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.dataset = v.into();
         self
     }
 
-    /// Sets the value of `source_language_code`.
+    /// Sets the value of [source_language_code][crate::model::Model::source_language_code].
     pub fn set_source_language_code<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -2667,7 +2671,7 @@ impl Model {
         self
     }
 
-    /// Sets the value of `target_language_code`.
+    /// Sets the value of [target_language_code][crate::model::Model::target_language_code].
     pub fn set_target_language_code<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -2676,25 +2680,25 @@ impl Model {
         self
     }
 
-    /// Sets the value of `train_example_count`.
+    /// Sets the value of [train_example_count][crate::model::Model::train_example_count].
     pub fn set_train_example_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.train_example_count = v.into();
         self
     }
 
-    /// Sets the value of `validate_example_count`.
+    /// Sets the value of [validate_example_count][crate::model::Model::validate_example_count].
     pub fn set_validate_example_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.validate_example_count = v.into();
         self
     }
 
-    /// Sets the value of `test_example_count`.
+    /// Sets the value of [test_example_count][crate::model::Model::test_example_count].
     pub fn set_test_example_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.test_example_count = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::Model::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2703,7 +2707,7 @@ impl Model {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::Model::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2731,7 +2735,7 @@ pub struct GcsInputSource {
 }
 
 impl GcsInputSource {
-    /// Sets the value of `input_uri`.
+    /// Sets the value of [input_uri][crate::model::GcsInputSource::input_uri].
     pub fn set_input_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.input_uri = v.into();
         self
@@ -2765,19 +2769,19 @@ pub struct FileInputSource {
 }
 
 impl FileInputSource {
-    /// Sets the value of `mime_type`.
+    /// Sets the value of [mime_type][crate::model::FileInputSource::mime_type].
     pub fn set_mime_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.mime_type = v.into();
         self
     }
 
-    /// Sets the value of `content`.
+    /// Sets the value of [content][crate::model::FileInputSource::content].
     pub fn set_content<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.content = v.into();
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::FileInputSource::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
         self
@@ -2804,7 +2808,7 @@ pub struct GcsOutputDestination {
 }
 
 impl GcsOutputDestination {
-    /// Sets the value of `output_uri_prefix`.
+    /// Sets the value of [output_uri_prefix][crate::model::GcsOutputDestination::output_uri_prefix].
     pub fn set_output_uri_prefix<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -2843,13 +2847,13 @@ pub struct GlossaryEntry {
 }
 
 impl GlossaryEntry {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GlossaryEntry::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::GlossaryEntry::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
@@ -2894,7 +2898,7 @@ pub mod glossary_entry {
     }
 
     impl GlossaryTermsPair {
-        /// Sets the value of `source_term`.
+        /// Sets the value of [source_term][crate::model::glossary_entry::GlossaryTermsPair::source_term].
         pub fn set_source_term<
             T: std::convert::Into<std::option::Option<crate::model::GlossaryTerm>>,
         >(
@@ -2905,7 +2909,7 @@ pub mod glossary_entry {
             self
         }
 
-        /// Sets the value of `target_term`.
+        /// Sets the value of [target_term][crate::model::glossary_entry::GlossaryTermsPair::target_term].
         pub fn set_target_term<
             T: std::convert::Into<std::option::Option<crate::model::GlossaryTerm>>,
         >(
@@ -2938,12 +2942,14 @@ pub mod glossary_entry {
     }
 
     impl GlossaryTermsSet {
-        /// Sets the value of `terms`.
-        pub fn set_terms<T: std::convert::Into<std::vec::Vec<crate::model::GlossaryTerm>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.terms = v.into();
+        /// Sets the value of [terms][crate::model::glossary_entry::GlossaryTermsSet::terms].
+        pub fn set_terms<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::GlossaryTerm>,
+        {
+            use std::iter::Iterator;
+            self.terms = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -2983,13 +2989,13 @@ pub struct GlossaryTerm {
 }
 
 impl GlossaryTerm {
-    /// Sets the value of `language_code`.
+    /// Sets the value of [language_code][crate::model::GlossaryTerm::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
         self
     }
 
-    /// Sets the value of `text`.
+    /// Sets the value of [text][crate::model::GlossaryTerm::text].
     pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.text = v.into();
         self
@@ -3014,7 +3020,7 @@ pub struct TransliterationConfig {
 }
 
 impl TransliterationConfig {
-    /// Sets the value of `enable_transliteration`.
+    /// Sets the value of [enable_transliteration][crate::model::TransliterationConfig::enable_transliteration].
     pub fn set_enable_transliteration<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enable_transliteration = v.into();
         self
@@ -3120,22 +3126,13 @@ pub struct TranslateTextRequest {
 }
 
 impl TranslateTextRequest {
-    /// Sets the value of `contents`.
-    pub fn set_contents<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.contents = v.into();
-        self
-    }
-
-    /// Sets the value of `mime_type`.
+    /// Sets the value of [mime_type][crate::model::TranslateTextRequest::mime_type].
     pub fn set_mime_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.mime_type = v.into();
         self
     }
 
-    /// Sets the value of `source_language_code`.
+    /// Sets the value of [source_language_code][crate::model::TranslateTextRequest::source_language_code].
     pub fn set_source_language_code<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -3144,7 +3141,7 @@ impl TranslateTextRequest {
         self
     }
 
-    /// Sets the value of `target_language_code`.
+    /// Sets the value of [target_language_code][crate::model::TranslateTextRequest::target_language_code].
     pub fn set_target_language_code<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -3153,19 +3150,19 @@ impl TranslateTextRequest {
         self
     }
 
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::TranslateTextRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `model`.
+    /// Sets the value of [model][crate::model::TranslateTextRequest::model].
     pub fn set_model<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.model = v.into();
         self
     }
 
-    /// Sets the value of `glossary_config`.
+    /// Sets the value of [glossary_config][crate::model::TranslateTextRequest::glossary_config].
     pub fn set_glossary_config<
         T: std::convert::Into<std::option::Option<crate::model::TranslateTextGlossaryConfig>>,
     >(
@@ -3176,7 +3173,7 @@ impl TranslateTextRequest {
         self
     }
 
-    /// Sets the value of `transliteration_config`.
+    /// Sets the value of [transliteration_config][crate::model::TranslateTextRequest::transliteration_config].
     pub fn set_transliteration_config<
         T: std::convert::Into<std::option::Option<crate::model::TransliterationConfig>>,
     >(
@@ -3187,14 +3184,26 @@ impl TranslateTextRequest {
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
+    /// Sets the value of [contents][crate::model::TranslateTextRequest::contents].
+    pub fn set_contents<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.contents = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::TranslateTextRequest::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -3231,23 +3240,25 @@ pub struct TranslateTextResponse {
 }
 
 impl TranslateTextResponse {
-    /// Sets the value of `translations`.
-    pub fn set_translations<T: std::convert::Into<std::vec::Vec<crate::model::Translation>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.translations = v.into();
+    /// Sets the value of [translations][crate::model::TranslateTextResponse::translations].
+    pub fn set_translations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Translation>,
+    {
+        use std::iter::Iterator;
+        self.translations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
-    /// Sets the value of `glossary_translations`.
-    pub fn set_glossary_translations<
-        T: std::convert::Into<std::vec::Vec<crate::model::Translation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.glossary_translations = v.into();
+    /// Sets the value of [glossary_translations][crate::model::TranslateTextResponse::glossary_translations].
+    pub fn set_glossary_translations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Translation>,
+    {
+        use std::iter::Iterator;
+        self.glossary_translations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3294,19 +3305,19 @@ pub struct Translation {
 }
 
 impl Translation {
-    /// Sets the value of `translated_text`.
+    /// Sets the value of [translated_text][crate::model::Translation::translated_text].
     pub fn set_translated_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.translated_text = v.into();
         self
     }
 
-    /// Sets the value of `model`.
+    /// Sets the value of [model][crate::model::Translation::model].
     pub fn set_model<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.model = v.into();
         self
     }
 
-    /// Sets the value of `detected_language_code`.
+    /// Sets the value of [detected_language_code][crate::model::Translation::detected_language_code].
     pub fn set_detected_language_code<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -3315,7 +3326,7 @@ impl Translation {
         self
     }
 
-    /// Sets the value of `glossary_config`.
+    /// Sets the value of [glossary_config][crate::model::Translation::glossary_config].
     pub fn set_glossary_config<
         T: std::convert::Into<std::option::Option<crate::model::TranslateTextGlossaryConfig>>,
     >(
@@ -3363,27 +3374,29 @@ pub struct RomanizeTextRequest {
 }
 
 impl RomanizeTextRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::RomanizeTextRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `contents`.
-    pub fn set_contents<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.contents = v.into();
-        self
-    }
-
-    /// Sets the value of `source_language_code`.
+    /// Sets the value of [source_language_code][crate::model::RomanizeTextRequest::source_language_code].
     pub fn set_source_language_code<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
     ) -> Self {
         self.source_language_code = v.into();
+        self
+    }
+
+    /// Sets the value of [contents][crate::model::RomanizeTextRequest::contents].
+    pub fn set_contents<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.contents = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3415,13 +3428,13 @@ pub struct Romanization {
 }
 
 impl Romanization {
-    /// Sets the value of `romanized_text`.
+    /// Sets the value of [romanized_text][crate::model::Romanization::romanized_text].
     pub fn set_romanized_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.romanized_text = v.into();
         self
     }
 
-    /// Sets the value of `detected_language_code`.
+    /// Sets the value of [detected_language_code][crate::model::Romanization::detected_language_code].
     pub fn set_detected_language_code<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -3453,12 +3466,14 @@ pub struct RomanizeTextResponse {
 }
 
 impl RomanizeTextResponse {
-    /// Sets the value of `romanizations`.
-    pub fn set_romanizations<T: std::convert::Into<std::vec::Vec<crate::model::Romanization>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.romanizations = v.into();
+    /// Sets the value of [romanizations][crate::model::RomanizeTextResponse::romanizations].
+    pub fn set_romanizations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Romanization>,
+    {
+        use std::iter::Iterator;
+        self.romanizations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3524,32 +3539,33 @@ pub struct DetectLanguageRequest {
 }
 
 impl DetectLanguageRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::DetectLanguageRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `model`.
+    /// Sets the value of [model][crate::model::DetectLanguageRequest::model].
     pub fn set_model<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.model = v.into();
         self
     }
 
-    /// Sets the value of `mime_type`.
+    /// Sets the value of [mime_type][crate::model::DetectLanguageRequest::mime_type].
     pub fn set_mime_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.mime_type = v.into();
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
+    /// Sets the value of [labels][crate::model::DetectLanguageRequest::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -3602,13 +3618,13 @@ pub struct DetectedLanguage {
 }
 
 impl DetectedLanguage {
-    /// Sets the value of `language_code`.
+    /// Sets the value of [language_code][crate::model::DetectedLanguage::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
         self
     }
 
-    /// Sets the value of `confidence`.
+    /// Sets the value of [confidence][crate::model::DetectedLanguage::confidence].
     pub fn set_confidence<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
         self.confidence = v.into();
         self
@@ -3634,12 +3650,14 @@ pub struct DetectLanguageResponse {
 }
 
 impl DetectLanguageResponse {
-    /// Sets the value of `languages`.
-    pub fn set_languages<T: std::convert::Into<std::vec::Vec<crate::model::DetectedLanguage>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.languages = v.into();
+    /// Sets the value of [languages][crate::model::DetectLanguageResponse::languages].
+    pub fn set_languages<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DetectedLanguage>,
+    {
+        use std::iter::Iterator;
+        self.languages = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3696,13 +3714,13 @@ pub struct GetSupportedLanguagesRequest {
 }
 
 impl GetSupportedLanguagesRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::GetSupportedLanguagesRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `display_language_code`.
+    /// Sets the value of [display_language_code][crate::model::GetSupportedLanguagesRequest::display_language_code].
     pub fn set_display_language_code<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -3711,7 +3729,7 @@ impl GetSupportedLanguagesRequest {
         self
     }
 
-    /// Sets the value of `model`.
+    /// Sets the value of [model][crate::model::GetSupportedLanguagesRequest::model].
     pub fn set_model<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.model = v.into();
         self
@@ -3737,12 +3755,14 @@ pub struct SupportedLanguages {
 }
 
 impl SupportedLanguages {
-    /// Sets the value of `languages`.
-    pub fn set_languages<T: std::convert::Into<std::vec::Vec<crate::model::SupportedLanguage>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.languages = v.into();
+    /// Sets the value of [languages][crate::model::SupportedLanguages::languages].
+    pub fn set_languages<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SupportedLanguage>,
+    {
+        use std::iter::Iterator;
+        self.languages = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3780,25 +3800,25 @@ pub struct SupportedLanguage {
 }
 
 impl SupportedLanguage {
-    /// Sets the value of `language_code`.
+    /// Sets the value of [language_code][crate::model::SupportedLanguage::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::SupportedLanguage::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
         self
     }
 
-    /// Sets the value of `support_source`.
+    /// Sets the value of [support_source][crate::model::SupportedLanguage::support_source].
     pub fn set_support_source<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.support_source = v.into();
         self
     }
 
-    /// Sets the value of `support_target`.
+    /// Sets the value of [support_target][crate::model::SupportedLanguage::support_target].
     pub fn set_support_target<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.support_target = v.into();
         self
@@ -3823,7 +3843,7 @@ pub struct GcsSource {
 }
 
 impl GcsSource {
-    /// Sets the value of `input_uri`.
+    /// Sets the value of [input_uri][crate::model::GcsSource::input_uri].
     pub fn set_input_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.input_uri = v.into();
         self
@@ -3855,7 +3875,7 @@ pub struct InputConfig {
 }
 
 impl InputConfig {
-    /// Sets the value of `mime_type`.
+    /// Sets the value of [mime_type][crate::model::InputConfig::mime_type].
     pub fn set_mime_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.mime_type = v.into();
         self
@@ -3927,7 +3947,7 @@ pub struct GcsDestination {
 }
 
 impl GcsDestination {
-    /// Sets the value of `output_uri_prefix`.
+    /// Sets the value of [output_uri_prefix][crate::model::GcsDestination::output_uri_prefix].
     pub fn set_output_uri_prefix<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -4091,7 +4111,7 @@ pub struct DocumentInputConfig {
 }
 
 impl DocumentInputConfig {
-    /// Sets the value of `mime_type`.
+    /// Sets the value of [mime_type][crate::model::DocumentInputConfig::mime_type].
     pub fn set_mime_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.mime_type = v.into();
         self
@@ -4170,7 +4190,7 @@ pub struct DocumentOutputConfig {
 }
 
 impl DocumentOutputConfig {
-    /// Sets the value of `mime_type`.
+    /// Sets the value of [mime_type][crate::model::DocumentOutputConfig::mime_type].
     pub fn set_mime_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.mime_type = v.into();
         self
@@ -4361,13 +4381,13 @@ pub struct TranslateDocumentRequest {
 }
 
 impl TranslateDocumentRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::TranslateDocumentRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `source_language_code`.
+    /// Sets the value of [source_language_code][crate::model::TranslateDocumentRequest::source_language_code].
     pub fn set_source_language_code<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -4376,7 +4396,7 @@ impl TranslateDocumentRequest {
         self
     }
 
-    /// Sets the value of `target_language_code`.
+    /// Sets the value of [target_language_code][crate::model::TranslateDocumentRequest::target_language_code].
     pub fn set_target_language_code<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -4385,7 +4405,7 @@ impl TranslateDocumentRequest {
         self
     }
 
-    /// Sets the value of `document_input_config`.
+    /// Sets the value of [document_input_config][crate::model::TranslateDocumentRequest::document_input_config].
     pub fn set_document_input_config<
         T: std::convert::Into<std::option::Option<crate::model::DocumentInputConfig>>,
     >(
@@ -4396,7 +4416,7 @@ impl TranslateDocumentRequest {
         self
     }
 
-    /// Sets the value of `document_output_config`.
+    /// Sets the value of [document_output_config][crate::model::TranslateDocumentRequest::document_output_config].
     pub fn set_document_output_config<
         T: std::convert::Into<std::option::Option<crate::model::DocumentOutputConfig>>,
     >(
@@ -4407,13 +4427,13 @@ impl TranslateDocumentRequest {
         self
     }
 
-    /// Sets the value of `model`.
+    /// Sets the value of [model][crate::model::TranslateDocumentRequest::model].
     pub fn set_model<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.model = v.into();
         self
     }
 
-    /// Sets the value of `glossary_config`.
+    /// Sets the value of [glossary_config][crate::model::TranslateDocumentRequest::glossary_config].
     pub fn set_glossary_config<
         T: std::convert::Into<std::option::Option<crate::model::TranslateTextGlossaryConfig>>,
     >(
@@ -4424,18 +4444,7 @@ impl TranslateDocumentRequest {
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `customized_attribution`.
+    /// Sets the value of [customized_attribution][crate::model::TranslateDocumentRequest::customized_attribution].
     pub fn set_customized_attribution<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -4444,13 +4453,13 @@ impl TranslateDocumentRequest {
         self
     }
 
-    /// Sets the value of `is_translate_native_pdf_only`.
+    /// Sets the value of [is_translate_native_pdf_only][crate::model::TranslateDocumentRequest::is_translate_native_pdf_only].
     pub fn set_is_translate_native_pdf_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.is_translate_native_pdf_only = v.into();
         self
     }
 
-    /// Sets the value of `enable_shadow_removal_native_pdf`.
+    /// Sets the value of [enable_shadow_removal_native_pdf][crate::model::TranslateDocumentRequest::enable_shadow_removal_native_pdf].
     pub fn set_enable_shadow_removal_native_pdf<T: std::convert::Into<bool>>(
         mut self,
         v: T,
@@ -4459,9 +4468,21 @@ impl TranslateDocumentRequest {
         self
     }
 
-    /// Sets the value of `enable_rotation_correction`.
+    /// Sets the value of [enable_rotation_correction][crate::model::TranslateDocumentRequest::enable_rotation_correction].
     pub fn set_enable_rotation_correction<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enable_rotation_correction = v.into();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::TranslateDocumentRequest::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4499,27 +4520,29 @@ pub struct DocumentTranslation {
 }
 
 impl DocumentTranslation {
-    /// Sets the value of `byte_stream_outputs`.
-    pub fn set_byte_stream_outputs<T: std::convert::Into<std::vec::Vec<bytes::Bytes>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.byte_stream_outputs = v.into();
-        self
-    }
-
-    /// Sets the value of `mime_type`.
+    /// Sets the value of [mime_type][crate::model::DocumentTranslation::mime_type].
     pub fn set_mime_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.mime_type = v.into();
         self
     }
 
-    /// Sets the value of `detected_language_code`.
+    /// Sets the value of [detected_language_code][crate::model::DocumentTranslation::detected_language_code].
     pub fn set_detected_language_code<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
     ) -> Self {
         self.detected_language_code = v.into();
+        self
+    }
+
+    /// Sets the value of [byte_stream_outputs][crate::model::DocumentTranslation::byte_stream_outputs].
+    pub fn set_byte_stream_outputs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<bytes::Bytes>,
+    {
+        use std::iter::Iterator;
+        self.byte_stream_outputs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4563,7 +4586,7 @@ pub struct TranslateDocumentResponse {
 }
 
 impl TranslateDocumentResponse {
-    /// Sets the value of `document_translation`.
+    /// Sets the value of [document_translation][crate::model::TranslateDocumentResponse::document_translation].
     pub fn set_document_translation<
         T: std::convert::Into<std::option::Option<crate::model::DocumentTranslation>>,
     >(
@@ -4574,7 +4597,7 @@ impl TranslateDocumentResponse {
         self
     }
 
-    /// Sets the value of `glossary_document_translation`.
+    /// Sets the value of [glossary_document_translation][crate::model::TranslateDocumentResponse::glossary_document_translation].
     pub fn set_glossary_document_translation<
         T: std::convert::Into<std::option::Option<crate::model::DocumentTranslation>>,
     >(
@@ -4585,13 +4608,13 @@ impl TranslateDocumentResponse {
         self
     }
 
-    /// Sets the value of `model`.
+    /// Sets the value of [model][crate::model::TranslateDocumentResponse::model].
     pub fn set_model<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.model = v.into();
         self
     }
 
-    /// Sets the value of `glossary_config`.
+    /// Sets the value of [glossary_config][crate::model::TranslateDocumentResponse::glossary_config].
     pub fn set_glossary_config<
         T: std::convert::Into<std::option::Option<crate::model::TranslateTextGlossaryConfig>>,
     >(
@@ -4686,13 +4709,13 @@ pub struct BatchTranslateTextRequest {
 }
 
 impl BatchTranslateTextRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::BatchTranslateTextRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `source_language_code`.
+    /// Sets the value of [source_language_code][crate::model::BatchTranslateTextRequest::source_language_code].
     pub fn set_source_language_code<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -4701,36 +4724,7 @@ impl BatchTranslateTextRequest {
         self
     }
 
-    /// Sets the value of `target_language_codes`.
-    pub fn set_target_language_codes<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target_language_codes = v.into();
-        self
-    }
-
-    /// Sets the value of `models`.
-    pub fn set_models<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.models = v.into();
-        self
-    }
-
-    /// Sets the value of `input_configs`.
-    pub fn set_input_configs<T: std::convert::Into<std::vec::Vec<crate::model::InputConfig>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.input_configs = v.into();
-        self
-    }
-
-    /// Sets the value of `output_config`.
+    /// Sets the value of [output_config][crate::model::BatchTranslateTextRequest::output_config].
     pub fn set_output_config<
         T: std::convert::Into<std::option::Option<crate::model::OutputConfig>>,
     >(
@@ -4741,30 +4735,61 @@ impl BatchTranslateTextRequest {
         self
     }
 
-    /// Sets the value of `glossaries`.
-    pub fn set_glossaries<
-        T: std::convert::Into<
-            std::collections::HashMap<
-                std::string::String,
-                crate::model::TranslateTextGlossaryConfig,
-            >,
-        >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.glossaries = v.into();
+    /// Sets the value of [target_language_codes][crate::model::BatchTranslateTextRequest::target_language_codes].
+    pub fn set_target_language_codes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.target_language_codes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
+    /// Sets the value of [input_configs][crate::model::BatchTranslateTextRequest::input_configs].
+    pub fn set_input_configs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::InputConfig>,
+    {
+        use std::iter::Iterator;
+        self.input_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [models][crate::model::BatchTranslateTextRequest::models].
+    pub fn set_models<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.models = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [glossaries][crate::model::BatchTranslateTextRequest::glossaries].
+    pub fn set_glossaries<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::TranslateTextGlossaryConfig>,
+    {
+        use std::iter::Iterator;
+        self.glossaries = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::BatchTranslateTextRequest::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4805,7 +4830,7 @@ pub struct BatchTranslateMetadata {
 }
 
 impl BatchTranslateMetadata {
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::BatchTranslateMetadata::state].
     pub fn set_state<T: std::convert::Into<crate::model::batch_translate_metadata::State>>(
         mut self,
         v: T,
@@ -4814,25 +4839,25 @@ impl BatchTranslateMetadata {
         self
     }
 
-    /// Sets the value of `translated_characters`.
+    /// Sets the value of [translated_characters][crate::model::BatchTranslateMetadata::translated_characters].
     pub fn set_translated_characters<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.translated_characters = v.into();
         self
     }
 
-    /// Sets the value of `failed_characters`.
+    /// Sets the value of [failed_characters][crate::model::BatchTranslateMetadata::failed_characters].
     pub fn set_failed_characters<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.failed_characters = v.into();
         self
     }
 
-    /// Sets the value of `total_characters`.
+    /// Sets the value of [total_characters][crate::model::BatchTranslateMetadata::total_characters].
     pub fn set_total_characters<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.total_characters = v.into();
         self
     }
 
-    /// Sets the value of `submit_time`.
+    /// Sets the value of [submit_time][crate::model::BatchTranslateMetadata::submit_time].
     pub fn set_submit_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -4934,25 +4959,25 @@ pub struct BatchTranslateResponse {
 }
 
 impl BatchTranslateResponse {
-    /// Sets the value of `total_characters`.
+    /// Sets the value of [total_characters][crate::model::BatchTranslateResponse::total_characters].
     pub fn set_total_characters<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.total_characters = v.into();
         self
     }
 
-    /// Sets the value of `translated_characters`.
+    /// Sets the value of [translated_characters][crate::model::BatchTranslateResponse::translated_characters].
     pub fn set_translated_characters<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.translated_characters = v.into();
         self
     }
 
-    /// Sets the value of `failed_characters`.
+    /// Sets the value of [failed_characters][crate::model::BatchTranslateResponse::failed_characters].
     pub fn set_failed_characters<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.failed_characters = v.into();
         self
     }
 
-    /// Sets the value of `submit_time`.
+    /// Sets the value of [submit_time][crate::model::BatchTranslateResponse::submit_time].
     pub fn set_submit_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -4961,7 +4986,7 @@ impl BatchTranslateResponse {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::BatchTranslateResponse::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -5080,13 +5105,13 @@ pub struct Glossary {
 }
 
 impl Glossary {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Glossary::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `input_config`.
+    /// Sets the value of [input_config][crate::model::Glossary::input_config].
     pub fn set_input_config<
         T: std::convert::Into<std::option::Option<crate::model::GlossaryInputConfig>>,
     >(
@@ -5097,13 +5122,13 @@ impl Glossary {
         self
     }
 
-    /// Sets the value of `entry_count`.
+    /// Sets the value of [entry_count][crate::model::Glossary::entry_count].
     pub fn set_entry_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.entry_count = v.into();
         self
     }
 
-    /// Sets the value of `submit_time`.
+    /// Sets the value of [submit_time][crate::model::Glossary::submit_time].
     pub fn set_submit_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -5112,7 +5137,7 @@ impl Glossary {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::Glossary::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -5121,7 +5146,7 @@ impl Glossary {
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::Glossary::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
         self
@@ -5168,7 +5193,7 @@ pub mod glossary {
     }
 
     impl LanguageCodePair {
-        /// Sets the value of `source_language_code`.
+        /// Sets the value of [source_language_code][crate::model::glossary::LanguageCodePair::source_language_code].
         pub fn set_source_language_code<T: std::convert::Into<std::string::String>>(
             mut self,
             v: T,
@@ -5177,7 +5202,7 @@ pub mod glossary {
             self
         }
 
-        /// Sets the value of `target_language_code`.
+        /// Sets the value of [target_language_code][crate::model::glossary::LanguageCodePair::target_language_code].
         pub fn set_target_language_code<T: std::convert::Into<std::string::String>>(
             mut self,
             v: T,
@@ -5207,12 +5232,14 @@ pub mod glossary {
     }
 
     impl LanguageCodesSet {
-        /// Sets the value of `language_codes`.
-        pub fn set_language_codes<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.language_codes = v.into();
+        /// Sets the value of [language_codes][crate::model::glossary::LanguageCodesSet::language_codes].
+        pub fn set_language_codes<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.language_codes = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -5251,13 +5278,13 @@ pub struct CreateGlossaryRequest {
 }
 
 impl CreateGlossaryRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateGlossaryRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `glossary`.
+    /// Sets the value of [glossary][crate::model::CreateGlossaryRequest::glossary].
     pub fn set_glossary<T: std::convert::Into<std::option::Option<crate::model::Glossary>>>(
         mut self,
         v: T,
@@ -5290,7 +5317,7 @@ pub struct UpdateGlossaryRequest {
 }
 
 impl UpdateGlossaryRequest {
-    /// Sets the value of `glossary`.
+    /// Sets the value of [glossary][crate::model::UpdateGlossaryRequest::glossary].
     pub fn set_glossary<T: std::convert::Into<std::option::Option<crate::model::Glossary>>>(
         mut self,
         v: T,
@@ -5299,7 +5326,7 @@ impl UpdateGlossaryRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateGlossaryRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -5327,7 +5354,7 @@ pub struct GetGlossaryRequest {
 }
 
 impl GetGlossaryRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetGlossaryRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -5352,7 +5379,7 @@ pub struct DeleteGlossaryRequest {
 }
 
 impl DeleteGlossaryRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteGlossaryRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -5407,25 +5434,25 @@ pub struct ListGlossariesRequest {
 }
 
 impl ListGlossariesRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListGlossariesRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListGlossariesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListGlossariesRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListGlossariesRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
@@ -5456,18 +5483,20 @@ pub struct ListGlossariesResponse {
 }
 
 impl ListGlossariesResponse {
-    /// Sets the value of `glossaries`.
-    pub fn set_glossaries<T: std::convert::Into<std::vec::Vec<crate::model::Glossary>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.glossaries = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListGlossariesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [glossaries][crate::model::ListGlossariesResponse::glossaries].
+    pub fn set_glossaries<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Glossary>,
+    {
+        use std::iter::Iterator;
+        self.glossaries = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5503,7 +5532,7 @@ pub struct GetGlossaryEntryRequest {
 }
 
 impl GetGlossaryEntryRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetGlossaryEntryRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -5528,7 +5557,7 @@ pub struct DeleteGlossaryEntryRequest {
 }
 
 impl DeleteGlossaryEntryRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteGlossaryEntryRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -5565,19 +5594,19 @@ pub struct ListGlossaryEntriesRequest {
 }
 
 impl ListGlossaryEntriesRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListGlossaryEntriesRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListGlossaryEntriesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListGlossaryEntriesRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -5607,20 +5636,20 @@ pub struct ListGlossaryEntriesResponse {
 }
 
 impl ListGlossaryEntriesResponse {
-    /// Sets the value of `glossary_entries`.
-    pub fn set_glossary_entries<
-        T: std::convert::Into<std::vec::Vec<crate::model::GlossaryEntry>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.glossary_entries = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListGlossaryEntriesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [glossary_entries][crate::model::ListGlossaryEntriesResponse::glossary_entries].
+    pub fn set_glossary_entries<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::GlossaryEntry>,
+    {
+        use std::iter::Iterator;
+        self.glossary_entries = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5660,13 +5689,13 @@ pub struct CreateGlossaryEntryRequest {
 }
 
 impl CreateGlossaryEntryRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateGlossaryEntryRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `glossary_entry`.
+    /// Sets the value of [glossary_entry][crate::model::CreateGlossaryEntryRequest::glossary_entry].
     pub fn set_glossary_entry<
         T: std::convert::Into<std::option::Option<crate::model::GlossaryEntry>>,
     >(
@@ -5696,7 +5725,7 @@ pub struct UpdateGlossaryEntryRequest {
 }
 
 impl UpdateGlossaryEntryRequest {
-    /// Sets the value of `glossary_entry`.
+    /// Sets the value of [glossary_entry][crate::model::UpdateGlossaryEntryRequest::glossary_entry].
     pub fn set_glossary_entry<
         T: std::convert::Into<std::option::Option<crate::model::GlossaryEntry>>,
     >(
@@ -5737,13 +5766,13 @@ pub struct CreateGlossaryMetadata {
 }
 
 impl CreateGlossaryMetadata {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::CreateGlossaryMetadata::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::CreateGlossaryMetadata::state].
     pub fn set_state<T: std::convert::Into<crate::model::create_glossary_metadata::State>>(
         mut self,
         v: T,
@@ -5752,7 +5781,7 @@ impl CreateGlossaryMetadata {
         self
     }
 
-    /// Sets the value of `submit_time`.
+    /// Sets the value of [submit_time][crate::model::CreateGlossaryMetadata::submit_time].
     pub fn set_submit_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -5838,7 +5867,7 @@ pub struct UpdateGlossaryMetadata {
 }
 
 impl UpdateGlossaryMetadata {
-    /// Sets the value of `glossary`.
+    /// Sets the value of [glossary][crate::model::UpdateGlossaryMetadata::glossary].
     pub fn set_glossary<T: std::convert::Into<std::option::Option<crate::model::Glossary>>>(
         mut self,
         v: T,
@@ -5847,7 +5876,7 @@ impl UpdateGlossaryMetadata {
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::UpdateGlossaryMetadata::state].
     pub fn set_state<T: std::convert::Into<crate::model::update_glossary_metadata::State>>(
         mut self,
         v: T,
@@ -5856,7 +5885,7 @@ impl UpdateGlossaryMetadata {
         self
     }
 
-    /// Sets the value of `submit_time`.
+    /// Sets the value of [submit_time][crate::model::UpdateGlossaryMetadata::submit_time].
     pub fn set_submit_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -5941,13 +5970,13 @@ pub struct DeleteGlossaryMetadata {
 }
 
 impl DeleteGlossaryMetadata {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteGlossaryMetadata::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::DeleteGlossaryMetadata::state].
     pub fn set_state<T: std::convert::Into<crate::model::delete_glossary_metadata::State>>(
         mut self,
         v: T,
@@ -5956,7 +5985,7 @@ impl DeleteGlossaryMetadata {
         self
     }
 
-    /// Sets the value of `submit_time`.
+    /// Sets the value of [submit_time][crate::model::DeleteGlossaryMetadata::submit_time].
     pub fn set_submit_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -6046,13 +6075,13 @@ pub struct DeleteGlossaryResponse {
 }
 
 impl DeleteGlossaryResponse {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteGlossaryResponse::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `submit_time`.
+    /// Sets the value of [submit_time][crate::model::DeleteGlossaryResponse::submit_time].
     pub fn set_submit_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -6061,7 +6090,7 @@ impl DeleteGlossaryResponse {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::DeleteGlossaryResponse::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -6174,13 +6203,13 @@ pub struct BatchTranslateDocumentRequest {
 }
 
 impl BatchTranslateDocumentRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::BatchTranslateDocumentRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `source_language_code`.
+    /// Sets the value of [source_language_code][crate::model::BatchTranslateDocumentRequest::source_language_code].
     pub fn set_source_language_code<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -6189,27 +6218,7 @@ impl BatchTranslateDocumentRequest {
         self
     }
 
-    /// Sets the value of `target_language_codes`.
-    pub fn set_target_language_codes<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target_language_codes = v.into();
-        self
-    }
-
-    /// Sets the value of `input_configs`.
-    pub fn set_input_configs<
-        T: std::convert::Into<std::vec::Vec<crate::model::BatchDocumentInputConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.input_configs = v.into();
-        self
-    }
-
-    /// Sets the value of `output_config`.
+    /// Sets the value of [output_config][crate::model::BatchTranslateDocumentRequest::output_config].
     pub fn set_output_config<
         T: std::convert::Into<std::option::Option<crate::model::BatchDocumentOutputConfig>>,
     >(
@@ -6220,45 +6229,7 @@ impl BatchTranslateDocumentRequest {
         self
     }
 
-    /// Sets the value of `models`.
-    pub fn set_models<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.models = v.into();
-        self
-    }
-
-    /// Sets the value of `glossaries`.
-    pub fn set_glossaries<
-        T: std::convert::Into<
-            std::collections::HashMap<
-                std::string::String,
-                crate::model::TranslateTextGlossaryConfig,
-            >,
-        >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.glossaries = v.into();
-        self
-    }
-
-    /// Sets the value of `format_conversions`.
-    pub fn set_format_conversions<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.format_conversions = v.into();
-        self
-    }
-
-    /// Sets the value of `customized_attribution`.
+    /// Sets the value of [customized_attribution][crate::model::BatchTranslateDocumentRequest::customized_attribution].
     pub fn set_customized_attribution<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -6267,7 +6238,7 @@ impl BatchTranslateDocumentRequest {
         self
     }
 
-    /// Sets the value of `enable_shadow_removal_native_pdf`.
+    /// Sets the value of [enable_shadow_removal_native_pdf][crate::model::BatchTranslateDocumentRequest::enable_shadow_removal_native_pdf].
     pub fn set_enable_shadow_removal_native_pdf<T: std::convert::Into<bool>>(
         mut self,
         v: T,
@@ -6276,9 +6247,67 @@ impl BatchTranslateDocumentRequest {
         self
     }
 
-    /// Sets the value of `enable_rotation_correction`.
+    /// Sets the value of [enable_rotation_correction][crate::model::BatchTranslateDocumentRequest::enable_rotation_correction].
     pub fn set_enable_rotation_correction<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enable_rotation_correction = v.into();
+        self
+    }
+
+    /// Sets the value of [target_language_codes][crate::model::BatchTranslateDocumentRequest::target_language_codes].
+    pub fn set_target_language_codes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.target_language_codes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [input_configs][crate::model::BatchTranslateDocumentRequest::input_configs].
+    pub fn set_input_configs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::BatchDocumentInputConfig>,
+    {
+        use std::iter::Iterator;
+        self.input_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [models][crate::model::BatchTranslateDocumentRequest::models].
+    pub fn set_models<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.models = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [glossaries][crate::model::BatchTranslateDocumentRequest::glossaries].
+    pub fn set_glossaries<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::TranslateTextGlossaryConfig>,
+    {
+        use std::iter::Iterator;
+        self.glossaries = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [format_conversions][crate::model::BatchTranslateDocumentRequest::format_conversions].
+    pub fn set_format_conversions<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.format_conversions = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -6510,55 +6539,55 @@ pub struct BatchTranslateDocumentResponse {
 }
 
 impl BatchTranslateDocumentResponse {
-    /// Sets the value of `total_pages`.
+    /// Sets the value of [total_pages][crate::model::BatchTranslateDocumentResponse::total_pages].
     pub fn set_total_pages<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.total_pages = v.into();
         self
     }
 
-    /// Sets the value of `translated_pages`.
+    /// Sets the value of [translated_pages][crate::model::BatchTranslateDocumentResponse::translated_pages].
     pub fn set_translated_pages<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.translated_pages = v.into();
         self
     }
 
-    /// Sets the value of `failed_pages`.
+    /// Sets the value of [failed_pages][crate::model::BatchTranslateDocumentResponse::failed_pages].
     pub fn set_failed_pages<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.failed_pages = v.into();
         self
     }
 
-    /// Sets the value of `total_billable_pages`.
+    /// Sets the value of [total_billable_pages][crate::model::BatchTranslateDocumentResponse::total_billable_pages].
     pub fn set_total_billable_pages<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.total_billable_pages = v.into();
         self
     }
 
-    /// Sets the value of `total_characters`.
+    /// Sets the value of [total_characters][crate::model::BatchTranslateDocumentResponse::total_characters].
     pub fn set_total_characters<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.total_characters = v.into();
         self
     }
 
-    /// Sets the value of `translated_characters`.
+    /// Sets the value of [translated_characters][crate::model::BatchTranslateDocumentResponse::translated_characters].
     pub fn set_translated_characters<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.translated_characters = v.into();
         self
     }
 
-    /// Sets the value of `failed_characters`.
+    /// Sets the value of [failed_characters][crate::model::BatchTranslateDocumentResponse::failed_characters].
     pub fn set_failed_characters<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.failed_characters = v.into();
         self
     }
 
-    /// Sets the value of `total_billable_characters`.
+    /// Sets the value of [total_billable_characters][crate::model::BatchTranslateDocumentResponse::total_billable_characters].
     pub fn set_total_billable_characters<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.total_billable_characters = v.into();
         self
     }
 
-    /// Sets the value of `submit_time`.
+    /// Sets the value of [submit_time][crate::model::BatchTranslateDocumentResponse::submit_time].
     pub fn set_submit_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -6567,7 +6596,7 @@ impl BatchTranslateDocumentResponse {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::BatchTranslateDocumentResponse::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -6637,7 +6666,7 @@ pub struct BatchTranslateDocumentMetadata {
 }
 
 impl BatchTranslateDocumentMetadata {
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::BatchTranslateDocumentMetadata::state].
     pub fn set_state<
         T: std::convert::Into<crate::model::batch_translate_document_metadata::State>,
     >(
@@ -6648,55 +6677,55 @@ impl BatchTranslateDocumentMetadata {
         self
     }
 
-    /// Sets the value of `total_pages`.
+    /// Sets the value of [total_pages][crate::model::BatchTranslateDocumentMetadata::total_pages].
     pub fn set_total_pages<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.total_pages = v.into();
         self
     }
 
-    /// Sets the value of `translated_pages`.
+    /// Sets the value of [translated_pages][crate::model::BatchTranslateDocumentMetadata::translated_pages].
     pub fn set_translated_pages<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.translated_pages = v.into();
         self
     }
 
-    /// Sets the value of `failed_pages`.
+    /// Sets the value of [failed_pages][crate::model::BatchTranslateDocumentMetadata::failed_pages].
     pub fn set_failed_pages<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.failed_pages = v.into();
         self
     }
 
-    /// Sets the value of `total_billable_pages`.
+    /// Sets the value of [total_billable_pages][crate::model::BatchTranslateDocumentMetadata::total_billable_pages].
     pub fn set_total_billable_pages<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.total_billable_pages = v.into();
         self
     }
 
-    /// Sets the value of `total_characters`.
+    /// Sets the value of [total_characters][crate::model::BatchTranslateDocumentMetadata::total_characters].
     pub fn set_total_characters<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.total_characters = v.into();
         self
     }
 
-    /// Sets the value of `translated_characters`.
+    /// Sets the value of [translated_characters][crate::model::BatchTranslateDocumentMetadata::translated_characters].
     pub fn set_translated_characters<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.translated_characters = v.into();
         self
     }
 
-    /// Sets the value of `failed_characters`.
+    /// Sets the value of [failed_characters][crate::model::BatchTranslateDocumentMetadata::failed_characters].
     pub fn set_failed_characters<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.failed_characters = v.into();
         self
     }
 
-    /// Sets the value of `total_billable_characters`.
+    /// Sets the value of [total_billable_characters][crate::model::BatchTranslateDocumentMetadata::total_billable_characters].
     pub fn set_total_billable_characters<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.total_billable_characters = v.into();
         self
     }
 
-    /// Sets the value of `submit_time`.
+    /// Sets the value of [submit_time][crate::model::BatchTranslateDocumentMetadata::submit_time].
     pub fn set_submit_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -6786,19 +6815,19 @@ pub struct TranslateTextGlossaryConfig {
 }
 
 impl TranslateTextGlossaryConfig {
-    /// Sets the value of `glossary`.
+    /// Sets the value of [glossary][crate::model::TranslateTextGlossaryConfig::glossary].
     pub fn set_glossary<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.glossary = v.into();
         self
     }
 
-    /// Sets the value of `ignore_case`.
+    /// Sets the value of [ignore_case][crate::model::TranslateTextGlossaryConfig::ignore_case].
     pub fn set_ignore_case<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.ignore_case = v.into();
         self
     }
 
-    /// Sets the value of `contextual_translation_enabled`.
+    /// Sets the value of [contextual_translation_enabled][crate::model::TranslateTextGlossaryConfig::contextual_translation_enabled].
     pub fn set_contextual_translation_enabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.contextual_translation_enabled = v.into();
         self

--- a/src/generated/cloud/webrisk/v1/src/builders.rs
+++ b/src/generated/cloud/webrisk/v1/src/builders.rs
@@ -70,19 +70,19 @@ pub mod web_risk_service {
                 .await
         }
 
-        /// Sets the value of `threat_type`.
+        /// Sets the value of [threat_type][crate::model::ComputeThreatListDiffRequest::threat_type].
         pub fn set_threat_type<T: Into<crate::model::ThreatType>>(mut self, v: T) -> Self {
             self.0.request.threat_type = v.into();
             self
         }
 
-        /// Sets the value of `version_token`.
+        /// Sets the value of [version_token][crate::model::ComputeThreatListDiffRequest::version_token].
         pub fn set_version_token<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.version_token = v.into();
             self
         }
 
-        /// Sets the value of `constraints`.
+        /// Sets the value of [constraints][crate::model::ComputeThreatListDiffRequest::constraints].
         pub fn set_constraints<
             T: Into<std::option::Option<crate::model::compute_threat_list_diff_request::Constraints>>,
         >(
@@ -128,18 +128,20 @@ pub mod web_risk_service {
                 .await
         }
 
-        /// Sets the value of `uri`.
+        /// Sets the value of [uri][crate::model::SearchUrisRequest::uri].
         pub fn set_uri<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.uri = v.into();
             self
         }
 
-        /// Sets the value of `threat_types`.
-        pub fn set_threat_types<T: Into<std::vec::Vec<crate::model::ThreatType>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.threat_types = v.into();
+        /// Sets the value of [threat_types][crate::model::SearchUrisRequest::threat_types].
+        pub fn set_threat_types<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::ThreatType>,
+        {
+            use std::iter::Iterator;
+            self.0.request.threat_types = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -178,18 +180,20 @@ pub mod web_risk_service {
                 .await
         }
 
-        /// Sets the value of `hash_prefix`.
+        /// Sets the value of [hash_prefix][crate::model::SearchHashesRequest::hash_prefix].
         pub fn set_hash_prefix<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.hash_prefix = v.into();
             self
         }
 
-        /// Sets the value of `threat_types`.
-        pub fn set_threat_types<T: Into<std::vec::Vec<crate::model::ThreatType>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.threat_types = v.into();
+        /// Sets the value of [threat_types][crate::model::SearchHashesRequest::threat_types].
+        pub fn set_threat_types<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::ThreatType>,
+        {
+            use std::iter::Iterator;
+            self.0.request.threat_types = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -231,13 +235,13 @@ pub mod web_risk_service {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateSubmissionRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `submission`.
+        /// Sets the value of [submission][crate::model::CreateSubmissionRequest::submission].
         pub fn set_submission<T: Into<std::option::Option<crate::model::Submission>>>(
             mut self,
             v: T,
@@ -319,13 +323,13 @@ pub mod web_risk_service {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::SubmitUriRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `submission`.
+        /// Sets the value of [submission][crate::model::SubmitUriRequest::submission].
         pub fn set_submission<T: Into<std::option::Option<crate::model::Submission>>>(
             mut self,
             v: T,
@@ -334,7 +338,7 @@ pub mod web_risk_service {
             self
         }
 
-        /// Sets the value of `threat_info`.
+        /// Sets the value of [threat_info][crate::model::SubmitUriRequest::threat_info].
         pub fn set_threat_info<T: Into<std::option::Option<crate::model::ThreatInfo>>>(
             mut self,
             v: T,
@@ -343,7 +347,7 @@ pub mod web_risk_service {
             self
         }
 
-        /// Sets the value of `threat_discovery`.
+        /// Sets the value of [threat_discovery][crate::model::SubmitUriRequest::threat_discovery].
         pub fn set_threat_discovery<T: Into<std::option::Option<crate::model::ThreatDiscovery>>>(
             mut self,
             v: T,
@@ -405,25 +409,25 @@ pub mod web_risk_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::ListOperationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][longrunning::model::ListOperationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][longrunning::model::ListOperationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][longrunning::model::ListOperationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -467,7 +471,7 @@ pub mod web_risk_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::GetOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -511,7 +515,7 @@ pub mod web_risk_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::DeleteOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -555,7 +559,7 @@ pub mod web_risk_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::CancelOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self

--- a/src/generated/cloud/webrisk/v1/src/model.rs
+++ b/src/generated/cloud/webrisk/v1/src/model.rs
@@ -59,7 +59,7 @@ pub struct ComputeThreatListDiffRequest {
 }
 
 impl ComputeThreatListDiffRequest {
-    /// Sets the value of `threat_type`.
+    /// Sets the value of [threat_type][crate::model::ComputeThreatListDiffRequest::threat_type].
     pub fn set_threat_type<T: std::convert::Into<crate::model::ThreatType>>(
         mut self,
         v: T,
@@ -68,13 +68,13 @@ impl ComputeThreatListDiffRequest {
         self
     }
 
-    /// Sets the value of `version_token`.
+    /// Sets the value of [version_token][crate::model::ComputeThreatListDiffRequest::version_token].
     pub fn set_version_token<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.version_token = v.into();
         self
     }
 
-    /// Sets the value of `constraints`.
+    /// Sets the value of [constraints][crate::model::ComputeThreatListDiffRequest::constraints].
     pub fn set_constraints<
         T: std::convert::Into<
             std::option::Option<crate::model::compute_threat_list_diff_request::Constraints>,
@@ -121,26 +121,26 @@ pub mod compute_threat_list_diff_request {
     }
 
     impl Constraints {
-        /// Sets the value of `max_diff_entries`.
+        /// Sets the value of [max_diff_entries][crate::model::compute_threat_list_diff_request::Constraints::max_diff_entries].
         pub fn set_max_diff_entries<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
             self.max_diff_entries = v.into();
             self
         }
 
-        /// Sets the value of `max_database_entries`.
+        /// Sets the value of [max_database_entries][crate::model::compute_threat_list_diff_request::Constraints::max_database_entries].
         pub fn set_max_database_entries<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
             self.max_database_entries = v.into();
             self
         }
 
-        /// Sets the value of `supported_compressions`.
-        pub fn set_supported_compressions<
-            T: std::convert::Into<std::vec::Vec<crate::model::CompressionType>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.supported_compressions = v.into();
+        /// Sets the value of [supported_compressions][crate::model::compute_threat_list_diff_request::Constraints::supported_compressions].
+        pub fn set_supported_compressions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::CompressionType>,
+        {
+            use std::iter::Iterator;
+            self.supported_compressions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -193,7 +193,7 @@ pub struct ComputeThreatListDiffResponse {
 }
 
 impl ComputeThreatListDiffResponse {
-    /// Sets the value of `response_type`.
+    /// Sets the value of [response_type][crate::model::ComputeThreatListDiffResponse::response_type].
     pub fn set_response_type<
         T: std::convert::Into<crate::model::compute_threat_list_diff_response::ResponseType>,
     >(
@@ -204,7 +204,7 @@ impl ComputeThreatListDiffResponse {
         self
     }
 
-    /// Sets the value of `additions`.
+    /// Sets the value of [additions][crate::model::ComputeThreatListDiffResponse::additions].
     pub fn set_additions<
         T: std::convert::Into<std::option::Option<crate::model::ThreatEntryAdditions>>,
     >(
@@ -215,7 +215,7 @@ impl ComputeThreatListDiffResponse {
         self
     }
 
-    /// Sets the value of `removals`.
+    /// Sets the value of [removals][crate::model::ComputeThreatListDiffResponse::removals].
     pub fn set_removals<
         T: std::convert::Into<std::option::Option<crate::model::ThreatEntryRemovals>>,
     >(
@@ -226,13 +226,13 @@ impl ComputeThreatListDiffResponse {
         self
     }
 
-    /// Sets the value of `new_version_token`.
+    /// Sets the value of [new_version_token][crate::model::ComputeThreatListDiffResponse::new_version_token].
     pub fn set_new_version_token<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.new_version_token = v.into();
         self
     }
 
-    /// Sets the value of `checksum`.
+    /// Sets the value of [checksum][crate::model::ComputeThreatListDiffResponse::checksum].
     pub fn set_checksum<
         T: std::convert::Into<
             std::option::Option<crate::model::compute_threat_list_diff_response::Checksum>,
@@ -245,7 +245,7 @@ impl ComputeThreatListDiffResponse {
         self
     }
 
-    /// Sets the value of `recommended_next_diff`.
+    /// Sets the value of [recommended_next_diff][crate::model::ComputeThreatListDiffResponse::recommended_next_diff].
     pub fn set_recommended_next_diff<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -280,7 +280,7 @@ pub mod compute_threat_list_diff_response {
     }
 
     impl Checksum {
-        /// Sets the value of `sha256`.
+        /// Sets the value of [sha256][crate::model::compute_threat_list_diff_response::Checksum::sha256].
         pub fn set_sha256<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.sha256 = v.into();
             self
@@ -343,18 +343,20 @@ pub struct SearchUrisRequest {
 }
 
 impl SearchUrisRequest {
-    /// Sets the value of `uri`.
+    /// Sets the value of [uri][crate::model::SearchUrisRequest::uri].
     pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.uri = v.into();
         self
     }
 
-    /// Sets the value of `threat_types`.
-    pub fn set_threat_types<T: std::convert::Into<std::vec::Vec<crate::model::ThreatType>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.threat_types = v.into();
+    /// Sets the value of [threat_types][crate::model::SearchUrisRequest::threat_types].
+    pub fn set_threat_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ThreatType>,
+    {
+        use std::iter::Iterator;
+        self.threat_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -376,7 +378,7 @@ pub struct SearchUrisResponse {
 }
 
 impl SearchUrisResponse {
-    /// Sets the value of `threat`.
+    /// Sets the value of [threat][crate::model::SearchUrisResponse::threat].
     pub fn set_threat<
         T: std::convert::Into<std::option::Option<crate::model::search_uris_response::ThreatUri>>,
     >(
@@ -416,21 +418,23 @@ pub mod search_uris_response {
     }
 
     impl ThreatUri {
-        /// Sets the value of `threat_types`.
-        pub fn set_threat_types<T: std::convert::Into<std::vec::Vec<crate::model::ThreatType>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.threat_types = v.into();
-            self
-        }
-
-        /// Sets the value of `expire_time`.
+        /// Sets the value of [expire_time][crate::model::search_uris_response::ThreatUri::expire_time].
         pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
             mut self,
             v: T,
         ) -> Self {
             self.expire_time = v.into();
+            self
+        }
+
+        /// Sets the value of [threat_types][crate::model::search_uris_response::ThreatUri::threat_types].
+        pub fn set_threat_types<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::ThreatType>,
+        {
+            use std::iter::Iterator;
+            self.threat_types = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -463,18 +467,20 @@ pub struct SearchHashesRequest {
 }
 
 impl SearchHashesRequest {
-    /// Sets the value of `hash_prefix`.
+    /// Sets the value of [hash_prefix][crate::model::SearchHashesRequest::hash_prefix].
     pub fn set_hash_prefix<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.hash_prefix = v.into();
         self
     }
 
-    /// Sets the value of `threat_types`.
-    pub fn set_threat_types<T: std::convert::Into<std::vec::Vec<crate::model::ThreatType>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.threat_types = v.into();
+    /// Sets the value of [threat_types][crate::model::SearchHashesRequest::threat_types].
+    pub fn set_threat_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ThreatType>,
+    {
+        use std::iter::Iterator;
+        self.threat_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -502,23 +508,23 @@ pub struct SearchHashesResponse {
 }
 
 impl SearchHashesResponse {
-    /// Sets the value of `threats`.
-    pub fn set_threats<
-        T: std::convert::Into<std::vec::Vec<crate::model::search_hashes_response::ThreatHash>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.threats = v.into();
-        self
-    }
-
-    /// Sets the value of `negative_expire_time`.
+    /// Sets the value of [negative_expire_time][crate::model::SearchHashesResponse::negative_expire_time].
     pub fn set_negative_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
     ) -> Self {
         self.negative_expire_time = v.into();
+        self
+    }
+
+    /// Sets the value of [threats][crate::model::SearchHashesResponse::threats].
+    pub fn set_threats<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::search_hashes_response::ThreatHash>,
+    {
+        use std::iter::Iterator;
+        self.threats = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -558,27 +564,29 @@ pub mod search_hashes_response {
     }
 
     impl ThreatHash {
-        /// Sets the value of `threat_types`.
-        pub fn set_threat_types<T: std::convert::Into<std::vec::Vec<crate::model::ThreatType>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.threat_types = v.into();
-            self
-        }
-
-        /// Sets the value of `hash`.
+        /// Sets the value of [hash][crate::model::search_hashes_response::ThreatHash::hash].
         pub fn set_hash<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.hash = v.into();
             self
         }
 
-        /// Sets the value of `expire_time`.
+        /// Sets the value of [expire_time][crate::model::search_hashes_response::ThreatHash::expire_time].
         pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
             mut self,
             v: T,
         ) -> Self {
             self.expire_time = v.into();
+            self
+        }
+
+        /// Sets the value of [threat_types][crate::model::search_hashes_response::ThreatHash::threat_types].
+        pub fn set_threat_types<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::ThreatType>,
+        {
+            use std::iter::Iterator;
+            self.threat_types = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -610,16 +618,7 @@ pub struct ThreatEntryAdditions {
 }
 
 impl ThreatEntryAdditions {
-    /// Sets the value of `raw_hashes`.
-    pub fn set_raw_hashes<T: std::convert::Into<std::vec::Vec<crate::model::RawHashes>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.raw_hashes = v.into();
-        self
-    }
-
-    /// Sets the value of `rice_hashes`.
+    /// Sets the value of [rice_hashes][crate::model::ThreatEntryAdditions::rice_hashes].
     pub fn set_rice_hashes<
         T: std::convert::Into<std::option::Option<crate::model::RiceDeltaEncoding>>,
     >(
@@ -627,6 +626,17 @@ impl ThreatEntryAdditions {
         v: T,
     ) -> Self {
         self.rice_hashes = v.into();
+        self
+    }
+
+    /// Sets the value of [raw_hashes][crate::model::ThreatEntryAdditions::raw_hashes].
+    pub fn set_raw_hashes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::RawHashes>,
+    {
+        use std::iter::Iterator;
+        self.raw_hashes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -656,7 +666,7 @@ pub struct ThreatEntryRemovals {
 }
 
 impl ThreatEntryRemovals {
-    /// Sets the value of `raw_indices`.
+    /// Sets the value of [raw_indices][crate::model::ThreatEntryRemovals::raw_indices].
     pub fn set_raw_indices<T: std::convert::Into<std::option::Option<crate::model::RawIndices>>>(
         mut self,
         v: T,
@@ -665,7 +675,7 @@ impl ThreatEntryRemovals {
         self
     }
 
-    /// Sets the value of `rice_indices`.
+    /// Sets the value of [rice_indices][crate::model::ThreatEntryRemovals::rice_indices].
     pub fn set_rice_indices<
         T: std::convert::Into<std::option::Option<crate::model::RiceDeltaEncoding>>,
     >(
@@ -695,9 +705,14 @@ pub struct RawIndices {
 }
 
 impl RawIndices {
-    /// Sets the value of `indices`.
-    pub fn set_indices<T: std::convert::Into<std::vec::Vec<i32>>>(mut self, v: T) -> Self {
-        self.indices = v.into();
+    /// Sets the value of [indices][crate::model::RawIndices::indices].
+    pub fn set_indices<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<i32>,
+    {
+        use std::iter::Iterator;
+        self.indices = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -735,13 +750,13 @@ pub struct RawHashes {
 }
 
 impl RawHashes {
-    /// Sets the value of `prefix_size`.
+    /// Sets the value of [prefix_size][crate::model::RawHashes::prefix_size].
     pub fn set_prefix_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.prefix_size = v.into();
         self
     }
 
-    /// Sets the value of `raw_hashes`.
+    /// Sets the value of [raw_hashes][crate::model::RawHashes::raw_hashes].
     pub fn set_raw_hashes<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.raw_hashes = v.into();
         self
@@ -783,25 +798,25 @@ pub struct RiceDeltaEncoding {
 }
 
 impl RiceDeltaEncoding {
-    /// Sets the value of `first_value`.
+    /// Sets the value of [first_value][crate::model::RiceDeltaEncoding::first_value].
     pub fn set_first_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.first_value = v.into();
         self
     }
 
-    /// Sets the value of `rice_parameter`.
+    /// Sets the value of [rice_parameter][crate::model::RiceDeltaEncoding::rice_parameter].
     pub fn set_rice_parameter<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.rice_parameter = v.into();
         self
     }
 
-    /// Sets the value of `entry_count`.
+    /// Sets the value of [entry_count][crate::model::RiceDeltaEncoding::entry_count].
     pub fn set_entry_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.entry_count = v.into();
         self
     }
 
-    /// Sets the value of `encoded_data`.
+    /// Sets the value of [encoded_data][crate::model::RiceDeltaEncoding::encoded_data].
     pub fn set_encoded_data<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.encoded_data = v.into();
         self
@@ -833,18 +848,20 @@ pub struct Submission {
 }
 
 impl Submission {
-    /// Sets the value of `uri`.
+    /// Sets the value of [uri][crate::model::Submission::uri].
     pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.uri = v.into();
         self
     }
 
-    /// Sets the value of `threat_types`.
-    pub fn set_threat_types<T: std::convert::Into<std::vec::Vec<crate::model::ThreatType>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.threat_types = v.into();
+    /// Sets the value of [threat_types][crate::model::Submission::threat_types].
+    pub fn set_threat_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ThreatType>,
+    {
+        use std::iter::Iterator;
+        self.threat_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -876,7 +893,7 @@ pub struct ThreatInfo {
 }
 
 impl ThreatInfo {
-    /// Sets the value of `abuse_type`.
+    /// Sets the value of [abuse_type][crate::model::ThreatInfo::abuse_type].
     pub fn set_abuse_type<T: std::convert::Into<crate::model::threat_info::AbuseType>>(
         mut self,
         v: T,
@@ -885,7 +902,7 @@ impl ThreatInfo {
         self
     }
 
-    /// Sets the value of `threat_confidence`.
+    /// Sets the value of [threat_confidence][crate::model::ThreatInfo::threat_confidence].
     pub fn set_threat_confidence<
         T: std::convert::Into<std::option::Option<crate::model::threat_info::Confidence>>,
     >(
@@ -896,7 +913,7 @@ impl ThreatInfo {
         self
     }
 
-    /// Sets the value of `threat_justification`.
+    /// Sets the value of [threat_justification][crate::model::ThreatInfo::threat_justification].
     pub fn set_threat_justification<
         T: std::convert::Into<std::option::Option<crate::model::threat_info::ThreatJustification>>,
     >(
@@ -1016,25 +1033,27 @@ pub mod threat_info {
     }
 
     impl ThreatJustification {
-        /// Sets the value of `labels`.
-        pub fn set_labels<
-            T: std::convert::Into<
-                std::vec::Vec<crate::model::threat_info::threat_justification::JustificationLabel>,
+        /// Sets the value of [labels][crate::model::threat_info::ThreatJustification::labels].
+        pub fn set_labels<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<
+                crate::model::threat_info::threat_justification::JustificationLabel,
             >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.labels = v.into();
+        {
+            use std::iter::Iterator;
+            self.labels = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
-        /// Sets the value of `comments`.
-        pub fn set_comments<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.comments = v.into();
+        /// Sets the value of [comments][crate::model::threat_info::ThreatJustification::comments].
+        pub fn set_comments<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.comments = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1134,7 +1153,7 @@ pub struct ThreatDiscovery {
 }
 
 impl ThreatDiscovery {
-    /// Sets the value of `platform`.
+    /// Sets the value of [platform][crate::model::ThreatDiscovery::platform].
     pub fn set_platform<T: std::convert::Into<crate::model::threat_discovery::Platform>>(
         mut self,
         v: T,
@@ -1143,12 +1162,14 @@ impl ThreatDiscovery {
         self
     }
 
-    /// Sets the value of `region_codes`.
-    pub fn set_region_codes<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.region_codes = v.into();
+    /// Sets the value of [region_codes][crate::model::ThreatDiscovery::region_codes].
+    pub fn set_region_codes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.region_codes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1218,13 +1239,13 @@ pub struct CreateSubmissionRequest {
 }
 
 impl CreateSubmissionRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateSubmissionRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `submission`.
+    /// Sets the value of [submission][crate::model::CreateSubmissionRequest::submission].
     pub fn set_submission<T: std::convert::Into<std::option::Option<crate::model::Submission>>>(
         mut self,
         v: T,
@@ -1265,13 +1286,13 @@ pub struct SubmitUriRequest {
 }
 
 impl SubmitUriRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::SubmitUriRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `submission`.
+    /// Sets the value of [submission][crate::model::SubmitUriRequest::submission].
     pub fn set_submission<T: std::convert::Into<std::option::Option<crate::model::Submission>>>(
         mut self,
         v: T,
@@ -1280,7 +1301,7 @@ impl SubmitUriRequest {
         self
     }
 
-    /// Sets the value of `threat_info`.
+    /// Sets the value of [threat_info][crate::model::SubmitUriRequest::threat_info].
     pub fn set_threat_info<T: std::convert::Into<std::option::Option<crate::model::ThreatInfo>>>(
         mut self,
         v: T,
@@ -1289,7 +1310,7 @@ impl SubmitUriRequest {
         self
     }
 
-    /// Sets the value of `threat_discovery`.
+    /// Sets the value of [threat_discovery][crate::model::SubmitUriRequest::threat_discovery].
     pub fn set_threat_discovery<
         T: std::convert::Into<std::option::Option<crate::model::ThreatDiscovery>>,
     >(
@@ -1327,7 +1348,7 @@ pub struct SubmitUriMetadata {
 }
 
 impl SubmitUriMetadata {
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::SubmitUriMetadata::state].
     pub fn set_state<T: std::convert::Into<crate::model::submit_uri_metadata::State>>(
         mut self,
         v: T,
@@ -1336,7 +1357,7 @@ impl SubmitUriMetadata {
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::SubmitUriMetadata::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1345,7 +1366,7 @@ impl SubmitUriMetadata {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::SubmitUriMetadata::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,

--- a/src/generated/cloud/workflows/v1/src/builders.rs
+++ b/src/generated/cloud/workflows/v1/src/builders.rs
@@ -82,31 +82,31 @@ pub mod workflows {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListWorkflowsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListWorkflowsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListWorkflowsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListWorkflowsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `order_by`.
+        /// Sets the value of [order_by][crate::model::ListWorkflowsRequest::order_by].
         pub fn set_order_by<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.order_by = v.into();
             self
@@ -147,13 +147,13 @@ pub mod workflows {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetWorkflowRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `revision_id`.
+        /// Sets the value of [revision_id][crate::model::GetWorkflowRequest::revision_id].
         pub fn set_revision_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.revision_id = v.into();
             self
@@ -232,13 +232,13 @@ pub mod workflows {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateWorkflowRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `workflow`.
+        /// Sets the value of [workflow][crate::model::CreateWorkflowRequest::workflow].
         pub fn set_workflow<T: Into<std::option::Option<crate::model::Workflow>>>(
             mut self,
             v: T,
@@ -247,7 +247,7 @@ pub mod workflows {
             self
         }
 
-        /// Sets the value of `workflow_id`.
+        /// Sets the value of [workflow_id][crate::model::CreateWorkflowRequest::workflow_id].
         pub fn set_workflow_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.workflow_id = v.into();
             self
@@ -323,7 +323,7 @@ pub mod workflows {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteWorkflowRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -402,7 +402,7 @@ pub mod workflows {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `workflow`.
+        /// Sets the value of [workflow][crate::model::UpdateWorkflowRequest::workflow].
         pub fn set_workflow<T: Into<std::option::Option<crate::model::Workflow>>>(
             mut self,
             v: T,
@@ -411,7 +411,7 @@ pub mod workflows {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateWorkflowRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -473,25 +473,25 @@ pub mod workflows {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][location::model::ListLocationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][location::model::ListLocationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][location::model::ListLocationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][location::model::ListLocationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -532,7 +532,7 @@ pub mod workflows {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][location::model::GetLocationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -591,25 +591,25 @@ pub mod workflows {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::ListOperationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][longrunning::model::ListOperationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][longrunning::model::ListOperationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][longrunning::model::ListOperationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -653,7 +653,7 @@ pub mod workflows {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::GetOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -697,7 +697,7 @@ pub mod workflows {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::DeleteOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self

--- a/src/generated/cloud/workflows/v1/src/model.rs
+++ b/src/generated/cloud/workflows/v1/src/model.rs
@@ -146,31 +146,31 @@ pub struct Workflow {
 }
 
 impl Workflow {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Workflow::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::Workflow::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::Workflow::state].
     pub fn set_state<T: std::convert::Into<crate::model::workflow::State>>(mut self, v: T) -> Self {
         self.state = v.into();
         self
     }
 
-    /// Sets the value of `revision_id`.
+    /// Sets the value of [revision_id][crate::model::Workflow::revision_id].
     pub fn set_revision_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.revision_id = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::Workflow::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -179,7 +179,7 @@ impl Workflow {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::Workflow::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -188,7 +188,7 @@ impl Workflow {
         self
     }
 
-    /// Sets the value of `revision_create_time`.
+    /// Sets the value of [revision_create_time][crate::model::Workflow::revision_create_time].
     pub fn set_revision_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -197,30 +197,19 @@ impl Workflow {
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `service_account`.
+    /// Sets the value of [service_account][crate::model::Workflow::service_account].
     pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_account = v.into();
         self
     }
 
-    /// Sets the value of `crypto_key_name`.
+    /// Sets the value of [crypto_key_name][crate::model::Workflow::crypto_key_name].
     pub fn set_crypto_key_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.crypto_key_name = v.into();
         self
     }
 
-    /// Sets the value of `state_error`.
+    /// Sets the value of [state_error][crate::model::Workflow::state_error].
     pub fn set_state_error<
         T: std::convert::Into<std::option::Option<crate::model::workflow::StateError>>,
     >(
@@ -231,7 +220,7 @@ impl Workflow {
         self
     }
 
-    /// Sets the value of `call_log_level`.
+    /// Sets the value of [call_log_level][crate::model::Workflow::call_log_level].
     pub fn set_call_log_level<T: std::convert::Into<crate::model::workflow::CallLogLevel>>(
         mut self,
         v: T,
@@ -240,14 +229,27 @@ impl Workflow {
         self
     }
 
-    /// Sets the value of `user_env_vars`.
-    pub fn set_user_env_vars<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.user_env_vars = v.into();
+    /// Sets the value of [labels][crate::model::Workflow::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [user_env_vars][crate::model::Workflow::user_env_vars].
+    pub fn set_user_env_vars<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.user_env_vars = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -290,13 +292,13 @@ pub mod workflow {
     }
 
     impl StateError {
-        /// Sets the value of `details`.
+        /// Sets the value of [details][crate::model::workflow::StateError::details].
         pub fn set_details<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.details = v.into();
             self
         }
 
-        /// Sets the value of `r#type`.
+        /// Sets the value of [r#type][crate::model::workflow::StateError::type].
         pub fn set_type<T: std::convert::Into<crate::model::workflow::state_error::Type>>(
             mut self,
             v: T,
@@ -464,31 +466,31 @@ pub struct ListWorkflowsRequest {
 }
 
 impl ListWorkflowsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListWorkflowsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListWorkflowsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListWorkflowsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListWorkflowsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
     }
 
-    /// Sets the value of `order_by`.
+    /// Sets the value of [order_by][crate::model::ListWorkflowsRequest::order_by].
     pub fn set_order_by<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.order_by = v.into();
         self
@@ -526,27 +528,31 @@ pub struct ListWorkflowsResponse {
 }
 
 impl ListWorkflowsResponse {
-    /// Sets the value of `workflows`.
-    pub fn set_workflows<T: std::convert::Into<std::vec::Vec<crate::model::Workflow>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.workflows = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListWorkflowsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `unreachable`.
-    pub fn set_unreachable<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.unreachable = v.into();
+    /// Sets the value of [workflows][crate::model::ListWorkflowsResponse::workflows].
+    pub fn set_workflows<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Workflow>,
+    {
+        use std::iter::Iterator;
+        self.workflows = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [unreachable][crate::model::ListWorkflowsResponse::unreachable].
+    pub fn set_unreachable<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.unreachable = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -594,13 +600,13 @@ pub struct GetWorkflowRequest {
 }
 
 impl GetWorkflowRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetWorkflowRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `revision_id`.
+    /// Sets the value of [revision_id][crate::model::GetWorkflowRequest::revision_id].
     pub fn set_revision_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.revision_id = v.into();
         self
@@ -645,13 +651,13 @@ pub struct CreateWorkflowRequest {
 }
 
 impl CreateWorkflowRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateWorkflowRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `workflow`.
+    /// Sets the value of [workflow][crate::model::CreateWorkflowRequest::workflow].
     pub fn set_workflow<T: std::convert::Into<std::option::Option<crate::model::Workflow>>>(
         mut self,
         v: T,
@@ -660,7 +666,7 @@ impl CreateWorkflowRequest {
         self
     }
 
-    /// Sets the value of `workflow_id`.
+    /// Sets the value of [workflow_id][crate::model::CreateWorkflowRequest::workflow_id].
     pub fn set_workflow_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.workflow_id = v.into();
         self
@@ -690,7 +696,7 @@ pub struct DeleteWorkflowRequest {
 }
 
 impl DeleteWorkflowRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteWorkflowRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -724,7 +730,7 @@ pub struct UpdateWorkflowRequest {
 }
 
 impl UpdateWorkflowRequest {
-    /// Sets the value of `workflow`.
+    /// Sets the value of [workflow][crate::model::UpdateWorkflowRequest::workflow].
     pub fn set_workflow<T: std::convert::Into<std::option::Option<crate::model::Workflow>>>(
         mut self,
         v: T,
@@ -733,7 +739,7 @@ impl UpdateWorkflowRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateWorkflowRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -777,7 +783,7 @@ pub struct OperationMetadata {
 }
 
 impl OperationMetadata {
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::OperationMetadata::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -786,7 +792,7 @@ impl OperationMetadata {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::OperationMetadata::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -795,19 +801,19 @@ impl OperationMetadata {
         self
     }
 
-    /// Sets the value of `target`.
+    /// Sets the value of [target][crate::model::OperationMetadata::target].
     pub fn set_target<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.target = v.into();
         self
     }
 
-    /// Sets the value of `verb`.
+    /// Sets the value of [verb][crate::model::OperationMetadata::verb].
     pub fn set_verb<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.verb = v.into();
         self
     }
 
-    /// Sets the value of `api_version`.
+    /// Sets the value of [api_version][crate::model::OperationMetadata::api_version].
     pub fn set_api_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.api_version = v.into();
         self

--- a/src/generated/devtools/cloudbuild/v2/src/builders.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/builders.rs
@@ -108,13 +108,13 @@ pub mod repository_manager {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateConnectionRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `connection`.
+        /// Sets the value of [connection][crate::model::CreateConnectionRequest::connection].
         pub fn set_connection<T: Into<std::option::Option<crate::model::Connection>>>(
             mut self,
             v: T,
@@ -123,7 +123,7 @@ pub mod repository_manager {
             self
         }
 
-        /// Sets the value of `connection_id`.
+        /// Sets the value of [connection_id][crate::model::CreateConnectionRequest::connection_id].
         pub fn set_connection_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.connection_id = v.into();
             self
@@ -164,7 +164,7 @@ pub mod repository_manager {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetConnectionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -220,19 +220,19 @@ pub mod repository_manager {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListConnectionsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListConnectionsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListConnectionsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -314,7 +314,7 @@ pub mod repository_manager {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `connection`.
+        /// Sets the value of [connection][crate::model::UpdateConnectionRequest::connection].
         pub fn set_connection<T: Into<std::option::Option<crate::model::Connection>>>(
             mut self,
             v: T,
@@ -323,7 +323,7 @@ pub mod repository_manager {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateConnectionRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -332,13 +332,13 @@ pub mod repository_manager {
             self
         }
 
-        /// Sets the value of `allow_missing`.
+        /// Sets the value of [allow_missing][crate::model::UpdateConnectionRequest::allow_missing].
         pub fn set_allow_missing<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.allow_missing = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::UpdateConnectionRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -417,19 +417,19 @@ pub mod repository_manager {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteConnectionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DeleteConnectionRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
         }
 
-        /// Sets the value of `validate_only`.
+        /// Sets the value of [validate_only][crate::model::DeleteConnectionRequest::validate_only].
         pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.validate_only = v.into();
             self
@@ -511,13 +511,13 @@ pub mod repository_manager {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateRepositoryRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `repository`.
+        /// Sets the value of [repository][crate::model::CreateRepositoryRequest::repository].
         pub fn set_repository<T: Into<std::option::Option<crate::model::Repository>>>(
             mut self,
             v: T,
@@ -526,7 +526,7 @@ pub mod repository_manager {
             self
         }
 
-        /// Sets the value of `repository_id`.
+        /// Sets the value of [repository_id][crate::model::CreateRepositoryRequest::repository_id].
         pub fn set_repository_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.repository_id = v.into();
             self
@@ -615,18 +615,20 @@ pub mod repository_manager {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::BatchCreateRepositoriesRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `requests`.
-        pub fn set_requests<T: Into<std::vec::Vec<crate::model::CreateRepositoryRequest>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.requests = v.into();
+        /// Sets the value of [requests][crate::model::BatchCreateRepositoriesRequest::requests].
+        pub fn set_requests<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::CreateRepositoryRequest>,
+        {
+            use std::iter::Iterator;
+            self.0.request.requests = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -665,7 +667,7 @@ pub mod repository_manager {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetRepositoryRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -724,25 +726,25 @@ pub mod repository_manager {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListRepositoriesRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListRepositoriesRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListRepositoriesRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListRepositoriesRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
@@ -821,19 +823,19 @@ pub mod repository_manager {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteRepositoryRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DeleteRepositoryRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
         }
 
-        /// Sets the value of `validate_only`.
+        /// Sets the value of [validate_only][crate::model::DeleteRepositoryRequest::validate_only].
         pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.validate_only = v.into();
             self
@@ -877,7 +879,7 @@ pub mod repository_manager {
                 .await
         }
 
-        /// Sets the value of `repository`.
+        /// Sets the value of [repository][crate::model::FetchReadWriteTokenRequest::repository].
         pub fn set_repository<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.repository = v.into();
             self
@@ -918,7 +920,7 @@ pub mod repository_manager {
                 .await
         }
 
-        /// Sets the value of `repository`.
+        /// Sets the value of [repository][crate::model::FetchReadTokenRequest::repository].
         pub fn set_repository<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.repository = v.into();
             self
@@ -981,19 +983,19 @@ pub mod repository_manager {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `connection`.
+        /// Sets the value of [connection][crate::model::FetchLinkableRepositoriesRequest::connection].
         pub fn set_connection<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.connection = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::FetchLinkableRepositoriesRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::FetchLinkableRepositoriesRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -1034,13 +1036,13 @@ pub mod repository_manager {
                 .await
         }
 
-        /// Sets the value of `repository`.
+        /// Sets the value of [repository][crate::model::FetchGitRefsRequest::repository].
         pub fn set_repository<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.repository = v.into();
             self
         }
 
-        /// Sets the value of `ref_type`.
+        /// Sets the value of [ref_type][crate::model::FetchGitRefsRequest::ref_type].
         pub fn set_ref_type<T: Into<crate::model::fetch_git_refs_request::RefType>>(
             mut self,
             v: T,
@@ -1084,13 +1086,13 @@ pub mod repository_manager {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::SetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][iam_v1::model::SetIamPolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<iam_v1::model::Policy>>>(
             mut self,
             v: T,
@@ -1099,7 +1101,7 @@ pub mod repository_manager {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][iam_v1::model::SetIamPolicyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -1143,13 +1145,13 @@ pub mod repository_manager {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::GetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `options`.
+        /// Sets the value of [options][iam_v1::model::GetIamPolicyRequest::options].
         pub fn set_options<T: Into<std::option::Option<iam_v1::model::GetPolicyOptions>>>(
             mut self,
             v: T,
@@ -1196,18 +1198,20 @@ pub mod repository_manager {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::TestIamPermissionsRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `permissions`.
-        pub fn set_permissions<T: Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.permissions = v.into();
+        /// Sets the value of [permissions][iam_v1::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1249,7 +1253,7 @@ pub mod repository_manager {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::GetOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1293,7 +1297,7 @@ pub mod repository_manager {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::CancelOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self

--- a/src/generated/devtools/cloudbuild/v2/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/model.rs
@@ -76,7 +76,7 @@ pub struct OperationMetadata {
 }
 
 impl OperationMetadata {
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::OperationMetadata::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -85,7 +85,7 @@ impl OperationMetadata {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::OperationMetadata::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -94,31 +94,31 @@ impl OperationMetadata {
         self
     }
 
-    /// Sets the value of `target`.
+    /// Sets the value of [target][crate::model::OperationMetadata::target].
     pub fn set_target<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.target = v.into();
         self
     }
 
-    /// Sets the value of `verb`.
+    /// Sets the value of [verb][crate::model::OperationMetadata::verb].
     pub fn set_verb<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.verb = v.into();
         self
     }
 
-    /// Sets the value of `status_message`.
+    /// Sets the value of [status_message][crate::model::OperationMetadata::status_message].
     pub fn set_status_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.status_message = v.into();
         self
     }
 
-    /// Sets the value of `requested_cancellation`.
+    /// Sets the value of [requested_cancellation][crate::model::OperationMetadata::requested_cancellation].
     pub fn set_requested_cancellation<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.requested_cancellation = v.into();
         self
     }
 
-    /// Sets the value of `api_version`.
+    /// Sets the value of [api_version][crate::model::OperationMetadata::api_version].
     pub fn set_api_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.api_version = v.into();
         self
@@ -172,7 +172,7 @@ pub struct RunWorkflowCustomOperationMetadata {
 }
 
 impl RunWorkflowCustomOperationMetadata {
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::RunWorkflowCustomOperationMetadata::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -181,7 +181,7 @@ impl RunWorkflowCustomOperationMetadata {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::RunWorkflowCustomOperationMetadata::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -190,31 +190,31 @@ impl RunWorkflowCustomOperationMetadata {
         self
     }
 
-    /// Sets the value of `verb`.
+    /// Sets the value of [verb][crate::model::RunWorkflowCustomOperationMetadata::verb].
     pub fn set_verb<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.verb = v.into();
         self
     }
 
-    /// Sets the value of `requested_cancellation`.
+    /// Sets the value of [requested_cancellation][crate::model::RunWorkflowCustomOperationMetadata::requested_cancellation].
     pub fn set_requested_cancellation<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.requested_cancellation = v.into();
         self
     }
 
-    /// Sets the value of `api_version`.
+    /// Sets the value of [api_version][crate::model::RunWorkflowCustomOperationMetadata::api_version].
     pub fn set_api_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.api_version = v.into();
         self
     }
 
-    /// Sets the value of `target`.
+    /// Sets the value of [target][crate::model::RunWorkflowCustomOperationMetadata::target].
     pub fn set_target<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.target = v.into();
         self
     }
 
-    /// Sets the value of `pipeline_run_id`.
+    /// Sets the value of [pipeline_run_id][crate::model::RunWorkflowCustomOperationMetadata::pipeline_run_id].
     pub fn set_pipeline_run_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.pipeline_run_id = v.into();
         self
@@ -276,13 +276,13 @@ pub struct Connection {
 }
 
 impl Connection {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Connection::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::Connection::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -291,7 +291,7 @@ impl Connection {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::Connection::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -300,7 +300,7 @@ impl Connection {
         self
     }
 
-    /// Sets the value of `installation_state`.
+    /// Sets the value of [installation_state][crate::model::Connection::installation_state].
     pub fn set_installation_state<
         T: std::convert::Into<std::option::Option<crate::model::InstallationState>>,
     >(
@@ -311,32 +311,33 @@ impl Connection {
         self
     }
 
-    /// Sets the value of `disabled`.
+    /// Sets the value of [disabled][crate::model::Connection::disabled].
     pub fn set_disabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.disabled = v.into();
         self
     }
 
-    /// Sets the value of `reconciling`.
+    /// Sets the value of [reconciling][crate::model::Connection::reconciling].
     pub fn set_reconciling<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.reconciling = v.into();
         self
     }
 
-    /// Sets the value of `annotations`.
-    pub fn set_annotations<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.annotations = v.into();
+    /// Sets the value of [etag][crate::model::Connection::etag].
+    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.etag = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
-    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.etag = v.into();
+    /// Sets the value of [annotations][crate::model::Connection::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -405,7 +406,7 @@ pub struct InstallationState {
 }
 
 impl InstallationState {
-    /// Sets the value of `stage`.
+    /// Sets the value of [stage][crate::model::InstallationState::stage].
     pub fn set_stage<T: std::convert::Into<crate::model::installation_state::Stage>>(
         mut self,
         v: T,
@@ -414,13 +415,13 @@ impl InstallationState {
         self
     }
 
-    /// Sets the value of `message`.
+    /// Sets the value of [message][crate::model::InstallationState::message].
     pub fn set_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.message = v.into();
         self
     }
 
-    /// Sets the value of `action_uri`.
+    /// Sets the value of [action_uri][crate::model::InstallationState::action_uri].
     pub fn set_action_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.action_uri = v.into();
         self
@@ -496,19 +497,19 @@ pub struct FetchLinkableRepositoriesRequest {
 }
 
 impl FetchLinkableRepositoriesRequest {
-    /// Sets the value of `connection`.
+    /// Sets the value of [connection][crate::model::FetchLinkableRepositoriesRequest::connection].
     pub fn set_connection<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.connection = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::FetchLinkableRepositoriesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::FetchLinkableRepositoriesRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -537,18 +538,20 @@ pub struct FetchLinkableRepositoriesResponse {
 }
 
 impl FetchLinkableRepositoriesResponse {
-    /// Sets the value of `repositories`.
-    pub fn set_repositories<T: std::convert::Into<std::vec::Vec<crate::model::Repository>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.repositories = v.into();
+    /// Sets the value of [next_page_token][crate::model::FetchLinkableRepositoriesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [repositories][crate::model::FetchLinkableRepositoriesResponse::repositories].
+    pub fn set_repositories<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Repository>,
+    {
+        use std::iter::Iterator;
+        self.repositories = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -590,7 +593,7 @@ pub struct GitHubConfig {
 }
 
 impl GitHubConfig {
-    /// Sets the value of `authorizer_credential`.
+    /// Sets the value of [authorizer_credential][crate::model::GitHubConfig::authorizer_credential].
     pub fn set_authorizer_credential<
         T: std::convert::Into<std::option::Option<crate::model::OAuthCredential>>,
     >(
@@ -601,7 +604,7 @@ impl GitHubConfig {
         self
     }
 
-    /// Sets the value of `app_installation_id`.
+    /// Sets the value of [app_installation_id][crate::model::GitHubConfig::app_installation_id].
     pub fn set_app_installation_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.app_installation_id = v.into();
         self
@@ -668,31 +671,31 @@ pub struct GitHubEnterpriseConfig {
 }
 
 impl GitHubEnterpriseConfig {
-    /// Sets the value of `host_uri`.
+    /// Sets the value of [host_uri][crate::model::GitHubEnterpriseConfig::host_uri].
     pub fn set_host_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.host_uri = v.into();
         self
     }
 
-    /// Sets the value of `api_key`.
+    /// Sets the value of [api_key][crate::model::GitHubEnterpriseConfig::api_key].
     pub fn set_api_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.api_key = v.into();
         self
     }
 
-    /// Sets the value of `app_id`.
+    /// Sets the value of [app_id][crate::model::GitHubEnterpriseConfig::app_id].
     pub fn set_app_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.app_id = v.into();
         self
     }
 
-    /// Sets the value of `app_slug`.
+    /// Sets the value of [app_slug][crate::model::GitHubEnterpriseConfig::app_slug].
     pub fn set_app_slug<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.app_slug = v.into();
         self
     }
 
-    /// Sets the value of `private_key_secret_version`.
+    /// Sets the value of [private_key_secret_version][crate::model::GitHubEnterpriseConfig::private_key_secret_version].
     pub fn set_private_key_secret_version<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -701,7 +704,7 @@ impl GitHubEnterpriseConfig {
         self
     }
 
-    /// Sets the value of `webhook_secret_secret_version`.
+    /// Sets the value of [webhook_secret_secret_version][crate::model::GitHubEnterpriseConfig::webhook_secret_secret_version].
     pub fn set_webhook_secret_secret_version<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -710,13 +713,13 @@ impl GitHubEnterpriseConfig {
         self
     }
 
-    /// Sets the value of `app_installation_id`.
+    /// Sets the value of [app_installation_id][crate::model::GitHubEnterpriseConfig::app_installation_id].
     pub fn set_app_installation_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.app_installation_id = v.into();
         self
     }
 
-    /// Sets the value of `service_directory_config`.
+    /// Sets the value of [service_directory_config][crate::model::GitHubEnterpriseConfig::service_directory_config].
     pub fn set_service_directory_config<
         T: std::convert::Into<std::option::Option<crate::model::ServiceDirectoryConfig>>,
     >(
@@ -727,13 +730,13 @@ impl GitHubEnterpriseConfig {
         self
     }
 
-    /// Sets the value of `ssl_ca`.
+    /// Sets the value of [ssl_ca][crate::model::GitHubEnterpriseConfig::ssl_ca].
     pub fn set_ssl_ca<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.ssl_ca = v.into();
         self
     }
 
-    /// Sets the value of `server_version`.
+    /// Sets the value of [server_version][crate::model::GitHubEnterpriseConfig::server_version].
     pub fn set_server_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.server_version = v.into();
         self
@@ -792,13 +795,13 @@ pub struct GitLabConfig {
 }
 
 impl GitLabConfig {
-    /// Sets the value of `host_uri`.
+    /// Sets the value of [host_uri][crate::model::GitLabConfig::host_uri].
     pub fn set_host_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.host_uri = v.into();
         self
     }
 
-    /// Sets the value of `webhook_secret_secret_version`.
+    /// Sets the value of [webhook_secret_secret_version][crate::model::GitLabConfig::webhook_secret_secret_version].
     pub fn set_webhook_secret_secret_version<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -807,7 +810,7 @@ impl GitLabConfig {
         self
     }
 
-    /// Sets the value of `read_authorizer_credential`.
+    /// Sets the value of [read_authorizer_credential][crate::model::GitLabConfig::read_authorizer_credential].
     pub fn set_read_authorizer_credential<
         T: std::convert::Into<std::option::Option<crate::model::UserCredential>>,
     >(
@@ -818,7 +821,7 @@ impl GitLabConfig {
         self
     }
 
-    /// Sets the value of `authorizer_credential`.
+    /// Sets the value of [authorizer_credential][crate::model::GitLabConfig::authorizer_credential].
     pub fn set_authorizer_credential<
         T: std::convert::Into<std::option::Option<crate::model::UserCredential>>,
     >(
@@ -829,7 +832,7 @@ impl GitLabConfig {
         self
     }
 
-    /// Sets the value of `service_directory_config`.
+    /// Sets the value of [service_directory_config][crate::model::GitLabConfig::service_directory_config].
     pub fn set_service_directory_config<
         T: std::convert::Into<std::option::Option<crate::model::ServiceDirectoryConfig>>,
     >(
@@ -840,13 +843,13 @@ impl GitLabConfig {
         self
     }
 
-    /// Sets the value of `ssl_ca`.
+    /// Sets the value of [ssl_ca][crate::model::GitLabConfig::ssl_ca].
     pub fn set_ssl_ca<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.ssl_ca = v.into();
         self
     }
 
-    /// Sets the value of `server_version`.
+    /// Sets the value of [server_version][crate::model::GitLabConfig::server_version].
     pub fn set_server_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.server_version = v.into();
         self
@@ -903,13 +906,13 @@ pub struct BitbucketDataCenterConfig {
 }
 
 impl BitbucketDataCenterConfig {
-    /// Sets the value of `host_uri`.
+    /// Sets the value of [host_uri][crate::model::BitbucketDataCenterConfig::host_uri].
     pub fn set_host_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.host_uri = v.into();
         self
     }
 
-    /// Sets the value of `webhook_secret_secret_version`.
+    /// Sets the value of [webhook_secret_secret_version][crate::model::BitbucketDataCenterConfig::webhook_secret_secret_version].
     pub fn set_webhook_secret_secret_version<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -918,7 +921,7 @@ impl BitbucketDataCenterConfig {
         self
     }
 
-    /// Sets the value of `read_authorizer_credential`.
+    /// Sets the value of [read_authorizer_credential][crate::model::BitbucketDataCenterConfig::read_authorizer_credential].
     pub fn set_read_authorizer_credential<
         T: std::convert::Into<std::option::Option<crate::model::UserCredential>>,
     >(
@@ -929,7 +932,7 @@ impl BitbucketDataCenterConfig {
         self
     }
 
-    /// Sets the value of `authorizer_credential`.
+    /// Sets the value of [authorizer_credential][crate::model::BitbucketDataCenterConfig::authorizer_credential].
     pub fn set_authorizer_credential<
         T: std::convert::Into<std::option::Option<crate::model::UserCredential>>,
     >(
@@ -940,7 +943,7 @@ impl BitbucketDataCenterConfig {
         self
     }
 
-    /// Sets the value of `service_directory_config`.
+    /// Sets the value of [service_directory_config][crate::model::BitbucketDataCenterConfig::service_directory_config].
     pub fn set_service_directory_config<
         T: std::convert::Into<std::option::Option<crate::model::ServiceDirectoryConfig>>,
     >(
@@ -951,13 +954,13 @@ impl BitbucketDataCenterConfig {
         self
     }
 
-    /// Sets the value of `ssl_ca`.
+    /// Sets the value of [ssl_ca][crate::model::BitbucketDataCenterConfig::ssl_ca].
     pub fn set_ssl_ca<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.ssl_ca = v.into();
         self
     }
 
-    /// Sets the value of `server_version`.
+    /// Sets the value of [server_version][crate::model::BitbucketDataCenterConfig::server_version].
     pub fn set_server_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.server_version = v.into();
         self
@@ -1001,13 +1004,13 @@ pub struct BitbucketCloudConfig {
 }
 
 impl BitbucketCloudConfig {
-    /// Sets the value of `workspace`.
+    /// Sets the value of [workspace][crate::model::BitbucketCloudConfig::workspace].
     pub fn set_workspace<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.workspace = v.into();
         self
     }
 
-    /// Sets the value of `webhook_secret_secret_version`.
+    /// Sets the value of [webhook_secret_secret_version][crate::model::BitbucketCloudConfig::webhook_secret_secret_version].
     pub fn set_webhook_secret_secret_version<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -1016,7 +1019,7 @@ impl BitbucketCloudConfig {
         self
     }
 
-    /// Sets the value of `read_authorizer_credential`.
+    /// Sets the value of [read_authorizer_credential][crate::model::BitbucketCloudConfig::read_authorizer_credential].
     pub fn set_read_authorizer_credential<
         T: std::convert::Into<std::option::Option<crate::model::UserCredential>>,
     >(
@@ -1027,7 +1030,7 @@ impl BitbucketCloudConfig {
         self
     }
 
-    /// Sets the value of `authorizer_credential`.
+    /// Sets the value of [authorizer_credential][crate::model::BitbucketCloudConfig::authorizer_credential].
     pub fn set_authorizer_credential<
         T: std::convert::Into<std::option::Option<crate::model::UserCredential>>,
     >(
@@ -1060,7 +1063,7 @@ pub struct ServiceDirectoryConfig {
 }
 
 impl ServiceDirectoryConfig {
-    /// Sets the value of `service`.
+    /// Sets the value of [service][crate::model::ServiceDirectoryConfig::service].
     pub fn set_service<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service = v.into();
         self
@@ -1112,19 +1115,19 @@ pub struct Repository {
 }
 
 impl Repository {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Repository::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `remote_uri`.
+    /// Sets the value of [remote_uri][crate::model::Repository::remote_uri].
     pub fn set_remote_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.remote_uri = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::Repository::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1133,7 +1136,7 @@ impl Repository {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::Repository::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1142,26 +1145,27 @@ impl Repository {
         self
     }
 
-    /// Sets the value of `annotations`.
-    pub fn set_annotations<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.annotations = v.into();
-        self
-    }
-
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::Repository::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `webhook_id`.
+    /// Sets the value of [webhook_id][crate::model::Repository::webhook_id].
     pub fn set_webhook_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.webhook_id = v.into();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::Repository::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1190,7 +1194,7 @@ pub struct OAuthCredential {
 }
 
 impl OAuthCredential {
-    /// Sets the value of `oauth_token_secret_version`.
+    /// Sets the value of [oauth_token_secret_version][crate::model::OAuthCredential::oauth_token_secret_version].
     pub fn set_oauth_token_secret_version<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -1199,7 +1203,7 @@ impl OAuthCredential {
         self
     }
 
-    /// Sets the value of `username`.
+    /// Sets the value of [username][crate::model::OAuthCredential::username].
     pub fn set_username<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.username = v.into();
         self
@@ -1231,7 +1235,7 @@ pub struct UserCredential {
 }
 
 impl UserCredential {
-    /// Sets the value of `user_token_secret_version`.
+    /// Sets the value of [user_token_secret_version][crate::model::UserCredential::user_token_secret_version].
     pub fn set_user_token_secret_version<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -1240,7 +1244,7 @@ impl UserCredential {
         self
     }
 
-    /// Sets the value of `username`.
+    /// Sets the value of [username][crate::model::UserCredential::username].
     pub fn set_username<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.username = v.into();
         self
@@ -1277,13 +1281,13 @@ pub struct CreateConnectionRequest {
 }
 
 impl CreateConnectionRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateConnectionRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `connection`.
+    /// Sets the value of [connection][crate::model::CreateConnectionRequest::connection].
     pub fn set_connection<T: std::convert::Into<std::option::Option<crate::model::Connection>>>(
         mut self,
         v: T,
@@ -1292,7 +1296,7 @@ impl CreateConnectionRequest {
         self
     }
 
-    /// Sets the value of `connection_id`.
+    /// Sets the value of [connection_id][crate::model::CreateConnectionRequest::connection_id].
     pub fn set_connection_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.connection_id = v.into();
         self
@@ -1318,7 +1322,7 @@ pub struct GetConnectionRequest {
 }
 
 impl GetConnectionRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetConnectionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1351,19 +1355,19 @@ pub struct ListConnectionsRequest {
 }
 
 impl ListConnectionsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListConnectionsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListConnectionsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListConnectionsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -1392,18 +1396,20 @@ pub struct ListConnectionsResponse {
 }
 
 impl ListConnectionsResponse {
-    /// Sets the value of `connections`.
-    pub fn set_connections<T: std::convert::Into<std::vec::Vec<crate::model::Connection>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connections = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListConnectionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [connections][crate::model::ListConnectionsResponse::connections].
+    pub fn set_connections<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Connection>,
+    {
+        use std::iter::Iterator;
+        self.connections = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1456,7 +1462,7 @@ pub struct UpdateConnectionRequest {
 }
 
 impl UpdateConnectionRequest {
-    /// Sets the value of `connection`.
+    /// Sets the value of [connection][crate::model::UpdateConnectionRequest::connection].
     pub fn set_connection<T: std::convert::Into<std::option::Option<crate::model::Connection>>>(
         mut self,
         v: T,
@@ -1465,7 +1471,7 @@ impl UpdateConnectionRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateConnectionRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -1474,13 +1480,13 @@ impl UpdateConnectionRequest {
         self
     }
 
-    /// Sets the value of `allow_missing`.
+    /// Sets the value of [allow_missing][crate::model::UpdateConnectionRequest::allow_missing].
     pub fn set_allow_missing<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.allow_missing = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::UpdateConnectionRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
@@ -1515,19 +1521,19 @@ pub struct DeleteConnectionRequest {
 }
 
 impl DeleteConnectionRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteConnectionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DeleteConnectionRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `validate_only`.
+    /// Sets the value of [validate_only][crate::model::DeleteConnectionRequest::validate_only].
     pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.validate_only = v.into();
         self
@@ -1565,13 +1571,13 @@ pub struct CreateRepositoryRequest {
 }
 
 impl CreateRepositoryRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateRepositoryRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `repository`.
+    /// Sets the value of [repository][crate::model::CreateRepositoryRequest::repository].
     pub fn set_repository<T: std::convert::Into<std::option::Option<crate::model::Repository>>>(
         mut self,
         v: T,
@@ -1580,7 +1586,7 @@ impl CreateRepositoryRequest {
         self
     }
 
-    /// Sets the value of `repository_id`.
+    /// Sets the value of [repository_id][crate::model::CreateRepositoryRequest::repository_id].
     pub fn set_repository_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.repository_id = v.into();
         self
@@ -1612,20 +1618,20 @@ pub struct BatchCreateRepositoriesRequest {
 }
 
 impl BatchCreateRepositoriesRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::BatchCreateRepositoriesRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `requests`.
-    pub fn set_requests<
-        T: std::convert::Into<std::vec::Vec<crate::model::CreateRepositoryRequest>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.requests = v.into();
+    /// Sets the value of [requests][crate::model::BatchCreateRepositoriesRequest::requests].
+    pub fn set_requests<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::CreateRepositoryRequest>,
+    {
+        use std::iter::Iterator;
+        self.requests = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1648,12 +1654,14 @@ pub struct BatchCreateRepositoriesResponse {
 }
 
 impl BatchCreateRepositoriesResponse {
-    /// Sets the value of `repositories`.
-    pub fn set_repositories<T: std::convert::Into<std::vec::Vec<crate::model::Repository>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.repositories = v.into();
+    /// Sets the value of [repositories][crate::model::BatchCreateRepositoriesResponse::repositories].
+    pub fn set_repositories<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Repository>,
+    {
+        use std::iter::Iterator;
+        self.repositories = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1677,7 +1685,7 @@ pub struct GetRepositoryRequest {
 }
 
 impl GetRepositoryRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetRepositoryRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1717,25 +1725,25 @@ pub struct ListRepositoriesRequest {
 }
 
 impl ListRepositoriesRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListRepositoriesRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListRepositoriesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListRepositoriesRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListRepositoriesRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
@@ -1764,18 +1772,20 @@ pub struct ListRepositoriesResponse {
 }
 
 impl ListRepositoriesResponse {
-    /// Sets the value of `repositories`.
-    pub fn set_repositories<T: std::convert::Into<std::vec::Vec<crate::model::Repository>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.repositories = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListRepositoriesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [repositories][crate::model::ListRepositoriesResponse::repositories].
+    pub fn set_repositories<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Repository>,
+    {
+        use std::iter::Iterator;
+        self.repositories = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1821,19 +1831,19 @@ pub struct DeleteRepositoryRequest {
 }
 
 impl DeleteRepositoryRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteRepositoryRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DeleteRepositoryRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `validate_only`.
+    /// Sets the value of [validate_only][crate::model::DeleteRepositoryRequest::validate_only].
     pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.validate_only = v.into();
         self
@@ -1859,7 +1869,7 @@ pub struct FetchReadWriteTokenRequest {
 }
 
 impl FetchReadWriteTokenRequest {
-    /// Sets the value of `repository`.
+    /// Sets the value of [repository][crate::model::FetchReadWriteTokenRequest::repository].
     pub fn set_repository<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.repository = v.into();
         self
@@ -1885,7 +1895,7 @@ pub struct FetchReadTokenRequest {
 }
 
 impl FetchReadTokenRequest {
-    /// Sets the value of `repository`.
+    /// Sets the value of [repository][crate::model::FetchReadTokenRequest::repository].
     pub fn set_repository<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.repository = v.into();
         self
@@ -1914,13 +1924,13 @@ pub struct FetchReadTokenResponse {
 }
 
 impl FetchReadTokenResponse {
-    /// Sets the value of `token`.
+    /// Sets the value of [token][crate::model::FetchReadTokenResponse::token].
     pub fn set_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.token = v.into();
         self
     }
 
-    /// Sets the value of `expiration_time`.
+    /// Sets the value of [expiration_time][crate::model::FetchReadTokenResponse::expiration_time].
     pub fn set_expiration_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1952,13 +1962,13 @@ pub struct FetchReadWriteTokenResponse {
 }
 
 impl FetchReadWriteTokenResponse {
-    /// Sets the value of `token`.
+    /// Sets the value of [token][crate::model::FetchReadWriteTokenResponse::token].
     pub fn set_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.token = v.into();
         self
     }
 
-    /// Sets the value of `expiration_time`.
+    /// Sets the value of [expiration_time][crate::model::FetchReadWriteTokenResponse::expiration_time].
     pub fn set_expiration_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1996,13 +2006,13 @@ pub struct ProcessWebhookRequest {
 }
 
 impl ProcessWebhookRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ProcessWebhookRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `body`.
+    /// Sets the value of [body][crate::model::ProcessWebhookRequest::body].
     pub fn set_body<T: std::convert::Into<std::option::Option<api::model::HttpBody>>>(
         mut self,
         v: T,
@@ -2011,7 +2021,7 @@ impl ProcessWebhookRequest {
         self
     }
 
-    /// Sets the value of `webhook_key`.
+    /// Sets the value of [webhook_key][crate::model::ProcessWebhookRequest::webhook_key].
     pub fn set_webhook_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.webhook_key = v.into();
         self
@@ -2040,13 +2050,13 @@ pub struct FetchGitRefsRequest {
 }
 
 impl FetchGitRefsRequest {
-    /// Sets the value of `repository`.
+    /// Sets the value of [repository][crate::model::FetchGitRefsRequest::repository].
     pub fn set_repository<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.repository = v.into();
         self
     }
 
-    /// Sets the value of `ref_type`.
+    /// Sets the value of [ref_type][crate::model::FetchGitRefsRequest::ref_type].
     pub fn set_ref_type<T: std::convert::Into<crate::model::fetch_git_refs_request::RefType>>(
         mut self,
         v: T,
@@ -2110,12 +2120,14 @@ pub struct FetchGitRefsResponse {
 }
 
 impl FetchGitRefsResponse {
-    /// Sets the value of `ref_names`.
-    pub fn set_ref_names<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.ref_names = v.into();
+    /// Sets the value of [ref_names][crate::model::FetchGitRefsResponse::ref_names].
+    pub fn set_ref_names<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.ref_names = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/devtools/cloudtrace/v2/src/builders.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/builders.rs
@@ -67,15 +67,20 @@ pub mod trace_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::BatchWriteSpansRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `spans`.
-        pub fn set_spans<T: Into<std::vec::Vec<crate::model::Span>>>(mut self, v: T) -> Self {
-            self.0.request.spans = v.into();
+        /// Sets the value of [spans][crate::model::BatchWriteSpansRequest::spans].
+        pub fn set_spans<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::Span>,
+        {
+            use std::iter::Iterator;
+            self.0.request.spans = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -114,25 +119,25 @@ pub mod trace_service {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::Span::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `span_id`.
+        /// Sets the value of [span_id][crate::model::Span::span_id].
         pub fn set_span_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.span_id = v.into();
             self
         }
 
-        /// Sets the value of `parent_span_id`.
+        /// Sets the value of [parent_span_id][crate::model::Span::parent_span_id].
         pub fn set_parent_span_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent_span_id = v.into();
             self
         }
 
-        /// Sets the value of `display_name`.
+        /// Sets the value of [display_name][crate::model::Span::display_name].
         pub fn set_display_name<T: Into<std::option::Option<crate::model::TruncatableString>>>(
             mut self,
             v: T,
@@ -141,7 +146,7 @@ pub mod trace_service {
             self
         }
 
-        /// Sets the value of `start_time`.
+        /// Sets the value of [start_time][crate::model::Span::start_time].
         pub fn set_start_time<T: Into<std::option::Option<wkt::Timestamp>>>(
             mut self,
             v: T,
@@ -150,13 +155,13 @@ pub mod trace_service {
             self
         }
 
-        /// Sets the value of `end_time`.
+        /// Sets the value of [end_time][crate::model::Span::end_time].
         pub fn set_end_time<T: Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
             self.0.request.end_time = v.into();
             self
         }
 
-        /// Sets the value of `attributes`.
+        /// Sets the value of [attributes][crate::model::Span::attributes].
         pub fn set_attributes<T: Into<std::option::Option<crate::model::span::Attributes>>>(
             mut self,
             v: T,
@@ -165,7 +170,7 @@ pub mod trace_service {
             self
         }
 
-        /// Sets the value of `stack_trace`.
+        /// Sets the value of [stack_trace][crate::model::Span::stack_trace].
         pub fn set_stack_trace<T: Into<std::option::Option<crate::model::StackTrace>>>(
             mut self,
             v: T,
@@ -174,7 +179,7 @@ pub mod trace_service {
             self
         }
 
-        /// Sets the value of `time_events`.
+        /// Sets the value of [time_events][crate::model::Span::time_events].
         pub fn set_time_events<T: Into<std::option::Option<crate::model::span::TimeEvents>>>(
             mut self,
             v: T,
@@ -183,7 +188,7 @@ pub mod trace_service {
             self
         }
 
-        /// Sets the value of `links`.
+        /// Sets the value of [links][crate::model::Span::links].
         pub fn set_links<T: Into<std::option::Option<crate::model::span::Links>>>(
             mut self,
             v: T,
@@ -192,7 +197,7 @@ pub mod trace_service {
             self
         }
 
-        /// Sets the value of `status`.
+        /// Sets the value of [status][crate::model::Span::status].
         pub fn set_status<T: Into<std::option::Option<rpc::model::Status>>>(
             mut self,
             v: T,
@@ -201,7 +206,7 @@ pub mod trace_service {
             self
         }
 
-        /// Sets the value of `same_process_as_parent_span`.
+        /// Sets the value of [same_process_as_parent_span][crate::model::Span::same_process_as_parent_span].
         pub fn set_same_process_as_parent_span<T: Into<std::option::Option<wkt::BoolValue>>>(
             mut self,
             v: T,
@@ -210,7 +215,7 @@ pub mod trace_service {
             self
         }
 
-        /// Sets the value of `child_span_count`.
+        /// Sets the value of [child_span_count][crate::model::Span::child_span_count].
         pub fn set_child_span_count<T: Into<std::option::Option<wkt::Int32Value>>>(
             mut self,
             v: T,
@@ -219,7 +224,7 @@ pub mod trace_service {
             self
         }
 
-        /// Sets the value of `span_kind`.
+        /// Sets the value of [span_kind][crate::model::Span::span_kind].
         pub fn set_span_kind<T: Into<crate::model::span::SpanKind>>(mut self, v: T) -> Self {
             self.0.request.span_kind = v.into();
             self

--- a/src/generated/devtools/cloudtrace/v2/src/model.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/model.rs
@@ -131,25 +131,25 @@ pub struct Span {
 }
 
 impl Span {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Span::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `span_id`.
+    /// Sets the value of [span_id][crate::model::Span::span_id].
     pub fn set_span_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.span_id = v.into();
         self
     }
 
-    /// Sets the value of `parent_span_id`.
+    /// Sets the value of [parent_span_id][crate::model::Span::parent_span_id].
     pub fn set_parent_span_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent_span_id = v.into();
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::Span::display_name].
     pub fn set_display_name<
         T: std::convert::Into<std::option::Option<crate::model::TruncatableString>>,
     >(
@@ -160,7 +160,7 @@ impl Span {
         self
     }
 
-    /// Sets the value of `start_time`.
+    /// Sets the value of [start_time][crate::model::Span::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -169,7 +169,7 @@ impl Span {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::Span::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -178,7 +178,7 @@ impl Span {
         self
     }
 
-    /// Sets the value of `attributes`.
+    /// Sets the value of [attributes][crate::model::Span::attributes].
     pub fn set_attributes<
         T: std::convert::Into<std::option::Option<crate::model::span::Attributes>>,
     >(
@@ -189,7 +189,7 @@ impl Span {
         self
     }
 
-    /// Sets the value of `stack_trace`.
+    /// Sets the value of [stack_trace][crate::model::Span::stack_trace].
     pub fn set_stack_trace<T: std::convert::Into<std::option::Option<crate::model::StackTrace>>>(
         mut self,
         v: T,
@@ -198,7 +198,7 @@ impl Span {
         self
     }
 
-    /// Sets the value of `time_events`.
+    /// Sets the value of [time_events][crate::model::Span::time_events].
     pub fn set_time_events<
         T: std::convert::Into<std::option::Option<crate::model::span::TimeEvents>>,
     >(
@@ -209,7 +209,7 @@ impl Span {
         self
     }
 
-    /// Sets the value of `links`.
+    /// Sets the value of [links][crate::model::Span::links].
     pub fn set_links<T: std::convert::Into<std::option::Option<crate::model::span::Links>>>(
         mut self,
         v: T,
@@ -218,7 +218,7 @@ impl Span {
         self
     }
 
-    /// Sets the value of `status`.
+    /// Sets the value of [status][crate::model::Span::status].
     pub fn set_status<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
         mut self,
         v: T,
@@ -227,7 +227,7 @@ impl Span {
         self
     }
 
-    /// Sets the value of `same_process_as_parent_span`.
+    /// Sets the value of [same_process_as_parent_span][crate::model::Span::same_process_as_parent_span].
     pub fn set_same_process_as_parent_span<
         T: std::convert::Into<std::option::Option<wkt::BoolValue>>,
     >(
@@ -238,7 +238,7 @@ impl Span {
         self
     }
 
-    /// Sets the value of `child_span_count`.
+    /// Sets the value of [child_span_count][crate::model::Span::child_span_count].
     pub fn set_child_span_count<T: std::convert::Into<std::option::Option<wkt::Int32Value>>>(
         mut self,
         v: T,
@@ -247,7 +247,7 @@ impl Span {
         self
     }
 
-    /// Sets the value of `span_kind`.
+    /// Sets the value of [span_kind][crate::model::Span::span_kind].
     pub fn set_span_kind<T: std::convert::Into<crate::model::span::SpanKind>>(
         mut self,
         v: T,
@@ -294,22 +294,21 @@ pub mod span {
     }
 
     impl Attributes {
-        /// Sets the value of `attribute_map`.
-        pub fn set_attribute_map<
-            T: std::convert::Into<
-                std::collections::HashMap<std::string::String, crate::model::AttributeValue>,
-            >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.attribute_map = v.into();
+        /// Sets the value of [dropped_attributes_count][crate::model::span::Attributes::dropped_attributes_count].
+        pub fn set_dropped_attributes_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.dropped_attributes_count = v.into();
             self
         }
 
-        /// Sets the value of `dropped_attributes_count`.
-        pub fn set_dropped_attributes_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.dropped_attributes_count = v.into();
+        /// Sets the value of [attribute_map][crate::model::span::Attributes::attribute_map].
+        pub fn set_attribute_map<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<crate::model::AttributeValue>,
+        {
+            use std::iter::Iterator;
+            self.attribute_map = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -337,7 +336,7 @@ pub mod span {
     }
 
     impl TimeEvent {
-        /// Sets the value of `time`.
+        /// Sets the value of [time][crate::model::span::TimeEvent::time].
         pub fn set_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
             mut self,
             v: T,
@@ -387,7 +386,7 @@ pub mod span {
         }
 
         impl Annotation {
-            /// Sets the value of `description`.
+            /// Sets the value of [description][crate::model::span::time_event::Annotation::description].
             pub fn set_description<
                 T: std::convert::Into<std::option::Option<crate::model::TruncatableString>>,
             >(
@@ -398,7 +397,7 @@ pub mod span {
                 self
             }
 
-            /// Sets the value of `attributes`.
+            /// Sets the value of [attributes][crate::model::span::time_event::Annotation::attributes].
             pub fn set_attributes<
                 T: std::convert::Into<std::option::Option<crate::model::span::Attributes>>,
             >(
@@ -444,7 +443,7 @@ pub mod span {
         }
 
         impl MessageEvent {
-            /// Sets the value of `r#type`.
+            /// Sets the value of [r#type][crate::model::span::time_event::MessageEvent::type].
             pub fn set_type<
                 T: std::convert::Into<crate::model::span::time_event::message_event::Type>,
             >(
@@ -455,19 +454,19 @@ pub mod span {
                 self
             }
 
-            /// Sets the value of `id`.
+            /// Sets the value of [id][crate::model::span::time_event::MessageEvent::id].
             pub fn set_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
                 self.id = v.into();
                 self
             }
 
-            /// Sets the value of `uncompressed_size_bytes`.
+            /// Sets the value of [uncompressed_size_bytes][crate::model::span::time_event::MessageEvent::uncompressed_size_bytes].
             pub fn set_uncompressed_size_bytes<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
                 self.uncompressed_size_bytes = v.into();
                 self
             }
 
-            /// Sets the value of `compressed_size_bytes`.
+            /// Sets the value of [compressed_size_bytes][crate::model::span::time_event::MessageEvent::compressed_size_bytes].
             pub fn set_compressed_size_bytes<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
                 self.compressed_size_bytes = v.into();
                 self
@@ -554,29 +553,29 @@ pub mod span {
     }
 
     impl TimeEvents {
-        /// Sets the value of `time_event`.
-        pub fn set_time_event<
-            T: std::convert::Into<std::vec::Vec<crate::model::span::TimeEvent>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.time_event = v.into();
-            self
-        }
-
-        /// Sets the value of `dropped_annotations_count`.
+        /// Sets the value of [dropped_annotations_count][crate::model::span::TimeEvents::dropped_annotations_count].
         pub fn set_dropped_annotations_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
             self.dropped_annotations_count = v.into();
             self
         }
 
-        /// Sets the value of `dropped_message_events_count`.
+        /// Sets the value of [dropped_message_events_count][crate::model::span::TimeEvents::dropped_message_events_count].
         pub fn set_dropped_message_events_count<T: std::convert::Into<i32>>(
             mut self,
             v: T,
         ) -> Self {
             self.dropped_message_events_count = v.into();
+            self
+        }
+
+        /// Sets the value of [time_event][crate::model::span::TimeEvents::time_event].
+        pub fn set_time_event<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::span::TimeEvent>,
+        {
+            use std::iter::Iterator;
+            self.time_event = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -615,19 +614,19 @@ pub mod span {
     }
 
     impl Link {
-        /// Sets the value of `trace_id`.
+        /// Sets the value of [trace_id][crate::model::span::Link::trace_id].
         pub fn set_trace_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.trace_id = v.into();
             self
         }
 
-        /// Sets the value of `span_id`.
+        /// Sets the value of [span_id][crate::model::span::Link::span_id].
         pub fn set_span_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.span_id = v.into();
             self
         }
 
-        /// Sets the value of `r#type`.
+        /// Sets the value of [r#type][crate::model::span::Link::type].
         pub fn set_type<T: std::convert::Into<crate::model::span::link::Type>>(
             mut self,
             v: T,
@@ -636,7 +635,7 @@ pub mod span {
             self
         }
 
-        /// Sets the value of `attributes`.
+        /// Sets the value of [attributes][crate::model::span::Link::attributes].
         pub fn set_attributes<
             T: std::convert::Into<std::option::Option<crate::model::span::Attributes>>,
         >(
@@ -708,18 +707,20 @@ pub mod span {
     }
 
     impl Links {
-        /// Sets the value of `link`.
-        pub fn set_link<T: std::convert::Into<std::vec::Vec<crate::model::span::Link>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.link = v.into();
+        /// Sets the value of [dropped_links_count][crate::model::span::Links::dropped_links_count].
+        pub fn set_dropped_links_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.dropped_links_count = v.into();
             self
         }
 
-        /// Sets the value of `dropped_links_count`.
-        pub fn set_dropped_links_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.dropped_links_count = v.into();
+        /// Sets the value of [link][crate::model::span::Links::link].
+        pub fn set_link<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::span::Link>,
+        {
+            use std::iter::Iterator;
+            self.link = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -853,7 +854,7 @@ pub struct StackTrace {
 }
 
 impl StackTrace {
-    /// Sets the value of `stack_frames`.
+    /// Sets the value of [stack_frames][crate::model::StackTrace::stack_frames].
     pub fn set_stack_frames<
         T: std::convert::Into<std::option::Option<crate::model::stack_trace::StackFrames>>,
     >(
@@ -864,7 +865,7 @@ impl StackTrace {
         self
     }
 
-    /// Sets the value of `stack_trace_hash_id`.
+    /// Sets the value of [stack_trace_hash_id][crate::model::StackTrace::stack_trace_hash_id].
     pub fn set_stack_trace_hash_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.stack_trace_hash_id = v.into();
         self
@@ -924,7 +925,7 @@ pub mod stack_trace {
     }
 
     impl StackFrame {
-        /// Sets the value of `function_name`.
+        /// Sets the value of [function_name][crate::model::stack_trace::StackFrame::function_name].
         pub fn set_function_name<
             T: std::convert::Into<std::option::Option<crate::model::TruncatableString>>,
         >(
@@ -935,7 +936,7 @@ pub mod stack_trace {
             self
         }
 
-        /// Sets the value of `original_function_name`.
+        /// Sets the value of [original_function_name][crate::model::stack_trace::StackFrame::original_function_name].
         pub fn set_original_function_name<
             T: std::convert::Into<std::option::Option<crate::model::TruncatableString>>,
         >(
@@ -946,7 +947,7 @@ pub mod stack_trace {
             self
         }
 
-        /// Sets the value of `file_name`.
+        /// Sets the value of [file_name][crate::model::stack_trace::StackFrame::file_name].
         pub fn set_file_name<
             T: std::convert::Into<std::option::Option<crate::model::TruncatableString>>,
         >(
@@ -957,19 +958,19 @@ pub mod stack_trace {
             self
         }
 
-        /// Sets the value of `line_number`.
+        /// Sets the value of [line_number][crate::model::stack_trace::StackFrame::line_number].
         pub fn set_line_number<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
             self.line_number = v.into();
             self
         }
 
-        /// Sets the value of `column_number`.
+        /// Sets the value of [column_number][crate::model::stack_trace::StackFrame::column_number].
         pub fn set_column_number<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
             self.column_number = v.into();
             self
         }
 
-        /// Sets the value of `load_module`.
+        /// Sets the value of [load_module][crate::model::stack_trace::StackFrame::load_module].
         pub fn set_load_module<T: std::convert::Into<std::option::Option<crate::model::Module>>>(
             mut self,
             v: T,
@@ -978,7 +979,7 @@ pub mod stack_trace {
             self
         }
 
-        /// Sets the value of `source_version`.
+        /// Sets the value of [source_version][crate::model::stack_trace::StackFrame::source_version].
         pub fn set_source_version<
             T: std::convert::Into<std::option::Option<crate::model::TruncatableString>>,
         >(
@@ -1013,20 +1014,20 @@ pub mod stack_trace {
     }
 
     impl StackFrames {
-        /// Sets the value of `frame`.
-        pub fn set_frame<
-            T: std::convert::Into<std::vec::Vec<crate::model::stack_trace::StackFrame>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.frame = v.into();
+        /// Sets the value of [dropped_frames_count][crate::model::stack_trace::StackFrames::dropped_frames_count].
+        pub fn set_dropped_frames_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.dropped_frames_count = v.into();
             self
         }
 
-        /// Sets the value of `dropped_frames_count`.
-        pub fn set_dropped_frames_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.dropped_frames_count = v.into();
+        /// Sets the value of [frame][crate::model::stack_trace::StackFrames::frame].
+        pub fn set_frame<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::stack_trace::StackFrame>,
+        {
+            use std::iter::Iterator;
+            self.frame = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1056,7 +1057,7 @@ pub struct Module {
 }
 
 impl Module {
-    /// Sets the value of `module`.
+    /// Sets the value of [module][crate::model::Module::module].
     pub fn set_module<
         T: std::convert::Into<std::option::Option<crate::model::TruncatableString>>,
     >(
@@ -1067,7 +1068,7 @@ impl Module {
         self
     }
 
-    /// Sets the value of `build_id`.
+    /// Sets the value of [build_id][crate::model::Module::build_id].
     pub fn set_build_id<
         T: std::convert::Into<std::option::Option<crate::model::TruncatableString>>,
     >(
@@ -1107,13 +1108,13 @@ pub struct TruncatableString {
 }
 
 impl TruncatableString {
-    /// Sets the value of `value`.
+    /// Sets the value of [value][crate::model::TruncatableString::value].
     pub fn set_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.value = v.into();
         self
     }
 
-    /// Sets the value of `truncated_byte_count`.
+    /// Sets the value of [truncated_byte_count][crate::model::TruncatableString::truncated_byte_count].
     pub fn set_truncated_byte_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.truncated_byte_count = v.into();
         self
@@ -1144,18 +1145,20 @@ pub struct BatchWriteSpansRequest {
 }
 
 impl BatchWriteSpansRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::BatchWriteSpansRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `spans`.
-    pub fn set_spans<T: std::convert::Into<std::vec::Vec<crate::model::Span>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.spans = v.into();
+    /// Sets the value of [spans][crate::model::BatchWriteSpansRequest::spans].
+    pub fn set_spans<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Span>,
+    {
+        use std::iter::Iterator;
+        self.spans = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/iam/admin/v1/src/builders.rs
+++ b/src/generated/iam/admin/v1/src/builders.rs
@@ -85,19 +85,19 @@ pub mod iam {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::ListServiceAccountsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListServiceAccountsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListServiceAccountsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -141,7 +141,7 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetServiceAccountRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -185,19 +185,19 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::CreateServiceAccountRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `account_id`.
+        /// Sets the value of [account_id][crate::model::CreateServiceAccountRequest::account_id].
         pub fn set_account_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.account_id = v.into();
             self
         }
 
-        /// Sets the value of `service_account`.
+        /// Sets the value of [service_account][crate::model::CreateServiceAccountRequest::service_account].
         pub fn set_service_account<T: Into<std::option::Option<crate::model::ServiceAccount>>>(
             mut self,
             v: T,
@@ -241,55 +241,55 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::ServiceAccount::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `project_id`.
+        /// Sets the value of [project_id][crate::model::ServiceAccount::project_id].
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
-        /// Sets the value of `unique_id`.
+        /// Sets the value of [unique_id][crate::model::ServiceAccount::unique_id].
         pub fn set_unique_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.unique_id = v.into();
             self
         }
 
-        /// Sets the value of `email`.
+        /// Sets the value of [email][crate::model::ServiceAccount::email].
         pub fn set_email<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.email = v.into();
             self
         }
 
-        /// Sets the value of `display_name`.
+        /// Sets the value of [display_name][crate::model::ServiceAccount::display_name].
         pub fn set_display_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.display_name = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::ServiceAccount::etag].
         pub fn set_etag<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
         }
 
-        /// Sets the value of `description`.
+        /// Sets the value of [description][crate::model::ServiceAccount::description].
         pub fn set_description<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.description = v.into();
             self
         }
 
-        /// Sets the value of `oauth2_client_id`.
+        /// Sets the value of [oauth2_client_id][crate::model::ServiceAccount::oauth2_client_id].
         pub fn set_oauth2_client_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.oauth2_client_id = v.into();
             self
         }
 
-        /// Sets the value of `disabled`.
+        /// Sets the value of [disabled][crate::model::ServiceAccount::disabled].
         pub fn set_disabled<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.disabled = v.into();
             self
@@ -333,7 +333,7 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `service_account`.
+        /// Sets the value of [service_account][crate::model::PatchServiceAccountRequest::service_account].
         pub fn set_service_account<T: Into<std::option::Option<crate::model::ServiceAccount>>>(
             mut self,
             v: T,
@@ -342,7 +342,7 @@ pub mod iam {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::PatchServiceAccountRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -389,7 +389,7 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteServiceAccountRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -433,7 +433,7 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::UndeleteServiceAccountRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -477,7 +477,7 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::EnableServiceAccountRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -521,7 +521,7 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DisableServiceAccountRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -565,20 +565,20 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::ListServiceAccountKeysRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `key_types`.
-        pub fn set_key_types<
-            T: Into<std::vec::Vec<crate::model::list_service_account_keys_request::KeyType>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.key_types = v.into();
+        /// Sets the value of [key_types][crate::model::ListServiceAccountKeysRequest::key_types].
+        pub fn set_key_types<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::list_service_account_keys_request::KeyType>,
+        {
+            use std::iter::Iterator;
+            self.0.request.key_types = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -620,13 +620,13 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetServiceAccountKeyRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `public_key_type`.
+        /// Sets the value of [public_key_type][crate::model::GetServiceAccountKeyRequest::public_key_type].
         pub fn set_public_key_type<T: Into<crate::model::ServiceAccountPublicKeyType>>(
             mut self,
             v: T,
@@ -675,13 +675,13 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::CreateServiceAccountKeyRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `private_key_type`.
+        /// Sets the value of [private_key_type][crate::model::CreateServiceAccountKeyRequest::private_key_type].
         pub fn set_private_key_type<T: Into<crate::model::ServiceAccountPrivateKeyType>>(
             mut self,
             v: T,
@@ -690,7 +690,7 @@ pub mod iam {
             self
         }
 
-        /// Sets the value of `key_algorithm`.
+        /// Sets the value of [key_algorithm][crate::model::CreateServiceAccountKeyRequest::key_algorithm].
         pub fn set_key_algorithm<T: Into<crate::model::ServiceAccountKeyAlgorithm>>(
             mut self,
             v: T,
@@ -739,13 +739,13 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::UploadServiceAccountKeyRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `public_key_data`.
+        /// Sets the value of [public_key_data][crate::model::UploadServiceAccountKeyRequest::public_key_data].
         pub fn set_public_key_data<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.public_key_data = v.into();
             self
@@ -791,7 +791,7 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteServiceAccountKeyRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -837,7 +837,7 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DisableServiceAccountKeyRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -883,7 +883,7 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::EnableServiceAccountKeyRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -924,13 +924,13 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::SignBlobRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `bytes_to_sign`.
+        /// Sets the value of [bytes_to_sign][crate::model::SignBlobRequest::bytes_to_sign].
         pub fn set_bytes_to_sign<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.bytes_to_sign = v.into();
             self
@@ -971,13 +971,13 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::SignJwtRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `payload`.
+        /// Sets the value of [payload][crate::model::SignJwtRequest::payload].
         pub fn set_payload<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.payload = v.into();
             self
@@ -1018,13 +1018,13 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::GetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `options`.
+        /// Sets the value of [options][iam_v1::model::GetIamPolicyRequest::options].
         pub fn set_options<T: Into<std::option::Option<iam_v1::model::GetPolicyOptions>>>(
             mut self,
             v: T,
@@ -1068,13 +1068,13 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::SetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][iam_v1::model::SetIamPolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<iam_v1::model::Policy>>>(
             mut self,
             v: T,
@@ -1083,7 +1083,7 @@ pub mod iam {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][iam_v1::model::SetIamPolicyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -1130,18 +1130,20 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::TestIamPermissionsRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `permissions`.
-        pub fn set_permissions<T: Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.permissions = v.into();
+        /// Sets the value of [permissions][iam_v1::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1198,25 +1200,25 @@ pub mod iam {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `full_resource_name`.
+        /// Sets the value of [full_resource_name][crate::model::QueryGrantableRolesRequest::full_resource_name].
         pub fn set_full_resource_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.full_resource_name = v.into();
             self
         }
 
-        /// Sets the value of `view`.
+        /// Sets the value of [view][crate::model::QueryGrantableRolesRequest::view].
         pub fn set_view<T: Into<crate::model::RoleView>>(mut self, v: T) -> Self {
             self.0.request.view = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::QueryGrantableRolesRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::QueryGrantableRolesRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -1271,31 +1273,31 @@ pub mod iam {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListRolesRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListRolesRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListRolesRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `view`.
+        /// Sets the value of [view][crate::model::ListRolesRequest::view].
         pub fn set_view<T: Into<crate::model::RoleView>>(mut self, v: T) -> Self {
             self.0.request.view = v.into();
             self
         }
 
-        /// Sets the value of `show_deleted`.
+        /// Sets the value of [show_deleted][crate::model::ListRolesRequest::show_deleted].
         pub fn set_show_deleted<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.show_deleted = v.into();
             self
@@ -1336,7 +1338,7 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetRoleRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1377,19 +1379,19 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateRoleRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `role_id`.
+        /// Sets the value of [role_id][crate::model::CreateRoleRequest::role_id].
         pub fn set_role_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.role_id = v.into();
             self
         }
 
-        /// Sets the value of `role`.
+        /// Sets the value of [role][crate::model::CreateRoleRequest::role].
         pub fn set_role<T: Into<std::option::Option<crate::model::Role>>>(mut self, v: T) -> Self {
             self.0.request.role = v.into();
             self
@@ -1430,19 +1432,19 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::UpdateRoleRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `role`.
+        /// Sets the value of [role][crate::model::UpdateRoleRequest::role].
         pub fn set_role<T: Into<std::option::Option<crate::model::Role>>>(mut self, v: T) -> Self {
             self.0.request.role = v.into();
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateRoleRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -1486,13 +1488,13 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteRoleRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DeleteRoleRequest::etag].
         pub fn set_etag<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -1533,13 +1535,13 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::UndeleteRoleRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::UndeleteRoleRequest::etag].
         pub fn set_etag<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -1602,19 +1604,19 @@ pub mod iam {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `full_resource_name`.
+        /// Sets the value of [full_resource_name][crate::model::QueryTestablePermissionsRequest::full_resource_name].
         pub fn set_full_resource_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.full_resource_name = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::QueryTestablePermissionsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::QueryTestablePermissionsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -1658,7 +1660,7 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `full_resource_name`.
+        /// Sets the value of [full_resource_name][crate::model::QueryAuditableServicesRequest::full_resource_name].
         pub fn set_full_resource_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.full_resource_name = v.into();
             self
@@ -1699,7 +1701,7 @@ pub mod iam {
                 .await
         }
 
-        /// Sets the value of `full_resource_name`.
+        /// Sets the value of [full_resource_name][crate::model::LintPolicyRequest::full_resource_name].
         pub fn set_full_resource_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.full_resource_name = v.into();
             self

--- a/src/generated/iam/admin/v1/src/model.rs
+++ b/src/generated/iam/admin/v1/src/model.rs
@@ -46,7 +46,7 @@ pub struct AuditData {
 }
 
 impl AuditData {
-    /// Sets the value of `permission_delta`.
+    /// Sets the value of [permission_delta][crate::model::AuditData::permission_delta].
     pub fn set_permission_delta<
         T: std::convert::Into<std::option::Option<crate::model::audit_data::PermissionDelta>>,
     >(
@@ -86,23 +86,25 @@ pub mod audit_data {
     }
 
     impl PermissionDelta {
-        /// Sets the value of `added_permissions`.
-        pub fn set_added_permissions<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.added_permissions = v.into();
+        /// Sets the value of [added_permissions][crate::model::audit_data::PermissionDelta::added_permissions].
+        pub fn set_added_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.added_permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
-        /// Sets the value of `removed_permissions`.
-        pub fn set_removed_permissions<
-            T: std::convert::Into<std::vec::Vec<std::string::String>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.removed_permissions = v.into();
+        /// Sets the value of [removed_permissions][crate::model::audit_data::PermissionDelta::removed_permissions].
+        pub fn set_removed_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.removed_permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -193,49 +195,49 @@ pub struct ServiceAccount {
 }
 
 impl ServiceAccount {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::ServiceAccount::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `project_id`.
+    /// Sets the value of [project_id][crate::model::ServiceAccount::project_id].
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
-    /// Sets the value of `unique_id`.
+    /// Sets the value of [unique_id][crate::model::ServiceAccount::unique_id].
     pub fn set_unique_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.unique_id = v.into();
         self
     }
 
-    /// Sets the value of `email`.
+    /// Sets the value of [email][crate::model::ServiceAccount::email].
     pub fn set_email<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.email = v.into();
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::ServiceAccount::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::ServiceAccount::etag].
     pub fn set_etag<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::ServiceAccount::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
     }
 
-    /// Sets the value of `oauth2_client_id`.
+    /// Sets the value of [oauth2_client_id][crate::model::ServiceAccount::oauth2_client_id].
     pub fn set_oauth2_client_id<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -244,7 +246,7 @@ impl ServiceAccount {
         self
     }
 
-    /// Sets the value of `disabled`.
+    /// Sets the value of [disabled][crate::model::ServiceAccount::disabled].
     pub fn set_disabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.disabled = v.into();
         self
@@ -285,19 +287,19 @@ pub struct CreateServiceAccountRequest {
 }
 
 impl CreateServiceAccountRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::CreateServiceAccountRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `account_id`.
+    /// Sets the value of [account_id][crate::model::CreateServiceAccountRequest::account_id].
     pub fn set_account_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.account_id = v.into();
         self
     }
 
-    /// Sets the value of `service_account`.
+    /// Sets the value of [service_account][crate::model::CreateServiceAccountRequest::service_account].
     pub fn set_service_account<
         T: std::convert::Into<std::option::Option<crate::model::ServiceAccount>>,
     >(
@@ -345,19 +347,19 @@ pub struct ListServiceAccountsRequest {
 }
 
 impl ListServiceAccountsRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::ListServiceAccountsRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListServiceAccountsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListServiceAccountsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -390,18 +392,20 @@ pub struct ListServiceAccountsResponse {
 }
 
 impl ListServiceAccountsResponse {
-    /// Sets the value of `accounts`.
-    pub fn set_accounts<T: std::convert::Into<std::vec::Vec<crate::model::ServiceAccount>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.accounts = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListServiceAccountsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [accounts][crate::model::ListServiceAccountsResponse::accounts].
+    pub fn set_accounts<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ServiceAccount>,
+    {
+        use std::iter::Iterator;
+        self.accounts = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -441,7 +445,7 @@ pub struct GetServiceAccountRequest {
 }
 
 impl GetServiceAccountRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetServiceAccountRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -470,7 +474,7 @@ pub struct DeleteServiceAccountRequest {
 }
 
 impl DeleteServiceAccountRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteServiceAccountRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -503,7 +507,7 @@ pub struct PatchServiceAccountRequest {
 }
 
 impl PatchServiceAccountRequest {
-    /// Sets the value of `service_account`.
+    /// Sets the value of [service_account][crate::model::PatchServiceAccountRequest::service_account].
     pub fn set_service_account<
         T: std::convert::Into<std::option::Option<crate::model::ServiceAccount>>,
     >(
@@ -514,7 +518,7 @@ impl PatchServiceAccountRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::PatchServiceAccountRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -545,7 +549,7 @@ pub struct UndeleteServiceAccountRequest {
 }
 
 impl UndeleteServiceAccountRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::UndeleteServiceAccountRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -569,7 +573,7 @@ pub struct UndeleteServiceAccountResponse {
 }
 
 impl UndeleteServiceAccountResponse {
-    /// Sets the value of `restored_account`.
+    /// Sets the value of [restored_account][crate::model::UndeleteServiceAccountResponse::restored_account].
     pub fn set_restored_account<
         T: std::convert::Into<std::option::Option<crate::model::ServiceAccount>>,
     >(
@@ -603,7 +607,7 @@ pub struct EnableServiceAccountRequest {
 }
 
 impl EnableServiceAccountRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::EnableServiceAccountRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -632,7 +636,7 @@ pub struct DisableServiceAccountRequest {
 }
 
 impl DisableServiceAccountRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DisableServiceAccountRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -668,20 +672,20 @@ pub struct ListServiceAccountKeysRequest {
 }
 
 impl ListServiceAccountKeysRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::ListServiceAccountKeysRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `key_types`.
-    pub fn set_key_types<
-        T: std::convert::Into<std::vec::Vec<crate::model::list_service_account_keys_request::KeyType>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.key_types = v.into();
+    /// Sets the value of [key_types][crate::model::ListServiceAccountKeysRequest::key_types].
+    pub fn set_key_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::list_service_account_keys_request::KeyType>,
+    {
+        use std::iter::Iterator;
+        self.key_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -742,12 +746,14 @@ pub struct ListServiceAccountKeysResponse {
 }
 
 impl ListServiceAccountKeysResponse {
-    /// Sets the value of `keys`.
-    pub fn set_keys<T: std::convert::Into<std::vec::Vec<crate::model::ServiceAccountKey>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.keys = v.into();
+    /// Sets the value of [keys][crate::model::ListServiceAccountKeysResponse::keys].
+    pub fn set_keys<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ServiceAccountKey>,
+    {
+        use std::iter::Iterator;
+        self.keys = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -779,13 +785,13 @@ pub struct GetServiceAccountKeyRequest {
 }
 
 impl GetServiceAccountKeyRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetServiceAccountKeyRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `public_key_type`.
+    /// Sets the value of [public_key_type][crate::model::GetServiceAccountKeyRequest::public_key_type].
     pub fn set_public_key_type<T: std::convert::Into<crate::model::ServiceAccountPublicKeyType>>(
         mut self,
         v: T,
@@ -884,13 +890,13 @@ pub struct ServiceAccountKey {
 }
 
 impl ServiceAccountKey {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::ServiceAccountKey::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `private_key_type`.
+    /// Sets the value of [private_key_type][crate::model::ServiceAccountKey::private_key_type].
     pub fn set_private_key_type<
         T: std::convert::Into<crate::model::ServiceAccountPrivateKeyType>,
     >(
@@ -901,7 +907,7 @@ impl ServiceAccountKey {
         self
     }
 
-    /// Sets the value of `key_algorithm`.
+    /// Sets the value of [key_algorithm][crate::model::ServiceAccountKey::key_algorithm].
     pub fn set_key_algorithm<T: std::convert::Into<crate::model::ServiceAccountKeyAlgorithm>>(
         mut self,
         v: T,
@@ -910,19 +916,19 @@ impl ServiceAccountKey {
         self
     }
 
-    /// Sets the value of `private_key_data`.
+    /// Sets the value of [private_key_data][crate::model::ServiceAccountKey::private_key_data].
     pub fn set_private_key_data<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.private_key_data = v.into();
         self
     }
 
-    /// Sets the value of `public_key_data`.
+    /// Sets the value of [public_key_data][crate::model::ServiceAccountKey::public_key_data].
     pub fn set_public_key_data<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.public_key_data = v.into();
         self
     }
 
-    /// Sets the value of `valid_after_time`.
+    /// Sets the value of [valid_after_time][crate::model::ServiceAccountKey::valid_after_time].
     pub fn set_valid_after_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -931,7 +937,7 @@ impl ServiceAccountKey {
         self
     }
 
-    /// Sets the value of `valid_before_time`.
+    /// Sets the value of [valid_before_time][crate::model::ServiceAccountKey::valid_before_time].
     pub fn set_valid_before_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -940,7 +946,7 @@ impl ServiceAccountKey {
         self
     }
 
-    /// Sets the value of `key_origin`.
+    /// Sets the value of [key_origin][crate::model::ServiceAccountKey::key_origin].
     pub fn set_key_origin<T: std::convert::Into<crate::model::ServiceAccountKeyOrigin>>(
         mut self,
         v: T,
@@ -949,7 +955,7 @@ impl ServiceAccountKey {
         self
     }
 
-    /// Sets the value of `key_type`.
+    /// Sets the value of [key_type][crate::model::ServiceAccountKey::key_type].
     pub fn set_key_type<
         T: std::convert::Into<crate::model::list_service_account_keys_request::KeyType>,
     >(
@@ -960,7 +966,7 @@ impl ServiceAccountKey {
         self
     }
 
-    /// Sets the value of `disabled`.
+    /// Sets the value of [disabled][crate::model::ServiceAccountKey::disabled].
     pub fn set_disabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.disabled = v.into();
         self
@@ -999,13 +1005,13 @@ pub struct CreateServiceAccountKeyRequest {
 }
 
 impl CreateServiceAccountKeyRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::CreateServiceAccountKeyRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `private_key_type`.
+    /// Sets the value of [private_key_type][crate::model::CreateServiceAccountKeyRequest::private_key_type].
     pub fn set_private_key_type<
         T: std::convert::Into<crate::model::ServiceAccountPrivateKeyType>,
     >(
@@ -1016,7 +1022,7 @@ impl CreateServiceAccountKeyRequest {
         self
     }
 
-    /// Sets the value of `key_algorithm`.
+    /// Sets the value of [key_algorithm][crate::model::CreateServiceAccountKeyRequest::key_algorithm].
     pub fn set_key_algorithm<T: std::convert::Into<crate::model::ServiceAccountKeyAlgorithm>>(
         mut self,
         v: T,
@@ -1056,13 +1062,13 @@ pub struct UploadServiceAccountKeyRequest {
 }
 
 impl UploadServiceAccountKeyRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::UploadServiceAccountKeyRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `public_key_data`.
+    /// Sets the value of [public_key_data][crate::model::UploadServiceAccountKeyRequest::public_key_data].
     pub fn set_public_key_data<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.public_key_data = v.into();
         self
@@ -1091,7 +1097,7 @@ pub struct DeleteServiceAccountKeyRequest {
 }
 
 impl DeleteServiceAccountKeyRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteServiceAccountKeyRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1121,7 +1127,7 @@ pub struct DisableServiceAccountKeyRequest {
 }
 
 impl DisableServiceAccountKeyRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DisableServiceAccountKeyRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1151,7 +1157,7 @@ pub struct EnableServiceAccountKeyRequest {
 }
 
 impl EnableServiceAccountKeyRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::EnableServiceAccountKeyRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1194,13 +1200,13 @@ pub struct SignBlobRequest {
 }
 
 impl SignBlobRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::SignBlobRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `bytes_to_sign`.
+    /// Sets the value of [bytes_to_sign][crate::model::SignBlobRequest::bytes_to_sign].
     pub fn set_bytes_to_sign<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.bytes_to_sign = v.into();
         self
@@ -1239,13 +1245,13 @@ pub struct SignBlobResponse {
 }
 
 impl SignBlobResponse {
-    /// Sets the value of `key_id`.
+    /// Sets the value of [key_id][crate::model::SignBlobResponse::key_id].
     pub fn set_key_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.key_id = v.into();
         self
     }
 
-    /// Sets the value of `signature`.
+    /// Sets the value of [signature][crate::model::SignBlobResponse::signature].
     pub fn set_signature<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.signature = v.into();
         self
@@ -1296,13 +1302,13 @@ pub struct SignJwtRequest {
 }
 
 impl SignJwtRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::SignJwtRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `payload`.
+    /// Sets the value of [payload][crate::model::SignJwtRequest::payload].
     pub fn set_payload<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.payload = v.into();
         self
@@ -1340,13 +1346,13 @@ pub struct SignJwtResponse {
 }
 
 impl SignJwtResponse {
-    /// Sets the value of `key_id`.
+    /// Sets the value of [key_id][crate::model::SignJwtResponse::key_id].
     pub fn set_key_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.key_id = v.into();
         self
     }
 
-    /// Sets the value of `signed_jwt`.
+    /// Sets the value of [signed_jwt][crate::model::SignJwtResponse::signed_jwt].
     pub fn set_signed_jwt<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.signed_jwt = v.into();
         self
@@ -1404,34 +1410,25 @@ pub struct Role {
 }
 
 impl Role {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Role::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `title`.
+    /// Sets the value of [title][crate::model::Role::title].
     pub fn set_title<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.title = v.into();
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::Role::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
     }
 
-    /// Sets the value of `included_permissions`.
-    pub fn set_included_permissions<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.included_permissions = v.into();
-        self
-    }
-
-    /// Sets the value of `stage`.
+    /// Sets the value of [stage][crate::model::Role::stage].
     pub fn set_stage<T: std::convert::Into<crate::model::role::RoleLaunchStage>>(
         mut self,
         v: T,
@@ -1440,15 +1437,26 @@ impl Role {
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::Role::etag].
     pub fn set_etag<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `deleted`.
+    /// Sets the value of [deleted][crate::model::Role::deleted].
     pub fn set_deleted<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.deleted = v.into();
+        self
+    }
+
+    /// Sets the value of [included_permissions][crate::model::Role::included_permissions].
+    pub fn set_included_permissions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.included_permissions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1535,7 +1543,7 @@ pub struct QueryGrantableRolesRequest {
 }
 
 impl QueryGrantableRolesRequest {
-    /// Sets the value of `full_resource_name`.
+    /// Sets the value of [full_resource_name][crate::model::QueryGrantableRolesRequest::full_resource_name].
     pub fn set_full_resource_name<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -1544,19 +1552,19 @@ impl QueryGrantableRolesRequest {
         self
     }
 
-    /// Sets the value of `view`.
+    /// Sets the value of [view][crate::model::QueryGrantableRolesRequest::view].
     pub fn set_view<T: std::convert::Into<crate::model::RoleView>>(mut self, v: T) -> Self {
         self.view = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::QueryGrantableRolesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::QueryGrantableRolesRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -1586,18 +1594,20 @@ pub struct QueryGrantableRolesResponse {
 }
 
 impl QueryGrantableRolesResponse {
-    /// Sets the value of `roles`.
-    pub fn set_roles<T: std::convert::Into<std::vec::Vec<crate::model::Role>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.roles = v.into();
+    /// Sets the value of [next_page_token][crate::model::QueryGrantableRolesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [roles][crate::model::QueryGrantableRolesResponse::roles].
+    pub fn set_roles<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Role>,
+    {
+        use std::iter::Iterator;
+        self.roles = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1681,31 +1691,31 @@ pub struct ListRolesRequest {
 }
 
 impl ListRolesRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListRolesRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListRolesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListRolesRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `view`.
+    /// Sets the value of [view][crate::model::ListRolesRequest::view].
     pub fn set_view<T: std::convert::Into<crate::model::RoleView>>(mut self, v: T) -> Self {
         self.view = v.into();
         self
     }
 
-    /// Sets the value of `show_deleted`.
+    /// Sets the value of [show_deleted][crate::model::ListRolesRequest::show_deleted].
     pub fn set_show_deleted<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.show_deleted = v.into();
         self
@@ -1735,18 +1745,20 @@ pub struct ListRolesResponse {
 }
 
 impl ListRolesResponse {
-    /// Sets the value of `roles`.
-    pub fn set_roles<T: std::convert::Into<std::vec::Vec<crate::model::Role>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.roles = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListRolesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [roles][crate::model::ListRolesResponse::roles].
+    pub fn set_roles<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Role>,
+    {
+        use std::iter::Iterator;
+        self.roles = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1813,7 +1825,7 @@ pub struct GetRoleRequest {
 }
 
 impl GetRoleRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetRoleRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1873,19 +1885,19 @@ pub struct CreateRoleRequest {
 }
 
 impl CreateRoleRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateRoleRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `role_id`.
+    /// Sets the value of [role_id][crate::model::CreateRoleRequest::role_id].
     pub fn set_role_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.role_id = v.into();
         self
     }
 
-    /// Sets the value of `role`.
+    /// Sets the value of [role][crate::model::CreateRoleRequest::role].
     pub fn set_role<T: std::convert::Into<std::option::Option<crate::model::Role>>>(
         mut self,
         v: T,
@@ -1944,13 +1956,13 @@ pub struct UpdateRoleRequest {
 }
 
 impl UpdateRoleRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::UpdateRoleRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `role`.
+    /// Sets the value of [role][crate::model::UpdateRoleRequest::role].
     pub fn set_role<T: std::convert::Into<std::option::Option<crate::model::Role>>>(
         mut self,
         v: T,
@@ -1959,7 +1971,7 @@ impl UpdateRoleRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateRoleRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -2015,13 +2027,13 @@ pub struct DeleteRoleRequest {
 }
 
 impl DeleteRoleRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteRoleRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DeleteRoleRequest::etag].
     pub fn set_etag<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
@@ -2074,13 +2086,13 @@ pub struct UndeleteRoleRequest {
 }
 
 impl UndeleteRoleRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::UndeleteRoleRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::UndeleteRoleRequest::etag].
     pub fn set_etag<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
@@ -2130,31 +2142,31 @@ pub struct Permission {
 }
 
 impl Permission {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Permission::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `title`.
+    /// Sets the value of [title][crate::model::Permission::title].
     pub fn set_title<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.title = v.into();
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::Permission::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
     }
 
-    /// Sets the value of `only_in_predefined_roles`.
+    /// Sets the value of [only_in_predefined_roles][crate::model::Permission::only_in_predefined_roles].
     pub fn set_only_in_predefined_roles<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.only_in_predefined_roles = v.into();
         self
     }
 
-    /// Sets the value of `stage`.
+    /// Sets the value of [stage][crate::model::Permission::stage].
     pub fn set_stage<T: std::convert::Into<crate::model::permission::PermissionLaunchStage>>(
         mut self,
         v: T,
@@ -2163,7 +2175,7 @@ impl Permission {
         self
     }
 
-    /// Sets the value of `custom_roles_support_level`.
+    /// Sets the value of [custom_roles_support_level][crate::model::Permission::custom_roles_support_level].
     pub fn set_custom_roles_support_level<
         T: std::convert::Into<crate::model::permission::CustomRolesSupportLevel>,
     >(
@@ -2174,13 +2186,13 @@ impl Permission {
         self
     }
 
-    /// Sets the value of `api_disabled`.
+    /// Sets the value of [api_disabled][crate::model::Permission::api_disabled].
     pub fn set_api_disabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.api_disabled = v.into();
         self
     }
 
-    /// Sets the value of `primary_permission`.
+    /// Sets the value of [primary_permission][crate::model::Permission::primary_permission].
     pub fn set_primary_permission<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -2292,7 +2304,7 @@ pub struct QueryTestablePermissionsRequest {
 }
 
 impl QueryTestablePermissionsRequest {
-    /// Sets the value of `full_resource_name`.
+    /// Sets the value of [full_resource_name][crate::model::QueryTestablePermissionsRequest::full_resource_name].
     pub fn set_full_resource_name<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -2301,13 +2313,13 @@ impl QueryTestablePermissionsRequest {
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::QueryTestablePermissionsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::QueryTestablePermissionsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -2337,18 +2349,20 @@ pub struct QueryTestablePermissionsResponse {
 }
 
 impl QueryTestablePermissionsResponse {
-    /// Sets the value of `permissions`.
-    pub fn set_permissions<T: std::convert::Into<std::vec::Vec<crate::model::Permission>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.permissions = v.into();
+    /// Sets the value of [next_page_token][crate::model::QueryTestablePermissionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [permissions][crate::model::QueryTestablePermissionsResponse::permissions].
+    pub fn set_permissions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Permission>,
+    {
+        use std::iter::Iterator;
+        self.permissions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2389,7 +2403,7 @@ pub struct QueryAuditableServicesRequest {
 }
 
 impl QueryAuditableServicesRequest {
-    /// Sets the value of `full_resource_name`.
+    /// Sets the value of [full_resource_name][crate::model::QueryAuditableServicesRequest::full_resource_name].
     pub fn set_full_resource_name<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -2417,16 +2431,14 @@ pub struct QueryAuditableServicesResponse {
 }
 
 impl QueryAuditableServicesResponse {
-    /// Sets the value of `services`.
-    pub fn set_services<
-        T: std::convert::Into<
-            std::vec::Vec<crate::model::query_auditable_services_response::AuditableService>,
-        >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.services = v.into();
+    /// Sets the value of [services][crate::model::QueryAuditableServicesResponse::services].
+    pub fn set_services<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::query_auditable_services_response::AuditableService>,
+    {
+        use std::iter::Iterator;
+        self.services = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2455,7 +2467,7 @@ pub mod query_auditable_services_response {
     }
 
     impl AuditableService {
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::query_auditable_services_response::AuditableService::name].
         pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.name = v.into();
             self
@@ -2493,7 +2505,7 @@ pub struct LintPolicyRequest {
 }
 
 impl LintPolicyRequest {
-    /// Sets the value of `full_resource_name`.
+    /// Sets the value of [full_resource_name][crate::model::LintPolicyRequest::full_resource_name].
     pub fn set_full_resource_name<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -2573,7 +2585,7 @@ pub struct LintResult {
 }
 
 impl LintResult {
-    /// Sets the value of `level`.
+    /// Sets the value of [level][crate::model::LintResult::level].
     pub fn set_level<T: std::convert::Into<crate::model::lint_result::Level>>(
         mut self,
         v: T,
@@ -2582,7 +2594,7 @@ impl LintResult {
         self
     }
 
-    /// Sets the value of `validation_unit_name`.
+    /// Sets the value of [validation_unit_name][crate::model::LintResult::validation_unit_name].
     pub fn set_validation_unit_name<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -2591,7 +2603,7 @@ impl LintResult {
         self
     }
 
-    /// Sets the value of `severity`.
+    /// Sets the value of [severity][crate::model::LintResult::severity].
     pub fn set_severity<T: std::convert::Into<crate::model::lint_result::Severity>>(
         mut self,
         v: T,
@@ -2600,19 +2612,19 @@ impl LintResult {
         self
     }
 
-    /// Sets the value of `field_name`.
+    /// Sets the value of [field_name][crate::model::LintResult::field_name].
     pub fn set_field_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.field_name = v.into();
         self
     }
 
-    /// Sets the value of `location_offset`.
+    /// Sets the value of [location_offset][crate::model::LintResult::location_offset].
     pub fn set_location_offset<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.location_offset = v.into();
         self
     }
 
-    /// Sets the value of `debug_message`.
+    /// Sets the value of [debug_message][crate::model::LintResult::debug_message].
     pub fn set_debug_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.debug_message = v.into();
         self
@@ -2727,12 +2739,14 @@ pub struct LintPolicyResponse {
 }
 
 impl LintPolicyResponse {
-    /// Sets the value of `lint_results`.
-    pub fn set_lint_results<T: std::convert::Into<std::vec::Vec<crate::model::LintResult>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.lint_results = v.into();
+    /// Sets the value of [lint_results][crate::model::LintPolicyResponse::lint_results].
+    pub fn set_lint_results<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::LintResult>,
+    {
+        use std::iter::Iterator;
+        self.lint_results = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/iam/credentials/v1/src/builders.rs
+++ b/src/generated/iam/credentials/v1/src/builders.rs
@@ -70,27 +70,37 @@ pub mod iam_credentials {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GenerateAccessTokenRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `delegates`.
-        pub fn set_delegates<T: Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-            self.0.request.delegates = v.into();
-            self
-        }
-
-        /// Sets the value of `scope`.
-        pub fn set_scope<T: Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-            self.0.request.scope = v.into();
-            self
-        }
-
-        /// Sets the value of `lifetime`.
+        /// Sets the value of [lifetime][crate::model::GenerateAccessTokenRequest::lifetime].
         pub fn set_lifetime<T: Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
             self.0.request.lifetime = v.into();
+            self
+        }
+
+        /// Sets the value of [delegates][crate::model::GenerateAccessTokenRequest::delegates].
+        pub fn set_delegates<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.delegates = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [scope][crate::model::GenerateAccessTokenRequest::scope].
+        pub fn set_scope<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.scope = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -129,27 +139,32 @@ pub mod iam_credentials {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GenerateIdTokenRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `delegates`.
-        pub fn set_delegates<T: Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-            self.0.request.delegates = v.into();
-            self
-        }
-
-        /// Sets the value of `audience`.
+        /// Sets the value of [audience][crate::model::GenerateIdTokenRequest::audience].
         pub fn set_audience<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.audience = v.into();
             self
         }
 
-        /// Sets the value of `include_email`.
+        /// Sets the value of [include_email][crate::model::GenerateIdTokenRequest::include_email].
         pub fn set_include_email<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.include_email = v.into();
+            self
+        }
+
+        /// Sets the value of [delegates][crate::model::GenerateIdTokenRequest::delegates].
+        pub fn set_delegates<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.delegates = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -188,21 +203,26 @@ pub mod iam_credentials {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::SignBlobRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `delegates`.
-        pub fn set_delegates<T: Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-            self.0.request.delegates = v.into();
+        /// Sets the value of [payload][crate::model::SignBlobRequest::payload].
+        pub fn set_payload<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
+            self.0.request.payload = v.into();
             self
         }
 
-        /// Sets the value of `payload`.
-        pub fn set_payload<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
-            self.0.request.payload = v.into();
+        /// Sets the value of [delegates][crate::model::SignBlobRequest::delegates].
+        pub fn set_delegates<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.delegates = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -241,21 +261,26 @@ pub mod iam_credentials {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::SignJwtRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `delegates`.
-        pub fn set_delegates<T: Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-            self.0.request.delegates = v.into();
+        /// Sets the value of [payload][crate::model::SignJwtRequest::payload].
+        pub fn set_payload<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.payload = v.into();
             self
         }
 
-        /// Sets the value of `payload`.
-        pub fn set_payload<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.payload = v.into();
+        /// Sets the value of [delegates][crate::model::SignJwtRequest::delegates].
+        pub fn set_delegates<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.delegates = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/src/generated/iam/credentials/v1/src/model.rs
+++ b/src/generated/iam/credentials/v1/src/model.rs
@@ -71,36 +71,40 @@ pub struct GenerateAccessTokenRequest {
 }
 
 impl GenerateAccessTokenRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GenerateAccessTokenRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `delegates`.
-    pub fn set_delegates<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.delegates = v.into();
-        self
-    }
-
-    /// Sets the value of `scope`.
-    pub fn set_scope<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.scope = v.into();
-        self
-    }
-
-    /// Sets the value of `lifetime`.
+    /// Sets the value of [lifetime][crate::model::GenerateAccessTokenRequest::lifetime].
     pub fn set_lifetime<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
     ) -> Self {
         self.lifetime = v.into();
+        self
+    }
+
+    /// Sets the value of [delegates][crate::model::GenerateAccessTokenRequest::delegates].
+    pub fn set_delegates<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.delegates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [scope][crate::model::GenerateAccessTokenRequest::scope].
+    pub fn set_scope<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.scope = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -127,13 +131,13 @@ pub struct GenerateAccessTokenResponse {
 }
 
 impl GenerateAccessTokenResponse {
-    /// Sets the value of `access_token`.
+    /// Sets the value of [access_token][crate::model::GenerateAccessTokenResponse::access_token].
     pub fn set_access_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.access_token = v.into();
         self
     }
 
-    /// Sets the value of `expire_time`.
+    /// Sets the value of [expire_time][crate::model::GenerateAccessTokenResponse::expire_time].
     pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -181,24 +185,26 @@ pub struct SignBlobRequest {
 }
 
 impl SignBlobRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::SignBlobRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `delegates`.
-    pub fn set_delegates<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.delegates = v.into();
+    /// Sets the value of [payload][crate::model::SignBlobRequest::payload].
+    pub fn set_payload<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
+        self.payload = v.into();
         self
     }
 
-    /// Sets the value of `payload`.
-    pub fn set_payload<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
-        self.payload = v.into();
+    /// Sets the value of [delegates][crate::model::SignBlobRequest::delegates].
+    pub fn set_delegates<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.delegates = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -225,13 +231,13 @@ pub struct SignBlobResponse {
 }
 
 impl SignBlobResponse {
-    /// Sets the value of `key_id`.
+    /// Sets the value of [key_id][crate::model::SignBlobResponse::key_id].
     pub fn set_key_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.key_id = v.into();
         self
     }
 
-    /// Sets the value of `signed_blob`.
+    /// Sets the value of [signed_blob][crate::model::SignBlobResponse::signed_blob].
     pub fn set_signed_blob<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.signed_blob = v.into();
         self
@@ -275,24 +281,26 @@ pub struct SignJwtRequest {
 }
 
 impl SignJwtRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::SignJwtRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `delegates`.
-    pub fn set_delegates<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.delegates = v.into();
+    /// Sets the value of [payload][crate::model::SignJwtRequest::payload].
+    pub fn set_payload<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.payload = v.into();
         self
     }
 
-    /// Sets the value of `payload`.
-    pub fn set_payload<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.payload = v.into();
+    /// Sets the value of [delegates][crate::model::SignJwtRequest::delegates].
+    pub fn set_delegates<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.delegates = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -318,13 +326,13 @@ pub struct SignJwtResponse {
 }
 
 impl SignJwtResponse {
-    /// Sets the value of `key_id`.
+    /// Sets the value of [key_id][crate::model::SignJwtResponse::key_id].
     pub fn set_key_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.key_id = v.into();
         self
     }
 
-    /// Sets the value of `signed_jwt`.
+    /// Sets the value of [signed_jwt][crate::model::SignJwtResponse::signed_jwt].
     pub fn set_signed_jwt<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.signed_jwt = v.into();
         self
@@ -373,30 +381,32 @@ pub struct GenerateIdTokenRequest {
 }
 
 impl GenerateIdTokenRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GenerateIdTokenRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `delegates`.
-    pub fn set_delegates<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.delegates = v.into();
-        self
-    }
-
-    /// Sets the value of `audience`.
+    /// Sets the value of [audience][crate::model::GenerateIdTokenRequest::audience].
     pub fn set_audience<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.audience = v.into();
         self
     }
 
-    /// Sets the value of `include_email`.
+    /// Sets the value of [include_email][crate::model::GenerateIdTokenRequest::include_email].
     pub fn set_include_email<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.include_email = v.into();
+        self
+    }
+
+    /// Sets the value of [delegates][crate::model::GenerateIdTokenRequest::delegates].
+    pub fn set_delegates<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.delegates = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -418,7 +428,7 @@ pub struct GenerateIdTokenResponse {
 }
 
 impl GenerateIdTokenResponse {
-    /// Sets the value of `token`.
+    /// Sets the value of [token][crate::model::GenerateIdTokenResponse::token].
     pub fn set_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.token = v.into();
         self

--- a/src/generated/iam/v1/src/builders.rs
+++ b/src/generated/iam/v1/src/builders.rs
@@ -67,13 +67,13 @@ pub mod iam_policy {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][crate::model::SetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][crate::model::SetIamPolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<crate::model::Policy>>>(
             mut self,
             v: T,
@@ -82,7 +82,7 @@ pub mod iam_policy {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::SetIamPolicyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -126,13 +126,13 @@ pub mod iam_policy {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][crate::model::GetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `options`.
+        /// Sets the value of [options][crate::model::GetIamPolicyRequest::options].
         pub fn set_options<T: Into<std::option::Option<crate::model::GetPolicyOptions>>>(
             mut self,
             v: T,
@@ -179,18 +179,20 @@ pub mod iam_policy {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][crate::model::TestIamPermissionsRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `permissions`.
-        pub fn set_permissions<T: Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.permissions = v.into();
+        /// Sets the value of [permissions][crate::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/src/generated/iam/v1/src/model.rs
+++ b/src/generated/iam/v1/src/model.rs
@@ -59,13 +59,13 @@ pub struct SetIamPolicyRequest {
 }
 
 impl SetIamPolicyRequest {
-    /// Sets the value of `resource`.
+    /// Sets the value of [resource][crate::model::SetIamPolicyRequest::resource].
     pub fn set_resource<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.resource = v.into();
         self
     }
 
-    /// Sets the value of `policy`.
+    /// Sets the value of [policy][crate::model::SetIamPolicyRequest::policy].
     pub fn set_policy<T: std::convert::Into<std::option::Option<crate::model::Policy>>>(
         mut self,
         v: T,
@@ -74,7 +74,7 @@ impl SetIamPolicyRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::SetIamPolicyRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -108,13 +108,13 @@ pub struct GetIamPolicyRequest {
 }
 
 impl GetIamPolicyRequest {
-    /// Sets the value of `resource`.
+    /// Sets the value of [resource][crate::model::GetIamPolicyRequest::resource].
     pub fn set_resource<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.resource = v.into();
         self
     }
 
-    /// Sets the value of `options`.
+    /// Sets the value of [options][crate::model::GetIamPolicyRequest::options].
     pub fn set_options<
         T: std::convert::Into<std::option::Option<crate::model::GetPolicyOptions>>,
     >(
@@ -152,18 +152,20 @@ pub struct TestIamPermissionsRequest {
 }
 
 impl TestIamPermissionsRequest {
-    /// Sets the value of `resource`.
+    /// Sets the value of [resource][crate::model::TestIamPermissionsRequest::resource].
     pub fn set_resource<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.resource = v.into();
         self
     }
 
-    /// Sets the value of `permissions`.
-    pub fn set_permissions<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.permissions = v.into();
+    /// Sets the value of [permissions][crate::model::TestIamPermissionsRequest::permissions].
+    pub fn set_permissions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.permissions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -187,12 +189,14 @@ pub struct TestIamPermissionsResponse {
 }
 
 impl TestIamPermissionsResponse {
-    /// Sets the value of `permissions`.
-    pub fn set_permissions<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.permissions = v.into();
+    /// Sets the value of [permissions][crate::model::TestIamPermissionsResponse::permissions].
+    pub fn set_permissions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.permissions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -231,7 +235,7 @@ pub struct GetPolicyOptions {
 }
 
 impl GetPolicyOptions {
-    /// Sets the value of `requested_policy_version`.
+    /// Sets the value of [requested_policy_version][crate::model::GetPolicyOptions::requested_policy_version].
     pub fn set_requested_policy_version<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.requested_policy_version = v.into();
         self
@@ -383,33 +387,37 @@ pub struct Policy {
 }
 
 impl Policy {
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::Policy::version].
     pub fn set_version<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
     }
 
-    /// Sets the value of `bindings`.
-    pub fn set_bindings<T: std::convert::Into<std::vec::Vec<crate::model::Binding>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.bindings = v.into();
-        self
-    }
-
-    /// Sets the value of `audit_configs`.
-    pub fn set_audit_configs<T: std::convert::Into<std::vec::Vec<crate::model::AuditConfig>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.audit_configs = v.into();
-        self
-    }
-
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::Policy::etag].
     pub fn set_etag<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [bindings][crate::model::Policy::bindings].
+    pub fn set_bindings<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Binding>,
+    {
+        use std::iter::Iterator;
+        self.bindings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [audit_configs][crate::model::Policy::audit_configs].
+    pub fn set_audit_configs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AuditConfig>,
+    {
+        use std::iter::Iterator;
+        self.audit_configs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -492,27 +500,29 @@ pub struct Binding {
 }
 
 impl Binding {
-    /// Sets the value of `role`.
+    /// Sets the value of [role][crate::model::Binding::role].
     pub fn set_role<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.role = v.into();
         self
     }
 
-    /// Sets the value of `members`.
-    pub fn set_members<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.members = v.into();
-        self
-    }
-
-    /// Sets the value of `condition`.
+    /// Sets the value of [condition][crate::model::Binding::condition].
     pub fn set_condition<T: std::convert::Into<std::option::Option<gtype::model::Expr>>>(
         mut self,
         v: T,
     ) -> Self {
         self.condition = v.into();
+        self
+    }
+
+    /// Sets the value of [members][crate::model::Binding::members].
+    pub fn set_members<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.members = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -593,20 +603,20 @@ pub struct AuditConfig {
 }
 
 impl AuditConfig {
-    /// Sets the value of `service`.
+    /// Sets the value of [service][crate::model::AuditConfig::service].
     pub fn set_service<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service = v.into();
         self
     }
 
-    /// Sets the value of `audit_log_configs`.
-    pub fn set_audit_log_configs<
-        T: std::convert::Into<std::vec::Vec<crate::model::AuditLogConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.audit_log_configs = v.into();
+    /// Sets the value of [audit_log_configs][crate::model::AuditConfig::audit_log_configs].
+    pub fn set_audit_log_configs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AuditLogConfig>,
+    {
+        use std::iter::Iterator;
+        self.audit_log_configs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -657,7 +667,7 @@ pub struct AuditLogConfig {
 }
 
 impl AuditLogConfig {
-    /// Sets the value of `log_type`.
+    /// Sets the value of [log_type][crate::model::AuditLogConfig::log_type].
     pub fn set_log_type<T: std::convert::Into<crate::model::audit_log_config::LogType>>(
         mut self,
         v: T,
@@ -666,12 +676,14 @@ impl AuditLogConfig {
         self
     }
 
-    /// Sets the value of `exempted_members`.
-    pub fn set_exempted_members<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.exempted_members = v.into();
+    /// Sets the value of [exempted_members][crate::model::AuditLogConfig::exempted_members].
+    pub fn set_exempted_members<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.exempted_members = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -738,23 +750,25 @@ pub struct PolicyDelta {
 }
 
 impl PolicyDelta {
-    /// Sets the value of `binding_deltas`.
-    pub fn set_binding_deltas<T: std::convert::Into<std::vec::Vec<crate::model::BindingDelta>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.binding_deltas = v.into();
+    /// Sets the value of [binding_deltas][crate::model::PolicyDelta::binding_deltas].
+    pub fn set_binding_deltas<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::BindingDelta>,
+    {
+        use std::iter::Iterator;
+        self.binding_deltas = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
-    /// Sets the value of `audit_config_deltas`.
-    pub fn set_audit_config_deltas<
-        T: std::convert::Into<std::vec::Vec<crate::model::AuditConfigDelta>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.audit_config_deltas = v.into();
+    /// Sets the value of [audit_config_deltas][crate::model::PolicyDelta::audit_config_deltas].
+    pub fn set_audit_config_deltas<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AuditConfigDelta>,
+    {
+        use std::iter::Iterator;
+        self.audit_config_deltas = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -794,7 +808,7 @@ pub struct BindingDelta {
 }
 
 impl BindingDelta {
-    /// Sets the value of `action`.
+    /// Sets the value of [action][crate::model::BindingDelta::action].
     pub fn set_action<T: std::convert::Into<crate::model::binding_delta::Action>>(
         mut self,
         v: T,
@@ -803,19 +817,19 @@ impl BindingDelta {
         self
     }
 
-    /// Sets the value of `role`.
+    /// Sets the value of [role][crate::model::BindingDelta::role].
     pub fn set_role<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.role = v.into();
         self
     }
 
-    /// Sets the value of `member`.
+    /// Sets the value of [member][crate::model::BindingDelta::member].
     pub fn set_member<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.member = v.into();
         self
     }
 
-    /// Sets the value of `condition`.
+    /// Sets the value of [condition][crate::model::BindingDelta::condition].
     pub fn set_condition<T: std::convert::Into<std::option::Option<gtype::model::Expr>>>(
         mut self,
         v: T,
@@ -899,7 +913,7 @@ pub struct AuditConfigDelta {
 }
 
 impl AuditConfigDelta {
-    /// Sets the value of `action`.
+    /// Sets the value of [action][crate::model::AuditConfigDelta::action].
     pub fn set_action<T: std::convert::Into<crate::model::audit_config_delta::Action>>(
         mut self,
         v: T,
@@ -908,19 +922,19 @@ impl AuditConfigDelta {
         self
     }
 
-    /// Sets the value of `service`.
+    /// Sets the value of [service][crate::model::AuditConfigDelta::service].
     pub fn set_service<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service = v.into();
         self
     }
 
-    /// Sets the value of `exempted_member`.
+    /// Sets the value of [exempted_member][crate::model::AuditConfigDelta::exempted_member].
     pub fn set_exempted_member<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.exempted_member = v.into();
         self
     }
 
-    /// Sets the value of `log_type`.
+    /// Sets the value of [log_type][crate::model::AuditConfigDelta::log_type].
     pub fn set_log_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.log_type = v.into();
         self
@@ -998,7 +1012,7 @@ pub struct ResourcePolicyMember {
 }
 
 impl ResourcePolicyMember {
-    /// Sets the value of `iam_policy_name_principal`.
+    /// Sets the value of [iam_policy_name_principal][crate::model::ResourcePolicyMember::iam_policy_name_principal].
     pub fn set_iam_policy_name_principal<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -1007,7 +1021,7 @@ impl ResourcePolicyMember {
         self
     }
 
-    /// Sets the value of `iam_policy_uid_principal`.
+    /// Sets the value of [iam_policy_uid_principal][crate::model::ResourcePolicyMember::iam_policy_uid_principal].
     pub fn set_iam_policy_uid_principal<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,

--- a/src/generated/iam/v2/src/builders.rs
+++ b/src/generated/iam/v2/src/builders.rs
@@ -82,19 +82,19 @@ pub mod policies {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListPoliciesRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListPoliciesRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListPoliciesRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -135,7 +135,7 @@ pub mod policies {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetPolicyRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -214,13 +214,13 @@ pub mod policies {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreatePolicyRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][crate::model::CreatePolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<crate::model::Policy>>>(
             mut self,
             v: T,
@@ -229,7 +229,7 @@ pub mod policies {
             self
         }
 
-        /// Sets the value of `policy_id`.
+        /// Sets the value of [policy_id][crate::model::CreatePolicyRequest::policy_id].
         pub fn set_policy_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.policy_id = v.into();
             self
@@ -308,7 +308,7 @@ pub mod policies {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][crate::model::UpdatePolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<crate::model::Policy>>>(
             mut self,
             v: T,
@@ -390,13 +390,13 @@ pub mod policies {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeletePolicyRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DeletePolicyRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -440,7 +440,7 @@ pub mod policies {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::GetOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self

--- a/src/generated/iam/v2/src/model.rs
+++ b/src/generated/iam/v2/src/model.rs
@@ -127,48 +127,56 @@ pub struct DenyRule {
 }
 
 impl DenyRule {
-    /// Sets the value of `denied_principals`.
-    pub fn set_denied_principals<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.denied_principals = v.into();
-        self
-    }
-
-    /// Sets the value of `exception_principals`.
-    pub fn set_exception_principals<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.exception_principals = v.into();
-        self
-    }
-
-    /// Sets the value of `denied_permissions`.
-    pub fn set_denied_permissions<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.denied_permissions = v.into();
-        self
-    }
-
-    /// Sets the value of `exception_permissions`.
-    pub fn set_exception_permissions<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.exception_permissions = v.into();
-        self
-    }
-
-    /// Sets the value of `denial_condition`.
+    /// Sets the value of [denial_condition][crate::model::DenyRule::denial_condition].
     pub fn set_denial_condition<T: std::convert::Into<std::option::Option<gtype::model::Expr>>>(
         mut self,
         v: T,
     ) -> Self {
         self.denial_condition = v.into();
+        self
+    }
+
+    /// Sets the value of [denied_principals][crate::model::DenyRule::denied_principals].
+    pub fn set_denied_principals<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.denied_principals = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [exception_principals][crate::model::DenyRule::exception_principals].
+    pub fn set_exception_principals<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.exception_principals = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [denied_permissions][crate::model::DenyRule::denied_permissions].
+    pub fn set_denied_permissions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.denied_permissions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [exception_permissions][crate::model::DenyRule::exception_permissions].
+    pub fn set_exception_permissions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.exception_permissions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -251,48 +259,37 @@ pub struct Policy {
 }
 
 impl Policy {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Policy::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `uid`.
+    /// Sets the value of [uid][crate::model::Policy::uid].
     pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.uid = v.into();
         self
     }
 
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::model::Policy::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::Policy::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
         self
     }
 
-    /// Sets the value of `annotations`.
-    pub fn set_annotations<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.annotations = v.into();
-        self
-    }
-
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::Policy::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::Policy::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -301,7 +298,7 @@ impl Policy {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::Policy::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -310,7 +307,7 @@ impl Policy {
         self
     }
 
-    /// Sets the value of `delete_time`.
+    /// Sets the value of [delete_time][crate::model::Policy::delete_time].
     pub fn set_delete_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -319,21 +316,35 @@ impl Policy {
         self
     }
 
-    /// Sets the value of `rules`.
-    pub fn set_rules<T: std::convert::Into<std::vec::Vec<crate::model::PolicyRule>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rules = v.into();
-        self
-    }
-
-    /// Sets the value of `managing_authority`.
+    /// Sets the value of [managing_authority][crate::model::Policy::managing_authority].
     pub fn set_managing_authority<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
     ) -> Self {
         self.managing_authority = v.into();
+        self
+    }
+
+    /// Sets the value of [rules][crate::model::Policy::rules].
+    pub fn set_rules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::PolicyRule>,
+    {
+        use std::iter::Iterator;
+        self.rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::Policy::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -360,7 +371,7 @@ pub struct PolicyRule {
 }
 
 impl PolicyRule {
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::PolicyRule::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
@@ -429,19 +440,19 @@ pub struct ListPoliciesRequest {
 }
 
 impl ListPoliciesRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListPoliciesRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListPoliciesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListPoliciesRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -473,18 +484,20 @@ pub struct ListPoliciesResponse {
 }
 
 impl ListPoliciesResponse {
-    /// Sets the value of `policies`.
-    pub fn set_policies<T: std::convert::Into<std::vec::Vec<crate::model::Policy>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.policies = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListPoliciesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [policies][crate::model::ListPoliciesResponse::policies].
+    pub fn set_policies<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Policy>,
+    {
+        use std::iter::Iterator;
+        self.policies = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -528,7 +541,7 @@ pub struct GetPolicyRequest {
 }
 
 impl GetPolicyRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetPolicyRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -573,13 +586,13 @@ pub struct CreatePolicyRequest {
 }
 
 impl CreatePolicyRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreatePolicyRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `policy`.
+    /// Sets the value of [policy][crate::model::CreatePolicyRequest::policy].
     pub fn set_policy<T: std::convert::Into<std::option::Option<crate::model::Policy>>>(
         mut self,
         v: T,
@@ -588,7 +601,7 @@ impl CreatePolicyRequest {
         self
     }
 
-    /// Sets the value of `policy_id`.
+    /// Sets the value of [policy_id][crate::model::CreatePolicyRequest::policy_id].
     pub fn set_policy_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.policy_id = v.into();
         self
@@ -617,7 +630,7 @@ pub struct UpdatePolicyRequest {
 }
 
 impl UpdatePolicyRequest {
-    /// Sets the value of `policy`.
+    /// Sets the value of [policy][crate::model::UpdatePolicyRequest::policy].
     pub fn set_policy<T: std::convert::Into<std::option::Option<crate::model::Policy>>>(
         mut self,
         v: T,
@@ -662,13 +675,13 @@ pub struct DeletePolicyRequest {
 }
 
 impl DeletePolicyRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeletePolicyRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DeletePolicyRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
@@ -693,7 +706,7 @@ pub struct PolicyOperationMetadata {
 }
 
 impl PolicyOperationMetadata {
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::PolicyOperationMetadata::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,

--- a/src/generated/longrunning/src/builders.rs
+++ b/src/generated/longrunning/src/builders.rs
@@ -82,25 +82,25 @@ pub mod operations {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::ListOperationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListOperationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListOperationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListOperationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -141,7 +141,7 @@ pub mod operations {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -182,7 +182,7 @@ pub mod operations {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -223,7 +223,7 @@ pub mod operations {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::CancelOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self

--- a/src/generated/longrunning/src/model.rs
+++ b/src/generated/longrunning/src/model.rs
@@ -65,13 +65,13 @@ pub struct Operation {
 }
 
 impl Operation {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Operation::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `metadata`.
+    /// Sets the value of [metadata][crate::model::Operation::metadata].
     pub fn set_metadata<T: std::convert::Into<std::option::Option<wkt::Any>>>(
         mut self,
         v: T,
@@ -80,7 +80,7 @@ impl Operation {
         self
     }
 
-    /// Sets the value of `done`.
+    /// Sets the value of [done][crate::model::Operation::done].
     pub fn set_done<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.done = v.into();
         self
@@ -146,7 +146,7 @@ pub struct GetOperationRequest {
 }
 
 impl GetOperationRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetOperationRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -185,25 +185,25 @@ pub struct ListOperationsRequest {
 }
 
 impl ListOperationsRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::ListOperationsRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListOperationsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListOperationsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListOperationsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -235,18 +235,20 @@ pub struct ListOperationsResponse {
 }
 
 impl ListOperationsResponse {
-    /// Sets the value of `operations`.
-    pub fn set_operations<T: std::convert::Into<std::vec::Vec<crate::model::Operation>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.operations = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListOperationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [operations][crate::model::ListOperationsResponse::operations].
+    pub fn set_operations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Operation>,
+    {
+        use std::iter::Iterator;
+        self.operations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -285,7 +287,7 @@ pub struct CancelOperationRequest {
 }
 
 impl CancelOperationRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::CancelOperationRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -313,7 +315,7 @@ pub struct DeleteOperationRequest {
 }
 
 impl DeleteOperationRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteOperationRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -345,13 +347,13 @@ pub struct WaitOperationRequest {
 }
 
 impl WaitOperationRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::WaitOperationRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `timeout`.
+    /// Sets the value of [timeout][crate::model::WaitOperationRequest::timeout].
     pub fn set_timeout<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
@@ -407,13 +409,13 @@ pub struct OperationInfo {
 }
 
 impl OperationInfo {
-    /// Sets the value of `response_type`.
+    /// Sets the value of [response_type][crate::model::OperationInfo::response_type].
     pub fn set_response_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.response_type = v.into();
         self
     }
 
-    /// Sets the value of `metadata_type`.
+    /// Sets the value of [metadata_type][crate::model::OperationInfo::metadata_type].
     pub fn set_metadata_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.metadata_type = v.into();
         self

--- a/src/generated/openapi-validation/src/builders.rs
+++ b/src/generated/openapi-validation/src/builders.rs
@@ -82,13 +82,13 @@ pub mod secret_manager_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::ListLocationsRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListLocationsRequest::filter].
         pub fn set_filter<T: Into<std::option::Option<std::string::String>>>(
             mut self,
             v: T,
@@ -97,13 +97,13 @@ pub mod secret_manager_service {
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListLocationsRequest::page_size].
         pub fn set_page_size<T: Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListLocationsRequest::page_token].
         pub fn set_page_token<T: Into<std::option::Option<std::string::String>>>(
             mut self,
             v: T,
@@ -147,13 +147,13 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::GetLocationRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::GetLocationRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -209,19 +209,19 @@ pub mod secret_manager_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::ListSecretsRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListSecretsRequest::page_size].
         pub fn set_page_size<T: Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListSecretsRequest::page_token].
         pub fn set_page_token<T: Into<std::option::Option<std::string::String>>>(
             mut self,
             v: T,
@@ -230,7 +230,7 @@ pub mod secret_manager_service {
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListSecretsRequest::filter].
         pub fn set_filter<T: Into<std::option::Option<std::string::String>>>(
             mut self,
             v: T,
@@ -274,7 +274,7 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `request_body`.
+        /// Sets the value of [request_body][crate::model::CreateSecretRequest::request_body].
         pub fn set_request_body<T: Into<std::option::Option<crate::model::Secret>>>(
             mut self,
             v: T,
@@ -283,13 +283,13 @@ pub mod secret_manager_service {
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::CreateSecretRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret_id`.
+        /// Sets the value of [secret_id][crate::model::CreateSecretRequest::secret_id].
         pub fn set_secret_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret_id = v.into();
             self
@@ -350,25 +350,25 @@ pub mod secret_manager_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::ListSecretsByProjectAndLocationRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::ListSecretsByProjectAndLocationRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListSecretsByProjectAndLocationRequest::page_size].
         pub fn set_page_size<T: Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListSecretsByProjectAndLocationRequest::page_token].
         pub fn set_page_token<T: Into<std::option::Option<std::string::String>>>(
             mut self,
             v: T,
@@ -377,7 +377,7 @@ pub mod secret_manager_service {
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListSecretsByProjectAndLocationRequest::filter].
         pub fn set_filter<T: Into<std::option::Option<std::string::String>>>(
             mut self,
             v: T,
@@ -426,7 +426,7 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `request_body`.
+        /// Sets the value of [request_body][crate::model::CreateSecretByProjectAndLocationRequest::request_body].
         pub fn set_request_body<T: Into<std::option::Option<crate::model::Secret>>>(
             mut self,
             v: T,
@@ -435,19 +435,19 @@ pub mod secret_manager_service {
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::CreateSecretByProjectAndLocationRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::CreateSecretByProjectAndLocationRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
         }
 
-        /// Sets the value of `secret_id`.
+        /// Sets the value of [secret_id][crate::model::CreateSecretByProjectAndLocationRequest::secret_id].
         pub fn set_secret_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret_id = v.into();
             self
@@ -491,7 +491,7 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `payload`.
+        /// Sets the value of [payload][crate::model::AddSecretVersionRequest::payload].
         pub fn set_payload<T: Into<std::option::Option<crate::model::SecretPayload>>>(
             mut self,
             v: T,
@@ -500,19 +500,19 @@ pub mod secret_manager_service {
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::AddSecretVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::AddSecretVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::AddSecretVersionRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -561,7 +561,7 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `payload`.
+        /// Sets the value of [payload][crate::model::AddSecretVersionRequest::payload].
         pub fn set_payload<T: Into<std::option::Option<crate::model::SecretPayload>>>(
             mut self,
             v: T,
@@ -570,19 +570,19 @@ pub mod secret_manager_service {
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::AddSecretVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::AddSecretVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::AddSecretVersionRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -623,13 +623,13 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::GetSecretRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::GetSecretRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
@@ -670,19 +670,19 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::DeleteSecretRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::DeleteSecretRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DeleteSecretRequest::etag].
         pub fn set_etag<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -723,7 +723,7 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `request_body`.
+        /// Sets the value of [request_body][crate::model::UpdateSecretRequest::request_body].
         pub fn set_request_body<T: Into<std::option::Option<crate::model::Secret>>>(
             mut self,
             v: T,
@@ -732,19 +732,19 @@ pub mod secret_manager_service {
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::UpdateSecretRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::UpdateSecretRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateSecretRequest::update_mask].
         pub fn set_update_mask<T: Into<wkt::FieldMask>>(mut self, v: T) -> Self {
             self.0.request.update_mask = v.into();
             self
@@ -792,19 +792,19 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::GetSecretByProjectAndLocationAndSecretRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::GetSecretByProjectAndLocationAndSecretRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::GetSecretByProjectAndLocationAndSecretRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
@@ -852,25 +852,25 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::DeleteSecretByProjectAndLocationAndSecretRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::DeleteSecretByProjectAndLocationAndSecretRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::DeleteSecretByProjectAndLocationAndSecretRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DeleteSecretByProjectAndLocationAndSecretRequest::etag].
         pub fn set_etag<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -918,7 +918,7 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `request_body`.
+        /// Sets the value of [request_body][crate::model::UpdateSecretByProjectAndLocationAndSecretRequest::request_body].
         pub fn set_request_body<T: Into<std::option::Option<crate::model::Secret>>>(
             mut self,
             v: T,
@@ -927,25 +927,25 @@ pub mod secret_manager_service {
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::UpdateSecretByProjectAndLocationAndSecretRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::UpdateSecretByProjectAndLocationAndSecretRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::UpdateSecretByProjectAndLocationAndSecretRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateSecretByProjectAndLocationAndSecretRequest::update_mask].
         pub fn set_update_mask<T: Into<wkt::FieldMask>>(mut self, v: T) -> Self {
             self.0.request.update_mask = v.into();
             self
@@ -1004,25 +1004,25 @@ pub mod secret_manager_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::ListSecretVersionsRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::ListSecretVersionsRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListSecretVersionsRequest::page_size].
         pub fn set_page_size<T: Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListSecretVersionsRequest::page_token].
         pub fn set_page_token<T: Into<std::option::Option<std::string::String>>>(
             mut self,
             v: T,
@@ -1031,7 +1031,7 @@ pub mod secret_manager_service {
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListSecretVersionsRequest::filter].
         pub fn set_filter<T: Into<std::option::Option<std::string::String>>>(
             mut self,
             v: T,
@@ -1100,31 +1100,31 @@ pub mod secret_manager_service {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::page_size].
         pub fn set_page_size<T: Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::page_token].
         pub fn set_page_token<T: Into<std::option::Option<std::string::String>>>(
             mut self,
             v: T,
@@ -1133,7 +1133,7 @@ pub mod secret_manager_service {
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::filter].
         pub fn set_filter<T: Into<std::option::Option<std::string::String>>>(
             mut self,
             v: T,
@@ -1180,19 +1180,19 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::GetSecretVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::GetSecretVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `version`.
+        /// Sets the value of [version][crate::model::GetSecretVersionRequest::version].
         pub fn set_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.version = v.into();
             self
@@ -1245,25 +1245,25 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `version`.
+        /// Sets the value of [version][crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest::version].
         pub fn set_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.version = v.into();
             self
@@ -1307,19 +1307,19 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::AccessSecretVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::AccessSecretVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `version`.
+        /// Sets the value of [version][crate::model::AccessSecretVersionRequest::version].
         pub fn set_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.version = v.into();
             self
@@ -1372,25 +1372,25 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `version`.
+        /// Sets the value of [version][crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest::version].
         pub fn set_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.version = v.into();
             self
@@ -1434,31 +1434,31 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DisableSecretVersionRequest::etag].
         pub fn set_etag<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::DisableSecretVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::DisableSecretVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `version`.
+        /// Sets the value of [version][crate::model::DisableSecretVersionRequest::version].
         pub fn set_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.version = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::DisableSecretVersionRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -1507,31 +1507,31 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DisableSecretVersionRequest::etag].
         pub fn set_etag<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::DisableSecretVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::DisableSecretVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `version`.
+        /// Sets the value of [version][crate::model::DisableSecretVersionRequest::version].
         pub fn set_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.version = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::DisableSecretVersionRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -1575,31 +1575,31 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::EnableSecretVersionRequest::etag].
         pub fn set_etag<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::EnableSecretVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::EnableSecretVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `version`.
+        /// Sets the value of [version][crate::model::EnableSecretVersionRequest::version].
         pub fn set_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.version = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::EnableSecretVersionRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -1648,31 +1648,31 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::EnableSecretVersionRequest::etag].
         pub fn set_etag<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::EnableSecretVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::EnableSecretVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `version`.
+        /// Sets the value of [version][crate::model::EnableSecretVersionRequest::version].
         pub fn set_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.version = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::EnableSecretVersionRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -1716,31 +1716,31 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DestroySecretVersionRequest::etag].
         pub fn set_etag<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::DestroySecretVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::DestroySecretVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `version`.
+        /// Sets the value of [version][crate::model::DestroySecretVersionRequest::version].
         pub fn set_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.version = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::DestroySecretVersionRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -1789,31 +1789,31 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DestroySecretVersionRequest::etag].
         pub fn set_etag<T: Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::DestroySecretVersionRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::DestroySecretVersionRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `version`.
+        /// Sets the value of [version][crate::model::DestroySecretVersionRequest::version].
         pub fn set_version<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.version = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::DestroySecretVersionRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -1854,7 +1854,7 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][crate::model::SetIamPolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<crate::model::Policy>>>(
             mut self,
             v: T,
@@ -1863,7 +1863,7 @@ pub mod secret_manager_service {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::SetIamPolicyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -1872,19 +1872,19 @@ pub mod secret_manager_service {
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SetIamPolicyRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::SetIamPolicyRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::SetIamPolicyRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -1927,7 +1927,7 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][crate::model::SetIamPolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<crate::model::Policy>>>(
             mut self,
             v: T,
@@ -1936,7 +1936,7 @@ pub mod secret_manager_service {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::SetIamPolicyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -1945,19 +1945,19 @@ pub mod secret_manager_service {
             self
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::SetIamPolicyRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::SetIamPolicyRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::SetIamPolicyRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
@@ -1998,19 +1998,19 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::GetIamPolicyRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::GetIamPolicyRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `options_requested_policy_version`.
+        /// Sets the value of [options_requested_policy_version][crate::model::GetIamPolicyRequest::options_requested_policy_version].
         pub fn set_options_requested_policy_version<T: Into<std::option::Option<i32>>>(
             mut self,
             v: T,
@@ -2061,25 +2061,25 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `options_requested_policy_version`.
+        /// Sets the value of [options_requested_policy_version][crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest::options_requested_policy_version].
         pub fn set_options_requested_policy_version<T: Into<std::option::Option<i32>>>(
             mut self,
             v: T,
@@ -2126,30 +2126,32 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `permissions`.
-        pub fn set_permissions<T: Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.permissions = v.into();
-            self
-        }
-
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::TestIamPermissionsRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::TestIamPermissionsRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::TestIamPermissionsRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
+            self
+        }
+
+        /// Sets the value of [permissions][crate::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -2196,30 +2198,32 @@ pub mod secret_manager_service {
                 .await
         }
 
-        /// Sets the value of `permissions`.
-        pub fn set_permissions<T: Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.permissions = v.into();
-            self
-        }
-
-        /// Sets the value of `project`.
+        /// Sets the value of [project][crate::model::TestIamPermissionsRequest::project].
         pub fn set_project<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project = v.into();
             self
         }
 
-        /// Sets the value of `secret`.
+        /// Sets the value of [secret][crate::model::TestIamPermissionsRequest::secret].
         pub fn set_secret<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.secret = v.into();
             self
         }
 
-        /// Sets the value of `location`.
+        /// Sets the value of [location][crate::model::TestIamPermissionsRequest::location].
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
+            self
+        }
+
+        /// Sets the value of [permissions][crate::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/src/generated/openapi-validation/src/model.rs
+++ b/src/generated/openapi-validation/src/model.rs
@@ -46,21 +46,23 @@ pub struct ListLocationsResponse {
 }
 
 impl ListLocationsResponse {
-    /// Sets the value of `locations`.
-    pub fn set_locations<T: std::convert::Into<std::vec::Vec<crate::model::Location>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.locations = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListLocationsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
     ) -> Self {
         self.next_page_token = v.into();
+        self
+    }
+
+    /// Sets the value of [locations][crate::model::ListLocationsResponse::locations].
+    pub fn set_locations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Location>,
+    {
+        use std::iter::Iterator;
+        self.locations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -119,7 +121,7 @@ pub struct Location {
 }
 
 impl Location {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Location::name].
     pub fn set_name<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -128,7 +130,7 @@ impl Location {
         self
     }
 
-    /// Sets the value of `location_id`.
+    /// Sets the value of [location_id][crate::model::Location::location_id].
     pub fn set_location_id<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -137,7 +139,7 @@ impl Location {
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::Location::display_name].
     pub fn set_display_name<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -146,23 +148,24 @@ impl Location {
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `metadata`.
+    /// Sets the value of [metadata][crate::model::Location::metadata].
     pub fn set_metadata<T: std::convert::Into<std::option::Option<wkt::Any>>>(
         mut self,
         v: T,
     ) -> Self {
         self.metadata = v.into();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Location::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -196,16 +199,7 @@ pub struct ListSecretsResponse {
 }
 
 impl ListSecretsResponse {
-    /// Sets the value of `secrets`.
-    pub fn set_secrets<T: std::convert::Into<std::vec::Vec<crate::model::Secret>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.secrets = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListSecretsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -214,9 +208,20 @@ impl ListSecretsResponse {
         self
     }
 
-    /// Sets the value of `total_size`.
+    /// Sets the value of [total_size][crate::model::ListSecretsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
         self.total_size = v.into();
+        self
+    }
+
+    /// Sets the value of [secrets][crate::model::ListSecretsResponse::secrets].
+    pub fn set_secrets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Secret>,
+    {
+        use std::iter::Iterator;
+        self.secrets = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -351,7 +356,7 @@ pub struct Secret {
 }
 
 impl Secret {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Secret::name].
     pub fn set_name<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -360,7 +365,7 @@ impl Secret {
         self
     }
 
-    /// Sets the value of `replication`.
+    /// Sets the value of [replication][crate::model::Secret::replication].
     pub fn set_replication<
         T: std::convert::Into<std::option::Option<crate::model::Replication>>,
     >(
@@ -371,7 +376,7 @@ impl Secret {
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::Secret::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -380,27 +385,7 @@ impl Secret {
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `topics`.
-    pub fn set_topics<T: std::convert::Into<std::vec::Vec<crate::model::Topic>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.topics = v.into();
-        self
-    }
-
-    /// Sets the value of `expire_time`.
+    /// Sets the value of [expire_time][crate::model::Secret::expire_time].
     pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -409,7 +394,7 @@ impl Secret {
         self
     }
 
-    /// Sets the value of `ttl`.
+    /// Sets the value of [ttl][crate::model::Secret::ttl].
     pub fn set_ttl<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
@@ -418,7 +403,7 @@ impl Secret {
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::Secret::etag].
     pub fn set_etag<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -427,7 +412,7 @@ impl Secret {
         self
     }
 
-    /// Sets the value of `rotation`.
+    /// Sets the value of [rotation][crate::model::Secret::rotation].
     pub fn set_rotation<T: std::convert::Into<std::option::Option<crate::model::Rotation>>>(
         mut self,
         v: T,
@@ -436,29 +421,7 @@ impl Secret {
         self
     }
 
-    /// Sets the value of `version_aliases`.
-    pub fn set_version_aliases<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, i64>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.version_aliases = v.into();
-        self
-    }
-
-    /// Sets the value of `annotations`.
-    pub fn set_annotations<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.annotations = v.into();
-        self
-    }
-
-    /// Sets the value of `version_destroy_ttl`.
+    /// Sets the value of [version_destroy_ttl][crate::model::Secret::version_destroy_ttl].
     pub fn set_version_destroy_ttl<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
@@ -467,7 +430,7 @@ impl Secret {
         self
     }
 
-    /// Sets the value of `customer_managed_encryption`.
+    /// Sets the value of [customer_managed_encryption][crate::model::Secret::customer_managed_encryption].
     pub fn set_customer_managed_encryption<
         T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryption>>,
     >(
@@ -475,6 +438,53 @@ impl Secret {
         v: T,
     ) -> Self {
         self.customer_managed_encryption = v.into();
+        self
+    }
+
+    /// Sets the value of [topics][crate::model::Secret::topics].
+    pub fn set_topics<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Topic>,
+    {
+        use std::iter::Iterator;
+        self.topics = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Secret::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [version_aliases][crate::model::Secret::version_aliases].
+    pub fn set_version_aliases<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<i64>,
+    {
+        use std::iter::Iterator;
+        self.version_aliases = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::Secret::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -501,7 +511,7 @@ pub struct Replication {
 }
 
 impl Replication {
-    /// Sets the value of `automatic`.
+    /// Sets the value of [automatic][crate::model::Replication::automatic].
     pub fn set_automatic<T: std::convert::Into<std::option::Option<crate::model::Automatic>>>(
         mut self,
         v: T,
@@ -510,7 +520,7 @@ impl Replication {
         self
     }
 
-    /// Sets the value of `user_managed`.
+    /// Sets the value of [user_managed][crate::model::Replication::user_managed].
     pub fn set_user_managed<
         T: std::convert::Into<std::option::Option<crate::model::UserManaged>>,
     >(
@@ -546,7 +556,7 @@ pub struct Automatic {
 }
 
 impl Automatic {
-    /// Sets the value of `customer_managed_encryption`.
+    /// Sets the value of [customer_managed_encryption][crate::model::Automatic::customer_managed_encryption].
     pub fn set_customer_managed_encryption<
         T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryption>>,
     >(
@@ -587,7 +597,7 @@ pub struct CustomerManagedEncryption {
 }
 
 impl CustomerManagedEncryption {
-    /// Sets the value of `kms_key_name`.
+    /// Sets the value of [kms_key_name][crate::model::CustomerManagedEncryption::kms_key_name].
     pub fn set_kms_key_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kms_key_name = v.into();
         self
@@ -615,12 +625,14 @@ pub struct UserManaged {
 }
 
 impl UserManaged {
-    /// Sets the value of `replicas`.
-    pub fn set_replicas<T: std::convert::Into<std::vec::Vec<crate::model::Replica>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.replicas = v.into();
+    /// Sets the value of [replicas][crate::model::UserManaged::replicas].
+    pub fn set_replicas<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Replica>,
+    {
+        use std::iter::Iterator;
+        self.replicas = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -654,7 +666,7 @@ pub struct Replica {
 }
 
 impl Replica {
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::Replica::location].
     pub fn set_location<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -663,7 +675,7 @@ impl Replica {
         self
     }
 
-    /// Sets the value of `customer_managed_encryption`.
+    /// Sets the value of [customer_managed_encryption][crate::model::Replica::customer_managed_encryption].
     pub fn set_customer_managed_encryption<
         T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryption>>,
     >(
@@ -698,7 +710,7 @@ pub struct Topic {
 }
 
 impl Topic {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Topic::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -738,7 +750,7 @@ pub struct Rotation {
 }
 
 impl Rotation {
-    /// Sets the value of `next_rotation_time`.
+    /// Sets the value of [next_rotation_time][crate::model::Rotation::next_rotation_time].
     pub fn set_next_rotation_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -747,7 +759,7 @@ impl Rotation {
         self
     }
 
-    /// Sets the value of `rotation_period`.
+    /// Sets the value of [rotation_period][crate::model::Rotation::rotation_period].
     pub fn set_rotation_period<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
@@ -793,7 +805,7 @@ pub struct AddSecretVersionRequest {
 }
 
 impl AddSecretVersionRequest {
-    /// Sets the value of `payload`.
+    /// Sets the value of [payload][crate::model::AddSecretVersionRequest::payload].
     pub fn set_payload<T: std::convert::Into<std::option::Option<crate::model::SecretPayload>>>(
         mut self,
         v: T,
@@ -802,19 +814,19 @@ impl AddSecretVersionRequest {
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::AddSecretVersionRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::AddSecretVersionRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::AddSecretVersionRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
@@ -850,7 +862,7 @@ pub struct SecretPayload {
 }
 
 impl SecretPayload {
-    /// Sets the value of `data`.
+    /// Sets the value of [data][crate::model::SecretPayload::data].
     pub fn set_data<T: std::convert::Into<std::option::Option<bytes::Bytes>>>(
         mut self,
         v: T,
@@ -859,7 +871,7 @@ impl SecretPayload {
         self
     }
 
-    /// Sets the value of `data_crc_32_c`.
+    /// Sets the value of [data_crc_32_c][crate::model::SecretPayload::data_crc_32_c].
     pub fn set_data_crc_32_c<T: std::convert::Into<std::option::Option<i64>>>(
         mut self,
         v: T,
@@ -934,7 +946,7 @@ pub struct SecretVersion {
 }
 
 impl SecretVersion {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::SecretVersion::name].
     pub fn set_name<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -943,7 +955,7 @@ impl SecretVersion {
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::SecretVersion::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -952,7 +964,7 @@ impl SecretVersion {
         self
     }
 
-    /// Sets the value of `destroy_time`.
+    /// Sets the value of [destroy_time][crate::model::SecretVersion::destroy_time].
     pub fn set_destroy_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -961,7 +973,7 @@ impl SecretVersion {
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::SecretVersion::state].
     pub fn set_state<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -970,7 +982,7 @@ impl SecretVersion {
         self
     }
 
-    /// Sets the value of `replication_status`.
+    /// Sets the value of [replication_status][crate::model::SecretVersion::replication_status].
     pub fn set_replication_status<
         T: std::convert::Into<std::option::Option<crate::model::ReplicationStatus>>,
     >(
@@ -981,7 +993,7 @@ impl SecretVersion {
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::SecretVersion::etag].
     pub fn set_etag<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -990,7 +1002,7 @@ impl SecretVersion {
         self
     }
 
-    /// Sets the value of `client_specified_payload_checksum`.
+    /// Sets the value of [client_specified_payload_checksum][crate::model::SecretVersion::client_specified_payload_checksum].
     pub fn set_client_specified_payload_checksum<
         T: std::convert::Into<std::option::Option<bool>>,
     >(
@@ -1001,7 +1013,7 @@ impl SecretVersion {
         self
     }
 
-    /// Sets the value of `scheduled_destroy_time`.
+    /// Sets the value of [scheduled_destroy_time][crate::model::SecretVersion::scheduled_destroy_time].
     pub fn set_scheduled_destroy_time<
         T: std::convert::Into<std::option::Option<wkt::Timestamp>>,
     >(
@@ -1012,7 +1024,7 @@ impl SecretVersion {
         self
     }
 
-    /// Sets the value of `customer_managed_encryption`.
+    /// Sets the value of [customer_managed_encryption][crate::model::SecretVersion::customer_managed_encryption].
     pub fn set_customer_managed_encryption<
         T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryptionStatus>>,
     >(
@@ -1054,7 +1066,7 @@ pub struct ReplicationStatus {
 }
 
 impl ReplicationStatus {
-    /// Sets the value of `automatic`.
+    /// Sets the value of [automatic][crate::model::ReplicationStatus::automatic].
     pub fn set_automatic<
         T: std::convert::Into<std::option::Option<crate::model::AutomaticStatus>>,
     >(
@@ -1065,7 +1077,7 @@ impl ReplicationStatus {
         self
     }
 
-    /// Sets the value of `user_managed`.
+    /// Sets the value of [user_managed][crate::model::ReplicationStatus::user_managed].
     pub fn set_user_managed<
         T: std::convert::Into<std::option::Option<crate::model::UserManagedStatus>>,
     >(
@@ -1100,7 +1112,7 @@ pub struct AutomaticStatus {
 }
 
 impl AutomaticStatus {
-    /// Sets the value of `customer_managed_encryption`.
+    /// Sets the value of [customer_managed_encryption][crate::model::AutomaticStatus::customer_managed_encryption].
     pub fn set_customer_managed_encryption<
         T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryptionStatus>>,
     >(
@@ -1132,7 +1144,7 @@ pub struct CustomerManagedEncryptionStatus {
 }
 
 impl CustomerManagedEncryptionStatus {
-    /// Sets the value of `kms_key_version_name`.
+    /// Sets the value of [kms_key_version_name][crate::model::CustomerManagedEncryptionStatus::kms_key_version_name].
     pub fn set_kms_key_version_name<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -1164,12 +1176,14 @@ pub struct UserManagedStatus {
 }
 
 impl UserManagedStatus {
-    /// Sets the value of `replicas`.
-    pub fn set_replicas<T: std::convert::Into<std::vec::Vec<crate::model::ReplicaStatus>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.replicas = v.into();
+    /// Sets the value of [replicas][crate::model::UserManagedStatus::replicas].
+    pub fn set_replicas<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ReplicaStatus>,
+    {
+        use std::iter::Iterator;
+        self.replicas = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1199,7 +1213,7 @@ pub struct ReplicaStatus {
 }
 
 impl ReplicaStatus {
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::ReplicaStatus::location].
     pub fn set_location<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -1208,7 +1222,7 @@ impl ReplicaStatus {
         self
     }
 
-    /// Sets the value of `customer_managed_encryption`.
+    /// Sets the value of [customer_managed_encryption][crate::model::ReplicaStatus::customer_managed_encryption].
     pub fn set_customer_managed_encryption<
         T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryptionStatus>>,
     >(
@@ -1272,16 +1286,7 @@ pub struct ListSecretVersionsResponse {
 }
 
 impl ListSecretVersionsResponse {
-    /// Sets the value of `versions`.
-    pub fn set_versions<T: std::convert::Into<std::vec::Vec<crate::model::SecretVersion>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.versions = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListSecretVersionsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -1290,9 +1295,20 @@ impl ListSecretVersionsResponse {
         self
     }
 
-    /// Sets the value of `total_size`.
+    /// Sets the value of [total_size][crate::model::ListSecretVersionsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
         self.total_size = v.into();
+        self
+    }
+
+    /// Sets the value of [versions][crate::model::ListSecretVersionsResponse::versions].
+    pub fn set_versions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SecretVersion>,
+    {
+        use std::iter::Iterator;
+        self.versions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1334,7 +1350,7 @@ pub struct AccessSecretVersionResponse {
 }
 
 impl AccessSecretVersionResponse {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::AccessSecretVersionResponse::name].
     pub fn set_name<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -1343,7 +1359,7 @@ impl AccessSecretVersionResponse {
         self
     }
 
-    /// Sets the value of `payload`.
+    /// Sets the value of [payload][crate::model::AccessSecretVersionResponse::payload].
     pub fn set_payload<T: std::convert::Into<std::option::Option<crate::model::SecretPayload>>>(
         mut self,
         v: T,
@@ -1397,7 +1413,7 @@ pub struct DisableSecretVersionRequest {
 }
 
 impl DisableSecretVersionRequest {
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DisableSecretVersionRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -1406,25 +1422,25 @@ impl DisableSecretVersionRequest {
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::DisableSecretVersionRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::DisableSecretVersionRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::DisableSecretVersionRequest::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::DisableSecretVersionRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
@@ -1469,7 +1485,7 @@ pub struct EnableSecretVersionRequest {
 }
 
 impl EnableSecretVersionRequest {
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::EnableSecretVersionRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -1478,25 +1494,25 @@ impl EnableSecretVersionRequest {
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::EnableSecretVersionRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::EnableSecretVersionRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::EnableSecretVersionRequest::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::EnableSecretVersionRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
@@ -1541,7 +1557,7 @@ pub struct DestroySecretVersionRequest {
 }
 
 impl DestroySecretVersionRequest {
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DestroySecretVersionRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -1550,25 +1566,25 @@ impl DestroySecretVersionRequest {
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::DestroySecretVersionRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::DestroySecretVersionRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::DestroySecretVersionRequest::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::DestroySecretVersionRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
@@ -1616,7 +1632,7 @@ pub struct SetIamPolicyRequest {
 }
 
 impl SetIamPolicyRequest {
-    /// Sets the value of `policy`.
+    /// Sets the value of [policy][crate::model::SetIamPolicyRequest::policy].
     pub fn set_policy<T: std::convert::Into<std::option::Option<crate::model::Policy>>>(
         mut self,
         v: T,
@@ -1625,7 +1641,7 @@ impl SetIamPolicyRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::SetIamPolicyRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -1634,19 +1650,19 @@ impl SetIamPolicyRequest {
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::SetIamPolicyRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::SetIamPolicyRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::SetIamPolicyRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
@@ -1790,36 +1806,40 @@ pub struct Policy {
 }
 
 impl Policy {
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::Policy::version].
     pub fn set_version<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
     }
 
-    /// Sets the value of `bindings`.
-    pub fn set_bindings<T: std::convert::Into<std::vec::Vec<crate::model::Binding>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.bindings = v.into();
-        self
-    }
-
-    /// Sets the value of `audit_configs`.
-    pub fn set_audit_configs<T: std::convert::Into<std::vec::Vec<crate::model::AuditConfig>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.audit_configs = v.into();
-        self
-    }
-
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::Policy::etag].
     pub fn set_etag<T: std::convert::Into<std::option::Option<bytes::Bytes>>>(
         mut self,
         v: T,
     ) -> Self {
         self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [bindings][crate::model::Policy::bindings].
+    pub fn set_bindings<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Binding>,
+    {
+        use std::iter::Iterator;
+        self.bindings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [audit_configs][crate::model::Policy::audit_configs].
+    pub fn set_audit_configs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AuditConfig>,
+    {
+        use std::iter::Iterator;
+        self.audit_configs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1944,7 +1964,7 @@ pub struct Binding {
 }
 
 impl Binding {
-    /// Sets the value of `role`.
+    /// Sets the value of [role][crate::model::Binding::role].
     pub fn set_role<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -1953,21 +1973,23 @@ impl Binding {
         self
     }
 
-    /// Sets the value of `members`.
-    pub fn set_members<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.members = v.into();
-        self
-    }
-
-    /// Sets the value of `condition`.
+    /// Sets the value of [condition][crate::model::Binding::condition].
     pub fn set_condition<T: std::convert::Into<std::option::Option<crate::model::Expr>>>(
         mut self,
         v: T,
     ) -> Self {
         self.condition = v.into();
+        self
+    }
+
+    /// Sets the value of [members][crate::model::Binding::members].
+    pub fn set_members<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.members = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2045,7 +2067,7 @@ pub struct Expr {
 }
 
 impl Expr {
-    /// Sets the value of `expression`.
+    /// Sets the value of [expression][crate::model::Expr::expression].
     pub fn set_expression<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -2054,7 +2076,7 @@ impl Expr {
         self
     }
 
-    /// Sets the value of `title`.
+    /// Sets the value of [title][crate::model::Expr::title].
     pub fn set_title<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -2063,7 +2085,7 @@ impl Expr {
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::Expr::description].
     pub fn set_description<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -2072,7 +2094,7 @@ impl Expr {
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::Expr::location].
     pub fn set_location<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -2158,7 +2180,7 @@ pub struct AuditConfig {
 }
 
 impl AuditConfig {
-    /// Sets the value of `service`.
+    /// Sets the value of [service][crate::model::AuditConfig::service].
     pub fn set_service<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -2167,14 +2189,14 @@ impl AuditConfig {
         self
     }
 
-    /// Sets the value of `audit_log_configs`.
-    pub fn set_audit_log_configs<
-        T: std::convert::Into<std::vec::Vec<crate::model::AuditLogConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.audit_log_configs = v.into();
+    /// Sets the value of [audit_log_configs][crate::model::AuditConfig::audit_log_configs].
+    pub fn set_audit_log_configs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AuditLogConfig>,
+    {
+        use std::iter::Iterator;
+        self.audit_log_configs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2223,7 +2245,7 @@ pub struct AuditLogConfig {
 }
 
 impl AuditLogConfig {
-    /// Sets the value of `log_type`.
+    /// Sets the value of [log_type][crate::model::AuditLogConfig::log_type].
     pub fn set_log_type<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -2232,12 +2254,14 @@ impl AuditLogConfig {
         self
     }
 
-    /// Sets the value of `exempted_members`.
-    pub fn set_exempted_members<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.exempted_members = v.into();
+    /// Sets the value of [exempted_members][crate::model::AuditLogConfig::exempted_members].
+    pub fn set_exempted_members<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.exempted_members = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2281,30 +2305,32 @@ pub struct TestIamPermissionsRequest {
 }
 
 impl TestIamPermissionsRequest {
-    /// Sets the value of `permissions`.
-    pub fn set_permissions<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.permissions = v.into();
-        self
-    }
-
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::TestIamPermissionsRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::TestIamPermissionsRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::TestIamPermissionsRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
+        self
+    }
+
+    /// Sets the value of [permissions][crate::model::TestIamPermissionsRequest::permissions].
+    pub fn set_permissions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.permissions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2322,12 +2348,14 @@ pub struct TestIamPermissionsResponse {
 }
 
 impl TestIamPermissionsResponse {
-    /// Sets the value of `permissions`.
-    pub fn set_permissions<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.permissions = v.into();
+    /// Sets the value of [permissions][crate::model::TestIamPermissionsResponse::permissions].
+    pub fn set_permissions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.permissions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2368,13 +2396,13 @@ pub struct ListLocationsRequest {
 }
 
 impl ListLocationsRequest {
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::ListLocationsRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListLocationsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -2383,13 +2411,13 @@ impl ListLocationsRequest {
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListLocationsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListLocationsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -2419,13 +2447,13 @@ pub struct GetLocationRequest {
 }
 
 impl GetLocationRequest {
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::GetLocationRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::GetLocationRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
@@ -2465,19 +2493,19 @@ pub struct ListSecretsRequest {
 }
 
 impl ListSecretsRequest {
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::ListSecretsRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListSecretsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListSecretsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -2486,7 +2514,7 @@ impl ListSecretsRequest {
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListSecretsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -2522,7 +2550,7 @@ pub struct CreateSecretRequest {
 }
 
 impl CreateSecretRequest {
-    /// Sets the value of `request_body`.
+    /// Sets the value of [request_body][crate::model::CreateSecretRequest::request_body].
     pub fn set_request_body<T: std::convert::Into<std::option::Option<crate::model::Secret>>>(
         mut self,
         v: T,
@@ -2531,13 +2559,13 @@ impl CreateSecretRequest {
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::CreateSecretRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret_id`.
+    /// Sets the value of [secret_id][crate::model::CreateSecretRequest::secret_id].
     pub fn set_secret_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret_id = v.into();
         self
@@ -2583,25 +2611,25 @@ pub struct ListSecretsByProjectAndLocationRequest {
 }
 
 impl ListSecretsByProjectAndLocationRequest {
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::ListSecretsByProjectAndLocationRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::ListSecretsByProjectAndLocationRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListSecretsByProjectAndLocationRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListSecretsByProjectAndLocationRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -2610,7 +2638,7 @@ impl ListSecretsByProjectAndLocationRequest {
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListSecretsByProjectAndLocationRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -2652,7 +2680,7 @@ pub struct CreateSecretByProjectAndLocationRequest {
 }
 
 impl CreateSecretByProjectAndLocationRequest {
-    /// Sets the value of `request_body`.
+    /// Sets the value of [request_body][crate::model::CreateSecretByProjectAndLocationRequest::request_body].
     pub fn set_request_body<T: std::convert::Into<std::option::Option<crate::model::Secret>>>(
         mut self,
         v: T,
@@ -2661,19 +2689,19 @@ impl CreateSecretByProjectAndLocationRequest {
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::CreateSecretByProjectAndLocationRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::CreateSecretByProjectAndLocationRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `secret_id`.
+    /// Sets the value of [secret_id][crate::model::CreateSecretByProjectAndLocationRequest::secret_id].
     pub fn set_secret_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret_id = v.into();
         self
@@ -2700,13 +2728,13 @@ pub struct GetSecretRequest {
 }
 
 impl GetSecretRequest {
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::GetSecretRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::GetSecretRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
@@ -2739,19 +2767,19 @@ pub struct DeleteSecretRequest {
 }
 
 impl DeleteSecretRequest {
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::DeleteSecretRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::DeleteSecretRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DeleteSecretRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -2789,7 +2817,7 @@ pub struct UpdateSecretRequest {
 }
 
 impl UpdateSecretRequest {
-    /// Sets the value of `request_body`.
+    /// Sets the value of [request_body][crate::model::UpdateSecretRequest::request_body].
     pub fn set_request_body<T: std::convert::Into<std::option::Option<crate::model::Secret>>>(
         mut self,
         v: T,
@@ -2798,19 +2826,19 @@ impl UpdateSecretRequest {
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::UpdateSecretRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::UpdateSecretRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateSecretRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<wkt::FieldMask>>(mut self, v: T) -> Self {
         self.update_mask = v.into();
         self
@@ -2843,19 +2871,19 @@ pub struct GetSecretByProjectAndLocationAndSecretRequest {
 }
 
 impl GetSecretByProjectAndLocationAndSecretRequest {
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::GetSecretByProjectAndLocationAndSecretRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::GetSecretByProjectAndLocationAndSecretRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::GetSecretByProjectAndLocationAndSecretRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
@@ -2894,25 +2922,25 @@ pub struct DeleteSecretByProjectAndLocationAndSecretRequest {
 }
 
 impl DeleteSecretByProjectAndLocationAndSecretRequest {
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::DeleteSecretByProjectAndLocationAndSecretRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::DeleteSecretByProjectAndLocationAndSecretRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::DeleteSecretByProjectAndLocationAndSecretRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DeleteSecretByProjectAndLocationAndSecretRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -2956,7 +2984,7 @@ pub struct UpdateSecretByProjectAndLocationAndSecretRequest {
 }
 
 impl UpdateSecretByProjectAndLocationAndSecretRequest {
-    /// Sets the value of `request_body`.
+    /// Sets the value of [request_body][crate::model::UpdateSecretByProjectAndLocationAndSecretRequest::request_body].
     pub fn set_request_body<T: std::convert::Into<std::option::Option<crate::model::Secret>>>(
         mut self,
         v: T,
@@ -2965,25 +2993,25 @@ impl UpdateSecretByProjectAndLocationAndSecretRequest {
         self
     }
 
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::UpdateSecretByProjectAndLocationAndSecretRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::UpdateSecretByProjectAndLocationAndSecretRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::UpdateSecretByProjectAndLocationAndSecretRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateSecretByProjectAndLocationAndSecretRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<wkt::FieldMask>>(mut self, v: T) -> Self {
         self.update_mask = v.into();
         self
@@ -3029,25 +3057,25 @@ pub struct ListSecretVersionsRequest {
 }
 
 impl ListSecretVersionsRequest {
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::ListSecretVersionsRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::ListSecretVersionsRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListSecretVersionsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListSecretVersionsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -3056,7 +3084,7 @@ impl ListSecretVersionsRequest {
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListSecretVersionsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -3111,31 +3139,31 @@ pub struct ListSecretVersionsByProjectAndLocationAndSecretRequest {
 }
 
 impl ListSecretVersionsByProjectAndLocationAndSecretRequest {
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -3144,7 +3172,7 @@ impl ListSecretVersionsByProjectAndLocationAndSecretRequest {
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
         v: T,
@@ -3180,19 +3208,19 @@ pub struct GetSecretVersionRequest {
 }
 
 impl GetSecretVersionRequest {
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::GetSecretVersionRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::GetSecretVersionRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::GetSecretVersionRequest::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
@@ -3231,25 +3259,25 @@ pub struct GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest {
 }
 
 impl GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest {
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::GetSecretVersionByProjectAndLocationAndSecretAndVersionRequest::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
@@ -3282,19 +3310,19 @@ pub struct AccessSecretVersionRequest {
 }
 
 impl AccessSecretVersionRequest {
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::AccessSecretVersionRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::AccessSecretVersionRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::AccessSecretVersionRequest::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
@@ -3333,25 +3361,25 @@ pub struct AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest {
 }
 
 impl AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest {
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::AccessSecretVersionByProjectAndLocationAndSecretAndVersionRequest::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
@@ -3399,19 +3427,19 @@ pub struct GetIamPolicyRequest {
 }
 
 impl GetIamPolicyRequest {
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::GetIamPolicyRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::GetIamPolicyRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `options_requested_policy_version`.
+    /// Sets the value of [options_requested_policy_version][crate::model::GetIamPolicyRequest::options_requested_policy_version].
     pub fn set_options_requested_policy_version<T: std::convert::Into<std::option::Option<i32>>>(
         mut self,
         v: T,
@@ -3468,25 +3496,25 @@ pub struct GetIamPolicyByProjectAndLocationAndSecretRequest {
 }
 
 impl GetIamPolicyByProjectAndLocationAndSecretRequest {
-    /// Sets the value of `project`.
+    /// Sets the value of [project][crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `secret`.
+    /// Sets the value of [secret][crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest::secret].
     pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret = v.into();
         self
     }
 
-    /// Sets the value of `options_requested_policy_version`.
+    /// Sets the value of [options_requested_policy_version][crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest::options_requested_policy_version].
     pub fn set_options_requested_policy_version<T: std::convert::Into<std::option::Option<i32>>>(
         mut self,
         v: T,

--- a/src/generated/rpc/src/model.rs
+++ b/src/generated/rpc/src/model.rs
@@ -88,26 +88,27 @@ pub struct ErrorInfo {
 }
 
 impl ErrorInfo {
-    /// Sets the value of `reason`.
+    /// Sets the value of [reason][crate::model::ErrorInfo::reason].
     pub fn set_reason<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.reason = v.into();
         self
     }
 
-    /// Sets the value of `domain`.
+    /// Sets the value of [domain][crate::model::ErrorInfo::domain].
     pub fn set_domain<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.domain = v.into();
         self
     }
 
-    /// Sets the value of `metadata`.
-    pub fn set_metadata<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metadata = v.into();
+    /// Sets the value of [metadata][crate::model::ErrorInfo::metadata].
+    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -142,7 +143,7 @@ pub struct RetryInfo {
 }
 
 impl RetryInfo {
-    /// Sets the value of `retry_delay`.
+    /// Sets the value of [retry_delay][crate::model::RetryInfo::retry_delay].
     pub fn set_retry_delay<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
@@ -174,18 +175,20 @@ pub struct DebugInfo {
 }
 
 impl DebugInfo {
-    /// Sets the value of `stack_entries`.
-    pub fn set_stack_entries<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.stack_entries = v.into();
+    /// Sets the value of [detail][crate::model::DebugInfo::detail].
+    pub fn set_detail<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.detail = v.into();
         self
     }
 
-    /// Sets the value of `detail`.
-    pub fn set_detail<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.detail = v.into();
+    /// Sets the value of [stack_entries][crate::model::DebugInfo::stack_entries].
+    pub fn set_stack_entries<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.stack_entries = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -218,14 +221,14 @@ pub struct QuotaFailure {
 }
 
 impl QuotaFailure {
-    /// Sets the value of `violations`.
-    pub fn set_violations<
-        T: std::convert::Into<std::vec::Vec<crate::model::quota_failure::Violation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.violations = v.into();
+    /// Sets the value of [violations][crate::model::QuotaFailure::violations].
+    pub fn set_violations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::quota_failure::Violation>,
+    {
+        use std::iter::Iterator;
+        self.violations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -266,13 +269,13 @@ pub mod quota_failure {
     }
 
     impl Violation {
-        /// Sets the value of `subject`.
+        /// Sets the value of [subject][crate::model::quota_failure::Violation::subject].
         pub fn set_subject<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.subject = v.into();
             self
         }
 
-        /// Sets the value of `description`.
+        /// Sets the value of [description][crate::model::quota_failure::Violation::description].
         pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.description = v.into();
             self
@@ -302,14 +305,14 @@ pub struct PreconditionFailure {
 }
 
 impl PreconditionFailure {
-    /// Sets the value of `violations`.
-    pub fn set_violations<
-        T: std::convert::Into<std::vec::Vec<crate::model::precondition_failure::Violation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.violations = v.into();
+    /// Sets the value of [violations][crate::model::PreconditionFailure::violations].
+    pub fn set_violations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::precondition_failure::Violation>,
+    {
+        use std::iter::Iterator;
+        self.violations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -353,19 +356,19 @@ pub mod precondition_failure {
     }
 
     impl Violation {
-        /// Sets the value of `r#type`.
+        /// Sets the value of [r#type][crate::model::precondition_failure::Violation::type].
         pub fn set_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.r#type = v.into();
             self
         }
 
-        /// Sets the value of `subject`.
+        /// Sets the value of [subject][crate::model::precondition_failure::Violation::subject].
         pub fn set_subject<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.subject = v.into();
             self
         }
 
-        /// Sets the value of `description`.
+        /// Sets the value of [description][crate::model::precondition_failure::Violation::description].
         pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.description = v.into();
             self
@@ -392,14 +395,14 @@ pub struct BadRequest {
 }
 
 impl BadRequest {
-    /// Sets the value of `field_violations`.
-    pub fn set_field_violations<
-        T: std::convert::Into<std::vec::Vec<crate::model::bad_request::FieldViolation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.field_violations = v.into();
+    /// Sets the value of [field_violations][crate::model::BadRequest::field_violations].
+    pub fn set_field_violations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::bad_request::FieldViolation>,
+    {
+        use std::iter::Iterator;
+        self.field_violations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -483,25 +486,25 @@ pub mod bad_request {
     }
 
     impl FieldViolation {
-        /// Sets the value of `field`.
+        /// Sets the value of [field][crate::model::bad_request::FieldViolation::field].
         pub fn set_field<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.field = v.into();
             self
         }
 
-        /// Sets the value of `description`.
+        /// Sets the value of [description][crate::model::bad_request::FieldViolation::description].
         pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.description = v.into();
             self
         }
 
-        /// Sets the value of `reason`.
+        /// Sets the value of [reason][crate::model::bad_request::FieldViolation::reason].
         pub fn set_reason<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.reason = v.into();
             self
         }
 
-        /// Sets the value of `localized_message`.
+        /// Sets the value of [localized_message][crate::model::bad_request::FieldViolation::localized_message].
         pub fn set_localized_message<
             T: std::convert::Into<std::option::Option<crate::model::LocalizedMessage>>,
         >(
@@ -539,13 +542,13 @@ pub struct RequestInfo {
 }
 
 impl RequestInfo {
-    /// Sets the value of `request_id`.
+    /// Sets the value of [request_id][crate::model::RequestInfo::request_id].
     pub fn set_request_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.request_id = v.into();
         self
     }
 
-    /// Sets the value of `serving_data`.
+    /// Sets the value of [serving_data][crate::model::RequestInfo::serving_data].
     pub fn set_serving_data<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.serving_data = v.into();
         self
@@ -593,25 +596,25 @@ pub struct ResourceInfo {
 }
 
 impl ResourceInfo {
-    /// Sets the value of `resource_type`.
+    /// Sets the value of [resource_type][crate::model::ResourceInfo::resource_type].
     pub fn set_resource_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.resource_type = v.into();
         self
     }
 
-    /// Sets the value of `resource_name`.
+    /// Sets the value of [resource_name][crate::model::ResourceInfo::resource_name].
     pub fn set_resource_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.resource_name = v.into();
         self
     }
 
-    /// Sets the value of `owner`.
+    /// Sets the value of [owner][crate::model::ResourceInfo::owner].
     pub fn set_owner<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.owner = v.into();
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::ResourceInfo::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
@@ -640,12 +643,14 @@ pub struct Help {
 }
 
 impl Help {
-    /// Sets the value of `links`.
-    pub fn set_links<T: std::convert::Into<std::vec::Vec<crate::model::help::Link>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.links = v.into();
+    /// Sets the value of [links][crate::model::Help::links].
+    pub fn set_links<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::help::Link>,
+    {
+        use std::iter::Iterator;
+        self.links = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -677,13 +682,13 @@ pub mod help {
     }
 
     impl Link {
-        /// Sets the value of `description`.
+        /// Sets the value of [description][crate::model::help::Link::description].
         pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.description = v.into();
             self
         }
 
-        /// Sets the value of `url`.
+        /// Sets the value of [url][crate::model::help::Link::url].
         pub fn set_url<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.url = v.into();
             self
@@ -716,13 +721,13 @@ pub struct LocalizedMessage {
 }
 
 impl LocalizedMessage {
-    /// Sets the value of `locale`.
+    /// Sets the value of [locale][crate::model::LocalizedMessage::locale].
     pub fn set_locale<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.locale = v.into();
         self
     }
 
-    /// Sets the value of `message`.
+    /// Sets the value of [message][crate::model::LocalizedMessage::message].
     pub fn set_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.message = v.into();
         self
@@ -761,30 +766,32 @@ pub struct HttpRequest {
 }
 
 impl HttpRequest {
-    /// Sets the value of `method`.
+    /// Sets the value of [method][crate::model::HttpRequest::method].
     pub fn set_method<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.method = v.into();
         self
     }
 
-    /// Sets the value of `uri`.
+    /// Sets the value of [uri][crate::model::HttpRequest::uri].
     pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.uri = v.into();
         self
     }
 
-    /// Sets the value of `headers`.
-    pub fn set_headers<T: std::convert::Into<std::vec::Vec<crate::model::HttpHeader>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.headers = v.into();
+    /// Sets the value of [body][crate::model::HttpRequest::body].
+    pub fn set_body<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
+        self.body = v.into();
         self
     }
 
-    /// Sets the value of `body`.
-    pub fn set_body<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
-        self.body = v.into();
+    /// Sets the value of [headers][crate::model::HttpRequest::headers].
+    pub fn set_headers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::HttpHeader>,
+    {
+        use std::iter::Iterator;
+        self.headers = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -820,30 +827,32 @@ pub struct HttpResponse {
 }
 
 impl HttpResponse {
-    /// Sets the value of `status`.
+    /// Sets the value of [status][crate::model::HttpResponse::status].
     pub fn set_status<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.status = v.into();
         self
     }
 
-    /// Sets the value of `reason`.
+    /// Sets the value of [reason][crate::model::HttpResponse::reason].
     pub fn set_reason<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.reason = v.into();
         self
     }
 
-    /// Sets the value of `headers`.
-    pub fn set_headers<T: std::convert::Into<std::vec::Vec<crate::model::HttpHeader>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.headers = v.into();
+    /// Sets the value of [body][crate::model::HttpResponse::body].
+    pub fn set_body<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
+        self.body = v.into();
         self
     }
 
-    /// Sets the value of `body`.
-    pub fn set_body<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
-        self.body = v.into();
+    /// Sets the value of [headers][crate::model::HttpResponse::headers].
+    pub fn set_headers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::HttpHeader>,
+    {
+        use std::iter::Iterator;
+        self.headers = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -870,13 +879,13 @@ pub struct HttpHeader {
 }
 
 impl HttpHeader {
-    /// Sets the value of `key`.
+    /// Sets the value of [key][crate::model::HttpHeader::key].
     pub fn set_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.key = v.into();
         self
     }
 
-    /// Sets the value of `value`.
+    /// Sets the value of [value][crate::model::HttpHeader::value].
     pub fn set_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.value = v.into();
         self
@@ -923,21 +932,26 @@ pub struct Status {
 }
 
 impl Status {
-    /// Sets the value of `code`.
+    /// Sets the value of [code][crate::model::Status::code].
     pub fn set_code<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.code = v.into();
         self
     }
 
-    /// Sets the value of `message`.
+    /// Sets the value of [message][crate::model::Status::message].
     pub fn set_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.message = v.into();
         self
     }
 
-    /// Sets the value of `details`.
-    pub fn set_details<T: std::convert::Into<std::vec::Vec<wkt::Any>>>(mut self, v: T) -> Self {
-        self.details = v.into();
+    /// Sets the value of [details][crate::model::Status::details].
+    pub fn set_details<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Any>,
+    {
+        use std::iter::Iterator;
+        self.details = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/spanner/admin/database/v1/src/builders.rs
+++ b/src/generated/spanner/admin/database/v1/src/builders.rs
@@ -82,19 +82,19 @@ pub mod database_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListDatabasesRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListDatabasesRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListDatabasesRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -174,28 +174,19 @@ pub mod database_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateDatabaseRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `create_statement`.
+        /// Sets the value of [create_statement][crate::model::CreateDatabaseRequest::create_statement].
         pub fn set_create_statement<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.create_statement = v.into();
             self
         }
 
-        /// Sets the value of `extra_statements`.
-        pub fn set_extra_statements<T: Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.extra_statements = v.into();
-            self
-        }
-
-        /// Sets the value of `encryption_config`.
+        /// Sets the value of [encryption_config][crate::model::CreateDatabaseRequest::encryption_config].
         pub fn set_encryption_config<
             T: Into<std::option::Option<crate::model::EncryptionConfig>>,
         >(
@@ -206,7 +197,7 @@ pub mod database_admin {
             self
         }
 
-        /// Sets the value of `database_dialect`.
+        /// Sets the value of [database_dialect][crate::model::CreateDatabaseRequest::database_dialect].
         pub fn set_database_dialect<T: Into<crate::model::DatabaseDialect>>(
             mut self,
             v: T,
@@ -215,9 +206,20 @@ pub mod database_admin {
             self
         }
 
-        /// Sets the value of `proto_descriptors`.
+        /// Sets the value of [proto_descriptors][crate::model::CreateDatabaseRequest::proto_descriptors].
         pub fn set_proto_descriptors<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.proto_descriptors = v.into();
+            self
+        }
+
+        /// Sets the value of [extra_statements][crate::model::CreateDatabaseRequest::extra_statements].
+        pub fn set_extra_statements<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.extra_statements = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -256,7 +258,7 @@ pub mod database_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetDatabaseRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -336,7 +338,7 @@ pub mod database_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `database`.
+        /// Sets the value of [database][crate::model::UpdateDatabaseRequest::database].
         pub fn set_database<T: Into<std::option::Option<crate::model::Database>>>(
             mut self,
             v: T,
@@ -345,7 +347,7 @@ pub mod database_admin {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateDatabaseRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -429,27 +431,32 @@ pub mod database_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `database`.
+        /// Sets the value of [database][crate::model::UpdateDatabaseDdlRequest::database].
         pub fn set_database<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.database = v.into();
             self
         }
 
-        /// Sets the value of `statements`.
-        pub fn set_statements<T: Into<std::vec::Vec<std::string::String>>>(mut self, v: T) -> Self {
-            self.0.request.statements = v.into();
-            self
-        }
-
-        /// Sets the value of `operation_id`.
+        /// Sets the value of [operation_id][crate::model::UpdateDatabaseDdlRequest::operation_id].
         pub fn set_operation_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.operation_id = v.into();
             self
         }
 
-        /// Sets the value of `proto_descriptors`.
+        /// Sets the value of [proto_descriptors][crate::model::UpdateDatabaseDdlRequest::proto_descriptors].
         pub fn set_proto_descriptors<T: Into<bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.proto_descriptors = v.into();
+            self
+        }
+
+        /// Sets the value of [statements][crate::model::UpdateDatabaseDdlRequest::statements].
+        pub fn set_statements<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.statements = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -488,7 +495,7 @@ pub mod database_admin {
                 .await
         }
 
-        /// Sets the value of `database`.
+        /// Sets the value of [database][crate::model::DropDatabaseRequest::database].
         pub fn set_database<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.database = v.into();
             self
@@ -529,7 +536,7 @@ pub mod database_admin {
                 .await
         }
 
-        /// Sets the value of `database`.
+        /// Sets the value of [database][crate::model::GetDatabaseDdlRequest::database].
         pub fn set_database<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.database = v.into();
             self
@@ -570,13 +577,13 @@ pub mod database_admin {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::SetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][iam_v1::model::SetIamPolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<iam_v1::model::Policy>>>(
             mut self,
             v: T,
@@ -585,7 +592,7 @@ pub mod database_admin {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][iam_v1::model::SetIamPolicyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -629,13 +636,13 @@ pub mod database_admin {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::GetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `options`.
+        /// Sets the value of [options][iam_v1::model::GetIamPolicyRequest::options].
         pub fn set_options<T: Into<std::option::Option<iam_v1::model::GetPolicyOptions>>>(
             mut self,
             v: T,
@@ -682,18 +689,20 @@ pub mod database_admin {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::TestIamPermissionsRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `permissions`.
-        pub fn set_permissions<T: Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.permissions = v.into();
+        /// Sets the value of [permissions][iam_v1::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -770,19 +779,19 @@ pub mod database_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateBackupRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `backup_id`.
+        /// Sets the value of [backup_id][crate::model::CreateBackupRequest::backup_id].
         pub fn set_backup_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.backup_id = v.into();
             self
         }
 
-        /// Sets the value of `backup`.
+        /// Sets the value of [backup][crate::model::CreateBackupRequest::backup].
         pub fn set_backup<T: Into<std::option::Option<crate::model::Backup>>>(
             mut self,
             v: T,
@@ -791,7 +800,7 @@ pub mod database_admin {
             self
         }
 
-        /// Sets the value of `encryption_config`.
+        /// Sets the value of [encryption_config][crate::model::CreateBackupRequest::encryption_config].
         pub fn set_encryption_config<
             T: Into<std::option::Option<crate::model::CreateBackupEncryptionConfig>>,
         >(
@@ -874,25 +883,25 @@ pub mod database_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CopyBackupRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `backup_id`.
+        /// Sets the value of [backup_id][crate::model::CopyBackupRequest::backup_id].
         pub fn set_backup_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.backup_id = v.into();
             self
         }
 
-        /// Sets the value of `source_backup`.
+        /// Sets the value of [source_backup][crate::model::CopyBackupRequest::source_backup].
         pub fn set_source_backup<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.source_backup = v.into();
             self
         }
 
-        /// Sets the value of `expire_time`.
+        /// Sets the value of [expire_time][crate::model::CopyBackupRequest::expire_time].
         pub fn set_expire_time<T: Into<std::option::Option<wkt::Timestamp>>>(
             mut self,
             v: T,
@@ -901,7 +910,7 @@ pub mod database_admin {
             self
         }
 
-        /// Sets the value of `encryption_config`.
+        /// Sets the value of [encryption_config][crate::model::CopyBackupRequest::encryption_config].
         pub fn set_encryption_config<
             T: Into<std::option::Option<crate::model::CopyBackupEncryptionConfig>>,
         >(
@@ -947,7 +956,7 @@ pub mod database_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetBackupRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -988,7 +997,7 @@ pub mod database_admin {
                 .await
         }
 
-        /// Sets the value of `backup`.
+        /// Sets the value of [backup][crate::model::UpdateBackupRequest::backup].
         pub fn set_backup<T: Into<std::option::Option<crate::model::Backup>>>(
             mut self,
             v: T,
@@ -997,7 +1006,7 @@ pub mod database_admin {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateBackupRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -1041,7 +1050,7 @@ pub mod database_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteBackupRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1097,25 +1106,25 @@ pub mod database_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListBackupsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListBackupsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListBackupsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListBackupsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -1195,19 +1204,19 @@ pub mod database_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::RestoreDatabaseRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `database_id`.
+        /// Sets the value of [database_id][crate::model::RestoreDatabaseRequest::database_id].
         pub fn set_database_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.database_id = v.into();
             self
         }
 
-        /// Sets the value of `encryption_config`.
+        /// Sets the value of [encryption_config][crate::model::RestoreDatabaseRequest::encryption_config].
         pub fn set_encryption_config<
             T: Into<std::option::Option<crate::model::RestoreDatabaseEncryptionConfig>>,
         >(
@@ -1282,25 +1291,25 @@ pub mod database_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListDatabaseOperationsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListDatabaseOperationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListDatabaseOperationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListDatabaseOperationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -1359,25 +1368,25 @@ pub mod database_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListBackupOperationsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListBackupOperationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListBackupOperationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListBackupOperationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -1436,19 +1445,19 @@ pub mod database_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListDatabaseRolesRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListDatabaseRolesRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListDatabaseRolesRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -1492,19 +1501,19 @@ pub mod database_admin {
                 .await
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateBackupScheduleRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `backup_schedule_id`.
+        /// Sets the value of [backup_schedule_id][crate::model::CreateBackupScheduleRequest::backup_schedule_id].
         pub fn set_backup_schedule_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.backup_schedule_id = v.into();
             self
         }
 
-        /// Sets the value of `backup_schedule`.
+        /// Sets the value of [backup_schedule][crate::model::CreateBackupScheduleRequest::backup_schedule].
         pub fn set_backup_schedule<T: Into<std::option::Option<crate::model::BackupSchedule>>>(
             mut self,
             v: T,
@@ -1551,7 +1560,7 @@ pub mod database_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetBackupScheduleRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1595,7 +1604,7 @@ pub mod database_admin {
                 .await
         }
 
-        /// Sets the value of `backup_schedule`.
+        /// Sets the value of [backup_schedule][crate::model::UpdateBackupScheduleRequest::backup_schedule].
         pub fn set_backup_schedule<T: Into<std::option::Option<crate::model::BackupSchedule>>>(
             mut self,
             v: T,
@@ -1604,7 +1613,7 @@ pub mod database_admin {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateBackupScheduleRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -1651,7 +1660,7 @@ pub mod database_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteBackupScheduleRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1710,19 +1719,19 @@ pub mod database_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListBackupSchedulesRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListBackupSchedulesRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListBackupSchedulesRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -1781,25 +1790,25 @@ pub mod database_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::ListOperationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][longrunning::model::ListOperationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][longrunning::model::ListOperationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][longrunning::model::ListOperationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -1843,7 +1852,7 @@ pub mod database_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::GetOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1887,7 +1896,7 @@ pub mod database_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::DeleteOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1931,7 +1940,7 @@ pub mod database_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::CancelOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self

--- a/src/generated/spanner/admin/database/v1/src/model.rs
+++ b/src/generated/spanner/admin/database/v1/src/model.rs
@@ -202,13 +202,13 @@ pub struct Backup {
 }
 
 impl Backup {
-    /// Sets the value of `database`.
+    /// Sets the value of [database][crate::model::Backup::database].
     pub fn set_database<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.database = v.into();
         self
     }
 
-    /// Sets the value of `version_time`.
+    /// Sets the value of [version_time][crate::model::Backup::version_time].
     pub fn set_version_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -217,7 +217,7 @@ impl Backup {
         self
     }
 
-    /// Sets the value of `expire_time`.
+    /// Sets the value of [expire_time][crate::model::Backup::expire_time].
     pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -226,13 +226,13 @@ impl Backup {
         self
     }
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Backup::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::Backup::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -241,40 +241,31 @@ impl Backup {
         self
     }
 
-    /// Sets the value of `size_bytes`.
+    /// Sets the value of [size_bytes][crate::model::Backup::size_bytes].
     pub fn set_size_bytes<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.size_bytes = v.into();
         self
     }
 
-    /// Sets the value of `freeable_size_bytes`.
+    /// Sets the value of [freeable_size_bytes][crate::model::Backup::freeable_size_bytes].
     pub fn set_freeable_size_bytes<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.freeable_size_bytes = v.into();
         self
     }
 
-    /// Sets the value of `exclusive_size_bytes`.
+    /// Sets the value of [exclusive_size_bytes][crate::model::Backup::exclusive_size_bytes].
     pub fn set_exclusive_size_bytes<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.exclusive_size_bytes = v.into();
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::Backup::state].
     pub fn set_state<T: std::convert::Into<crate::model::backup::State>>(mut self, v: T) -> Self {
         self.state = v.into();
         self
     }
 
-    /// Sets the value of `referencing_databases`.
-    pub fn set_referencing_databases<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.referencing_databases = v.into();
-        self
-    }
-
-    /// Sets the value of `encryption_info`.
+    /// Sets the value of [encryption_info][crate::model::Backup::encryption_info].
     pub fn set_encryption_info<
         T: std::convert::Into<std::option::Option<crate::model::EncryptionInfo>>,
     >(
@@ -285,18 +276,7 @@ impl Backup {
         self
     }
 
-    /// Sets the value of `encryption_information`.
-    pub fn set_encryption_information<
-        T: std::convert::Into<std::vec::Vec<crate::model::EncryptionInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.encryption_information = v.into();
-        self
-    }
-
-    /// Sets the value of `database_dialect`.
+    /// Sets the value of [database_dialect][crate::model::Backup::database_dialect].
     pub fn set_database_dialect<T: std::convert::Into<crate::model::DatabaseDialect>>(
         mut self,
         v: T,
@@ -305,16 +285,7 @@ impl Backup {
         self
     }
 
-    /// Sets the value of `referencing_backups`.
-    pub fn set_referencing_backups<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.referencing_backups = v.into();
-        self
-    }
-
-    /// Sets the value of `max_expire_time`.
+    /// Sets the value of [max_expire_time][crate::model::Backup::max_expire_time].
     pub fn set_max_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -323,16 +294,7 @@ impl Backup {
         self
     }
 
-    /// Sets the value of `backup_schedules`.
-    pub fn set_backup_schedules<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.backup_schedules = v.into();
-        self
-    }
-
-    /// Sets the value of `incremental_backup_chain_id`.
+    /// Sets the value of [incremental_backup_chain_id][crate::model::Backup::incremental_backup_chain_id].
     pub fn set_incremental_backup_chain_id<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -341,12 +303,56 @@ impl Backup {
         self
     }
 
-    /// Sets the value of `oldest_version_time`.
+    /// Sets the value of [oldest_version_time][crate::model::Backup::oldest_version_time].
     pub fn set_oldest_version_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
     ) -> Self {
         self.oldest_version_time = v.into();
+        self
+    }
+
+    /// Sets the value of [referencing_databases][crate::model::Backup::referencing_databases].
+    pub fn set_referencing_databases<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.referencing_databases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [encryption_information][crate::model::Backup::encryption_information].
+    pub fn set_encryption_information<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EncryptionInfo>,
+    {
+        use std::iter::Iterator;
+        self.encryption_information = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [referencing_backups][crate::model::Backup::referencing_backups].
+    pub fn set_referencing_backups<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.referencing_backups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [backup_schedules][crate::model::Backup::backup_schedules].
+    pub fn set_backup_schedules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.backup_schedules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -434,19 +440,19 @@ pub struct CreateBackupRequest {
 }
 
 impl CreateBackupRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateBackupRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `backup_id`.
+    /// Sets the value of [backup_id][crate::model::CreateBackupRequest::backup_id].
     pub fn set_backup_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.backup_id = v.into();
         self
     }
 
-    /// Sets the value of `backup`.
+    /// Sets the value of [backup][crate::model::CreateBackupRequest::backup].
     pub fn set_backup<T: std::convert::Into<std::option::Option<crate::model::Backup>>>(
         mut self,
         v: T,
@@ -455,7 +461,7 @@ impl CreateBackupRequest {
         self
     }
 
-    /// Sets the value of `encryption_config`.
+    /// Sets the value of [encryption_config][crate::model::CreateBackupRequest::encryption_config].
     pub fn set_encryption_config<
         T: std::convert::Into<std::option::Option<crate::model::CreateBackupEncryptionConfig>>,
     >(
@@ -518,19 +524,19 @@ pub struct CreateBackupMetadata {
 }
 
 impl CreateBackupMetadata {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::CreateBackupMetadata::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `database`.
+    /// Sets the value of [database][crate::model::CreateBackupMetadata::database].
     pub fn set_database<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.database = v.into();
         self
     }
 
-    /// Sets the value of `progress`.
+    /// Sets the value of [progress][crate::model::CreateBackupMetadata::progress].
     pub fn set_progress<
         T: std::convert::Into<std::option::Option<crate::model::OperationProgress>>,
     >(
@@ -541,7 +547,7 @@ impl CreateBackupMetadata {
         self
     }
 
-    /// Sets the value of `cancel_time`.
+    /// Sets the value of [cancel_time][crate::model::CreateBackupMetadata::cancel_time].
     pub fn set_cancel_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -606,25 +612,25 @@ pub struct CopyBackupRequest {
 }
 
 impl CopyBackupRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CopyBackupRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `backup_id`.
+    /// Sets the value of [backup_id][crate::model::CopyBackupRequest::backup_id].
     pub fn set_backup_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.backup_id = v.into();
         self
     }
 
-    /// Sets the value of `source_backup`.
+    /// Sets the value of [source_backup][crate::model::CopyBackupRequest::source_backup].
     pub fn set_source_backup<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.source_backup = v.into();
         self
     }
 
-    /// Sets the value of `expire_time`.
+    /// Sets the value of [expire_time][crate::model::CopyBackupRequest::expire_time].
     pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -633,7 +639,7 @@ impl CopyBackupRequest {
         self
     }
 
-    /// Sets the value of `encryption_config`.
+    /// Sets the value of [encryption_config][crate::model::CopyBackupRequest::encryption_config].
     pub fn set_encryption_config<
         T: std::convert::Into<std::option::Option<crate::model::CopyBackupEncryptionConfig>>,
     >(
@@ -700,19 +706,19 @@ pub struct CopyBackupMetadata {
 }
 
 impl CopyBackupMetadata {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::CopyBackupMetadata::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `source_backup`.
+    /// Sets the value of [source_backup][crate::model::CopyBackupMetadata::source_backup].
     pub fn set_source_backup<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.source_backup = v.into();
         self
     }
 
-    /// Sets the value of `progress`.
+    /// Sets the value of [progress][crate::model::CopyBackupMetadata::progress].
     pub fn set_progress<
         T: std::convert::Into<std::option::Option<crate::model::OperationProgress>>,
     >(
@@ -723,7 +729,7 @@ impl CopyBackupMetadata {
         self
     }
 
-    /// Sets the value of `cancel_time`.
+    /// Sets the value of [cancel_time][crate::model::CopyBackupMetadata::cancel_time].
     pub fn set_cancel_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -766,7 +772,7 @@ pub struct UpdateBackupRequest {
 }
 
 impl UpdateBackupRequest {
-    /// Sets the value of `backup`.
+    /// Sets the value of [backup][crate::model::UpdateBackupRequest::backup].
     pub fn set_backup<T: std::convert::Into<std::option::Option<crate::model::Backup>>>(
         mut self,
         v: T,
@@ -775,7 +781,7 @@ impl UpdateBackupRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateBackupRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -808,7 +814,7 @@ pub struct GetBackupRequest {
 }
 
 impl GetBackupRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetBackupRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -838,7 +844,7 @@ pub struct DeleteBackupRequest {
 }
 
 impl DeleteBackupRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteBackupRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -927,25 +933,25 @@ pub struct ListBackupsRequest {
 }
 
 impl ListBackupsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListBackupsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListBackupsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListBackupsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListBackupsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -982,18 +988,20 @@ pub struct ListBackupsResponse {
 }
 
 impl ListBackupsResponse {
-    /// Sets the value of `backups`.
-    pub fn set_backups<T: std::convert::Into<std::vec::Vec<crate::model::Backup>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.backups = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListBackupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [backups][crate::model::ListBackupsResponse::backups].
+    pub fn set_backups<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Backup>,
+    {
+        use std::iter::Iterator;
+        self.backups = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1125,25 +1133,25 @@ pub struct ListBackupOperationsRequest {
 }
 
 impl ListBackupOperationsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListBackupOperationsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListBackupOperationsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListBackupOperationsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListBackupOperationsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -1190,18 +1198,20 @@ pub struct ListBackupOperationsResponse {
 }
 
 impl ListBackupOperationsResponse {
-    /// Sets the value of `operations`.
-    pub fn set_operations<T: std::convert::Into<std::vec::Vec<longrunning::model::Operation>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.operations = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListBackupOperationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [operations][crate::model::ListBackupOperationsResponse::operations].
+    pub fn set_operations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<longrunning::model::Operation>,
+    {
+        use std::iter::Iterator;
+        self.operations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1259,13 +1269,13 @@ pub struct BackupInfo {
 }
 
 impl BackupInfo {
-    /// Sets the value of `backup`.
+    /// Sets the value of [backup][crate::model::BackupInfo::backup].
     pub fn set_backup<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.backup = v.into();
         self
     }
 
-    /// Sets the value of `version_time`.
+    /// Sets the value of [version_time][crate::model::BackupInfo::version_time].
     pub fn set_version_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1274,7 +1284,7 @@ impl BackupInfo {
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::BackupInfo::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1283,7 +1293,7 @@ impl BackupInfo {
         self
     }
 
-    /// Sets the value of `source_database`.
+    /// Sets the value of [source_database][crate::model::BackupInfo::source_database].
     pub fn set_source_database<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.source_database = v.into();
         self
@@ -1336,7 +1346,7 @@ pub struct CreateBackupEncryptionConfig {
 }
 
 impl CreateBackupEncryptionConfig {
-    /// Sets the value of `encryption_type`.
+    /// Sets the value of [encryption_type][crate::model::CreateBackupEncryptionConfig::encryption_type].
     pub fn set_encryption_type<
         T: std::convert::Into<crate::model::create_backup_encryption_config::EncryptionType>,
     >(
@@ -1347,18 +1357,20 @@ impl CreateBackupEncryptionConfig {
         self
     }
 
-    /// Sets the value of `kms_key_name`.
+    /// Sets the value of [kms_key_name][crate::model::CreateBackupEncryptionConfig::kms_key_name].
     pub fn set_kms_key_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kms_key_name = v.into();
         self
     }
 
-    /// Sets the value of `kms_key_names`.
-    pub fn set_kms_key_names<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kms_key_names = v.into();
+    /// Sets the value of [kms_key_names][crate::model::CreateBackupEncryptionConfig::kms_key_names].
+    pub fn set_kms_key_names<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.kms_key_names = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1457,7 +1469,7 @@ pub struct CopyBackupEncryptionConfig {
 }
 
 impl CopyBackupEncryptionConfig {
-    /// Sets the value of `encryption_type`.
+    /// Sets the value of [encryption_type][crate::model::CopyBackupEncryptionConfig::encryption_type].
     pub fn set_encryption_type<
         T: std::convert::Into<crate::model::copy_backup_encryption_config::EncryptionType>,
     >(
@@ -1468,18 +1480,20 @@ impl CopyBackupEncryptionConfig {
         self
     }
 
-    /// Sets the value of `kms_key_name`.
+    /// Sets the value of [kms_key_name][crate::model::CopyBackupEncryptionConfig::kms_key_name].
     pub fn set_kms_key_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kms_key_name = v.into();
         self
     }
 
-    /// Sets the value of `kms_key_names`.
-    pub fn set_kms_key_names<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kms_key_names = v.into();
+    /// Sets the value of [kms_key_names][crate::model::CopyBackupEncryptionConfig::kms_key_names].
+    pub fn set_kms_key_names<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.kms_key_names = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1674,13 +1688,13 @@ pub struct BackupSchedule {
 }
 
 impl BackupSchedule {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::BackupSchedule::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `spec`.
+    /// Sets the value of [spec][crate::model::BackupSchedule::spec].
     pub fn set_spec<
         T: std::convert::Into<std::option::Option<crate::model::BackupScheduleSpec>>,
     >(
@@ -1691,7 +1705,7 @@ impl BackupSchedule {
         self
     }
 
-    /// Sets the value of `retention_duration`.
+    /// Sets the value of [retention_duration][crate::model::BackupSchedule::retention_duration].
     pub fn set_retention_duration<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
@@ -1700,7 +1714,7 @@ impl BackupSchedule {
         self
     }
 
-    /// Sets the value of `encryption_config`.
+    /// Sets the value of [encryption_config][crate::model::BackupSchedule::encryption_config].
     pub fn set_encryption_config<
         T: std::convert::Into<std::option::Option<crate::model::CreateBackupEncryptionConfig>>,
     >(
@@ -1711,7 +1725,7 @@ impl BackupSchedule {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::BackupSchedule::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1796,19 +1810,19 @@ pub struct CrontabSpec {
 }
 
 impl CrontabSpec {
-    /// Sets the value of `text`.
+    /// Sets the value of [text][crate::model::CrontabSpec::text].
     pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.text = v.into();
         self
     }
 
-    /// Sets the value of `time_zone`.
+    /// Sets the value of [time_zone][crate::model::CrontabSpec::time_zone].
     pub fn set_time_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.time_zone = v.into();
         self
     }
 
-    /// Sets the value of `creation_window`.
+    /// Sets the value of [creation_window][crate::model::CrontabSpec::creation_window].
     pub fn set_creation_window<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
@@ -1849,13 +1863,13 @@ pub struct CreateBackupScheduleRequest {
 }
 
 impl CreateBackupScheduleRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateBackupScheduleRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `backup_schedule_id`.
+    /// Sets the value of [backup_schedule_id][crate::model::CreateBackupScheduleRequest::backup_schedule_id].
     pub fn set_backup_schedule_id<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -1864,7 +1878,7 @@ impl CreateBackupScheduleRequest {
         self
     }
 
-    /// Sets the value of `backup_schedule`.
+    /// Sets the value of [backup_schedule][crate::model::CreateBackupScheduleRequest::backup_schedule].
     pub fn set_backup_schedule<
         T: std::convert::Into<std::option::Option<crate::model::BackupSchedule>>,
     >(
@@ -1899,7 +1913,7 @@ pub struct GetBackupScheduleRequest {
 }
 
 impl GetBackupScheduleRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetBackupScheduleRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1929,7 +1943,7 @@ pub struct DeleteBackupScheduleRequest {
 }
 
 impl DeleteBackupScheduleRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteBackupScheduleRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1974,19 +1988,19 @@ pub struct ListBackupSchedulesRequest {
 }
 
 impl ListBackupSchedulesRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListBackupSchedulesRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListBackupSchedulesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListBackupSchedulesRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -2022,20 +2036,20 @@ pub struct ListBackupSchedulesResponse {
 }
 
 impl ListBackupSchedulesResponse {
-    /// Sets the value of `backup_schedules`.
-    pub fn set_backup_schedules<
-        T: std::convert::Into<std::vec::Vec<crate::model::BackupSchedule>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.backup_schedules = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListBackupSchedulesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [backup_schedules][crate::model::ListBackupSchedulesResponse::backup_schedules].
+    pub fn set_backup_schedules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::BackupSchedule>,
+    {
+        use std::iter::Iterator;
+        self.backup_schedules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2084,7 +2098,7 @@ pub struct UpdateBackupScheduleRequest {
 }
 
 impl UpdateBackupScheduleRequest {
-    /// Sets the value of `backup_schedule`.
+    /// Sets the value of [backup_schedule][crate::model::UpdateBackupScheduleRequest::backup_schedule].
     pub fn set_backup_schedule<
         T: std::convert::Into<std::option::Option<crate::model::BackupSchedule>>,
     >(
@@ -2095,7 +2109,7 @@ impl UpdateBackupScheduleRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateBackupScheduleRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -2133,13 +2147,13 @@ pub struct OperationProgress {
 }
 
 impl OperationProgress {
-    /// Sets the value of `progress_percent`.
+    /// Sets the value of [progress_percent][crate::model::OperationProgress::progress_percent].
     pub fn set_progress_percent<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.progress_percent = v.into();
         self
     }
 
-    /// Sets the value of `start_time`.
+    /// Sets the value of [start_time][crate::model::OperationProgress::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2148,7 +2162,7 @@ impl OperationProgress {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::OperationProgress::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2197,18 +2211,20 @@ pub struct EncryptionConfig {
 }
 
 impl EncryptionConfig {
-    /// Sets the value of `kms_key_name`.
+    /// Sets the value of [kms_key_name][crate::model::EncryptionConfig::kms_key_name].
     pub fn set_kms_key_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kms_key_name = v.into();
         self
     }
 
-    /// Sets the value of `kms_key_names`.
-    pub fn set_kms_key_names<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kms_key_names = v.into();
+    /// Sets the value of [kms_key_names][crate::model::EncryptionConfig::kms_key_names].
+    pub fn set_kms_key_names<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.kms_key_names = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2241,7 +2257,7 @@ pub struct EncryptionInfo {
 }
 
 impl EncryptionInfo {
-    /// Sets the value of `encryption_type`.
+    /// Sets the value of [encryption_type][crate::model::EncryptionInfo::encryption_type].
     pub fn set_encryption_type<T: std::convert::Into<crate::model::encryption_info::Type>>(
         mut self,
         v: T,
@@ -2250,7 +2266,7 @@ impl EncryptionInfo {
         self
     }
 
-    /// Sets the value of `encryption_status`.
+    /// Sets the value of [encryption_status][crate::model::EncryptionInfo::encryption_status].
     pub fn set_encryption_status<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
         mut self,
         v: T,
@@ -2259,7 +2275,7 @@ impl EncryptionInfo {
         self
     }
 
-    /// Sets the value of `kms_key_version`.
+    /// Sets the value of [kms_key_version][crate::model::EncryptionInfo::kms_key_version].
     pub fn set_kms_key_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kms_key_version = v.into();
         self
@@ -2327,7 +2343,7 @@ pub struct RestoreInfo {
 }
 
 impl RestoreInfo {
-    /// Sets the value of `source_type`.
+    /// Sets the value of [source_type][crate::model::RestoreInfo::source_type].
     pub fn set_source_type<T: std::convert::Into<crate::model::RestoreSourceType>>(
         mut self,
         v: T,
@@ -2458,19 +2474,19 @@ pub struct Database {
 }
 
 impl Database {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Database::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::Database::state].
     pub fn set_state<T: std::convert::Into<crate::model::database::State>>(mut self, v: T) -> Self {
         self.state = v.into();
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::Database::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2479,7 +2495,7 @@ impl Database {
         self
     }
 
-    /// Sets the value of `restore_info`.
+    /// Sets the value of [restore_info][crate::model::Database::restore_info].
     pub fn set_restore_info<
         T: std::convert::Into<std::option::Option<crate::model::RestoreInfo>>,
     >(
@@ -2490,7 +2506,7 @@ impl Database {
         self
     }
 
-    /// Sets the value of `encryption_config`.
+    /// Sets the value of [encryption_config][crate::model::Database::encryption_config].
     pub fn set_encryption_config<
         T: std::convert::Into<std::option::Option<crate::model::EncryptionConfig>>,
     >(
@@ -2501,18 +2517,7 @@ impl Database {
         self
     }
 
-    /// Sets the value of `encryption_info`.
-    pub fn set_encryption_info<
-        T: std::convert::Into<std::vec::Vec<crate::model::EncryptionInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.encryption_info = v.into();
-        self
-    }
-
-    /// Sets the value of `version_retention_period`.
+    /// Sets the value of [version_retention_period][crate::model::Database::version_retention_period].
     pub fn set_version_retention_period<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -2521,7 +2526,7 @@ impl Database {
         self
     }
 
-    /// Sets the value of `earliest_version_time`.
+    /// Sets the value of [earliest_version_time][crate::model::Database::earliest_version_time].
     pub fn set_earliest_version_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2530,13 +2535,13 @@ impl Database {
         self
     }
 
-    /// Sets the value of `default_leader`.
+    /// Sets the value of [default_leader][crate::model::Database::default_leader].
     pub fn set_default_leader<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.default_leader = v.into();
         self
     }
 
-    /// Sets the value of `database_dialect`.
+    /// Sets the value of [database_dialect][crate::model::Database::database_dialect].
     pub fn set_database_dialect<T: std::convert::Into<crate::model::DatabaseDialect>>(
         mut self,
         v: T,
@@ -2545,15 +2550,26 @@ impl Database {
         self
     }
 
-    /// Sets the value of `enable_drop_protection`.
+    /// Sets the value of [enable_drop_protection][crate::model::Database::enable_drop_protection].
     pub fn set_enable_drop_protection<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enable_drop_protection = v.into();
         self
     }
 
-    /// Sets the value of `reconciling`.
+    /// Sets the value of [reconciling][crate::model::Database::reconciling].
     pub fn set_reconciling<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.reconciling = v.into();
+        self
+    }
+
+    /// Sets the value of [encryption_info][crate::model::Database::encryption_info].
+    pub fn set_encryption_info<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EncryptionInfo>,
+    {
+        use std::iter::Iterator;
+        self.encryption_info = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2641,19 +2657,19 @@ pub struct ListDatabasesRequest {
 }
 
 impl ListDatabasesRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListDatabasesRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListDatabasesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListDatabasesRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -2689,18 +2705,20 @@ pub struct ListDatabasesResponse {
 }
 
 impl ListDatabasesResponse {
-    /// Sets the value of `databases`.
-    pub fn set_databases<T: std::convert::Into<std::vec::Vec<crate::model::Database>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.databases = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListDatabasesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [databases][crate::model::ListDatabasesResponse::databases].
+    pub fn set_databases<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Database>,
+    {
+        use std::iter::Iterator;
+        self.databases = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2785,13 +2803,13 @@ pub struct CreateDatabaseRequest {
 }
 
 impl CreateDatabaseRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateDatabaseRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `create_statement`.
+    /// Sets the value of [create_statement][crate::model::CreateDatabaseRequest::create_statement].
     pub fn set_create_statement<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -2800,16 +2818,7 @@ impl CreateDatabaseRequest {
         self
     }
 
-    /// Sets the value of `extra_statements`.
-    pub fn set_extra_statements<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.extra_statements = v.into();
-        self
-    }
-
-    /// Sets the value of `encryption_config`.
+    /// Sets the value of [encryption_config][crate::model::CreateDatabaseRequest::encryption_config].
     pub fn set_encryption_config<
         T: std::convert::Into<std::option::Option<crate::model::EncryptionConfig>>,
     >(
@@ -2820,7 +2829,7 @@ impl CreateDatabaseRequest {
         self
     }
 
-    /// Sets the value of `database_dialect`.
+    /// Sets the value of [database_dialect][crate::model::CreateDatabaseRequest::database_dialect].
     pub fn set_database_dialect<T: std::convert::Into<crate::model::DatabaseDialect>>(
         mut self,
         v: T,
@@ -2829,9 +2838,20 @@ impl CreateDatabaseRequest {
         self
     }
 
-    /// Sets the value of `proto_descriptors`.
+    /// Sets the value of [proto_descriptors][crate::model::CreateDatabaseRequest::proto_descriptors].
     pub fn set_proto_descriptors<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.proto_descriptors = v.into();
+        self
+    }
+
+    /// Sets the value of [extra_statements][crate::model::CreateDatabaseRequest::extra_statements].
+    pub fn set_extra_statements<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.extra_statements = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2857,7 +2877,7 @@ pub struct CreateDatabaseMetadata {
 }
 
 impl CreateDatabaseMetadata {
-    /// Sets the value of `database`.
+    /// Sets the value of [database][crate::model::CreateDatabaseMetadata::database].
     pub fn set_database<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.database = v.into();
         self
@@ -2886,7 +2906,7 @@ pub struct GetDatabaseRequest {
 }
 
 impl GetDatabaseRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetDatabaseRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -2921,7 +2941,7 @@ pub struct UpdateDatabaseRequest {
 }
 
 impl UpdateDatabaseRequest {
-    /// Sets the value of `database`.
+    /// Sets the value of [database][crate::model::UpdateDatabaseRequest::database].
     pub fn set_database<T: std::convert::Into<std::option::Option<crate::model::Database>>>(
         mut self,
         v: T,
@@ -2930,7 +2950,7 @@ impl UpdateDatabaseRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateDatabaseRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -2977,7 +2997,7 @@ pub struct UpdateDatabaseMetadata {
 }
 
 impl UpdateDatabaseMetadata {
-    /// Sets the value of `request`.
+    /// Sets the value of [request][crate::model::UpdateDatabaseMetadata::request].
     pub fn set_request<
         T: std::convert::Into<std::option::Option<crate::model::UpdateDatabaseRequest>>,
     >(
@@ -2988,7 +3008,7 @@ impl UpdateDatabaseMetadata {
         self
     }
 
-    /// Sets the value of `progress`.
+    /// Sets the value of [progress][crate::model::UpdateDatabaseMetadata::progress].
     pub fn set_progress<
         T: std::convert::Into<std::option::Option<crate::model::OperationProgress>>,
     >(
@@ -2999,7 +3019,7 @@ impl UpdateDatabaseMetadata {
         self
     }
 
-    /// Sets the value of `cancel_time`.
+    /// Sets the value of [cancel_time][crate::model::UpdateDatabaseMetadata::cancel_time].
     pub fn set_cancel_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3098,30 +3118,32 @@ pub struct UpdateDatabaseDdlRequest {
 }
 
 impl UpdateDatabaseDdlRequest {
-    /// Sets the value of `database`.
+    /// Sets the value of [database][crate::model::UpdateDatabaseDdlRequest::database].
     pub fn set_database<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.database = v.into();
         self
     }
 
-    /// Sets the value of `statements`.
-    pub fn set_statements<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.statements = v.into();
-        self
-    }
-
-    /// Sets the value of `operation_id`.
+    /// Sets the value of [operation_id][crate::model::UpdateDatabaseDdlRequest::operation_id].
     pub fn set_operation_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.operation_id = v.into();
         self
     }
 
-    /// Sets the value of `proto_descriptors`.
+    /// Sets the value of [proto_descriptors][crate::model::UpdateDatabaseDdlRequest::proto_descriptors].
     pub fn set_proto_descriptors<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
         self.proto_descriptors = v.into();
+        self
+    }
+
+    /// Sets the value of [statements][crate::model::UpdateDatabaseDdlRequest::statements].
+    pub fn set_statements<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.statements = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3164,24 +3186,26 @@ pub struct DdlStatementActionInfo {
 }
 
 impl DdlStatementActionInfo {
-    /// Sets the value of `action`.
+    /// Sets the value of [action][crate::model::DdlStatementActionInfo::action].
     pub fn set_action<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.action = v.into();
         self
     }
 
-    /// Sets the value of `entity_type`.
+    /// Sets the value of [entity_type][crate::model::DdlStatementActionInfo::entity_type].
     pub fn set_entity_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.entity_type = v.into();
         self
     }
 
-    /// Sets the value of `entity_names`.
-    pub fn set_entity_names<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.entity_names = v.into();
+    /// Sets the value of [entity_names][crate::model::DdlStatementActionInfo::entity_names].
+    pub fn set_entity_names<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.entity_names = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3240,53 +3264,59 @@ pub struct UpdateDatabaseDdlMetadata {
 }
 
 impl UpdateDatabaseDdlMetadata {
-    /// Sets the value of `database`.
+    /// Sets the value of [database][crate::model::UpdateDatabaseDdlMetadata::database].
     pub fn set_database<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.database = v.into();
         self
     }
 
-    /// Sets the value of `statements`.
-    pub fn set_statements<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.statements = v.into();
-        self
-    }
-
-    /// Sets the value of `commit_timestamps`.
-    pub fn set_commit_timestamps<T: std::convert::Into<std::vec::Vec<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.commit_timestamps = v.into();
-        self
-    }
-
-    /// Sets the value of `throttled`.
+    /// Sets the value of [throttled][crate::model::UpdateDatabaseDdlMetadata::throttled].
     pub fn set_throttled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.throttled = v.into();
         self
     }
 
-    /// Sets the value of `progress`.
-    pub fn set_progress<T: std::convert::Into<std::vec::Vec<crate::model::OperationProgress>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.progress = v.into();
+    /// Sets the value of [statements][crate::model::UpdateDatabaseDdlMetadata::statements].
+    pub fn set_statements<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.statements = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
-    /// Sets the value of `actions`.
-    pub fn set_actions<
-        T: std::convert::Into<std::vec::Vec<crate::model::DdlStatementActionInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.actions = v.into();
+    /// Sets the value of [commit_timestamps][crate::model::UpdateDatabaseDdlMetadata::commit_timestamps].
+    pub fn set_commit_timestamps<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Timestamp>,
+    {
+        use std::iter::Iterator;
+        self.commit_timestamps = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [progress][crate::model::UpdateDatabaseDdlMetadata::progress].
+    pub fn set_progress<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::OperationProgress>,
+    {
+        use std::iter::Iterator;
+        self.progress = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [actions][crate::model::UpdateDatabaseDdlMetadata::actions].
+    pub fn set_actions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DdlStatementActionInfo>,
+    {
+        use std::iter::Iterator;
+        self.actions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3312,7 +3342,7 @@ pub struct DropDatabaseRequest {
 }
 
 impl DropDatabaseRequest {
-    /// Sets the value of `database`.
+    /// Sets the value of [database][crate::model::DropDatabaseRequest::database].
     pub fn set_database<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.database = v.into();
         self
@@ -3342,7 +3372,7 @@ pub struct GetDatabaseDdlRequest {
 }
 
 impl GetDatabaseDdlRequest {
-    /// Sets the value of `database`.
+    /// Sets the value of [database][crate::model::GetDatabaseDdlRequest::database].
     pub fn set_database<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.database = v.into();
         self
@@ -3380,18 +3410,20 @@ pub struct GetDatabaseDdlResponse {
 }
 
 impl GetDatabaseDdlResponse {
-    /// Sets the value of `statements`.
-    pub fn set_statements<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.statements = v.into();
+    /// Sets the value of [proto_descriptors][crate::model::GetDatabaseDdlResponse::proto_descriptors].
+    pub fn set_proto_descriptors<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
+        self.proto_descriptors = v.into();
         self
     }
 
-    /// Sets the value of `proto_descriptors`.
-    pub fn set_proto_descriptors<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
-        self.proto_descriptors = v.into();
+    /// Sets the value of [statements][crate::model::GetDatabaseDdlResponse::statements].
+    pub fn set_statements<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.statements = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3484,25 +3516,25 @@ pub struct ListDatabaseOperationsRequest {
 }
 
 impl ListDatabaseOperationsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListDatabaseOperationsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListDatabaseOperationsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListDatabaseOperationsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListDatabaseOperationsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -3545,18 +3577,20 @@ pub struct ListDatabaseOperationsResponse {
 }
 
 impl ListDatabaseOperationsResponse {
-    /// Sets the value of `operations`.
-    pub fn set_operations<T: std::convert::Into<std::vec::Vec<longrunning::model::Operation>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.operations = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListDatabaseOperationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [operations][crate::model::ListDatabaseOperationsResponse::operations].
+    pub fn set_operations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<longrunning::model::Operation>,
+    {
+        use std::iter::Iterator;
+        self.operations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3621,19 +3655,19 @@ pub struct RestoreDatabaseRequest {
 }
 
 impl RestoreDatabaseRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::RestoreDatabaseRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `database_id`.
+    /// Sets the value of [database_id][crate::model::RestoreDatabaseRequest::database_id].
     pub fn set_database_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.database_id = v.into();
         self
     }
 
-    /// Sets the value of `encryption_config`.
+    /// Sets the value of [encryption_config][crate::model::RestoreDatabaseRequest::encryption_config].
     pub fn set_encryption_config<
         T: std::convert::Into<std::option::Option<crate::model::RestoreDatabaseEncryptionConfig>>,
     >(
@@ -3718,7 +3752,7 @@ pub struct RestoreDatabaseEncryptionConfig {
 }
 
 impl RestoreDatabaseEncryptionConfig {
-    /// Sets the value of `encryption_type`.
+    /// Sets the value of [encryption_type][crate::model::RestoreDatabaseEncryptionConfig::encryption_type].
     pub fn set_encryption_type<
         T: std::convert::Into<crate::model::restore_database_encryption_config::EncryptionType>,
     >(
@@ -3729,18 +3763,20 @@ impl RestoreDatabaseEncryptionConfig {
         self
     }
 
-    /// Sets the value of `kms_key_name`.
+    /// Sets the value of [kms_key_name][crate::model::RestoreDatabaseEncryptionConfig::kms_key_name].
     pub fn set_kms_key_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kms_key_name = v.into();
         self
     }
 
-    /// Sets the value of `kms_key_names`.
-    pub fn set_kms_key_names<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kms_key_names = v.into();
+    /// Sets the value of [kms_key_names][crate::model::RestoreDatabaseEncryptionConfig::kms_key_names].
+    pub fn set_kms_key_names<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.kms_key_names = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3864,13 +3900,13 @@ pub struct RestoreDatabaseMetadata {
 }
 
 impl RestoreDatabaseMetadata {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::RestoreDatabaseMetadata::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `source_type`.
+    /// Sets the value of [source_type][crate::model::RestoreDatabaseMetadata::source_type].
     pub fn set_source_type<T: std::convert::Into<crate::model::RestoreSourceType>>(
         mut self,
         v: T,
@@ -3879,7 +3915,7 @@ impl RestoreDatabaseMetadata {
         self
     }
 
-    /// Sets the value of `progress`.
+    /// Sets the value of [progress][crate::model::RestoreDatabaseMetadata::progress].
     pub fn set_progress<
         T: std::convert::Into<std::option::Option<crate::model::OperationProgress>>,
     >(
@@ -3890,7 +3926,7 @@ impl RestoreDatabaseMetadata {
         self
     }
 
-    /// Sets the value of `cancel_time`.
+    /// Sets the value of [cancel_time][crate::model::RestoreDatabaseMetadata::cancel_time].
     pub fn set_cancel_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3899,7 +3935,7 @@ impl RestoreDatabaseMetadata {
         self
     }
 
-    /// Sets the value of `optimize_database_operation_name`.
+    /// Sets the value of [optimize_database_operation_name][crate::model::RestoreDatabaseMetadata::optimize_database_operation_name].
     pub fn set_optimize_database_operation_name<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -3966,13 +4002,13 @@ pub struct OptimizeRestoredDatabaseMetadata {
 }
 
 impl OptimizeRestoredDatabaseMetadata {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::OptimizeRestoredDatabaseMetadata::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `progress`.
+    /// Sets the value of [progress][crate::model::OptimizeRestoredDatabaseMetadata::progress].
     pub fn set_progress<
         T: std::convert::Into<std::option::Option<crate::model::OperationProgress>>,
     >(
@@ -4004,7 +4040,7 @@ pub struct DatabaseRole {
 }
 
 impl DatabaseRole {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DatabaseRole::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -4048,19 +4084,19 @@ pub struct ListDatabaseRolesRequest {
 }
 
 impl ListDatabaseRolesRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListDatabaseRolesRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListDatabaseRolesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListDatabaseRolesRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -4096,18 +4132,20 @@ pub struct ListDatabaseRolesResponse {
 }
 
 impl ListDatabaseRolesResponse {
-    /// Sets the value of `database_roles`.
-    pub fn set_database_roles<T: std::convert::Into<std::vec::Vec<crate::model::DatabaseRole>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.database_roles = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListDatabaseRolesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [database_roles][crate::model::ListDatabaseRolesResponse::database_roles].
+    pub fn set_database_roles<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DatabaseRole>,
+    {
+        use std::iter::Iterator;
+        self.database_roles = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/spanner/admin/instance/v1/src/builders.rs
+++ b/src/generated/spanner/admin/instance/v1/src/builders.rs
@@ -85,19 +85,19 @@ pub mod instance_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListInstanceConfigsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListInstanceConfigsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListInstanceConfigsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -141,7 +141,7 @@ pub mod instance_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetInstanceConfigRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -226,19 +226,19 @@ pub mod instance_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateInstanceConfigRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `instance_config_id`.
+        /// Sets the value of [instance_config_id][crate::model::CreateInstanceConfigRequest::instance_config_id].
         pub fn set_instance_config_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance_config_id = v.into();
             self
         }
 
-        /// Sets the value of `instance_config`.
+        /// Sets the value of [instance_config][crate::model::CreateInstanceConfigRequest::instance_config].
         pub fn set_instance_config<T: Into<std::option::Option<crate::model::InstanceConfig>>>(
             mut self,
             v: T,
@@ -247,7 +247,7 @@ pub mod instance_admin {
             self
         }
 
-        /// Sets the value of `validate_only`.
+        /// Sets the value of [validate_only][crate::model::CreateInstanceConfigRequest::validate_only].
         pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.validate_only = v.into();
             self
@@ -332,7 +332,7 @@ pub mod instance_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `instance_config`.
+        /// Sets the value of [instance_config][crate::model::UpdateInstanceConfigRequest::instance_config].
         pub fn set_instance_config<T: Into<std::option::Option<crate::model::InstanceConfig>>>(
             mut self,
             v: T,
@@ -341,7 +341,7 @@ pub mod instance_admin {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][crate::model::UpdateInstanceConfigRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -350,7 +350,7 @@ pub mod instance_admin {
             self
         }
 
-        /// Sets the value of `validate_only`.
+        /// Sets the value of [validate_only][crate::model::UpdateInstanceConfigRequest::validate_only].
         pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.validate_only = v.into();
             self
@@ -394,19 +394,19 @@ pub mod instance_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteInstanceConfigRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DeleteInstanceConfigRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
         }
 
-        /// Sets the value of `validate_only`.
+        /// Sets the value of [validate_only][crate::model::DeleteInstanceConfigRequest::validate_only].
         pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.validate_only = v.into();
             self
@@ -469,25 +469,25 @@ pub mod instance_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListInstanceConfigOperationsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListInstanceConfigOperationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListInstanceConfigOperationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListInstanceConfigOperationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -543,31 +543,31 @@ pub mod instance_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListInstancesRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListInstancesRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListInstancesRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListInstancesRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `instance_deadline`.
+        /// Sets the value of [instance_deadline][crate::model::ListInstancesRequest::instance_deadline].
         pub fn set_instance_deadline<T: Into<std::option::Option<wkt::Timestamp>>>(
             mut self,
             v: T,
@@ -631,25 +631,25 @@ pub mod instance_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListInstancePartitionsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListInstancePartitionsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListInstancePartitionsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `instance_partition_deadline`.
+        /// Sets the value of [instance_partition_deadline][crate::model::ListInstancePartitionsRequest::instance_partition_deadline].
         pub fn set_instance_partition_deadline<T: Into<std::option::Option<wkt::Timestamp>>>(
             mut self,
             v: T,
@@ -693,13 +693,13 @@ pub mod instance_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetInstanceRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `field_mask`.
+        /// Sets the value of [field_mask][crate::model::GetInstanceRequest::field_mask].
         pub fn set_field_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -782,19 +782,19 @@ pub mod instance_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateInstanceRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `instance_id`.
+        /// Sets the value of [instance_id][crate::model::CreateInstanceRequest::instance_id].
         pub fn set_instance_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance_id = v.into();
             self
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::CreateInstanceRequest::instance].
         pub fn set_instance<T: Into<std::option::Option<crate::model::Instance>>>(
             mut self,
             v: T,
@@ -877,7 +877,7 @@ pub mod instance_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `instance`.
+        /// Sets the value of [instance][crate::model::UpdateInstanceRequest::instance].
         pub fn set_instance<T: Into<std::option::Option<crate::model::Instance>>>(
             mut self,
             v: T,
@@ -886,7 +886,7 @@ pub mod instance_admin {
             self
         }
 
-        /// Sets the value of `field_mask`.
+        /// Sets the value of [field_mask][crate::model::UpdateInstanceRequest::field_mask].
         pub fn set_field_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -930,7 +930,7 @@ pub mod instance_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteInstanceRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -971,13 +971,13 @@ pub mod instance_admin {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::SetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `policy`.
+        /// Sets the value of [policy][iam_v1::model::SetIamPolicyRequest::policy].
         pub fn set_policy<T: Into<std::option::Option<iam_v1::model::Policy>>>(
             mut self,
             v: T,
@@ -986,7 +986,7 @@ pub mod instance_admin {
             self
         }
 
-        /// Sets the value of `update_mask`.
+        /// Sets the value of [update_mask][iam_v1::model::SetIamPolicyRequest::update_mask].
         pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -1030,13 +1030,13 @@ pub mod instance_admin {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::GetIamPolicyRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `options`.
+        /// Sets the value of [options][iam_v1::model::GetIamPolicyRequest::options].
         pub fn set_options<T: Into<std::option::Option<iam_v1::model::GetPolicyOptions>>>(
             mut self,
             v: T,
@@ -1083,18 +1083,20 @@ pub mod instance_admin {
                 .await
         }
 
-        /// Sets the value of `resource`.
+        /// Sets the value of [resource][iam_v1::model::TestIamPermissionsRequest::resource].
         pub fn set_resource<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.resource = v.into();
             self
         }
 
-        /// Sets the value of `permissions`.
-        pub fn set_permissions<T: Into<std::vec::Vec<std::string::String>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.permissions = v.into();
+        /// Sets the value of [permissions][iam_v1::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1136,7 +1138,7 @@ pub mod instance_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::GetInstancePartitionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1225,19 +1227,19 @@ pub mod instance_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::CreateInstancePartitionRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `instance_partition_id`.
+        /// Sets the value of [instance_partition_id][crate::model::CreateInstancePartitionRequest::instance_partition_id].
         pub fn set_instance_partition_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.instance_partition_id = v.into();
             self
         }
 
-        /// Sets the value of `instance_partition`.
+        /// Sets the value of [instance_partition][crate::model::CreateInstancePartitionRequest::instance_partition].
         pub fn set_instance_partition<
             T: Into<std::option::Option<crate::model::InstancePartition>>,
         >(
@@ -1288,13 +1290,13 @@ pub mod instance_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::DeleteInstancePartitionRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `etag`.
+        /// Sets the value of [etag][crate::model::DeleteInstancePartitionRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -1383,7 +1385,7 @@ pub mod instance_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `instance_partition`.
+        /// Sets the value of [instance_partition][crate::model::UpdateInstancePartitionRequest::instance_partition].
         pub fn set_instance_partition<
             T: Into<std::option::Option<crate::model::InstancePartition>>,
         >(
@@ -1394,7 +1396,7 @@ pub mod instance_admin {
             self
         }
 
-        /// Sets the value of `field_mask`.
+        /// Sets the value of [field_mask][crate::model::UpdateInstancePartitionRequest::field_mask].
         pub fn set_field_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
             v: T,
@@ -1460,31 +1462,31 @@ pub mod instance_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `parent`.
+        /// Sets the value of [parent][crate::model::ListInstancePartitionOperationsRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][crate::model::ListInstancePartitionOperationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][crate::model::ListInstancePartitionOperationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][crate::model::ListInstancePartitionOperationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
         }
 
-        /// Sets the value of `instance_partition_deadline`.
+        /// Sets the value of [instance_partition_deadline][crate::model::ListInstancePartitionOperationsRequest::instance_partition_deadline].
         pub fn set_instance_partition_deadline<T: Into<std::option::Option<wkt::Timestamp>>>(
             mut self,
             v: T,
@@ -1569,13 +1571,13 @@ pub mod instance_admin {
             lro::new_poller(polling_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][crate::model::MoveInstanceRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `target_config`.
+        /// Sets the value of [target_config][crate::model::MoveInstanceRequest::target_config].
         pub fn set_target_config<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.target_config = v.into();
             self
@@ -1634,25 +1636,25 @@ pub mod instance_admin {
             gax::paginator::Paginator::new(token, execute)
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::ListOperationsRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
         }
 
-        /// Sets the value of `filter`.
+        /// Sets the value of [filter][longrunning::model::ListOperationsRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
             self
         }
 
-        /// Sets the value of `page_size`.
+        /// Sets the value of [page_size][longrunning::model::ListOperationsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
             self
         }
 
-        /// Sets the value of `page_token`.
+        /// Sets the value of [page_token][longrunning::model::ListOperationsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -1696,7 +1698,7 @@ pub mod instance_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::GetOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1740,7 +1742,7 @@ pub mod instance_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::DeleteOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1784,7 +1786,7 @@ pub mod instance_admin {
                 .await
         }
 
-        /// Sets the value of `name`.
+        /// Sets the value of [name][longrunning::model::CancelOperationRequest::name].
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self

--- a/src/generated/spanner/admin/instance/v1/src/model.rs
+++ b/src/generated/spanner/admin/instance/v1/src/model.rs
@@ -55,13 +55,13 @@ pub struct OperationProgress {
 }
 
 impl OperationProgress {
-    /// Sets the value of `progress_percent`.
+    /// Sets the value of [progress_percent][crate::model::OperationProgress::progress_percent].
     pub fn set_progress_percent<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.progress_percent = v.into();
         self
     }
 
-    /// Sets the value of `start_time`.
+    /// Sets the value of [start_time][crate::model::OperationProgress::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -70,7 +70,7 @@ impl OperationProgress {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::OperationProgress::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -98,7 +98,7 @@ pub struct ReplicaSelection {
 }
 
 impl ReplicaSelection {
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::ReplicaSelection::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
@@ -132,13 +132,13 @@ pub struct ReplicaInfo {
 }
 
 impl ReplicaInfo {
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::ReplicaInfo::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of `r#type`.
+    /// Sets the value of [r#type][crate::model::ReplicaInfo::type].
     pub fn set_type<T: std::convert::Into<crate::model::replica_info::ReplicaType>>(
         mut self,
         v: T,
@@ -147,7 +147,7 @@ impl ReplicaInfo {
         self
     }
 
-    /// Sets the value of `default_leader_location`.
+    /// Sets the value of [default_leader_location][crate::model::ReplicaInfo::default_leader_location].
     pub fn set_default_leader_location<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.default_leader_location = v.into();
         self
@@ -328,19 +328,19 @@ pub struct InstanceConfig {
 }
 
 impl InstanceConfig {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::InstanceConfig::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::InstanceConfig::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
         self
     }
 
-    /// Sets the value of `config_type`.
+    /// Sets the value of [config_type][crate::model::InstanceConfig::config_type].
     pub fn set_config_type<T: std::convert::Into<crate::model::instance_config::Type>>(
         mut self,
         v: T,
@@ -349,65 +349,25 @@ impl InstanceConfig {
         self
     }
 
-    /// Sets the value of `replicas`.
-    pub fn set_replicas<T: std::convert::Into<std::vec::Vec<crate::model::ReplicaInfo>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.replicas = v.into();
-        self
-    }
-
-    /// Sets the value of `optional_replicas`.
-    pub fn set_optional_replicas<
-        T: std::convert::Into<std::vec::Vec<crate::model::ReplicaInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.optional_replicas = v.into();
-        self
-    }
-
-    /// Sets the value of `base_config`.
+    /// Sets the value of [base_config][crate::model::InstanceConfig::base_config].
     pub fn set_base_config<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.base_config = v.into();
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::InstanceConfig::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `leader_options`.
-    pub fn set_leader_options<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.leader_options = v.into();
-        self
-    }
-
-    /// Sets the value of `reconciling`.
+    /// Sets the value of [reconciling][crate::model::InstanceConfig::reconciling].
     pub fn set_reconciling<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.reconciling = v.into();
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::InstanceConfig::state].
     pub fn set_state<T: std::convert::Into<crate::model::instance_config::State>>(
         mut self,
         v: T,
@@ -416,7 +376,7 @@ impl InstanceConfig {
         self
     }
 
-    /// Sets the value of `free_instance_availability`.
+    /// Sets the value of [free_instance_availability][crate::model::InstanceConfig::free_instance_availability].
     pub fn set_free_instance_availability<
         T: std::convert::Into<crate::model::instance_config::FreeInstanceAvailability>,
     >(
@@ -427,7 +387,7 @@ impl InstanceConfig {
         self
     }
 
-    /// Sets the value of `quorum_type`.
+    /// Sets the value of [quorum_type][crate::model::InstanceConfig::quorum_type].
     pub fn set_quorum_type<T: std::convert::Into<crate::model::instance_config::QuorumType>>(
         mut self,
         v: T,
@@ -436,12 +396,57 @@ impl InstanceConfig {
         self
     }
 
-    /// Sets the value of `storage_limit_per_processing_unit`.
+    /// Sets the value of [storage_limit_per_processing_unit][crate::model::InstanceConfig::storage_limit_per_processing_unit].
     pub fn set_storage_limit_per_processing_unit<T: std::convert::Into<i64>>(
         mut self,
         v: T,
     ) -> Self {
         self.storage_limit_per_processing_unit = v.into();
+        self
+    }
+
+    /// Sets the value of [replicas][crate::model::InstanceConfig::replicas].
+    pub fn set_replicas<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ReplicaInfo>,
+    {
+        use std::iter::Iterator;
+        self.replicas = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [optional_replicas][crate::model::InstanceConfig::optional_replicas].
+    pub fn set_optional_replicas<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ReplicaInfo>,
+    {
+        use std::iter::Iterator;
+        self.optional_replicas = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [leader_options][crate::model::InstanceConfig::leader_options].
+    pub fn set_leader_options<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.leader_options = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::InstanceConfig::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -626,7 +631,7 @@ pub struct ReplicaComputeCapacity {
 }
 
 impl ReplicaComputeCapacity {
-    /// Sets the value of `replica_selection`.
+    /// Sets the value of [replica_selection][crate::model::ReplicaComputeCapacity::replica_selection].
     pub fn set_replica_selection<
         T: std::convert::Into<std::option::Option<crate::model::ReplicaSelection>>,
     >(
@@ -715,7 +720,7 @@ pub struct AutoscalingConfig {
 }
 
 impl AutoscalingConfig {
-    /// Sets the value of `autoscaling_limits`.
+    /// Sets the value of [autoscaling_limits][crate::model::AutoscalingConfig::autoscaling_limits].
     pub fn set_autoscaling_limits<
         T: std::convert::Into<
             std::option::Option<crate::model::autoscaling_config::AutoscalingLimits>,
@@ -728,7 +733,7 @@ impl AutoscalingConfig {
         self
     }
 
-    /// Sets the value of `autoscaling_targets`.
+    /// Sets the value of [autoscaling_targets][crate::model::AutoscalingConfig::autoscaling_targets].
     pub fn set_autoscaling_targets<
         T: std::convert::Into<
             std::option::Option<crate::model::autoscaling_config::AutoscalingTargets>,
@@ -741,16 +746,14 @@ impl AutoscalingConfig {
         self
     }
 
-    /// Sets the value of `asymmetric_autoscaling_options`.
-    pub fn set_asymmetric_autoscaling_options<
-        T: std::convert::Into<
-            std::vec::Vec<crate::model::autoscaling_config::AsymmetricAutoscalingOption>,
-        >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.asymmetric_autoscaling_options = v.into();
+    /// Sets the value of [asymmetric_autoscaling_options][crate::model::AutoscalingConfig::asymmetric_autoscaling_options].
+    pub fn set_asymmetric_autoscaling_options<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::autoscaling_config::AsymmetricAutoscalingOption>,
+    {
+        use std::iter::Iterator;
+        self.asymmetric_autoscaling_options = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -878,7 +881,7 @@ pub mod autoscaling_config {
     }
 
     impl AutoscalingTargets {
-        /// Sets the value of `high_priority_cpu_utilization_percent`.
+        /// Sets the value of [high_priority_cpu_utilization_percent][crate::model::autoscaling_config::AutoscalingTargets::high_priority_cpu_utilization_percent].
         pub fn set_high_priority_cpu_utilization_percent<T: std::convert::Into<i32>>(
             mut self,
             v: T,
@@ -887,7 +890,7 @@ pub mod autoscaling_config {
             self
         }
 
-        /// Sets the value of `storage_utilization_percent`.
+        /// Sets the value of [storage_utilization_percent][crate::model::autoscaling_config::AutoscalingTargets::storage_utilization_percent].
         pub fn set_storage_utilization_percent<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
             self.storage_utilization_percent = v.into();
             self
@@ -920,7 +923,7 @@ pub mod autoscaling_config {
     }
 
     impl AsymmetricAutoscalingOption {
-        /// Sets the value of `replica_selection`.
+        /// Sets the value of [replica_selection][crate::model::autoscaling_config::AsymmetricAutoscalingOption::replica_selection].
         pub fn set_replica_selection<
             T: std::convert::Into<std::option::Option<crate::model::ReplicaSelection>>,
         >(
@@ -931,7 +934,7 @@ pub mod autoscaling_config {
             self
         }
 
-        /// Sets the value of `overrides`.
+        /// Sets the value of [overrides][crate::model::autoscaling_config::AsymmetricAutoscalingOption::overrides].
         pub fn set_overrides<T: std::convert::Into<std::option::Option<crate::model::autoscaling_config::asymmetric_autoscaling_option::AutoscalingConfigOverrides>>>(mut self, v: T) -> Self{
             self.overrides = v.into();
             self
@@ -971,7 +974,7 @@ pub mod autoscaling_config {
         }
 
         impl AutoscalingConfigOverrides {
-            /// Sets the value of `autoscaling_limits`.
+            /// Sets the value of [autoscaling_limits][crate::model::autoscaling_config::asymmetric_autoscaling_option::AutoscalingConfigOverrides::autoscaling_limits].
             pub fn set_autoscaling_limits<
                 T: std::convert::Into<
                     std::option::Option<crate::model::autoscaling_config::AutoscalingLimits>,
@@ -984,7 +987,7 @@ pub mod autoscaling_config {
                 self
             }
 
-            /// Sets the value of `autoscaling_target_high_priority_cpu_utilization_percent`.
+            /// Sets the value of [autoscaling_target_high_priority_cpu_utilization_percent][crate::model::autoscaling_config::asymmetric_autoscaling_option::AutoscalingConfigOverrides::autoscaling_target_high_priority_cpu_utilization_percent].
             pub fn set_autoscaling_target_high_priority_cpu_utilization_percent<
                 T: std::convert::Into<i32>,
             >(
@@ -1150,48 +1153,37 @@ pub struct Instance {
 }
 
 impl Instance {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::Instance::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `config`.
+    /// Sets the value of [config][crate::model::Instance::config].
     pub fn set_config<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.config = v.into();
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::Instance::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
         self
     }
 
-    /// Sets the value of `node_count`.
+    /// Sets the value of [node_count][crate::model::Instance::node_count].
     pub fn set_node_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.node_count = v.into();
         self
     }
 
-    /// Sets the value of `processing_units`.
+    /// Sets the value of [processing_units][crate::model::Instance::processing_units].
     pub fn set_processing_units<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.processing_units = v.into();
         self
     }
 
-    /// Sets the value of `replica_compute_capacity`.
-    pub fn set_replica_compute_capacity<
-        T: std::convert::Into<std::vec::Vec<crate::model::ReplicaComputeCapacity>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.replica_compute_capacity = v.into();
-        self
-    }
-
-    /// Sets the value of `autoscaling_config`.
+    /// Sets the value of [autoscaling_config][crate::model::Instance::autoscaling_config].
     pub fn set_autoscaling_config<
         T: std::convert::Into<std::option::Option<crate::model::AutoscalingConfig>>,
     >(
@@ -1202,24 +1194,13 @@ impl Instance {
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::Instance::state].
     pub fn set_state<T: std::convert::Into<crate::model::instance::State>>(mut self, v: T) -> Self {
         self.state = v.into();
         self
     }
 
-    /// Sets the value of `labels`.
-    pub fn set_labels<
-        T: std::convert::Into<std::collections::HashMap<std::string::String, std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.labels = v.into();
-        self
-    }
-
-    /// Sets the value of `instance_type`.
+    /// Sets the value of [instance_type][crate::model::Instance::instance_type].
     pub fn set_instance_type<T: std::convert::Into<crate::model::instance::InstanceType>>(
         mut self,
         v: T,
@@ -1228,16 +1209,7 @@ impl Instance {
         self
     }
 
-    /// Sets the value of `endpoint_uris`.
-    pub fn set_endpoint_uris<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.endpoint_uris = v.into();
-        self
-    }
-
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::Instance::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1246,7 +1218,7 @@ impl Instance {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::Instance::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -1255,7 +1227,7 @@ impl Instance {
         self
     }
 
-    /// Sets the value of `free_instance_metadata`.
+    /// Sets the value of [free_instance_metadata][crate::model::Instance::free_instance_metadata].
     pub fn set_free_instance_metadata<
         T: std::convert::Into<std::option::Option<crate::model::FreeInstanceMetadata>>,
     >(
@@ -1266,7 +1238,7 @@ impl Instance {
         self
     }
 
-    /// Sets the value of `edition`.
+    /// Sets the value of [edition][crate::model::Instance::edition].
     pub fn set_edition<T: std::convert::Into<crate::model::instance::Edition>>(
         mut self,
         v: T,
@@ -1275,7 +1247,7 @@ impl Instance {
         self
     }
 
-    /// Sets the value of `default_backup_schedule_type`.
+    /// Sets the value of [default_backup_schedule_type][crate::model::Instance::default_backup_schedule_type].
     pub fn set_default_backup_schedule_type<
         T: std::convert::Into<crate::model::instance::DefaultBackupScheduleType>,
     >(
@@ -1283,6 +1255,40 @@ impl Instance {
         v: T,
     ) -> Self {
         self.default_backup_schedule_type = v.into();
+        self
+    }
+
+    /// Sets the value of [replica_compute_capacity][crate::model::Instance::replica_compute_capacity].
+    pub fn set_replica_compute_capacity<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ReplicaComputeCapacity>,
+    {
+        use std::iter::Iterator;
+        self.replica_compute_capacity = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [endpoint_uris][crate::model::Instance::endpoint_uris].
+    pub fn set_endpoint_uris<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.endpoint_uris = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Instance::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1471,19 +1477,19 @@ pub struct ListInstanceConfigsRequest {
 }
 
 impl ListInstanceConfigsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListInstanceConfigsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListInstanceConfigsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListInstanceConfigsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -1519,20 +1525,20 @@ pub struct ListInstanceConfigsResponse {
 }
 
 impl ListInstanceConfigsResponse {
-    /// Sets the value of `instance_configs`.
-    pub fn set_instance_configs<
-        T: std::convert::Into<std::vec::Vec<crate::model::InstanceConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.instance_configs = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListInstanceConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [instance_configs][crate::model::ListInstanceConfigsResponse::instance_configs].
+    pub fn set_instance_configs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::InstanceConfig>,
+    {
+        use std::iter::Iterator;
+        self.instance_configs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1572,7 +1578,7 @@ pub struct GetInstanceConfigRequest {
 }
 
 impl GetInstanceConfigRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetInstanceConfigRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -1620,13 +1626,13 @@ pub struct CreateInstanceConfigRequest {
 }
 
 impl CreateInstanceConfigRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateInstanceConfigRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `instance_config_id`.
+    /// Sets the value of [instance_config_id][crate::model::CreateInstanceConfigRequest::instance_config_id].
     pub fn set_instance_config_id<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -1635,7 +1641,7 @@ impl CreateInstanceConfigRequest {
         self
     }
 
-    /// Sets the value of `instance_config`.
+    /// Sets the value of [instance_config][crate::model::CreateInstanceConfigRequest::instance_config].
     pub fn set_instance_config<
         T: std::convert::Into<std::option::Option<crate::model::InstanceConfig>>,
     >(
@@ -1646,7 +1652,7 @@ impl CreateInstanceConfigRequest {
         self
     }
 
-    /// Sets the value of `validate_only`.
+    /// Sets the value of [validate_only][crate::model::CreateInstanceConfigRequest::validate_only].
     pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.validate_only = v.into();
         self
@@ -1698,7 +1704,7 @@ pub struct UpdateInstanceConfigRequest {
 }
 
 impl UpdateInstanceConfigRequest {
-    /// Sets the value of `instance_config`.
+    /// Sets the value of [instance_config][crate::model::UpdateInstanceConfigRequest::instance_config].
     pub fn set_instance_config<
         T: std::convert::Into<std::option::Option<crate::model::InstanceConfig>>,
     >(
@@ -1709,7 +1715,7 @@ impl UpdateInstanceConfigRequest {
         self
     }
 
-    /// Sets the value of `update_mask`.
+    /// Sets the value of [update_mask][crate::model::UpdateInstanceConfigRequest::update_mask].
     pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -1718,7 +1724,7 @@ impl UpdateInstanceConfigRequest {
         self
     }
 
-    /// Sets the value of `validate_only`.
+    /// Sets the value of [validate_only][crate::model::UpdateInstanceConfigRequest::validate_only].
     pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.validate_only = v.into();
         self
@@ -1762,19 +1768,19 @@ pub struct DeleteInstanceConfigRequest {
 }
 
 impl DeleteInstanceConfigRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteInstanceConfigRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DeleteInstanceConfigRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of `validate_only`.
+    /// Sets the value of [validate_only][crate::model::DeleteInstanceConfigRequest::validate_only].
     pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.validate_only = v.into();
         self
@@ -1865,25 +1871,25 @@ pub struct ListInstanceConfigOperationsRequest {
 }
 
 impl ListInstanceConfigOperationsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListInstanceConfigOperationsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListInstanceConfigOperationsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListInstanceConfigOperationsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListInstanceConfigOperationsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -1923,18 +1929,20 @@ pub struct ListInstanceConfigOperationsResponse {
 }
 
 impl ListInstanceConfigOperationsResponse {
-    /// Sets the value of `operations`.
-    pub fn set_operations<T: std::convert::Into<std::vec::Vec<longrunning::model::Operation>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.operations = v.into();
+    /// Sets the value of [next_page_token][crate::model::ListInstanceConfigOperationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `next_page_token`.
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
+    /// Sets the value of [operations][crate::model::ListInstanceConfigOperationsResponse::operations].
+    pub fn set_operations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<longrunning::model::Operation>,
+    {
+        use std::iter::Iterator;
+        self.operations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1983,13 +1991,13 @@ pub struct GetInstanceRequest {
 }
 
 impl GetInstanceRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetInstanceRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `field_mask`.
+    /// Sets the value of [field_mask][crate::model::GetInstanceRequest::field_mask].
     pub fn set_field_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -2032,19 +2040,19 @@ pub struct CreateInstanceRequest {
 }
 
 impl CreateInstanceRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateInstanceRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `instance_id`.
+    /// Sets the value of [instance_id][crate::model::CreateInstanceRequest::instance_id].
     pub fn set_instance_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance_id = v.into();
         self
     }
 
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::CreateInstanceRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::option::Option<crate::model::Instance>>>(
         mut self,
         v: T,
@@ -2124,31 +2132,31 @@ pub struct ListInstancesRequest {
 }
 
 impl ListInstancesRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListInstancesRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListInstancesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListInstancesRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListInstancesRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
     }
 
-    /// Sets the value of `instance_deadline`.
+    /// Sets the value of [instance_deadline][crate::model::ListInstancesRequest::instance_deadline].
     pub fn set_instance_deadline<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2196,27 +2204,31 @@ pub struct ListInstancesResponse {
 }
 
 impl ListInstancesResponse {
-    /// Sets the value of `instances`.
-    pub fn set_instances<T: std::convert::Into<std::vec::Vec<crate::model::Instance>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.instances = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `unreachable`.
-    pub fn set_unreachable<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.unreachable = v.into();
+    /// Sets the value of [instances][crate::model::ListInstancesResponse::instances].
+    pub fn set_instances<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Instance>,
+    {
+        use std::iter::Iterator;
+        self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [unreachable][crate::model::ListInstancesResponse::unreachable].
+    pub fn set_unreachable<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.unreachable = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2270,7 +2282,7 @@ pub struct UpdateInstanceRequest {
 }
 
 impl UpdateInstanceRequest {
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::UpdateInstanceRequest::instance].
     pub fn set_instance<T: std::convert::Into<std::option::Option<crate::model::Instance>>>(
         mut self,
         v: T,
@@ -2279,7 +2291,7 @@ impl UpdateInstanceRequest {
         self
     }
 
-    /// Sets the value of `field_mask`.
+    /// Sets the value of [field_mask][crate::model::UpdateInstanceRequest::field_mask].
     pub fn set_field_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -2311,7 +2323,7 @@ pub struct DeleteInstanceRequest {
 }
 
 impl DeleteInstanceRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteInstanceRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -2360,7 +2372,7 @@ pub struct CreateInstanceMetadata {
 }
 
 impl CreateInstanceMetadata {
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::CreateInstanceMetadata::instance].
     pub fn set_instance<T: std::convert::Into<std::option::Option<crate::model::Instance>>>(
         mut self,
         v: T,
@@ -2369,7 +2381,7 @@ impl CreateInstanceMetadata {
         self
     }
 
-    /// Sets the value of `start_time`.
+    /// Sets the value of [start_time][crate::model::CreateInstanceMetadata::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2378,7 +2390,7 @@ impl CreateInstanceMetadata {
         self
     }
 
-    /// Sets the value of `cancel_time`.
+    /// Sets the value of [cancel_time][crate::model::CreateInstanceMetadata::cancel_time].
     pub fn set_cancel_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2387,7 +2399,7 @@ impl CreateInstanceMetadata {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::CreateInstanceMetadata::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2396,7 +2408,7 @@ impl CreateInstanceMetadata {
         self
     }
 
-    /// Sets the value of `expected_fulfillment_period`.
+    /// Sets the value of [expected_fulfillment_period][crate::model::CreateInstanceMetadata::expected_fulfillment_period].
     pub fn set_expected_fulfillment_period<
         T: std::convert::Into<crate::model::FulfillmentPeriod>,
     >(
@@ -2450,7 +2462,7 @@ pub struct UpdateInstanceMetadata {
 }
 
 impl UpdateInstanceMetadata {
-    /// Sets the value of `instance`.
+    /// Sets the value of [instance][crate::model::UpdateInstanceMetadata::instance].
     pub fn set_instance<T: std::convert::Into<std::option::Option<crate::model::Instance>>>(
         mut self,
         v: T,
@@ -2459,7 +2471,7 @@ impl UpdateInstanceMetadata {
         self
     }
 
-    /// Sets the value of `start_time`.
+    /// Sets the value of [start_time][crate::model::UpdateInstanceMetadata::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2468,7 +2480,7 @@ impl UpdateInstanceMetadata {
         self
     }
 
-    /// Sets the value of `cancel_time`.
+    /// Sets the value of [cancel_time][crate::model::UpdateInstanceMetadata::cancel_time].
     pub fn set_cancel_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2477,7 +2489,7 @@ impl UpdateInstanceMetadata {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::UpdateInstanceMetadata::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2486,7 +2498,7 @@ impl UpdateInstanceMetadata {
         self
     }
 
-    /// Sets the value of `expected_fulfillment_period`.
+    /// Sets the value of [expected_fulfillment_period][crate::model::UpdateInstanceMetadata::expected_fulfillment_period].
     pub fn set_expected_fulfillment_period<
         T: std::convert::Into<crate::model::FulfillmentPeriod>,
     >(
@@ -2530,7 +2542,7 @@ pub struct FreeInstanceMetadata {
 }
 
 impl FreeInstanceMetadata {
-    /// Sets the value of `expire_time`.
+    /// Sets the value of [expire_time][crate::model::FreeInstanceMetadata::expire_time].
     pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2539,7 +2551,7 @@ impl FreeInstanceMetadata {
         self
     }
 
-    /// Sets the value of `upgrade_time`.
+    /// Sets the value of [upgrade_time][crate::model::FreeInstanceMetadata::upgrade_time].
     pub fn set_upgrade_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2548,7 +2560,7 @@ impl FreeInstanceMetadata {
         self
     }
 
-    /// Sets the value of `expire_behavior`.
+    /// Sets the value of [expire_behavior][crate::model::FreeInstanceMetadata::expire_behavior].
     pub fn set_expire_behavior<
         T: std::convert::Into<crate::model::free_instance_metadata::ExpireBehavior>,
     >(
@@ -2631,7 +2643,7 @@ pub struct CreateInstanceConfigMetadata {
 }
 
 impl CreateInstanceConfigMetadata {
-    /// Sets the value of `instance_config`.
+    /// Sets the value of [instance_config][crate::model::CreateInstanceConfigMetadata::instance_config].
     pub fn set_instance_config<
         T: std::convert::Into<std::option::Option<crate::model::InstanceConfig>>,
     >(
@@ -2642,7 +2654,7 @@ impl CreateInstanceConfigMetadata {
         self
     }
 
-    /// Sets the value of `progress`.
+    /// Sets the value of [progress][crate::model::CreateInstanceConfigMetadata::progress].
     pub fn set_progress<
         T: std::convert::Into<std::option::Option<crate::model::OperationProgress>>,
     >(
@@ -2653,7 +2665,7 @@ impl CreateInstanceConfigMetadata {
         self
     }
 
-    /// Sets the value of `cancel_time`.
+    /// Sets the value of [cancel_time][crate::model::CreateInstanceConfigMetadata::cancel_time].
     pub fn set_cancel_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2696,7 +2708,7 @@ pub struct UpdateInstanceConfigMetadata {
 }
 
 impl UpdateInstanceConfigMetadata {
-    /// Sets the value of `instance_config`.
+    /// Sets the value of [instance_config][crate::model::UpdateInstanceConfigMetadata::instance_config].
     pub fn set_instance_config<
         T: std::convert::Into<std::option::Option<crate::model::InstanceConfig>>,
     >(
@@ -2707,7 +2719,7 @@ impl UpdateInstanceConfigMetadata {
         self
     }
 
-    /// Sets the value of `progress`.
+    /// Sets the value of [progress][crate::model::UpdateInstanceConfigMetadata::progress].
     pub fn set_progress<
         T: std::convert::Into<std::option::Option<crate::model::OperationProgress>>,
     >(
@@ -2718,7 +2730,7 @@ impl UpdateInstanceConfigMetadata {
         self
     }
 
-    /// Sets the value of `cancel_time`.
+    /// Sets the value of [cancel_time][crate::model::UpdateInstanceConfigMetadata::cancel_time].
     pub fn set_cancel_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2816,25 +2828,25 @@ pub struct InstancePartition {
 }
 
 impl InstancePartition {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::InstancePartition::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `config`.
+    /// Sets the value of [config][crate::model::InstancePartition::config].
     pub fn set_config<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.config = v.into();
         self
     }
 
-    /// Sets the value of `display_name`.
+    /// Sets the value of [display_name][crate::model::InstancePartition::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
         self
     }
 
-    /// Sets the value of `state`.
+    /// Sets the value of [state][crate::model::InstancePartition::state].
     pub fn set_state<T: std::convert::Into<crate::model::instance_partition::State>>(
         mut self,
         v: T,
@@ -2843,7 +2855,7 @@ impl InstancePartition {
         self
     }
 
-    /// Sets the value of `create_time`.
+    /// Sets the value of [create_time][crate::model::InstancePartition::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2852,7 +2864,7 @@ impl InstancePartition {
         self
     }
 
-    /// Sets the value of `update_time`.
+    /// Sets the value of [update_time][crate::model::InstancePartition::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -2861,27 +2873,31 @@ impl InstancePartition {
         self
     }
 
-    /// Sets the value of `referencing_databases`.
-    pub fn set_referencing_databases<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.referencing_databases = v.into();
-        self
-    }
-
-    /// Sets the value of `referencing_backups`.
-    pub fn set_referencing_backups<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.referencing_backups = v.into();
-        self
-    }
-
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::InstancePartition::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [referencing_databases][crate::model::InstancePartition::referencing_databases].
+    pub fn set_referencing_databases<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.referencing_databases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [referencing_backups][crate::model::InstancePartition::referencing_backups].
+    pub fn set_referencing_backups<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.referencing_backups = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -3003,7 +3019,7 @@ pub struct CreateInstancePartitionMetadata {
 }
 
 impl CreateInstancePartitionMetadata {
-    /// Sets the value of `instance_partition`.
+    /// Sets the value of [instance_partition][crate::model::CreateInstancePartitionMetadata::instance_partition].
     pub fn set_instance_partition<
         T: std::convert::Into<std::option::Option<crate::model::InstancePartition>>,
     >(
@@ -3014,7 +3030,7 @@ impl CreateInstancePartitionMetadata {
         self
     }
 
-    /// Sets the value of `start_time`.
+    /// Sets the value of [start_time][crate::model::CreateInstancePartitionMetadata::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3023,7 +3039,7 @@ impl CreateInstancePartitionMetadata {
         self
     }
 
-    /// Sets the value of `cancel_time`.
+    /// Sets the value of [cancel_time][crate::model::CreateInstancePartitionMetadata::cancel_time].
     pub fn set_cancel_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3032,7 +3048,7 @@ impl CreateInstancePartitionMetadata {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::CreateInstancePartitionMetadata::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3077,13 +3093,13 @@ pub struct CreateInstancePartitionRequest {
 }
 
 impl CreateInstancePartitionRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::CreateInstancePartitionRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `instance_partition_id`.
+    /// Sets the value of [instance_partition_id][crate::model::CreateInstancePartitionRequest::instance_partition_id].
     pub fn set_instance_partition_id<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -3092,7 +3108,7 @@ impl CreateInstancePartitionRequest {
         self
     }
 
-    /// Sets the value of `instance_partition`.
+    /// Sets the value of [instance_partition][crate::model::CreateInstancePartitionRequest::instance_partition].
     pub fn set_instance_partition<
         T: std::convert::Into<std::option::Option<crate::model::InstancePartition>>,
     >(
@@ -3134,13 +3150,13 @@ pub struct DeleteInstancePartitionRequest {
 }
 
 impl DeleteInstancePartitionRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::DeleteInstancePartitionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `etag`.
+    /// Sets the value of [etag][crate::model::DeleteInstancePartitionRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
@@ -3170,7 +3186,7 @@ pub struct GetInstancePartitionRequest {
 }
 
 impl GetInstancePartitionRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::GetInstancePartitionRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
@@ -3214,7 +3230,7 @@ pub struct UpdateInstancePartitionRequest {
 }
 
 impl UpdateInstancePartitionRequest {
-    /// Sets the value of `instance_partition`.
+    /// Sets the value of [instance_partition][crate::model::UpdateInstancePartitionRequest::instance_partition].
     pub fn set_instance_partition<
         T: std::convert::Into<std::option::Option<crate::model::InstancePartition>>,
     >(
@@ -3225,7 +3241,7 @@ impl UpdateInstancePartitionRequest {
         self
     }
 
-    /// Sets the value of `field_mask`.
+    /// Sets the value of [field_mask][crate::model::UpdateInstancePartitionRequest::field_mask].
     pub fn set_field_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -3274,7 +3290,7 @@ pub struct UpdateInstancePartitionMetadata {
 }
 
 impl UpdateInstancePartitionMetadata {
-    /// Sets the value of `instance_partition`.
+    /// Sets the value of [instance_partition][crate::model::UpdateInstancePartitionMetadata::instance_partition].
     pub fn set_instance_partition<
         T: std::convert::Into<std::option::Option<crate::model::InstancePartition>>,
     >(
@@ -3285,7 +3301,7 @@ impl UpdateInstancePartitionMetadata {
         self
     }
 
-    /// Sets the value of `start_time`.
+    /// Sets the value of [start_time][crate::model::UpdateInstancePartitionMetadata::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3294,7 +3310,7 @@ impl UpdateInstancePartitionMetadata {
         self
     }
 
-    /// Sets the value of `cancel_time`.
+    /// Sets the value of [cancel_time][crate::model::UpdateInstancePartitionMetadata::cancel_time].
     pub fn set_cancel_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3303,7 +3319,7 @@ impl UpdateInstancePartitionMetadata {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::UpdateInstancePartitionMetadata::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -3363,25 +3379,25 @@ pub struct ListInstancePartitionsRequest {
 }
 
 impl ListInstancePartitionsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListInstancePartitionsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListInstancePartitionsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListInstancePartitionsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `instance_partition_deadline`.
+    /// Sets the value of [instance_partition_deadline][crate::model::ListInstancePartitionsRequest::instance_partition_deadline].
     pub fn set_instance_partition_deadline<
         T: std::convert::Into<std::option::Option<wkt::Timestamp>>,
     >(
@@ -3431,29 +3447,31 @@ pub struct ListInstancePartitionsResponse {
 }
 
 impl ListInstancePartitionsResponse {
-    /// Sets the value of `instance_partitions`.
-    pub fn set_instance_partitions<
-        T: std::convert::Into<std::vec::Vec<crate::model::InstancePartition>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.instance_partitions = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListInstancePartitionsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `unreachable`.
-    pub fn set_unreachable<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.unreachable = v.into();
+    /// Sets the value of [instance_partitions][crate::model::ListInstancePartitionsResponse::instance_partitions].
+    pub fn set_instance_partitions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::InstancePartition>,
+    {
+        use std::iter::Iterator;
+        self.instance_partitions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [unreachable][crate::model::ListInstancePartitionsResponse::unreachable].
+    pub fn set_unreachable<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.unreachable = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3567,31 +3585,31 @@ pub struct ListInstancePartitionOperationsRequest {
 }
 
 impl ListInstancePartitionOperationsRequest {
-    /// Sets the value of `parent`.
+    /// Sets the value of [parent][crate::model::ListInstancePartitionOperationsRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
         self
     }
 
-    /// Sets the value of `filter`.
+    /// Sets the value of [filter][crate::model::ListInstancePartitionOperationsRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
         self
     }
 
-    /// Sets the value of `page_size`.
+    /// Sets the value of [page_size][crate::model::ListInstancePartitionOperationsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
         self
     }
 
-    /// Sets the value of `page_token`.
+    /// Sets the value of [page_token][crate::model::ListInstancePartitionOperationsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of `instance_partition_deadline`.
+    /// Sets the value of [instance_partition_deadline][crate::model::ListInstancePartitionOperationsRequest::instance_partition_deadline].
     pub fn set_instance_partition_deadline<
         T: std::convert::Into<std::option::Option<wkt::Timestamp>>,
     >(
@@ -3645,29 +3663,31 @@ pub struct ListInstancePartitionOperationsResponse {
 }
 
 impl ListInstancePartitionOperationsResponse {
-    /// Sets the value of `operations`.
-    pub fn set_operations<T: std::convert::Into<std::vec::Vec<longrunning::model::Operation>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.operations = v.into();
-        self
-    }
-
-    /// Sets the value of `next_page_token`.
+    /// Sets the value of [next_page_token][crate::model::ListInstancePartitionOperationsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
         self
     }
 
-    /// Sets the value of `unreachable_instance_partitions`.
-    pub fn set_unreachable_instance_partitions<
-        T: std::convert::Into<std::vec::Vec<std::string::String>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.unreachable_instance_partitions = v.into();
+    /// Sets the value of [operations][crate::model::ListInstancePartitionOperationsResponse::operations].
+    pub fn set_operations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<longrunning::model::Operation>,
+    {
+        use std::iter::Iterator;
+        self.operations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [unreachable_instance_partitions][crate::model::ListInstancePartitionOperationsResponse::unreachable_instance_partitions].
+    pub fn set_unreachable_instance_partitions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.unreachable_instance_partitions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3712,13 +3732,13 @@ pub struct MoveInstanceRequest {
 }
 
 impl MoveInstanceRequest {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::model::MoveInstanceRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `target_config`.
+    /// Sets the value of [target_config][crate::model::MoveInstanceRequest::target_config].
     pub fn set_target_config<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.target_config = v.into();
         self
@@ -3780,13 +3800,13 @@ pub struct MoveInstanceMetadata {
 }
 
 impl MoveInstanceMetadata {
-    /// Sets the value of `target_config`.
+    /// Sets the value of [target_config][crate::model::MoveInstanceMetadata::target_config].
     pub fn set_target_config<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.target_config = v.into();
         self
     }
 
-    /// Sets the value of `progress`.
+    /// Sets the value of [progress][crate::model::MoveInstanceMetadata::progress].
     pub fn set_progress<
         T: std::convert::Into<std::option::Option<crate::model::OperationProgress>>,
     >(
@@ -3797,7 +3817,7 @@ impl MoveInstanceMetadata {
         self
     }
 
-    /// Sets the value of `cancel_time`.
+    /// Sets the value of [cancel_time][crate::model::MoveInstanceMetadata::cancel_time].
     pub fn set_cancel_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,

--- a/src/generated/type/src/model.rs
+++ b/src/generated/type/src/model.rs
@@ -184,25 +184,25 @@ pub struct Color {
 }
 
 impl Color {
-    /// Sets the value of `red`.
+    /// Sets the value of [red][crate::model::Color::red].
     pub fn set_red<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
         self.red = v.into();
         self
     }
 
-    /// Sets the value of `green`.
+    /// Sets the value of [green][crate::model::Color::green].
     pub fn set_green<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
         self.green = v.into();
         self
     }
 
-    /// Sets the value of `blue`.
+    /// Sets the value of [blue][crate::model::Color::blue].
     pub fn set_blue<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
         self.blue = v.into();
         self
     }
 
-    /// Sets the value of `alpha`.
+    /// Sets the value of [alpha][crate::model::Color::alpha].
     pub fn set_alpha<T: std::convert::Into<std::option::Option<wkt::FloatValue>>>(
         mut self,
         v: T,
@@ -253,19 +253,19 @@ pub struct Date {
 }
 
 impl Date {
-    /// Sets the value of `year`.
+    /// Sets the value of [year][crate::model::Date::year].
     pub fn set_year<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.year = v.into();
         self
     }
 
-    /// Sets the value of `month`.
+    /// Sets the value of [month][crate::model::Date::month].
     pub fn set_month<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.month = v.into();
         self
     }
 
-    /// Sets the value of `day`.
+    /// Sets the value of [day][crate::model::Date::day].
     pub fn set_day<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.day = v.into();
         self
@@ -344,43 +344,43 @@ pub struct DateTime {
 }
 
 impl DateTime {
-    /// Sets the value of `year`.
+    /// Sets the value of [year][crate::model::DateTime::year].
     pub fn set_year<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.year = v.into();
         self
     }
 
-    /// Sets the value of `month`.
+    /// Sets the value of [month][crate::model::DateTime::month].
     pub fn set_month<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.month = v.into();
         self
     }
 
-    /// Sets the value of `day`.
+    /// Sets the value of [day][crate::model::DateTime::day].
     pub fn set_day<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.day = v.into();
         self
     }
 
-    /// Sets the value of `hours`.
+    /// Sets the value of [hours][crate::model::DateTime::hours].
     pub fn set_hours<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.hours = v.into();
         self
     }
 
-    /// Sets the value of `minutes`.
+    /// Sets the value of [minutes][crate::model::DateTime::minutes].
     pub fn set_minutes<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.minutes = v.into();
         self
     }
 
-    /// Sets the value of `seconds`.
+    /// Sets the value of [seconds][crate::model::DateTime::seconds].
     pub fn set_seconds<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.seconds = v.into();
         self
     }
 
-    /// Sets the value of `nanos`.
+    /// Sets the value of [nanos][crate::model::DateTime::nanos].
     pub fn set_nanos<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.nanos = v.into();
         self
@@ -444,13 +444,13 @@ pub struct TimeZone {
 }
 
 impl TimeZone {
-    /// Sets the value of `id`.
+    /// Sets the value of [id][crate::model::TimeZone::id].
     pub fn set_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.id = v.into();
         self
     }
 
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::model::TimeZone::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
@@ -543,7 +543,7 @@ pub struct Decimal {
 }
 
 impl Decimal {
-    /// Sets the value of `value`.
+    /// Sets the value of [value][crate::model::Decimal::value].
     pub fn set_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.value = v.into();
         self
@@ -623,25 +623,25 @@ pub struct Expr {
 }
 
 impl Expr {
-    /// Sets the value of `expression`.
+    /// Sets the value of [expression][crate::model::Expr::expression].
     pub fn set_expression<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.expression = v.into();
         self
     }
 
-    /// Sets the value of `title`.
+    /// Sets the value of [title][crate::model::Expr::title].
     pub fn set_title<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.title = v.into();
         self
     }
 
-    /// Sets the value of `description`.
+    /// Sets the value of [description][crate::model::Expr::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
         self
     }
 
-    /// Sets the value of `location`.
+    /// Sets the value of [location][crate::model::Expr::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
@@ -671,13 +671,13 @@ pub struct Fraction {
 }
 
 impl Fraction {
-    /// Sets the value of `numerator`.
+    /// Sets the value of [numerator][crate::model::Fraction::numerator].
     pub fn set_numerator<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.numerator = v.into();
         self
     }
 
-    /// Sets the value of `denominator`.
+    /// Sets the value of [denominator][crate::model::Fraction::denominator].
     pub fn set_denominator<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.denominator = v.into();
         self
@@ -717,7 +717,7 @@ pub struct Interval {
 }
 
 impl Interval {
-    /// Sets the value of `start_time`.
+    /// Sets the value of [start_time][crate::model::Interval::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -726,7 +726,7 @@ impl Interval {
         self
     }
 
-    /// Sets the value of `end_time`.
+    /// Sets the value of [end_time][crate::model::Interval::end_time].
     pub fn set_end_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -760,13 +760,13 @@ pub struct LatLng {
 }
 
 impl LatLng {
-    /// Sets the value of `latitude`.
+    /// Sets the value of [latitude][crate::model::LatLng::latitude].
     pub fn set_latitude<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
         self.latitude = v.into();
         self
     }
 
-    /// Sets the value of `longitude`.
+    /// Sets the value of [longitude][crate::model::LatLng::longitude].
     pub fn set_longitude<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
         self.longitude = v.into();
         self
@@ -798,13 +798,13 @@ pub struct LocalizedText {
 }
 
 impl LocalizedText {
-    /// Sets the value of `text`.
+    /// Sets the value of [text][crate::model::LocalizedText::text].
     pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.text = v.into();
         self
     }
 
-    /// Sets the value of `language_code`.
+    /// Sets the value of [language_code][crate::model::LocalizedText::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
         self
@@ -842,19 +842,19 @@ pub struct Money {
 }
 
 impl Money {
-    /// Sets the value of `currency_code`.
+    /// Sets the value of [currency_code][crate::model::Money::currency_code].
     pub fn set_currency_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.currency_code = v.into();
         self
     }
 
-    /// Sets the value of `units`.
+    /// Sets the value of [units][crate::model::Money::units].
     pub fn set_units<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.units = v.into();
         self
     }
 
-    /// Sets the value of `nanos`.
+    /// Sets the value of [nanos][crate::model::Money::nanos].
     pub fn set_nanos<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.nanos = v.into();
         self
@@ -921,7 +921,7 @@ pub struct PhoneNumber {
 }
 
 impl PhoneNumber {
-    /// Sets the value of `extension`.
+    /// Sets the value of [extension][crate::model::PhoneNumber::extension].
     pub fn set_extension<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.extension = v.into();
         self
@@ -980,13 +980,13 @@ pub mod phone_number {
     }
 
     impl ShortCode {
-        /// Sets the value of `region_code`.
+        /// Sets the value of [region_code][crate::model::phone_number::ShortCode::region_code].
         pub fn set_region_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.region_code = v.into();
             self
         }
 
-        /// Sets the value of `number`.
+        /// Sets the value of [number][crate::model::phone_number::ShortCode::number].
         pub fn set_number<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.number = v.into();
             self
@@ -1159,37 +1159,37 @@ pub struct PostalAddress {
 }
 
 impl PostalAddress {
-    /// Sets the value of `revision`.
+    /// Sets the value of [revision][crate::model::PostalAddress::revision].
     pub fn set_revision<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.revision = v.into();
         self
     }
 
-    /// Sets the value of `region_code`.
+    /// Sets the value of [region_code][crate::model::PostalAddress::region_code].
     pub fn set_region_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.region_code = v.into();
         self
     }
 
-    /// Sets the value of `language_code`.
+    /// Sets the value of [language_code][crate::model::PostalAddress::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
         self
     }
 
-    /// Sets the value of `postal_code`.
+    /// Sets the value of [postal_code][crate::model::PostalAddress::postal_code].
     pub fn set_postal_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.postal_code = v.into();
         self
     }
 
-    /// Sets the value of `sorting_code`.
+    /// Sets the value of [sorting_code][crate::model::PostalAddress::sorting_code].
     pub fn set_sorting_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.sorting_code = v.into();
         self
     }
 
-    /// Sets the value of `administrative_area`.
+    /// Sets the value of [administrative_area][crate::model::PostalAddress::administrative_area].
     pub fn set_administrative_area<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -1198,39 +1198,43 @@ impl PostalAddress {
         self
     }
 
-    /// Sets the value of `locality`.
+    /// Sets the value of [locality][crate::model::PostalAddress::locality].
     pub fn set_locality<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.locality = v.into();
         self
     }
 
-    /// Sets the value of `sublocality`.
+    /// Sets the value of [sublocality][crate::model::PostalAddress::sublocality].
     pub fn set_sublocality<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.sublocality = v.into();
         self
     }
 
-    /// Sets the value of `address_lines`.
-    pub fn set_address_lines<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.address_lines = v.into();
-        self
-    }
-
-    /// Sets the value of `recipients`.
-    pub fn set_recipients<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.recipients = v.into();
-        self
-    }
-
-    /// Sets the value of `organization`.
+    /// Sets the value of [organization][crate::model::PostalAddress::organization].
     pub fn set_organization<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.organization = v.into();
+        self
+    }
+
+    /// Sets the value of [address_lines][crate::model::PostalAddress::address_lines].
+    pub fn set_address_lines<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.address_lines = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [recipients][crate::model::PostalAddress::recipients].
+    pub fn set_recipients<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.recipients = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1319,25 +1323,25 @@ pub struct Quaternion {
 }
 
 impl Quaternion {
-    /// Sets the value of `x`.
+    /// Sets the value of [x][crate::model::Quaternion::x].
     pub fn set_x<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
         self.x = v.into();
         self
     }
 
-    /// Sets the value of `y`.
+    /// Sets the value of [y][crate::model::Quaternion::y].
     pub fn set_y<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
         self.y = v.into();
         self
     }
 
-    /// Sets the value of `z`.
+    /// Sets the value of [z][crate::model::Quaternion::z].
     pub fn set_z<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
         self.z = v.into();
         self
     }
 
-    /// Sets the value of `w`.
+    /// Sets the value of [w][crate::model::Quaternion::w].
     pub fn set_w<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
         self.w = v.into();
         self
@@ -1377,25 +1381,25 @@ pub struct TimeOfDay {
 }
 
 impl TimeOfDay {
-    /// Sets the value of `hours`.
+    /// Sets the value of [hours][crate::model::TimeOfDay::hours].
     pub fn set_hours<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.hours = v.into();
         self
     }
 
-    /// Sets the value of `minutes`.
+    /// Sets the value of [minutes][crate::model::TimeOfDay::minutes].
     pub fn set_minutes<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.minutes = v.into();
         self
     }
 
-    /// Sets the value of `seconds`.
+    /// Sets the value of [seconds][crate::model::TimeOfDay::seconds].
     pub fn set_seconds<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.seconds = v.into();
         self
     }
 
-    /// Sets the value of `nanos`.
+    /// Sets the value of [nanos][crate::model::TimeOfDay::nanos].
     pub fn set_nanos<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.nanos = v.into();
         self

--- a/src/integration-tests/src/secret_manager/openapi.rs
+++ b/src/integration-tests/src/secret_manager/openapi.rs
@@ -60,9 +60,7 @@ pub async fn run(config: Option<gax::options::ClientConfig>) -> Result<()> {
                     smo::model::Replication::default()
                         .set_automatic(smo::model::Automatic::default()),
                 )
-                .set_labels(
-                    [("integration-test", "true")].map(|(k, v)| (k.to_string(), v.to_string())),
-                ),
+                .set_labels([("integration-test", "true")]),
         )
         .send()
         .await?;

--- a/src/integration-tests/src/secret_manager/openapi_locational.rs
+++ b/src/integration-tests/src/secret_manager/openapi_locational.rs
@@ -50,9 +50,7 @@ pub async fn run(config: Option<gax::options::ClientConfig>) -> Result<()> {
     let create = client
         .create_secret_by_project_and_location(&project_id, &location_id)
         .set_secret_id(&secret_id)
-        .set_request_body(smo::model::Secret::default().set_labels(
-            [("integration-test", "true")].map(|(k, v)| (k.to_string(), v.to_string())),
-        ))
+        .set_request_body(smo::model::Secret::default().set_labels([("integration-test", "true")]))
         .send()
         .await?;
     println!("CREATE = {create:?}");

--- a/src/integration-tests/src/secret_manager/protobuf.rs
+++ b/src/integration-tests/src/secret_manager/protobuf.rs
@@ -66,9 +66,7 @@ pub async fn run(config: Option<gax::options::ClientConfig>) -> Result<()> {
                         sm::model::replication::Automatic::default(),
                     ),
                 ))
-                .set_labels(
-                    [("integration-test", "true")].map(|(k, v)| (k.to_string(), v.to_string())),
-                ),
+                .set_labels([("integration-test", "true")]),
         )
         .send()
         .await?;

--- a/src/integration-tests/src/workflows.rs
+++ b/src/integration-tests/src/workflows.rs
@@ -72,9 +72,7 @@ main:
         .set_workflow_id(&workflow_id)
         .set_workflow(
             wf::model::Workflow::default()
-                .set_labels(
-                    [("integration-test", "true")].map(|(k, v)| (k.to_string(), v.to_string())),
-                )
+                .set_labels([("integration-test", "true")])
                 .set_call_log_level(
                     wf::model::workflow::CallLogLevel::default()
                         .set_value(wf::model::workflow::call_log_level::LOG_ERRORS_ONLY),
@@ -156,9 +154,7 @@ main:
         .set_workflow_id(&workflow_id)
         .set_workflow(
             wf::model::Workflow::default()
-                .set_labels(
-                    [("integration-test", "true")].map(|(k, v)| (k.to_string(), v.to_string())),
-                )
+                .set_labels([("integration-test", "true")])
                 .set_call_log_level(
                     wf::model::workflow::CallLogLevel::default()
                         .set_value(wf::model::workflow::call_log_level::LOG_ERRORS_ONLY),

--- a/src/wkt/src/generated/mod.rs
+++ b/src/wkt/src/generated/mod.rs
@@ -81,37 +81,19 @@ pub struct Api {
 }
 
 impl Api {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::Api::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `methods`.
-    pub fn set_methods<T: std::convert::Into<std::vec::Vec<crate::Method>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.methods = v.into();
-        self
-    }
-
-    /// Sets the value of `options`.
-    pub fn set_options<T: std::convert::Into<std::vec::Vec<crate::Option>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.options = v.into();
-        self
-    }
-
-    /// Sets the value of `version`.
+    /// Sets the value of [version][crate::Api::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
         self
     }
 
-    /// Sets the value of `source_context`.
+    /// Sets the value of [source_context][crate::Api::source_context].
     pub fn set_source_context<T: std::convert::Into<std::option::Option<crate::SourceContext>>>(
         mut self,
         v: T,
@@ -120,15 +102,42 @@ impl Api {
         self
     }
 
-    /// Sets the value of `mixins`.
-    pub fn set_mixins<T: std::convert::Into<std::vec::Vec<crate::Mixin>>>(mut self, v: T) -> Self {
-        self.mixins = v.into();
+    /// Sets the value of [syntax][crate::Api::syntax].
+    pub fn set_syntax<T: std::convert::Into<crate::Syntax>>(mut self, v: T) -> Self {
+        self.syntax = v.into();
         self
     }
 
-    /// Sets the value of `syntax`.
-    pub fn set_syntax<T: std::convert::Into<crate::Syntax>>(mut self, v: T) -> Self {
-        self.syntax = v.into();
+    /// Sets the value of [methods][crate::Api::methods].
+    pub fn set_methods<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::Method>,
+    {
+        use std::iter::Iterator;
+        self.methods = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [options][crate::Api::options].
+    pub fn set_options<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::Option>,
+    {
+        use std::iter::Iterator;
+        self.options = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [mixins][crate::Api::mixins].
+    pub fn set_mixins<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::Mixin>,
+    {
+        use std::iter::Iterator;
+        self.mixins = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -172,13 +181,13 @@ pub struct Method {
 }
 
 impl Method {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::Method::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `request_type_url`.
+    /// Sets the value of [request_type_url][crate::Method::request_type_url].
     pub fn set_request_type_url<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -187,13 +196,13 @@ impl Method {
         self
     }
 
-    /// Sets the value of `request_streaming`.
+    /// Sets the value of [request_streaming][crate::Method::request_streaming].
     pub fn set_request_streaming<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.request_streaming = v.into();
         self
     }
 
-    /// Sets the value of `response_type_url`.
+    /// Sets the value of [response_type_url][crate::Method::response_type_url].
     pub fn set_response_type_url<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -202,24 +211,26 @@ impl Method {
         self
     }
 
-    /// Sets the value of `response_streaming`.
+    /// Sets the value of [response_streaming][crate::Method::response_streaming].
     pub fn set_response_streaming<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.response_streaming = v.into();
         self
     }
 
-    /// Sets the value of `options`.
-    pub fn set_options<T: std::convert::Into<std::vec::Vec<crate::Option>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.options = v.into();
+    /// Sets the value of [syntax][crate::Method::syntax].
+    pub fn set_syntax<T: std::convert::Into<crate::Syntax>>(mut self, v: T) -> Self {
+        self.syntax = v.into();
         self
     }
 
-    /// Sets the value of `syntax`.
-    pub fn set_syntax<T: std::convert::Into<crate::Syntax>>(mut self, v: T) -> Self {
-        self.syntax = v.into();
+    /// Sets the value of [options][crate::Method::options].
+    pub fn set_options<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::Option>,
+    {
+        use std::iter::Iterator;
+        self.options = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -335,13 +346,13 @@ pub struct Mixin {
 }
 
 impl Mixin {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::Mixin::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `root`.
+    /// Sets the value of [root][crate::Mixin::root].
     pub fn set_root<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.root = v.into();
         self
@@ -368,7 +379,7 @@ pub struct SourceContext {
 }
 
 impl SourceContext {
-    /// Sets the value of `file_name`.
+    /// Sets the value of [file_name][crate::SourceContext::file_name].
     pub fn set_file_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.file_name = v.into();
         self
@@ -416,37 +427,13 @@ pub struct Type {
 }
 
 impl Type {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::Type::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `fields`.
-    pub fn set_fields<T: std::convert::Into<std::vec::Vec<crate::Field>>>(mut self, v: T) -> Self {
-        self.fields = v.into();
-        self
-    }
-
-    /// Sets the value of `oneofs`.
-    pub fn set_oneofs<T: std::convert::Into<std::vec::Vec<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.oneofs = v.into();
-        self
-    }
-
-    /// Sets the value of `options`.
-    pub fn set_options<T: std::convert::Into<std::vec::Vec<crate::Option>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.options = v.into();
-        self
-    }
-
-    /// Sets the value of `source_context`.
+    /// Sets the value of [source_context][crate::Type::source_context].
     pub fn set_source_context<T: std::convert::Into<std::option::Option<crate::SourceContext>>>(
         mut self,
         v: T,
@@ -455,15 +442,48 @@ impl Type {
         self
     }
 
-    /// Sets the value of `syntax`.
+    /// Sets the value of [syntax][crate::Type::syntax].
     pub fn set_syntax<T: std::convert::Into<crate::Syntax>>(mut self, v: T) -> Self {
         self.syntax = v.into();
         self
     }
 
-    /// Sets the value of `edition`.
+    /// Sets the value of [edition][crate::Type::edition].
     pub fn set_edition<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.edition = v.into();
+        self
+    }
+
+    /// Sets the value of [fields][crate::Type::fields].
+    pub fn set_fields<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::Field>,
+    {
+        use std::iter::Iterator;
+        self.fields = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [oneofs][crate::Type::oneofs].
+    pub fn set_oneofs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.oneofs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [options][crate::Type::options].
+    pub fn set_options<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::Option>,
+    {
+        use std::iter::Iterator;
+        self.options = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -519,13 +539,13 @@ pub struct Field {
 }
 
 impl Field {
-    /// Sets the value of `kind`.
+    /// Sets the value of [kind][crate::Field::kind].
     pub fn set_kind<T: std::convert::Into<crate::field::Kind>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of `cardinality`.
+    /// Sets the value of [cardinality][crate::Field::cardinality].
     pub fn set_cardinality<T: std::convert::Into<crate::field::Cardinality>>(
         mut self,
         v: T,
@@ -534,54 +554,56 @@ impl Field {
         self
     }
 
-    /// Sets the value of `number`.
+    /// Sets the value of [number][crate::Field::number].
     pub fn set_number<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.number = v.into();
         self
     }
 
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::Field::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `type_url`.
+    /// Sets the value of [type_url][crate::Field::type_url].
     pub fn set_type_url<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.type_url = v.into();
         self
     }
 
-    /// Sets the value of `oneof_index`.
+    /// Sets the value of [oneof_index][crate::Field::oneof_index].
     pub fn set_oneof_index<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.oneof_index = v.into();
         self
     }
 
-    /// Sets the value of `packed`.
+    /// Sets the value of [packed][crate::Field::packed].
     pub fn set_packed<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.packed = v.into();
         self
     }
 
-    /// Sets the value of `options`.
-    pub fn set_options<T: std::convert::Into<std::vec::Vec<crate::Option>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.options = v.into();
-        self
-    }
-
-    /// Sets the value of `json_name`.
+    /// Sets the value of [json_name][crate::Field::json_name].
     pub fn set_json_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.json_name = v.into();
         self
     }
 
-    /// Sets the value of `default_value`.
+    /// Sets the value of [default_value][crate::Field::default_value].
     pub fn set_default_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.default_value = v.into();
+        self
+    }
+
+    /// Sets the value of [options][crate::Field::options].
+    pub fn set_options<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::Option>,
+    {
+        use std::iter::Iterator;
+        self.options = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -740,31 +762,13 @@ pub struct Enum {
 }
 
 impl Enum {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::Enum::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `enumvalue`.
-    pub fn set_enumvalue<T: std::convert::Into<std::vec::Vec<crate::EnumValue>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.enumvalue = v.into();
-        self
-    }
-
-    /// Sets the value of `options`.
-    pub fn set_options<T: std::convert::Into<std::vec::Vec<crate::Option>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.options = v.into();
-        self
-    }
-
-    /// Sets the value of `source_context`.
+    /// Sets the value of [source_context][crate::Enum::source_context].
     pub fn set_source_context<T: std::convert::Into<std::option::Option<crate::SourceContext>>>(
         mut self,
         v: T,
@@ -773,15 +777,37 @@ impl Enum {
         self
     }
 
-    /// Sets the value of `syntax`.
+    /// Sets the value of [syntax][crate::Enum::syntax].
     pub fn set_syntax<T: std::convert::Into<crate::Syntax>>(mut self, v: T) -> Self {
         self.syntax = v.into();
         self
     }
 
-    /// Sets the value of `edition`.
+    /// Sets the value of [edition][crate::Enum::edition].
     pub fn set_edition<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.edition = v.into();
+        self
+    }
+
+    /// Sets the value of [enumvalue][crate::Enum::enumvalue].
+    pub fn set_enumvalue<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::EnumValue>,
+    {
+        use std::iter::Iterator;
+        self.enumvalue = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [options][crate::Enum::options].
+    pub fn set_options<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::Option>,
+    {
+        use std::iter::Iterator;
+        self.options = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -811,24 +837,26 @@ pub struct EnumValue {
 }
 
 impl EnumValue {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::EnumValue::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `number`.
+    /// Sets the value of [number][crate::EnumValue::number].
     pub fn set_number<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.number = v.into();
         self
     }
 
-    /// Sets the value of `options`.
-    pub fn set_options<T: std::convert::Into<std::vec::Vec<crate::Option>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.options = v.into();
+    /// Sets the value of [options][crate::EnumValue::options].
+    pub fn set_options<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::Option>,
+    {
+        use std::iter::Iterator;
+        self.options = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -862,13 +890,13 @@ pub struct Option {
 }
 
 impl Option {
-    /// Sets the value of `name`.
+    /// Sets the value of [name][crate::Option::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
-    /// Sets the value of `value`.
+    /// Sets the value of [value][crate::Option::value].
     pub fn set_value<T: std::convert::Into<std::option::Option<crate::Any>>>(
         mut self,
         v: T,


### PR DESCRIPTION
The setters for `Vec<T>` fields now consume a `IntoIterator<Item = V>` where
`V` implements `Into<T>`.  Similarly, the setters for `HashMap<K, V>` fields
consume a `IntoIterator<Item = (KI, VI)>` where `KI` and `VI` do what you
expect.
    
I changed the integration tests to take advantage of this change.
    
Since I was changing all the setters, I also updated their comments to directly
link the field they are changing. That makes it easier to navigate to a
description of the field.

Fixes #627 and fixes #461. Related to #460.
