### PR TITLE
fix(generator/rust): MOAR cross-reference links

### DIFF
--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/model.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/model.rs
@@ -669,6 +669,7 @@ pub mod replication {
             /// afterwards. They do not apply retroactively to existing
             /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
             ///
+            /// [Replication.UserManaged.Replica]: crate::model::replication::user_managed::Replica
             /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
             /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
             #[serde(skip_serializing_if = "std::option::Option::is_none")]

--- a/src/generated/cloud/secretmanager/v1/src/model.rs
+++ b/src/generated/cloud/secretmanager/v1/src/model.rs
@@ -727,6 +727,7 @@ pub mod replication {
             /// afterwards. They do not apply retroactively to existing
             /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion].
             ///
+            /// [Replication.UserManaged.Replica]: crate::model::replication::user_managed::Replica
             /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
             /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
             #[serde(skip_serializing_if = "std::option::Option::is_none")]

--- a/src/generated/container/v1/src/model.rs
+++ b/src/generated/container/v1/src/model.rs
@@ -7233,6 +7233,8 @@ pub mod operation {
         ///
         /// In the event of the operation failing, the cluster will enter the [ERROR
         /// state][Cluster.Status.ERROR] and eventually be deleted.
+        ///
+        /// [Cluster.Status.ERROR]: crate::model::cluster::status::ERROR
         pub const CREATE_CLUSTER: &str = "CREATE_CLUSTER";
 
         /// The cluster is being deleted. The cluster should be assumed to be
@@ -7241,6 +7243,8 @@ pub mod operation {
         /// In the event of the operation failing, the cluster will enter the [ERROR
         /// state][Cluster.Status.ERROR] and the deletion will be automatically
         /// retried until completed.
+        ///
+        /// [Cluster.Status.ERROR]: crate::model::cluster::status::ERROR
         pub const DELETE_CLUSTER: &str = "DELETE_CLUSTER";
 
         /// The [cluster

--- a/src/wkt/src/generated/mod.rs
+++ b/src/wkt/src/generated/mod.rs
@@ -73,6 +73,8 @@ pub struct Api {
     pub source_context: std::option::Option<crate::SourceContext>,
 
     /// Included interfaces. See [Mixin][].
+    ///
+    /// [Mixin]: crate::Mixin
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub mixins: std::vec::Vec<crate::Mixin>,
 
@@ -330,6 +332,8 @@ impl wkt::message::Message for Method {
 ///   ...
 /// }
 /// ```
+///
+/// [Mixin.root]: crate::Mixin::root
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]


### PR DESCRIPTION
Fixed handling of implied (`[Thing][]`) and relative (`[blah][Thing]`)
cross-reference links. So far we only supported the fully-qualified
kind (as in `[blah][google.test.v1.Thing]`).

Fixes #850
