### PR TITLE
feat(generator/rust): box messages in `oneof`

### DIFF
--- a/generator/internal/language/codec.go
+++ b/generator/internal/language/codec.go
@@ -100,3 +100,13 @@ func hasNestedTypes(m *api.Message) bool {
 	}
 	return false
 }
+
+func fieldIsMap(f *api.Field, state *api.APIState) bool {
+	if f.Typez != api.MESSAGE_TYPE {
+		return false
+	}
+	if m, ok := state.MessageByID[f.TypezID]; ok {
+		return m.IsMap
+	}
+	return false
+}

--- a/generator/internal/language/templates/rust/common/oneof.mustache
+++ b/generator/internal/language/templates/rust/common/oneof.mustache
@@ -25,6 +25,6 @@ pub enum {{Codec.EnumName}} {
     {{#Codec.DocLines}}
     {{{.}}}
     {{/Codec.DocLines}}
-    {{Codec.BranchName}}{{{Codec.FieldType}}},
+    {{Codec.BranchName}}({{{Codec.FieldType}}}),
     {{/Fields}}
 }

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/model.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/model.rs
@@ -301,12 +301,12 @@ pub mod secret {
         /// This is always provided on output, regardless of what was sent on input.
         ///
         /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-        ExpireTime(wkt::Timestamp),
+        ExpireTime(std::boxed::Box<wkt::Timestamp>),
         /// Input only. The TTL for the
         /// [Secret][google.cloud.secretmanager.v1.Secret].
         ///
         /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-        Ttl(wkt::Duration),
+        Ttl(std::boxed::Box<wkt::Duration>),
     }
 }
 
@@ -707,12 +707,12 @@ pub mod replication {
         /// replicated without any restrictions.
         ///
         /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-        Automatic(crate::model::replication::Automatic),
+        Automatic(std::boxed::Box<crate::model::replication::Automatic>),
         /// The [Secret][google.cloud.secretmanager.v1.Secret] will only be
         /// replicated into the locations specified.
         ///
         /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-        UserManaged(crate::model::replication::UserManaged),
+        UserManaged(std::boxed::Box<crate::model::replication::UserManaged>),
     }
 }
 
@@ -950,7 +950,7 @@ pub mod replication_status {
         ///
         /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
         /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-        Automatic(crate::model::replication_status::AutomaticStatus),
+        Automatic(std::boxed::Box<crate::model::replication_status::AutomaticStatus>),
         /// Describes the replication status of a
         /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] with
         /// user-managed replication.
@@ -961,7 +961,7 @@ pub mod replication_status {
         ///
         /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
         /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-        UserManaged(crate::model::replication_status::UserManagedStatus),
+        UserManaged(std::boxed::Box<crate::model::replication_status::UserManagedStatus>),
     }
 }
 

--- a/src/generated/api/src/model.rs
+++ b/src/generated/api/src/model.rs
@@ -2864,11 +2864,13 @@ pub mod distribution {
         #[non_exhaustive]
         pub enum Options {
             /// The linear bucket.
-            LinearBuckets(crate::model::distribution::bucket_options::Linear),
+            LinearBuckets(std::boxed::Box<crate::model::distribution::bucket_options::Linear>),
             /// The exponential buckets.
-            ExponentialBuckets(crate::model::distribution::bucket_options::Exponential),
+            ExponentialBuckets(
+                std::boxed::Box<crate::model::distribution::bucket_options::Exponential>,
+            ),
             /// The explicit buckets.
-            ExplicitBuckets(crate::model::distribution::bucket_options::Explicit),
+            ExplicitBuckets(std::boxed::Box<crate::model::distribution::bucket_options::Explicit>),
         }
     }
 
@@ -3880,7 +3882,7 @@ pub mod http_rule {
         /// included in the `pattern` field, such as HEAD, or "*" to leave the
         /// HTTP method unspecified for this rule. The wild-card rule is useful
         /// for services that provide content to Web (HTML) clients.
-        Custom(crate::model::CustomHttpPattern),
+        Custom(std::boxed::Box<crate::model::CustomHttpPattern>),
     }
 }
 

--- a/src/generated/bigtable/admin/v2/src/model.rs
+++ b/src/generated/bigtable/admin/v2/src/model.rs
@@ -1594,7 +1594,7 @@ pub mod restore_table_metadata {
     #[serde(rename_all = "camelCase")]
     #[non_exhaustive]
     pub enum SourceInfo {
-        BackupInfo(crate::model::BackupInfo),
+        BackupInfo(std::boxed::Box<crate::model::BackupInfo>),
     }
 }
 
@@ -2400,10 +2400,10 @@ pub mod modify_column_families_request {
         pub enum Mod {
             /// Create a new column family with the specified schema, or fail if
             /// one already exists with the given ID.
-            Create(crate::model::ColumnFamily),
+            Create(std::boxed::Box<crate::model::ColumnFamily>),
             /// Update an existing column family to the specified schema, or fail
             /// if no column family exists with the given ID.
-            Update(crate::model::ColumnFamily),
+            Update(std::boxed::Box<crate::model::ColumnFamily>),
             /// Drop (delete) the column family with the given ID, or fail if no such
             /// family exists.
             Drop(bool),
@@ -2545,11 +2545,11 @@ pub mod check_consistency_request {
         /// Checks that reads using an app profile with `StandardIsolation` can
         /// see all writes committed before the token was created, even if the
         /// read and write target different clusters.
-        StandardReadRemoteWrites(crate::model::StandardReadRemoteWrites),
+        StandardReadRemoteWrites(std::boxed::Box<crate::model::StandardReadRemoteWrites>),
         /// Checks that reads using an app profile with `DataBoostIsolationReadOnly`
         /// can see all writes committed before the token was created, but only if
         /// the read and write target the same cluster.
-        DataBoostReadLocalWrites(crate::model::DataBoostReadLocalWrites),
+        DataBoostReadLocalWrites(std::boxed::Box<crate::model::DataBoostReadLocalWrites>),
     }
 }
 
@@ -4677,7 +4677,7 @@ pub mod cluster {
     #[non_exhaustive]
     pub enum Config {
         /// Configuration for this cluster.
-        ClusterConfig(crate::model::cluster::ClusterConfig),
+        ClusterConfig(std::boxed::Box<crate::model::cluster::ClusterConfig>),
     }
 }
 
@@ -4875,7 +4875,11 @@ pub mod app_profile {
         pub enum Affinity {
             /// Row affinity sticky routing based on the row key of the request.
             /// Requests that span multiple rows are routed non-deterministically.
-            RowAffinity(crate::model::app_profile::multi_cluster_routing_use_any::RowAffinity),
+            RowAffinity(
+                std::boxed::Box<
+                    crate::model::app_profile::multi_cluster_routing_use_any::RowAffinity,
+                >,
+            ),
         }
     }
 
@@ -5067,9 +5071,11 @@ pub mod app_profile {
     #[non_exhaustive]
     pub enum RoutingPolicy {
         /// Use a multi-cluster routing policy.
-        MultiClusterRoutingUseAny(crate::model::app_profile::MultiClusterRoutingUseAny),
+        MultiClusterRoutingUseAny(
+            std::boxed::Box<crate::model::app_profile::MultiClusterRoutingUseAny>,
+        ),
         /// Use a single-cluster routing policy.
-        SingleClusterRouting(crate::model::app_profile::SingleClusterRouting),
+        SingleClusterRouting(std::boxed::Box<crate::model::app_profile::SingleClusterRouting>),
     }
 
     /// Options for isolating this app profile's traffic from other use cases.
@@ -5084,10 +5090,12 @@ pub mod app_profile {
         Priority(crate::model::app_profile::Priority),
         /// The standard options used for isolating this app profile's traffic from
         /// other use cases.
-        StandardIsolation(crate::model::app_profile::StandardIsolation),
+        StandardIsolation(std::boxed::Box<crate::model::app_profile::StandardIsolation>),
         /// Specifies that this app profile is intended for read-only usage via the
         /// Data Boost feature.
-        DataBoostIsolationReadOnly(crate::model::app_profile::DataBoostIsolationReadOnly),
+        DataBoostIsolationReadOnly(
+            std::boxed::Box<crate::model::app_profile::DataBoostIsolationReadOnly>,
+        ),
     }
 }
 
@@ -5244,7 +5252,7 @@ pub mod restore_info {
     pub enum SourceInfo {
         /// Information about the backup used to restore the table. The backup
         /// may no longer exist.
-        BackupInfo(crate::model::BackupInfo),
+        BackupInfo(std::boxed::Box<crate::model::BackupInfo>),
     }
 }
 
@@ -5648,7 +5656,7 @@ pub mod table {
     pub enum AutomatedBackupConfig {
         /// If specified, automated backups are enabled for this table.
         /// Otherwise, automated backups are disabled.
-        AutomatedBackupPolicy(crate::model::table::AutomatedBackupPolicy),
+        AutomatedBackupPolicy(std::boxed::Box<crate::model::table::AutomatedBackupPolicy>),
     }
 }
 
@@ -5867,7 +5875,7 @@ pub mod authorized_view {
     #[non_exhaustive]
     pub enum AuthorizedView {
         /// An AuthorizedView permitting access to an explicit subset of a Table.
-        SubsetView(crate::model::authorized_view::SubsetView),
+        SubsetView(std::boxed::Box<crate::model::authorized_view::SubsetView>),
     }
 }
 
@@ -6029,11 +6037,11 @@ pub mod gc_rule {
         /// Delete cells in a column older than the given age.
         /// Values must be at least one millisecond, and will be truncated to
         /// microsecond granularity.
-        MaxAge(wkt::Duration),
+        MaxAge(std::boxed::Box<wkt::Duration>),
         /// Delete cells that would be deleted by every nested rule.
-        Intersection(crate::model::gc_rule::Intersection),
+        Intersection(std::boxed::Box<crate::model::gc_rule::Intersection>),
         /// Delete cells that would be deleted by any nested rule.
-        Union(crate::model::gc_rule::Union),
+        Union(std::boxed::Box<crate::model::gc_rule::Union>),
     }
 }
 
@@ -6764,7 +6772,7 @@ pub mod r#type {
             #[non_exhaustive]
             pub enum Encoding {
                 /// Use `Raw` encoding.
-                Raw(crate::model::r#type::bytes::encoding::Raw),
+                Raw(std::boxed::Box<crate::model::r#type::bytes::encoding::Raw>),
             }
         }
     }
@@ -6885,9 +6893,9 @@ pub mod r#type {
             #[non_exhaustive]
             pub enum Encoding {
                 /// Deprecated: if set, converts to an empty `utf8_bytes`.
-                Utf8Raw(crate::model::r#type::string::encoding::Utf8Raw),
+                Utf8Raw(std::boxed::Box<crate::model::r#type::string::encoding::Utf8Raw>),
                 /// Use `Utf8Bytes` encoding.
-                Utf8Bytes(crate::model::r#type::string::encoding::Utf8Bytes),
+                Utf8Bytes(std::boxed::Box<crate::model::r#type::string::encoding::Utf8Bytes>),
             }
         }
     }
@@ -7009,7 +7017,9 @@ pub mod r#type {
             #[non_exhaustive]
             pub enum Encoding {
                 /// Use `BigEndianBytes` encoding.
-                BigEndianBytes(crate::model::r#type::int_64::encoding::BigEndianBytes),
+                BigEndianBytes(
+                    std::boxed::Box<crate::model::r#type::int_64::encoding::BigEndianBytes>,
+                ),
             }
         }
     }
@@ -7412,13 +7422,15 @@ pub mod r#type {
         #[non_exhaustive]
         pub enum Aggregator {
             /// Sum aggregator.
-            Sum(crate::model::r#type::aggregate::Sum),
+            Sum(std::boxed::Box<crate::model::r#type::aggregate::Sum>),
             /// HyperLogLogPlusPlusUniqueCount aggregator.
-            HllppUniqueCount(crate::model::r#type::aggregate::HyperLogLogPlusPlusUniqueCount),
+            HllppUniqueCount(
+                std::boxed::Box<crate::model::r#type::aggregate::HyperLogLogPlusPlusUniqueCount>,
+            ),
             /// Max aggregator.
-            Max(crate::model::r#type::aggregate::Max),
+            Max(std::boxed::Box<crate::model::r#type::aggregate::Max>),
             /// Min aggregator.
-            Min(crate::model::r#type::aggregate::Min),
+            Min(std::boxed::Box<crate::model::r#type::aggregate::Min>),
         }
     }
 
@@ -7428,29 +7440,29 @@ pub mod r#type {
     #[non_exhaustive]
     pub enum Kind {
         /// Bytes
-        BytesType(crate::model::r#type::Bytes),
+        BytesType(std::boxed::Box<crate::model::r#type::Bytes>),
         /// String
-        StringType(crate::model::r#type::String),
+        StringType(std::boxed::Box<crate::model::r#type::String>),
         /// Int64
-        Int64Type(crate::model::r#type::Int64),
+        Int64Type(std::boxed::Box<crate::model::r#type::Int64>),
         /// Float32
-        Float32Type(crate::model::r#type::Float32),
+        Float32Type(std::boxed::Box<crate::model::r#type::Float32>),
         /// Float64
-        Float64Type(crate::model::r#type::Float64),
+        Float64Type(std::boxed::Box<crate::model::r#type::Float64>),
         /// Bool
-        BoolType(crate::model::r#type::Bool),
+        BoolType(std::boxed::Box<crate::model::r#type::Bool>),
         /// Timestamp
-        TimestampType(crate::model::r#type::Timestamp),
+        TimestampType(std::boxed::Box<crate::model::r#type::Timestamp>),
         /// Date
-        DateType(crate::model::r#type::Date),
+        DateType(std::boxed::Box<crate::model::r#type::Date>),
         /// Aggregate
-        AggregateType(crate::model::r#type::Aggregate),
+        AggregateType(std::boxed::Box<crate::model::r#type::Aggregate>),
         /// Struct
-        StructType(crate::model::r#type::Struct),
+        StructType(std::boxed::Box<crate::model::r#type::Struct>),
         /// Array
-        ArrayType(crate::model::r#type::Array),
+        ArrayType(std::boxed::Box<crate::model::r#type::Array>),
         /// Map
-        MapType(crate::model::r#type::Map),
+        MapType(std::boxed::Box<crate::model::r#type::Map>),
     }
 }
 

--- a/src/generated/cloud/functions/v2/src/model.rs
+++ b/src/generated/cloud/functions/v2/src/model.rs
@@ -575,10 +575,10 @@ pub mod source {
     #[non_exhaustive]
     pub enum Source {
         /// If provided, get the source from this location in Google Cloud Storage.
-        StorageSource(crate::model::StorageSource),
+        StorageSource(std::boxed::Box<crate::model::StorageSource>),
         /// If provided, get the source from this location in a Cloud Source
         /// Repository.
-        RepoSource(crate::model::RepoSource),
+        RepoSource(std::boxed::Box<crate::model::RepoSource>),
         /// If provided, get the source from GitHub repository. This option is valid
         /// only for GCF 1st Gen function.
         /// Example: <https://github.com/>\<user\>/\<repo\>/blob/\<commit\>/\<path-to-code\>
@@ -881,8 +881,8 @@ pub mod build_config {
     #[serde(rename_all = "camelCase")]
     #[non_exhaustive]
     pub enum RuntimeUpdatePolicy {
-        AutomaticUpdatePolicy(crate::model::AutomaticUpdatePolicy),
-        OnDeployUpdatePolicy(crate::model::OnDeployUpdatePolicy),
+        AutomaticUpdatePolicy(std::boxed::Box<crate::model::AutomaticUpdatePolicy>),
+        OnDeployUpdatePolicy(std::boxed::Box<crate::model::OnDeployUpdatePolicy>),
     }
 }
 

--- a/src/generated/cloud/kms/v1/src/model.rs
+++ b/src/generated/cloud/kms/v1/src/model.rs
@@ -1965,7 +1965,7 @@ pub mod crypto_key {
         /// [google.cloud.kms.v1.CryptoKey.next_rotation_time]: crate::model::CryptoKey::next_rotation_time
         /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
         /// [google.cloud.kms.v1.CryptoKey.rotation_period]: crate::model::CryptoKey::rotation_schedule
-        RotationPeriod(wkt::Duration),
+        RotationPeriod(std::boxed::Box<wkt::Duration>),
     }
 }
 

--- a/src/generated/cloud/run/v2/src/model.rs
+++ b/src/generated/cloud/run/v2/src/model.rs
@@ -264,7 +264,7 @@ pub mod submit_build_request {
     #[non_exhaustive]
     pub enum Source {
         /// Required. Source for the build.
-        StorageSource(crate::model::StorageSource),
+        StorageSource(std::boxed::Box<crate::model::StorageSource>),
     }
 
     /// Build type must be one of the following.
@@ -273,9 +273,9 @@ pub mod submit_build_request {
     #[non_exhaustive]
     pub enum BuildType {
         /// Build the source using Buildpacks.
-        BuildpackBuild(crate::model::submit_build_request::BuildpacksBuild),
+        BuildpackBuild(std::boxed::Box<crate::model::submit_build_request::BuildpacksBuild>),
         /// Build the source using Docker. This means the source has a Dockerfile.
-        DockerBuild(crate::model::submit_build_request::DockerBuild),
+        DockerBuild(std::boxed::Box<crate::model::submit_build_request::DockerBuild>),
     }
 }
 
@@ -2735,7 +2735,7 @@ pub mod env_var {
         /// Variable references are not supported in Cloud Run.
         Value(std::string::String),
         /// Source for the environment variable's value.
-        ValueSource(crate::model::EnvVarSource),
+        ValueSource(std::boxed::Box<crate::model::EnvVarSource>),
     }
 }
 
@@ -2933,17 +2933,17 @@ pub mod volume {
     #[non_exhaustive]
     pub enum VolumeType {
         /// Secret represents a secret that should populate this volume.
-        Secret(crate::model::SecretVolumeSource),
+        Secret(std::boxed::Box<crate::model::SecretVolumeSource>),
         /// For Cloud SQL volumes, contains the specific instances that should be
         /// mounted. Visit <https://cloud.google.com/sql/docs/mysql/connect-run> for
         /// more information on how to connect Cloud SQL and Cloud Run.
-        CloudSqlInstance(crate::model::CloudSqlInstance),
+        CloudSqlInstance(std::boxed::Box<crate::model::CloudSqlInstance>),
         /// Ephemeral storage used as a shared volume.
-        EmptyDir(crate::model::EmptyDirVolumeSource),
+        EmptyDir(std::boxed::Box<crate::model::EmptyDirVolumeSource>),
         /// For NFS Voumes, contains the path to the nfs Volume
-        Nfs(crate::model::NFSVolumeSource),
+        Nfs(std::boxed::Box<crate::model::NFSVolumeSource>),
         /// Persistent storage backed by a Google Cloud Storage bucket.
-        Gcs(crate::model::GCSVolumeSource),
+        Gcs(std::boxed::Box<crate::model::GCSVolumeSource>),
     }
 }
 
@@ -3381,13 +3381,13 @@ pub mod probe {
     pub enum ProbeType {
         /// Optional. HTTPGet specifies the http request to perform.
         /// Exactly one of httpGet, tcpSocket, or grpc must be specified.
-        HttpGet(crate::model::HTTPGetAction),
+        HttpGet(std::boxed::Box<crate::model::HTTPGetAction>),
         /// Optional. TCPSocket specifies an action involving a TCP port.
         /// Exactly one of httpGet, tcpSocket, or grpc must be specified.
-        TcpSocket(crate::model::TCPSocketAction),
+        TcpSocket(std::boxed::Box<crate::model::TCPSocketAction>),
         /// Optional. GRPC specifies an action involving a gRPC port.
         /// Exactly one of httpGet, tcpSocket, or grpc must be specified.
-        Grpc(crate::model::GRPCAction),
+        Grpc(std::boxed::Box<crate::model::GRPCAction>),
     }
 }
 

--- a/src/generated/cloud/scheduler/v1/src/model.rs
+++ b/src/generated/cloud/scheduler/v1/src/model.rs
@@ -720,11 +720,11 @@ pub mod job {
     #[non_exhaustive]
     pub enum Target {
         /// Pub/Sub target.
-        PubsubTarget(crate::model::PubsubTarget),
+        PubsubTarget(std::boxed::Box<crate::model::PubsubTarget>),
         /// App Engine HTTP target.
-        AppEngineHttpTarget(crate::model::AppEngineHttpTarget),
+        AppEngineHttpTarget(std::boxed::Box<crate::model::AppEngineHttpTarget>),
         /// HTTP target.
-        HttpTarget(crate::model::HttpTarget),
+        HttpTarget(std::boxed::Box<crate::model::HttpTarget>),
     }
 }
 
@@ -1030,7 +1030,7 @@ pub mod http_target {
         ///
         /// This type of authorization should generally only be used when calling
         /// Google APIs hosted on *.googleapis.com.
-        OauthToken(crate::model::OAuthToken),
+        OauthToken(std::boxed::Box<crate::model::OAuthToken>),
         /// If specified, an
         /// [OIDC](https://developers.google.com/identity/protocols/OpenIDConnect)
         /// token will be generated and attached as an `Authorization` header in the
@@ -1039,7 +1039,7 @@ pub mod http_target {
         /// This type of authorization can be used for many scenarios, including
         /// calling Cloud Run, or endpoints where you intend to validate the token
         /// yourself.
-        OidcToken(crate::model::OidcToken),
+        OidcToken(std::boxed::Box<crate::model::OidcToken>),
     }
 }
 

--- a/src/generated/cloud/secretmanager/v1/src/model.rs
+++ b/src/generated/cloud/secretmanager/v1/src/model.rs
@@ -331,12 +331,12 @@ pub mod secret {
         /// This is always provided on output, regardless of what was sent on input.
         ///
         /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-        ExpireTime(wkt::Timestamp),
+        ExpireTime(std::boxed::Box<wkt::Timestamp>),
         /// Input only. The TTL for the
         /// [Secret][google.cloud.secretmanager.v1.Secret].
         ///
         /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-        Ttl(wkt::Duration),
+        Ttl(std::boxed::Box<wkt::Duration>),
     }
 }
 
@@ -773,12 +773,12 @@ pub mod replication {
         /// replicated without any restrictions.
         ///
         /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-        Automatic(crate::model::replication::Automatic),
+        Automatic(std::boxed::Box<crate::model::replication::Automatic>),
         /// The [Secret][google.cloud.secretmanager.v1.Secret] will only be
         /// replicated into the locations specified.
         ///
         /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-        UserManaged(crate::model::replication::UserManaged),
+        UserManaged(std::boxed::Box<crate::model::replication::UserManaged>),
     }
 }
 
@@ -1032,7 +1032,7 @@ pub mod replication_status {
         ///
         /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
         /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-        Automatic(crate::model::replication_status::AutomaticStatus),
+        Automatic(std::boxed::Box<crate::model::replication_status::AutomaticStatus>),
         /// Describes the replication status of a
         /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] with
         /// user-managed replication.
@@ -1043,7 +1043,7 @@ pub mod replication_status {
         ///
         /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
         /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-        UserManaged(crate::model::replication_status::UserManagedStatus),
+        UserManaged(std::boxed::Box<crate::model::replication_status::UserManagedStatus>),
     }
 }
 

--- a/src/generated/cloud/sql/v1/src/model.rs
+++ b/src/generated/cloud/sql/v1/src/model.rs
@@ -2754,7 +2754,7 @@ pub mod sql_instances_verify_external_sync_settings_request {
     #[non_exhaustive]
     pub enum SyncConfig {
         /// Optional. MySQL-specific settings for start external sync.
-        MysqlSyncConfig(crate::model::MySqlSyncConfig),
+        MysqlSyncConfig(std::boxed::Box<crate::model::MySqlSyncConfig>),
     }
 }
 
@@ -2854,7 +2854,7 @@ pub mod sql_instances_start_external_sync_request {
     #[non_exhaustive]
     pub enum SyncConfig {
         /// MySQL-specific settings for start external sync.
-        MysqlSyncConfig(crate::model::MySqlSyncConfig),
+        MysqlSyncConfig(std::boxed::Box<crate::model::MySqlSyncConfig>),
     }
 }
 
@@ -6415,7 +6415,7 @@ pub mod database {
     #[serde(rename_all = "camelCase")]
     #[non_exhaustive]
     pub enum DatabaseDetails {
-        SqlserverDatabaseDetails(crate::model::SqlServerDatabaseDetails),
+        SqlserverDatabaseDetails(std::boxed::Box<crate::model::SqlServerDatabaseDetails>),
     }
 }
 
@@ -10956,7 +10956,7 @@ pub mod user {
     #[serde(rename_all = "camelCase")]
     #[non_exhaustive]
     pub enum UserDetails {
-        SqlserverUserDetails(crate::model::SqlServerUserDetails),
+        SqlserverUserDetails(std::boxed::Box<crate::model::SqlServerUserDetails>),
     }
 }
 

--- a/src/generated/cloud/translate/v3/src/model.rs
+++ b/src/generated/cloud/translate/v3/src/model.rs
@@ -891,9 +891,9 @@ pub mod import_adaptive_mt_file_request {
     #[non_exhaustive]
     pub enum Source {
         /// Inline file source.
-        FileInputSource(crate::model::FileInputSource),
+        FileInputSource(std::boxed::Box<crate::model::FileInputSource>),
         /// Google Cloud Storage file source.
-        GcsInputSource(crate::model::GcsInputSource),
+        GcsInputSource(std::boxed::Box<crate::model::GcsInputSource>),
     }
 }
 
@@ -1342,7 +1342,7 @@ pub mod dataset_input_config {
         #[non_exhaustive]
         pub enum Source {
             /// Google Cloud Storage file source.
-            GcsSource(crate::model::GcsInputSource),
+            GcsSource(std::boxed::Box<crate::model::GcsInputSource>),
         }
     }
 }
@@ -1492,7 +1492,7 @@ pub mod dataset_output_config {
     #[non_exhaustive]
     pub enum Destination {
         /// Google Cloud Storage destination to write the output.
-        GcsDestination(crate::model::GcsOutputDestination),
+        GcsDestination(std::boxed::Box<crate::model::GcsOutputDestination>),
     }
 }
 
@@ -2967,9 +2967,9 @@ pub mod glossary_entry {
     #[non_exhaustive]
     pub enum Data {
         /// Used for an unidirectional glossary.
-        TermsPair(crate::model::glossary_entry::GlossaryTermsPair),
+        TermsPair(std::boxed::Box<crate::model::glossary_entry::GlossaryTermsPair>),
         /// Used for an equivalent term sets glossary.
-        TermsSet(crate::model::glossary_entry::GlossaryTermsSet),
+        TermsSet(std::boxed::Box<crate::model::glossary_entry::GlossaryTermsSet>),
     }
 }
 
@@ -3927,7 +3927,7 @@ pub mod input_config {
         ///
         /// The other supported file extensions are `.txt` or `.html`, which is
         /// treated as a single large chunk of text.
-        GcsSource(crate::model::GcsSource),
+        GcsSource(std::boxed::Box<crate::model::GcsSource>),
     }
 }
 
@@ -4074,7 +4074,7 @@ pub mod output_config {
         /// If the input file extension is txt or html, glossary_error_file will be
         /// generated that contains error details. glossary_error_file has format of
         /// `gs://translation_test/a_b_c_'trg'_glossary_errors.[extension]`
-        GcsDestination(crate::model::GcsDestination),
+        GcsDestination(std::boxed::Box<crate::model::GcsDestination>),
     }
 }
 
@@ -4156,7 +4156,7 @@ pub mod document_input_config {
         Content(bytes::Bytes),
         /// Google Cloud Storage location. This must be a single file.
         /// For example: gs://example_bucket/example_file.pdf
-        GcsSource(crate::model::GcsSource),
+        GcsSource(std::boxed::Box<crate::model::GcsSource>),
     }
 }
 
@@ -4273,7 +4273,7 @@ pub mod document_output_config {
         /// Callers should expect no partial outputs. If there is any error during
         /// document translation, no output will be stored in the Cloud Storage
         /// bucket.
-        GcsDestination(crate::model::GcsDestination),
+        GcsDestination(std::boxed::Box<crate::model::GcsDestination>),
     }
 }
 
@@ -5064,7 +5064,7 @@ pub mod glossary_input_config {
         /// - CSV (`.csv`): Multi-column CSV file defining equivalent glossary terms
         ///   in multiple languages. See documentation for more information -
         ///   [glossaries](https://cloud.google.com/translate/docs/advanced/glossary).
-        GcsSource(crate::model::GcsSource),
+        GcsSource(std::boxed::Box<crate::model::GcsSource>),
     }
 }
 
@@ -5256,9 +5256,9 @@ pub mod glossary {
     #[non_exhaustive]
     pub enum Languages {
         /// Used with unidirectional glossaries.
-        LanguagePair(crate::model::glossary::LanguageCodePair),
+        LanguagePair(std::boxed::Box<crate::model::glossary::LanguageCodePair>),
         /// Used with equivalent term set glossaries.
-        LanguageCodesSet(crate::model::glossary::LanguageCodesSet),
+        LanguageCodesSet(std::boxed::Box<crate::model::glossary::LanguageCodesSet>),
     }
 }
 
@@ -6378,7 +6378,7 @@ pub mod batch_document_input_config {
         /// The max file size to support for `.pdf` is 1GB and the max page limit is
         /// 1000 pages.
         /// The max file size to support for all input documents is 1GB.
-        GcsSource(crate::model::GcsSource),
+        GcsSource(std::boxed::Box<crate::model::GcsSource>),
     }
 }
 
@@ -6471,7 +6471,7 @@ pub mod batch_document_output_config {
         /// `glossary_error_output`:
         /// `gs://translation_test/a_b_c_[trg]_glossary_translation.txt`. The error
         /// output is a txt file containing error details.
-        GcsDestination(crate::model::GcsDestination),
+        GcsDestination(std::boxed::Box<crate::model::GcsDestination>),
     }
 }
 

--- a/src/generated/container/v1/src/model.rs
+++ b/src/generated/container/v1/src/model.rs
@@ -2065,7 +2065,7 @@ pub mod containerd_config {
             #[non_exhaustive]
             pub enum CertificateConfig {
                 /// Google Secret Manager (GCP) certificate configuration.
-                GcpSecretManagerCertificateConfig(crate::model::containerd_config::private_registry_access_config::certificate_authority_domain_config::GCPSecretManagerCertificateConfig),
+                GcpSecretManagerCertificateConfig(std::boxed::Box<crate::model::containerd_config::private_registry_access_config::certificate_authority_domain_config::GCPSecretManagerCertificateConfig>),
             }
         }
     }
@@ -9840,7 +9840,9 @@ pub mod blue_green_settings {
     #[non_exhaustive]
     pub enum RolloutPolicy {
         /// Standard policy for the blue-green upgrade.
-        StandardRolloutPolicy(crate::model::blue_green_settings::StandardRolloutPolicy),
+        StandardRolloutPolicy(
+            std::boxed::Box<crate::model::blue_green_settings::StandardRolloutPolicy>,
+        ),
     }
 }
 
@@ -10867,11 +10869,11 @@ pub mod maintenance_window {
     #[non_exhaustive]
     pub enum Policy {
         /// DailyMaintenanceWindow specifies a daily maintenance operation window.
-        DailyMaintenanceWindow(crate::model::DailyMaintenanceWindow),
+        DailyMaintenanceWindow(std::boxed::Box<crate::model::DailyMaintenanceWindow>),
         /// RecurringWindow specifies some number of recurring time periods for
         /// maintenance to occur. The time windows may be overlapping. If no
         /// maintenance windows are set, maintenance can occur at any time.
-        RecurringWindow(crate::model::RecurringTimeWindow),
+        RecurringWindow(std::boxed::Box<crate::model::RecurringTimeWindow>),
     }
 }
 
@@ -10942,7 +10944,7 @@ pub mod time_window {
     pub enum Options {
         /// MaintenanceExclusionOptions provides maintenance exclusion related
         /// options.
-        MaintenanceExclusionOptions(crate::model::MaintenanceExclusionOptions),
+        MaintenanceExclusionOptions(std::boxed::Box<crate::model::MaintenanceExclusionOptions>),
     }
 }
 

--- a/src/generated/devtools/cloudbuild/v2/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/model.rs
@@ -370,16 +370,16 @@ pub mod connection {
     #[non_exhaustive]
     pub enum ConnectionConfig {
         /// Configuration for connections to github.com.
-        GithubConfig(crate::model::GitHubConfig),
+        GithubConfig(std::boxed::Box<crate::model::GitHubConfig>),
         /// Configuration for connections to an instance of GitHub Enterprise.
-        GithubEnterpriseConfig(crate::model::GitHubEnterpriseConfig),
+        GithubEnterpriseConfig(std::boxed::Box<crate::model::GitHubEnterpriseConfig>),
         /// Configuration for connections to gitlab.com or an instance of GitLab
         /// Enterprise.
-        GitlabConfig(crate::model::GitLabConfig),
+        GitlabConfig(std::boxed::Box<crate::model::GitLabConfig>),
         /// Configuration for connections to Bitbucket Data Center.
-        BitbucketDataCenterConfig(crate::model::BitbucketDataCenterConfig),
+        BitbucketDataCenterConfig(std::boxed::Box<crate::model::BitbucketDataCenterConfig>),
         /// Configuration for connections to Bitbucket Cloud.
-        BitbucketCloudConfig(crate::model::BitbucketCloudConfig),
+        BitbucketCloudConfig(std::boxed::Box<crate::model::BitbucketCloudConfig>),
     }
 }
 

--- a/src/generated/devtools/cloudtrace/v2/src/model.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/model.rs
@@ -525,9 +525,9 @@ pub mod span {
         #[non_exhaustive]
         pub enum Value {
             /// Text annotation with a set of attributes.
-            Annotation(crate::model::span::time_event::Annotation),
+            Annotation(std::boxed::Box<crate::model::span::time_event::Annotation>),
             /// An event describing a message sent/received between Spans.
-            MessageEvent(crate::model::span::time_event::MessageEvent),
+            MessageEvent(std::boxed::Box<crate::model::span::time_event::MessageEvent>),
         }
     }
 
@@ -822,7 +822,7 @@ pub mod attribute_value {
     #[non_exhaustive]
     pub enum Value {
         /// A string up to 256 bytes long.
-        StringValue(crate::model::TruncatableString),
+        StringValue(std::boxed::Box<crate::model::TruncatableString>),
         /// A 64-bit signed integer.
         IntValue(i64),
         /// A Boolean value represented by `true` or `false`.

--- a/src/generated/iam/admin/v1/src/model.rs
+++ b/src/generated/iam/admin/v1/src/model.rs
@@ -2543,7 +2543,7 @@ pub mod lint_policy_request {
     #[non_exhaustive]
     pub enum LintObject {
         /// [google.iam.v1.Binding.condition] [google.iam.v1.Binding.condition] object to be linted.
-        Condition(gtype::model::Expr),
+        Condition(std::boxed::Box<gtype::model::Expr>),
     }
 }
 

--- a/src/generated/iam/v2/src/model.rs
+++ b/src/generated/iam/v2/src/model.rs
@@ -403,7 +403,7 @@ pub mod policy_rule {
     #[non_exhaustive]
     pub enum Kind {
         /// A rule for a deny policy.
-        DenyRule(crate::model::DenyRule),
+        DenyRule(std::boxed::Box<crate::model::DenyRule>),
     }
 }
 

--- a/src/generated/longrunning/src/model.rs
+++ b/src/generated/longrunning/src/model.rs
@@ -118,7 +118,7 @@ pub mod operation {
     #[non_exhaustive]
     pub enum Result {
         /// The error result of the operation in case of failure or cancellation.
-        Error(rpc::model::Status),
+        Error(std::boxed::Box<rpc::model::Status>),
         /// The normal, successful response of the operation.  If the original
         /// method returns no data on success, such as `Delete`, the response is
         /// `google.protobuf.Empty`.  If the original method is standard
@@ -127,7 +127,7 @@ pub mod operation {
         /// is the original method name.  For example, if the original method name
         /// is `TakeSnapshot()`, the inferred response type is
         /// `TakeSnapshotResponse`.
-        Response(wkt::Any),
+        Response(std::boxed::Box<wkt::Any>),
     }
 }
 

--- a/src/generated/spanner/admin/database/v1/src/model.rs
+++ b/src/generated/spanner/admin/database/v1/src/model.rs
@@ -1632,7 +1632,7 @@ pub mod backup_schedule_spec {
     #[non_exhaustive]
     pub enum ScheduleSpec {
         /// Cron style schedule specification.
-        CronSpec(crate::model::CrontabSpec),
+        CronSpec(std::boxed::Box<crate::model::CrontabSpec>),
     }
 }
 
@@ -1764,9 +1764,9 @@ pub mod backup_schedule {
     #[non_exhaustive]
     pub enum BackupTypeSpec {
         /// The schedule creates only full backups.
-        FullBackupSpec(crate::model::FullBackupSpec),
+        FullBackupSpec(std::boxed::Box<crate::model::FullBackupSpec>),
         /// The schedule creates incremental backup chains.
-        IncrementalBackupSpec(crate::model::IncrementalBackupSpec),
+        IncrementalBackupSpec(std::boxed::Box<crate::model::IncrementalBackupSpec>),
     }
 }
 
@@ -2382,7 +2382,7 @@ pub mod restore_info {
     pub enum SourceInfo {
         /// Information about the backup used to restore the database. The backup
         /// may no longer exist.
-        BackupInfo(crate::model::BackupInfo),
+        BackupInfo(std::boxed::Box<crate::model::BackupInfo>),
     }
 }
 
@@ -3979,7 +3979,7 @@ pub mod restore_database_metadata {
     #[non_exhaustive]
     pub enum SourceInfo {
         /// Information about the backup used to restore the database.
-        BackupInfo(crate::model::BackupInfo),
+        BackupInfo(std::boxed::Box<crate::model::BackupInfo>),
     }
 }
 

--- a/src/generated/type/src/model.rs
+++ b/src/generated/type/src/model.rs
@@ -421,9 +421,9 @@ pub mod date_time {
         /// UTC offset. Must be whole seconds, between -18 hours and +18 hours.
         /// For example, a UTC offset of -4:00 would be represented as
         /// { seconds: -14400 }.
-        UtcOffset(wkt::Duration),
+        UtcOffset(std::boxed::Box<wkt::Duration>),
         /// Time zone.
-        TimeZone(crate::model::TimeZone),
+        TimeZone(std::boxed::Box<crate::model::TimeZone>),
     }
 }
 
@@ -1029,7 +1029,7 @@ pub mod phone_number {
         /// Reference(s):
         ///
         /// - <https://en.wikipedia.org/wiki/Short_code>
-        ShortCode(crate::model::phone_number::ShortCode),
+        ShortCode(std::boxed::Box<crate::model::phone_number::ShortCode>),
     }
 }
 

--- a/src/integration-tests/src/secret_manager/protobuf.rs
+++ b/src/integration-tests/src/secret_manager/protobuf.rs
@@ -63,7 +63,7 @@ pub async fn run(config: Option<gax::options::ClientConfig>) -> Result<()> {
             sm::model::Secret::default()
                 .set_replication(sm::model::Replication::default().set_replication(
                     sm::model::replication::Replication::Automatic(
-                        sm::model::replication::Automatic::default(),
+                        sm::model::replication::Automatic::default().into(),
                     ),
                 ))
                 .set_labels([("integration-test", "true")]),

--- a/src/integration-tests/src/workflows.rs
+++ b/src/integration-tests/src/workflows.rs
@@ -288,7 +288,7 @@ pub async fn manual(
         match result {
             LR::Error(status) => {
                 println!("LRO completed with error {status:?}");
-                let err = gax::error::ServiceError::from(status);
+                let err = gax::error::ServiceError::from(*status);
                 return Err(Error::rpc(err));
             }
             LR::Response(any) => {
@@ -328,7 +328,7 @@ pub async fn manual(
         match result {
             LR::Error(status) => {
                 println!("LRO completed with error {status:?}");
-                let err = gax::error::ServiceError::from(status);
+                let err = gax::error::ServiceError::from(*status);
                 return Err(Error::rpc(err));
             }
             LR::Response(any) => {

--- a/src/lro/src/details.rs
+++ b/src/lro/src/details.rs
@@ -280,9 +280,9 @@ mod test {
             .set_name("test-only-name")
             .set_done(true)
             .set_metadata(wkt::Any::try_from(&wkt::Timestamp::clamp(123, 0))?)
-            .set_result(operation::Result::Response(wkt::Any::try_from(
-                &wkt::Duration::clamp(234, 0),
-            )?));
+            .set_result(operation::Result::Response(
+                wkt::Any::try_from(&wkt::Duration::clamp(234, 0))?.into(),
+            ));
         let op = O::new(op);
         let (name, polling) = handle_common(op);
         assert_eq!(name, None);
@@ -323,9 +323,9 @@ mod test {
         type R = wkt::Duration;
         type M = wkt::Timestamp;
         type O = super::Operation<R, M>;
-        let op = Operation::default().set_result(operation::Result::Response(Any::try_from(
-            &wkt::Duration::clamp(123, 0),
-        )?));
+        let op = Operation::default().set_result(operation::Result::Response(
+            Any::try_from(&wkt::Duration::clamp(123, 0))?.into(),
+        ));
         let op = O::new(op);
         let result = as_result(op)?;
         assert_eq!(result, wkt::Duration::clamp(123, 0));
@@ -340,7 +340,9 @@ mod test {
         type M = wkt::Timestamp;
         type O = super::Operation<R, M>;
         let op = Operation::default().set_result(operation::Result::Error(
-            rpc::model::Status::default().set_message("test only"),
+            rpc::model::Status::default()
+                .set_message("test only")
+                .into(),
         ));
         let op = O::new(op);
         let result = as_result(op);
@@ -356,9 +358,9 @@ mod test {
         type R = wkt::Duration;
         type M = wkt::Timestamp;
         type O = super::Operation<R, M>;
-        let op = Operation::default().set_result(operation::Result::Response(Any::try_from(
-            &wkt::Timestamp::clamp(123, 0),
-        )?));
+        let op = Operation::default().set_result(operation::Result::Response(
+            Any::try_from(&wkt::Timestamp::clamp(123, 0))?.into(),
+        ));
         let op = O::new(op);
         let err = as_result(op).err().unwrap();
         assert_eq!(err.kind(), gax::error::ErrorKind::Other, "{err}");

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -86,14 +86,14 @@ impl<R, M> Operation<R, M> {
         use longrunning::model::operation::Result;
         self.inner.result.as_ref().and_then(|r| match r {
             Result::Error(_) => None,
-            Result::Response(r) => Some(r),
+            Result::Response(r) => Some(r.as_ref()),
             _ => None,
         })
     }
     fn error(&self) -> Option<&rpc::model::Status> {
         use longrunning::model::operation::Result;
         self.inner.result.as_ref().and_then(|r| match r {
-            Result::Error(rpc) => Some(rpc),
+            Result::Error(rpc) => Some(rpc.as_ref()),
             Result::Response(_) => None,
             _ => None,
         })
@@ -337,7 +337,7 @@ mod test {
             .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
         let op = longrunning::model::Operation::default()
             .set_name("test-only-name")
-            .set_result(longrunning::model::operation::Result::Response(any));
+            .set_result(longrunning::model::operation::Result::Response(any.into()));
         let op = TestOperation::new(op);
         assert_eq!(op.name(), "test-only-name");
         assert!(!op.done());
@@ -361,7 +361,9 @@ mod test {
             .set_code(16);
         let op = longrunning::model::Operation::default()
             .set_name("test-only-name")
-            .set_result(longrunning::model::operation::Result::Error(rpc.clone()));
+            .set_result(longrunning::model::operation::Result::Error(
+                rpc.clone().into(),
+            ));
         let op = TestOperation::new(op);
         assert_eq!(op.name(), "test-only-name");
         assert!(!op.done());
@@ -389,7 +391,7 @@ mod test {
         let query = |_: String| async move {
             let any = wkt::Any::try_from(&wkt::Duration::clamp(234, 0))
                 .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
-            let result = longrunning::model::operation::Result::Response(any);
+            let result = longrunning::model::operation::Result::Response(any.into());
             let op = longrunning::model::Operation::default()
                 .set_done(true)
                 .set_result(result);
@@ -444,7 +446,7 @@ mod test {
         let query = |_: String| async move {
             let any = wkt::Any::try_from(&wkt::Duration::clamp(234, 0))
                 .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
-            let result = longrunning::model::operation::Result::Response(any);
+            let result = longrunning::model::operation::Result::Response(any.into());
             let op = longrunning::model::Operation::default()
                 .set_done(true)
                 .set_result(result);
@@ -502,7 +504,7 @@ mod test {
         let query = |_: String| async move {
             let any = wkt::Any::try_from(&wkt::Duration::clamp(234, 0))
                 .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
-            let result = longrunning::model::operation::Result::Response(any);
+            let result = longrunning::model::operation::Result::Response(any.into());
             let op = longrunning::model::Operation::default()
                 .set_done(true)
                 .set_result(result);
@@ -553,7 +555,7 @@ mod test {
                 }
                 let any = wkt::Any::try_from(&wkt::Duration::clamp(234, 0))
                     .map_err(|e| Error::other(format!("unexpected error in Any::try_from {e}")))?;
-                let result = longrunning::model::operation::Result::Response(any);
+                let result = longrunning::model::operation::Result::Response(any.into());
                 let op = longrunning::model::Operation::default()
                     .set_done(true)
                     .set_result(result);

--- a/src/lro/tests/fake_responses/mod.rs
+++ b/src/lro/tests/fake_responses/mod.rs
@@ -25,7 +25,8 @@ pub fn success(
     };
     let metadata = model::CreateResourceMetadata { percent: 100 };
     let metadata = wkt::Any::try_from(&metadata)?;
-    let result = longrunning::model::operation::Result::Response(wkt::Any::try_from(&resource)?);
+    let result =
+        longrunning::model::operation::Result::Response(wkt::Any::try_from(&resource)?.into());
     let operation = longrunning::model::Operation::default()
         .set_name(name)
         .set_metadata(metadata)
@@ -49,7 +50,8 @@ pub fn operation_error(name: impl Into<String>) -> Result<(StatusCode, String)> 
     let error = rpc::model::Status::default()
         .set_code(gax::error::rpc::Code::AlreadyExists as i32)
         .set_message(format!("The resource  already exists"));
-    let result = longrunning::model::operation::Result::Response(wkt::Any::try_from(&error)?);
+    let result =
+        longrunning::model::operation::Result::Response(wkt::Any::try_from(&error)?.into());
     let operation = longrunning::model::Operation::default()
         .set_name(name)
         .set_done(true)


### PR DESCRIPTION
Messages is `oneof` fields may trigger clippy errors about branches with
radically different sizes. That seems like a good warning to heed.

Fixes #837
