### PR TITLE
fix(auth): scope serialization in jws claim

### DIFF
--- a/src/auth/src/credentials/service_account_credential.rs
+++ b/src/auth/src/credentials/service_account_credential.rs
@@ -33,7 +33,7 @@ const DEFAULT_HEADER: JwsHeader = JwsHeader {
     kid: None,
 };
 
-const DEFAULT_SCOPES: [&str; 1] = ["https://www.googleapis.com/auth/cloud-platform"];
+const DEFAULT_SCOPES: &str = "https://www.googleapis.com/auth/cloud-platform";
 
 /// A representation of a Service Account File. See [Service Account Keys](https://google.aip.dev/auth/4112)
 /// for more details.
@@ -72,7 +72,7 @@ impl TokenProvider for ServiceAccountTokenProvider {
         let exp = now + DEFAULT_TOKEN_TIMEOUT;
         let claims = JwsClaims {
             iss: self.service_account_info.client_email.clone(),
-            scope: Some(DEFAULT_SCOPES.map(|s| s.to_string()).to_vec()),
+            scope: Some(DEFAULT_SCOPES.to_string()),
             aud: None,
             exp,
             iat: now,

--- a/src/auth/src/credentials/util/jws.rs
+++ b/src/auth/src/credentials/util/jws.rs
@@ -32,7 +32,7 @@ pub(crate) const DEFAULT_TOKEN_TIMEOUT: Duration = Duration::from_secs(3600);
 pub struct JwsClaims {
     pub iss: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub scope: Option<Vec<String>>,
+    pub scope: Option<String>,
     pub aud: Option<String>,
     #[serde(with = "time::serde::timestamp")]
     pub exp: OffsetDateTime,
@@ -129,7 +129,7 @@ mod tests {
 
         let claims = JwsClaims {
             iss: "test_iss".to_string(),
-            scope: Some(vec!["scope1".to_string(), "scope2".to_string()]),
+            scope: Some("scope1 scope2".to_string()),
             aud: None,
             exp: then,
             iat: now,
@@ -147,7 +147,7 @@ mod tests {
         let v: Value = serde_json::from_str(&decoded).unwrap();
 
         assert_eq!(v["iss"], "test_iss");
-        assert_eq!(v["scope"], serde_json::json!(["scope1", "scope2"]));
+        assert_eq!(v["scope"], "scope1 scope2");
 
         assert_eq!(v["iat"], now.unix_timestamp());
         assert_eq!(v["exp"], then.unix_timestamp());
@@ -182,7 +182,7 @@ mod tests {
 
         let claims = JwsClaims {
             iss: "test_iss".to_string(),
-            scope: Some(vec!["scope".to_string()]),
+            scope: Some("scope".to_string()),
             aud: Some("test-aud".to_string()),
             exp: then,
             iat: now,


### PR DESCRIPTION
Part of the work for #679 

`scope` needs to be serialized as a space-separated string. Found this while running integration tests locally.

I considered implementing a `serde(serialize_with = ...)` but then figured a similar, simpler function could go into `service_account_credential.rs` when we are ready to handle custom scopes.