### PR TITLE
chore: update go version past vuln

### DIFF
--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        go-version: ['1.23']
+        go-version: ['1.23.5']
     defaults:
       run:
         working-directory: generator

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Go 1.23
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version: 1.23.5
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -96,7 +96,7 @@ jobs:
     strategy:
       matrix:
         rust-version: ['1.83']
-        go-version: ['1.23']
+        go-version: ['1.23.5']
     steps:
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
Apparently we need go > 1.23.4. ([build fail](https://github.com/googleapis/google-cloud-rust/actions/runs/13004718871/job/36269942403?pr=865))

I do not know the process to update go. Feel free to close this PR and do it better. Or wait until asking for `1.23` gives us `1.23.5`. (Also, I see there are other places where we pin go to `1.23.2`, we just don't `go test` with this version it looks like).

This PR unblocks me though ([build win](https://github.com/dbolduc/google-cloud-rust/actions/runs/13004855835))