### PR TITLE
chore: update go to 1.23.5

### DIFF
--- a/generator/go.mod
+++ b/generator/go.mod
@@ -1,6 +1,6 @@
 module github.com/googleapis/google-cloud-rust/generator
 
-go 1.23.2
+go 1.23.5
 
 require (
 	cloud.google.com/go/iam v1.3.1


### PR DESCRIPTION
Take the fixes for https://pkg.go.dev/vuln/GO-2025-3420