### PR TITLE
fix: update message template to have consistent naming

### DIFF
--- a/generator/internal/language/templates/rust/common/message.mustache
+++ b/generator/internal/language/templates/rust/common/message.mustache
@@ -89,7 +89,7 @@ impl {{Codec.Name}} {
 }
 {{^Codec.HasSyntheticFields}}
 
-impl wkt::message::Message for {{Name}} {
+impl wkt::message::Message for {{Codec.Name}} {
     fn typename() -> &'static str {
         "type.googleapis.com/{{Codec.SourceFQN}}"
     }


### PR DESCRIPTION
Fixes #868

Regenerating cloud/aiplatform/v1 with this template addressed the error:

```
error[E0412]: cannot find type `RRF` in this scope
     --> src/generated/cloud/aiplatform/v1/src/model.rs:35355:40
      |
35340 |         pub struct Rrf {
      |         -------------- similarly named struct `Rrf` defined here
...
35355 |         impl wkt::message::Message for RRF {
      |                                        ^^^ help: a struct with a similar name exists: `Rrf`
```


After the change( note that the other errors are being tracked in https://github.com/googleapis/google-cloud-rust/issues/845) :
<img width="1258" alt="Screenshot 2025-01-28 at 10 41 59 AM" src="https://github.com/user-attachments/assets/06a2c7da-b52d-44d5-9f4f-791a47a54937" />
