### PR TITLE
feat(generator/rust): oneof setters and getters

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -295,6 +295,9 @@ type Field struct {
 	// containing message. That triggers slightly different code generation for
 	// some languages.
 	Recursive bool
+	// For fields that are part of a OneOf, the group of fields that makes the
+	// OneOf.
+	Group *OneOf
 	// A placeholder to put language specific annotations.
 	Codec any
 }

--- a/generator/internal/api/xref.go
+++ b/generator/internal/api/xref.go
@@ -1,0 +1,36 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+// CrossReference fills out the cross-references in `model` that the parser(s)
+// missed.
+//
+// The parsers cannot always cross-reference all elements because the
+// elements are built incrementally, and may not be available until the parser
+// has completed all the work.
+//
+// This function is called after the parser has completed its work but before
+// the codecs run. It populates links between the parsed elements that the
+// codecs need. For example, the `oneof` fields use the containing `OneOf` to
+// reference any types or names of the `OneOf` during their generation.
+func CrossReference(model *API) {
+	for _, m := range model.State.MessageByID {
+		for _, o := range m.OneOfs {
+			for _, f := range o.Fields {
+				f.Group = o
+			}
+		}
+	}
+}

--- a/generator/internal/api/xref_test.go
+++ b/generator/internal/api/xref_test.go
@@ -1,0 +1,71 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestCrossReferenceOneOfs(t *testing.T) {
+	var fields []*Field
+	for i := range 4 {
+		name := fmt.Sprintf("field%d", i)
+		fields = append(fields, &Field{
+			Name:    name,
+			ID:      ".test.Message." + name,
+			Typez:   STRING_TYPE,
+			IsOneOf: true,
+		})
+	}
+	fields = append(fields, &Field{
+		Name:    "basic_field",
+		ID:      ".test.Message.basic_field",
+		Typez:   STRING_TYPE,
+		IsOneOf: true,
+	})
+	group0 := &OneOf{
+		Name:   "group0",
+		Fields: []*Field{fields[0], fields[1]},
+	}
+	group1 := &OneOf{
+		Name:   "group1",
+		Fields: []*Field{fields[2], fields[3]},
+	}
+	message := &Message{
+		Name:   "Message",
+		ID:     ".test.Message",
+		Fields: fields,
+		OneOfs: []*OneOf{group0, group1},
+	}
+	model := NewTestAPI([]*Message{message}, []*Enum{}, []*Service{})
+	CrossReference(model)
+
+	for _, test := range []struct {
+		field *Field
+		oneof *OneOf
+	}{
+		{fields[0], group0},
+		{fields[1], group0},
+		{fields[2], group1},
+		{fields[3], group1},
+		{fields[4], nil},
+	} {
+		if test.field.Group != test.oneof {
+			t.Errorf("mismatched group for %s, got=%v, want=%v", test.field.Name, test.field.Group, test.oneof)
+		}
+
+	}
+}

--- a/generator/internal/language/templates/rust/common/message.mustache
+++ b/generator/internal/language/templates/rust/common/message.mustache
@@ -81,10 +81,76 @@ impl {{Codec.Name}} {
     {{#OneOfs}}
 
     /// Sets the value of `{{Codec.FieldName}}`.
-    pub fn set_{{Codec.SetterName}}<T: std::convert::Into<std::option::Option<{{{Codec.FieldType}}}>>>(mut self, v: T) ->Self {
+    pub fn set_{{Codec.SetterName}}<T: std::convert::Into<std::option::Option<{{{Codec.FieldType}}}>>>(mut self, v: T) -> Self
+    {
         self.{{Codec.FieldName}} = v.into();
         self
     }
+    {{#Fields}}
+
+    /// The value of [{{Group.Codec.FieldName}}][{{Codec.FQMessageName}}::{{Group.Codec.FieldName}}]
+    /// if it holds a `{{Codec.BranchName}}`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_{{Codec.SetterName}}(&self) -> std::option::Option<&{{{Codec.FieldType}}}> {
+        {{! Rarely, oneofs have a single branch and then the `_` case is never matched. }}
+        #[allow(unreachable_patterns)]
+        self.{{Group.Codec.FieldName}}.as_ref().and_then(|v| match v {
+            {{Group.Codec.FQEnumName}}::{{Codec.BranchName}}(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+    {{/Fields}}
+    {{#Codec.SingularFields}}
+
+    /// Sets the value of [{{Group.Codec.FieldName}}][{{Codec.FQMessageName}}::{{Group.Codec.FieldName}}]
+    /// to hold a `{{Codec.BranchName}}`.
+    ///
+    /// Note that all the setters affecting `{{Group.Codec.FieldName}}` are
+    /// mutually exclusive.
+    pub fn set_{{Codec.SetterName}}<T: std::convert::Into<{{{Codec.FieldType}}}>>(mut self, v: T) -> Self {
+        self.{{Group.Codec.FieldName}} = std::option::Option::Some(
+            {{Group.Codec.FQEnumName}}::{{Codec.BranchName}}(
+                v.into()
+            )
+        );
+        self
+    }
+    {{/Codec.SingularFields}}
+    {{#Codec.RepeatedFields}}
+
+    /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Codec.SetterName}}].
+    pub fn set_{{Codec.SetterName}}<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<{{{Codec.PrimitiveFieldType}}}>
+    {
+        use std::iter::Iterator;
+        self.{{Group.Codec.FieldName}} = std::option::Option::Some(
+            {{Group.Codec.FQEnumName}}::{{Codec.BranchName}}(
+                v.into_iter().map(|i| i.into()).collect()
+            )
+        );
+        self
+    }
+    {{/Codec.RepeatedFields}}
+    {{#Codec.MapFields}}
+
+    /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Codec.SetterName}}].
+    pub fn set_{{Codec.SetterName}}<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<{{{Codec.KeyType}}}>,
+        V: std::convert::Into<{{{Codec.ValueType}}}>,
+    {
+        use std::iter::Iterator;
+        self.{{Group.Codec.FieldName}} = std::option::Option::Some(
+            {{Group.Codec.FQEnumName}}::{{Codec.BranchName}}(
+                v.into_iter().map(|(k, v)| (k.into(), v.into())).collect()
+            )
+        );
+        self
+    }
+    {{/Codec.MapFields}}
     {{/OneOfs}}
 }
 {{^Codec.HasSyntheticFields}}

--- a/generator/internal/sidekick/refresh.go
+++ b/generator/internal/sidekick/refresh.go
@@ -70,5 +70,6 @@ func refreshDir(rootConfig *config.Config, cmdLine *CommandLine, output string) 
 		return nil
 	}
 	api.LabelRecursiveFields(model)
+	api.CrossReference(model)
 	return language.GenerateClient(model, config.General.Language, output, config.Codec)
 }

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/model.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/model.rs
@@ -259,8 +259,59 @@ impl Secret {
     }
 
     /// Sets the value of `expiration`.
-    pub fn set_expiration<T: std::convert::Into<std::option::Option<crate::model::secret::Expiration>>>(mut self, v: T) ->Self {
+    pub fn set_expiration<T: std::convert::Into<std::option::Option<crate::model::secret::Expiration>>>(mut self, v: T) -> Self
+    {
         self.expiration = v.into();
+        self
+    }
+
+    /// The value of [expiration][crate::model::Secret::expiration]
+    /// if it holds a `ExpireTime`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_expire_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
+        #[allow(unreachable_patterns)]
+        self.expiration.as_ref().and_then(|v| match v {
+            crate::model::secret::Expiration::ExpireTime(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [expiration][crate::model::Secret::expiration]
+    /// if it holds a `Ttl`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_ttl(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
+        #[allow(unreachable_patterns)]
+        self.expiration.as_ref().and_then(|v| match v {
+            crate::model::secret::Expiration::Ttl(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [expiration][crate::model::Secret::expiration]
+    /// to hold a `ExpireTime`.
+    ///
+    /// Note that all the setters affecting `expiration` are
+    /// mutually exclusive.
+    pub fn set_expire_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(mut self, v: T) -> Self {
+        self.expiration = std::option::Option::Some(
+            crate::model::secret::Expiration::ExpireTime(
+                v.into()
+            )
+        );
+        self
+    }
+
+    /// Sets the value of [expiration][crate::model::Secret::expiration]
+    /// to hold a `Ttl`.
+    ///
+    /// Note that all the setters affecting `expiration` are
+    /// mutually exclusive.
+    pub fn set_ttl<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(mut self, v: T) -> Self {
+        self.expiration = std::option::Option::Some(
+            crate::model::secret::Expiration::Ttl(
+                v.into()
+            )
+        );
         self
     }
 }
@@ -536,8 +587,59 @@ pub struct Replication {
 impl Replication {
 
     /// Sets the value of `replication`.
-    pub fn set_replication<T: std::convert::Into<std::option::Option<crate::model::replication::Replication>>>(mut self, v: T) ->Self {
+    pub fn set_replication<T: std::convert::Into<std::option::Option<crate::model::replication::Replication>>>(mut self, v: T) -> Self
+    {
         self.replication = v.into();
+        self
+    }
+
+    /// The value of [replication][crate::model::Replication::replication]
+    /// if it holds a `Automatic`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_automatic(&self) -> std::option::Option<&std::boxed::Box<crate::model::replication::Automatic>> {
+        #[allow(unreachable_patterns)]
+        self.replication.as_ref().and_then(|v| match v {
+            crate::model::replication::Replication::Automatic(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [replication][crate::model::Replication::replication]
+    /// if it holds a `UserManaged`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_user_managed(&self) -> std::option::Option<&std::boxed::Box<crate::model::replication::UserManaged>> {
+        #[allow(unreachable_patterns)]
+        self.replication.as_ref().and_then(|v| match v {
+            crate::model::replication::Replication::UserManaged(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [replication][crate::model::Replication::replication]
+    /// to hold a `Automatic`.
+    ///
+    /// Note that all the setters affecting `replication` are
+    /// mutually exclusive.
+    pub fn set_automatic<T: std::convert::Into<std::boxed::Box<crate::model::replication::Automatic>>>(mut self, v: T) -> Self {
+        self.replication = std::option::Option::Some(
+            crate::model::replication::Replication::Automatic(
+                v.into()
+            )
+        );
+        self
+    }
+
+    /// Sets the value of [replication][crate::model::Replication::replication]
+    /// to hold a `UserManaged`.
+    ///
+    /// Note that all the setters affecting `replication` are
+    /// mutually exclusive.
+    pub fn set_user_managed<T: std::convert::Into<std::boxed::Box<crate::model::replication::UserManaged>>>(mut self, v: T) -> Self {
+        self.replication = std::option::Option::Some(
+            crate::model::replication::Replication::UserManaged(
+                v.into()
+            )
+        );
         self
     }
 }
@@ -779,8 +881,59 @@ pub struct ReplicationStatus {
 impl ReplicationStatus {
 
     /// Sets the value of `replication_status`.
-    pub fn set_replication_status<T: std::convert::Into<std::option::Option<crate::model::replication_status::ReplicationStatus>>>(mut self, v: T) ->Self {
+    pub fn set_replication_status<T: std::convert::Into<std::option::Option<crate::model::replication_status::ReplicationStatus>>>(mut self, v: T) -> Self
+    {
         self.replication_status = v.into();
+        self
+    }
+
+    /// The value of [replication_status][crate::model::ReplicationStatus::replication_status]
+    /// if it holds a `Automatic`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_automatic(&self) -> std::option::Option<&std::boxed::Box<crate::model::replication_status::AutomaticStatus>> {
+        #[allow(unreachable_patterns)]
+        self.replication_status.as_ref().and_then(|v| match v {
+            crate::model::replication_status::ReplicationStatus::Automatic(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [replication_status][crate::model::ReplicationStatus::replication_status]
+    /// if it holds a `UserManaged`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_user_managed(&self) -> std::option::Option<&std::boxed::Box<crate::model::replication_status::UserManagedStatus>> {
+        #[allow(unreachable_patterns)]
+        self.replication_status.as_ref().and_then(|v| match v {
+            crate::model::replication_status::ReplicationStatus::UserManaged(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [replication_status][crate::model::ReplicationStatus::replication_status]
+    /// to hold a `Automatic`.
+    ///
+    /// Note that all the setters affecting `replication_status` are
+    /// mutually exclusive.
+    pub fn set_automatic<T: std::convert::Into<std::boxed::Box<crate::model::replication_status::AutomaticStatus>>>(mut self, v: T) -> Self {
+        self.replication_status = std::option::Option::Some(
+            crate::model::replication_status::ReplicationStatus::Automatic(
+                v.into()
+            )
+        );
+        self
+    }
+
+    /// Sets the value of [replication_status][crate::model::ReplicationStatus::replication_status]
+    /// to hold a `UserManaged`.
+    ///
+    /// Note that all the setters affecting `replication_status` are
+    /// mutually exclusive.
+    pub fn set_user_managed<T: std::convert::Into<std::boxed::Box<crate::model::replication_status::UserManagedStatus>>>(mut self, v: T) -> Self {
+        self.replication_status = std::option::Option::Some(
+            crate::model::replication_status::ReplicationStatus::UserManaged(
+                v.into()
+            )
+        );
         self
     }
 }

--- a/src/generated/api/src/model.rs
+++ b/src/generated/api/src/model.rs
@@ -203,6 +203,69 @@ impl JwtLocation {
         self.r#in = v.into();
         self
     }
+
+    /// The value of [r#in][crate::model::JwtLocation::r#in]
+    /// if it holds a `Header`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_header(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.r#in.as_ref().and_then(|v| match v {
+            crate::model::jwt_location::In::Header(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [r#in][crate::model::JwtLocation::r#in]
+    /// if it holds a `Query`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_query(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.r#in.as_ref().and_then(|v| match v {
+            crate::model::jwt_location::In::Query(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [r#in][crate::model::JwtLocation::r#in]
+    /// if it holds a `Cookie`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_cookie(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.r#in.as_ref().and_then(|v| match v {
+            crate::model::jwt_location::In::Cookie(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [r#in][crate::model::JwtLocation::r#in]
+    /// to hold a `Header`.
+    ///
+    /// Note that all the setters affecting `r#in` are
+    /// mutually exclusive.
+    pub fn set_header<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.r#in = std::option::Option::Some(crate::model::jwt_location::In::Header(v.into()));
+        self
+    }
+
+    /// Sets the value of [r#in][crate::model::JwtLocation::r#in]
+    /// to hold a `Query`.
+    ///
+    /// Note that all the setters affecting `r#in` are
+    /// mutually exclusive.
+    pub fn set_query<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.r#in = std::option::Option::Some(crate::model::jwt_location::In::Query(v.into()));
+        self
+    }
+
+    /// Sets the value of [r#in][crate::model::JwtLocation::r#in]
+    /// to hold a `Cookie`.
+    ///
+    /// Note that all the setters affecting `r#in` are
+    /// mutually exclusive.
+    pub fn set_cookie<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.r#in = std::option::Option::Some(crate::model::jwt_location::In::Cookie(v.into()));
+        self
+    }
 }
 
 impl wkt::message::Message for JwtLocation {
@@ -696,6 +759,56 @@ impl BackendRule {
         v: T,
     ) -> Self {
         self.authentication = v.into();
+        self
+    }
+
+    /// The value of [authentication][crate::model::BackendRule::authentication]
+    /// if it holds a `JwtAudience`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_jwt_audience(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.authentication.as_ref().and_then(|v| match v {
+            crate::model::backend_rule::Authentication::JwtAudience(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [authentication][crate::model::BackendRule::authentication]
+    /// if it holds a `DisableAuth`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_disable_auth(&self) -> std::option::Option<&bool> {
+        #[allow(unreachable_patterns)]
+        self.authentication.as_ref().and_then(|v| match v {
+            crate::model::backend_rule::Authentication::DisableAuth(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [authentication][crate::model::BackendRule::authentication]
+    /// to hold a `JwtAudience`.
+    ///
+    /// Note that all the setters affecting `authentication` are
+    /// mutually exclusive.
+    pub fn set_jwt_audience<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.authentication = std::option::Option::Some(
+            crate::model::backend_rule::Authentication::JwtAudience(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [authentication][crate::model::BackendRule::authentication]
+    /// to hold a `DisableAuth`.
+    ///
+    /// Note that all the setters affecting `authentication` are
+    /// mutually exclusive.
+    pub fn set_disable_auth<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.authentication = std::option::Option::Some(
+            crate::model::backend_rule::Authentication::DisableAuth(v.into()),
+        );
         self
     }
 }
@@ -2702,6 +2815,111 @@ pub mod distribution {
             self.options = v.into();
             self
         }
+
+        /// The value of [options][crate::model::distribution::BucketOptions::options]
+        /// if it holds a `LinearBuckets`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_linear_buckets(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::distribution::bucket_options::Linear>>
+        {
+            #[allow(unreachable_patterns)]
+            self.options.as_ref().and_then(|v| match v {
+                crate::model::distribution::bucket_options::Options::LinearBuckets(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// The value of [options][crate::model::distribution::BucketOptions::options]
+        /// if it holds a `ExponentialBuckets`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_exponential_buckets(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::distribution::bucket_options::Exponential>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.options.as_ref().and_then(|v| match v {
+                crate::model::distribution::bucket_options::Options::ExponentialBuckets(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// The value of [options][crate::model::distribution::BucketOptions::options]
+        /// if it holds a `ExplicitBuckets`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_explicit_buckets(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::distribution::bucket_options::Explicit>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.options.as_ref().and_then(|v| match v {
+                crate::model::distribution::bucket_options::Options::ExplicitBuckets(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// Sets the value of [options][crate::model::distribution::BucketOptions::options]
+        /// to hold a `LinearBuckets`.
+        ///
+        /// Note that all the setters affecting `options` are
+        /// mutually exclusive.
+        pub fn set_linear_buckets<
+            T: std::convert::Into<std::boxed::Box<crate::model::distribution::bucket_options::Linear>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.options = std::option::Option::Some(
+                crate::model::distribution::bucket_options::Options::LinearBuckets(v.into()),
+            );
+            self
+        }
+
+        /// Sets the value of [options][crate::model::distribution::BucketOptions::options]
+        /// to hold a `ExponentialBuckets`.
+        ///
+        /// Note that all the setters affecting `options` are
+        /// mutually exclusive.
+        pub fn set_exponential_buckets<
+            T: std::convert::Into<
+                std::boxed::Box<crate::model::distribution::bucket_options::Exponential>,
+            >,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.options = std::option::Option::Some(
+                crate::model::distribution::bucket_options::Options::ExponentialBuckets(v.into()),
+            );
+            self
+        }
+
+        /// Sets the value of [options][crate::model::distribution::BucketOptions::options]
+        /// to hold a `ExplicitBuckets`.
+        ///
+        /// Note that all the setters affecting `options` are
+        /// mutually exclusive.
+        pub fn set_explicit_buckets<
+            T: std::convert::Into<
+                std::boxed::Box<crate::model::distribution::bucket_options::Explicit>,
+            >,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.options = std::option::Option::Some(
+                crate::model::distribution::bucket_options::Options::ExplicitBuckets(v.into()),
+            );
+            self
+        }
     }
 
     impl wkt::message::Message for BucketOptions {
@@ -3844,6 +4062,139 @@ impl HttpRule {
         v: T,
     ) -> Self {
         self.pattern = v.into();
+        self
+    }
+
+    /// The value of [pattern][crate::model::HttpRule::pattern]
+    /// if it holds a `Get`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_get(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.pattern.as_ref().and_then(|v| match v {
+            crate::model::http_rule::Pattern::Get(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [pattern][crate::model::HttpRule::pattern]
+    /// if it holds a `Put`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_put(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.pattern.as_ref().and_then(|v| match v {
+            crate::model::http_rule::Pattern::Put(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [pattern][crate::model::HttpRule::pattern]
+    /// if it holds a `Post`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_post(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.pattern.as_ref().and_then(|v| match v {
+            crate::model::http_rule::Pattern::Post(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [pattern][crate::model::HttpRule::pattern]
+    /// if it holds a `Delete`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_delete(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.pattern.as_ref().and_then(|v| match v {
+            crate::model::http_rule::Pattern::Delete(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [pattern][crate::model::HttpRule::pattern]
+    /// if it holds a `Patch`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_patch(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.pattern.as_ref().and_then(|v| match v {
+            crate::model::http_rule::Pattern::Patch(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [pattern][crate::model::HttpRule::pattern]
+    /// if it holds a `Custom`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_custom(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CustomHttpPattern>> {
+        #[allow(unreachable_patterns)]
+        self.pattern.as_ref().and_then(|v| match v {
+            crate::model::http_rule::Pattern::Custom(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [pattern][crate::model::HttpRule::pattern]
+    /// to hold a `Get`.
+    ///
+    /// Note that all the setters affecting `pattern` are
+    /// mutually exclusive.
+    pub fn set_get<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.pattern = std::option::Option::Some(crate::model::http_rule::Pattern::Get(v.into()));
+        self
+    }
+
+    /// Sets the value of [pattern][crate::model::HttpRule::pattern]
+    /// to hold a `Put`.
+    ///
+    /// Note that all the setters affecting `pattern` are
+    /// mutually exclusive.
+    pub fn set_put<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.pattern = std::option::Option::Some(crate::model::http_rule::Pattern::Put(v.into()));
+        self
+    }
+
+    /// Sets the value of [pattern][crate::model::HttpRule::pattern]
+    /// to hold a `Post`.
+    ///
+    /// Note that all the setters affecting `pattern` are
+    /// mutually exclusive.
+    pub fn set_post<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.pattern = std::option::Option::Some(crate::model::http_rule::Pattern::Post(v.into()));
+        self
+    }
+
+    /// Sets the value of [pattern][crate::model::HttpRule::pattern]
+    /// to hold a `Delete`.
+    ///
+    /// Note that all the setters affecting `pattern` are
+    /// mutually exclusive.
+    pub fn set_delete<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.pattern =
+            std::option::Option::Some(crate::model::http_rule::Pattern::Delete(v.into()));
+        self
+    }
+
+    /// Sets the value of [pattern][crate::model::HttpRule::pattern]
+    /// to hold a `Patch`.
+    ///
+    /// Note that all the setters affecting `pattern` are
+    /// mutually exclusive.
+    pub fn set_patch<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.pattern = std::option::Option::Some(crate::model::http_rule::Pattern::Patch(v.into()));
+        self
+    }
+
+    /// Sets the value of [pattern][crate::model::HttpRule::pattern]
+    /// to hold a `Custom`.
+    ///
+    /// Note that all the setters affecting `pattern` are
+    /// mutually exclusive.
+    pub fn set_custom<T: std::convert::Into<std::boxed::Box<crate::model::CustomHttpPattern>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.pattern =
+            std::option::Option::Some(crate::model::http_rule::Pattern::Custom(v.into()));
         self
     }
 }

--- a/src/generated/bigtable/admin/v2/src/model.rs
+++ b/src/generated/bigtable/admin/v2/src/model.rs
@@ -1454,6 +1454,29 @@ impl RestoreTableRequest {
         self.source = v.into();
         self
     }
+
+    /// The value of [source][crate::model::RestoreTableRequest::source]
+    /// if it holds a `Backup`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_backup(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::restore_table_request::Source::Backup(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [source][crate::model::RestoreTableRequest::source]
+    /// to hold a `Backup`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_backup<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.source = std::option::Option::Some(
+            crate::model::restore_table_request::Source::Backup(v.into()),
+        );
+        self
+    }
 }
 
 impl wkt::message::Message for RestoreTableRequest {
@@ -1569,6 +1592,36 @@ impl RestoreTableMetadata {
         v: T,
     ) -> Self {
         self.source_info = v.into();
+        self
+    }
+
+    /// The value of [source_info][crate::model::RestoreTableMetadata::source_info]
+    /// if it holds a `BackupInfo`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_backup_info(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BackupInfo>> {
+        #[allow(unreachable_patterns)]
+        self.source_info.as_ref().and_then(|v| match v {
+            crate::model::restore_table_metadata::SourceInfo::BackupInfo(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [source_info][crate::model::RestoreTableMetadata::source_info]
+    /// to hold a `BackupInfo`.
+    ///
+    /// Note that all the setters affecting `source_info` are
+    /// mutually exclusive.
+    pub fn set_backup_info<T: std::convert::Into<std::boxed::Box<crate::model::BackupInfo>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source_info = std::option::Option::Some(
+            crate::model::restore_table_metadata::SourceInfo::BackupInfo(v.into()),
+        );
         self
     }
 }
@@ -1849,6 +1902,56 @@ impl DropRowRangeRequest {
         v: T,
     ) -> Self {
         self.target = v.into();
+        self
+    }
+
+    /// The value of [target][crate::model::DropRowRangeRequest::target]
+    /// if it holds a `RowKeyPrefix`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_row_key_prefix(&self) -> std::option::Option<&bytes::Bytes> {
+        #[allow(unreachable_patterns)]
+        self.target.as_ref().and_then(|v| match v {
+            crate::model::drop_row_range_request::Target::RowKeyPrefix(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [target][crate::model::DropRowRangeRequest::target]
+    /// if it holds a `DeleteAllDataFromTable`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_delete_all_data_from_table(&self) -> std::option::Option<&bool> {
+        #[allow(unreachable_patterns)]
+        self.target.as_ref().and_then(|v| match v {
+            crate::model::drop_row_range_request::Target::DeleteAllDataFromTable(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [target][crate::model::DropRowRangeRequest::target]
+    /// to hold a `RowKeyPrefix`.
+    ///
+    /// Note that all the setters affecting `target` are
+    /// mutually exclusive.
+    pub fn set_row_key_prefix<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
+        self.target = std::option::Option::Some(
+            crate::model::drop_row_range_request::Target::RowKeyPrefix(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [target][crate::model::DropRowRangeRequest::target]
+    /// to hold a `DeleteAllDataFromTable`.
+    ///
+    /// Note that all the setters affecting `target` are
+    /// mutually exclusive.
+    pub fn set_delete_all_data_from_table<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.target = std::option::Option::Some(
+            crate::model::drop_row_range_request::Target::DeleteAllDataFromTable(v.into()),
+        );
         self
     }
 }
@@ -2379,6 +2482,91 @@ pub mod modify_column_families_request {
             self.r#mod = v.into();
             self
         }
+
+        /// The value of [r#mod][crate::model::modify_column_families_request::Modification::r#mod]
+        /// if it holds a `Create`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_create(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::ColumnFamily>> {
+            #[allow(unreachable_patterns)]
+            self.r#mod.as_ref().and_then(|v| match v {
+                crate::model::modify_column_families_request::modification::Mod::Create(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// The value of [r#mod][crate::model::modify_column_families_request::Modification::r#mod]
+        /// if it holds a `Update`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_update(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::ColumnFamily>> {
+            #[allow(unreachable_patterns)]
+            self.r#mod.as_ref().and_then(|v| match v {
+                crate::model::modify_column_families_request::modification::Mod::Update(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// The value of [r#mod][crate::model::modify_column_families_request::Modification::r#mod]
+        /// if it holds a `Drop`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_drop(&self) -> std::option::Option<&bool> {
+            #[allow(unreachable_patterns)]
+            self.r#mod.as_ref().and_then(|v| match v {
+                crate::model::modify_column_families_request::modification::Mod::Drop(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// Sets the value of [r#mod][crate::model::modify_column_families_request::Modification::r#mod]
+        /// to hold a `Create`.
+        ///
+        /// Note that all the setters affecting `r#mod` are
+        /// mutually exclusive.
+        pub fn set_create<T: std::convert::Into<std::boxed::Box<crate::model::ColumnFamily>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.r#mod = std::option::Option::Some(
+                crate::model::modify_column_families_request::modification::Mod::Create(v.into()),
+            );
+            self
+        }
+
+        /// Sets the value of [r#mod][crate::model::modify_column_families_request::Modification::r#mod]
+        /// to hold a `Update`.
+        ///
+        /// Note that all the setters affecting `r#mod` are
+        /// mutually exclusive.
+        pub fn set_update<T: std::convert::Into<std::boxed::Box<crate::model::ColumnFamily>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.r#mod = std::option::Option::Some(
+                crate::model::modify_column_families_request::modification::Mod::Update(v.into()),
+            );
+            self
+        }
+
+        /// Sets the value of [r#mod][crate::model::modify_column_families_request::Modification::r#mod]
+        /// to hold a `Drop`.
+        ///
+        /// Note that all the setters affecting `r#mod` are
+        /// mutually exclusive.
+        pub fn set_drop<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.r#mod = std::option::Option::Some(
+                crate::model::modify_column_families_request::modification::Mod::Drop(v.into()),
+            );
+            self
+        }
     }
 
     impl wkt::message::Message for Modification {
@@ -2520,6 +2708,70 @@ impl CheckConsistencyRequest {
         v: T,
     ) -> Self {
         self.mode = v.into();
+        self
+    }
+
+    /// The value of [mode][crate::model::CheckConsistencyRequest::mode]
+    /// if it holds a `StandardReadRemoteWrites`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_standard_read_remote_writes(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::StandardReadRemoteWrites>> {
+        #[allow(unreachable_patterns)]
+        self.mode.as_ref().and_then(|v| match v {
+            crate::model::check_consistency_request::Mode::StandardReadRemoteWrites(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [mode][crate::model::CheckConsistencyRequest::mode]
+    /// if it holds a `DataBoostReadLocalWrites`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_data_boost_read_local_writes(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DataBoostReadLocalWrites>> {
+        #[allow(unreachable_patterns)]
+        self.mode.as_ref().and_then(|v| match v {
+            crate::model::check_consistency_request::Mode::DataBoostReadLocalWrites(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [mode][crate::model::CheckConsistencyRequest::mode]
+    /// to hold a `StandardReadRemoteWrites`.
+    ///
+    /// Note that all the setters affecting `mode` are
+    /// mutually exclusive.
+    pub fn set_standard_read_remote_writes<
+        T: std::convert::Into<std::boxed::Box<crate::model::StandardReadRemoteWrites>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.mode = std::option::Option::Some(
+            crate::model::check_consistency_request::Mode::StandardReadRemoteWrites(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [mode][crate::model::CheckConsistencyRequest::mode]
+    /// to hold a `DataBoostReadLocalWrites`.
+    ///
+    /// Note that all the setters affecting `mode` are
+    /// mutually exclusive.
+    pub fn set_data_boost_read_local_writes<
+        T: std::convert::Into<std::boxed::Box<crate::model::DataBoostReadLocalWrites>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.mode = std::option::Option::Some(
+            crate::model::check_consistency_request::Mode::DataBoostReadLocalWrites(v.into()),
+        );
         self
     }
 }
@@ -4465,6 +4717,35 @@ impl Cluster {
         self.config = v.into();
         self
     }
+
+    /// The value of [config][crate::model::Cluster::config]
+    /// if it holds a `ClusterConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_cluster_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::cluster::ClusterConfig>> {
+        #[allow(unreachable_patterns)]
+        self.config.as_ref().and_then(|v| match v {
+            crate::model::cluster::Config::ClusterConfig(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [config][crate::model::Cluster::config]
+    /// to hold a `ClusterConfig`.
+    ///
+    /// Note that all the setters affecting `config` are
+    /// mutually exclusive.
+    pub fn set_cluster_config<
+        T: std::convert::Into<std::boxed::Box<crate::model::cluster::ClusterConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.config =
+            std::option::Option::Some(crate::model::cluster::Config::ClusterConfig(v.into()));
+        self
+    }
 }
 
 impl wkt::message::Message for Cluster {
@@ -4747,6 +5028,72 @@ impl AppProfile {
         self
     }
 
+    /// The value of [routing_policy][crate::model::AppProfile::routing_policy]
+    /// if it holds a `MultiClusterRoutingUseAny`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_multi_cluster_routing_use_any(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::app_profile::MultiClusterRoutingUseAny>>
+    {
+        #[allow(unreachable_patterns)]
+        self.routing_policy.as_ref().and_then(|v| match v {
+            crate::model::app_profile::RoutingPolicy::MultiClusterRoutingUseAny(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [routing_policy][crate::model::AppProfile::routing_policy]
+    /// if it holds a `SingleClusterRouting`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_single_cluster_routing(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::app_profile::SingleClusterRouting>>
+    {
+        #[allow(unreachable_patterns)]
+        self.routing_policy.as_ref().and_then(|v| match v {
+            crate::model::app_profile::RoutingPolicy::SingleClusterRouting(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [routing_policy][crate::model::AppProfile::routing_policy]
+    /// to hold a `MultiClusterRoutingUseAny`.
+    ///
+    /// Note that all the setters affecting `routing_policy` are
+    /// mutually exclusive.
+    pub fn set_multi_cluster_routing_use_any<
+        T: std::convert::Into<std::boxed::Box<crate::model::app_profile::MultiClusterRoutingUseAny>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.routing_policy = std::option::Option::Some(
+            crate::model::app_profile::RoutingPolicy::MultiClusterRoutingUseAny(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [routing_policy][crate::model::AppProfile::routing_policy]
+    /// to hold a `SingleClusterRouting`.
+    ///
+    /// Note that all the setters affecting `routing_policy` are
+    /// mutually exclusive.
+    pub fn set_single_cluster_routing<
+        T: std::convert::Into<std::boxed::Box<crate::model::app_profile::SingleClusterRouting>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.routing_policy = std::option::Option::Some(
+            crate::model::app_profile::RoutingPolicy::SingleClusterRouting(v.into()),
+        );
+        self
+    }
+
     /// Sets the value of `isolation`.
     pub fn set_isolation<
         T: std::convert::Into<std::option::Option<crate::model::app_profile::Isolation>>,
@@ -4755,6 +5102,96 @@ impl AppProfile {
         v: T,
     ) -> Self {
         self.isolation = v.into();
+        self
+    }
+
+    /// The value of [isolation][crate::model::AppProfile::isolation]
+    /// if it holds a `Priority`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_priority(&self) -> std::option::Option<&crate::model::app_profile::Priority> {
+        #[allow(unreachable_patterns)]
+        self.isolation.as_ref().and_then(|v| match v {
+            crate::model::app_profile::Isolation::Priority(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [isolation][crate::model::AppProfile::isolation]
+    /// if it holds a `StandardIsolation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_standard_isolation(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::app_profile::StandardIsolation>> {
+        #[allow(unreachable_patterns)]
+        self.isolation.as_ref().and_then(|v| match v {
+            crate::model::app_profile::Isolation::StandardIsolation(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [isolation][crate::model::AppProfile::isolation]
+    /// if it holds a `DataBoostIsolationReadOnly`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_data_boost_isolation_read_only(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::app_profile::DataBoostIsolationReadOnly>>
+    {
+        #[allow(unreachable_patterns)]
+        self.isolation.as_ref().and_then(|v| match v {
+            crate::model::app_profile::Isolation::DataBoostIsolationReadOnly(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [isolation][crate::model::AppProfile::isolation]
+    /// to hold a `Priority`.
+    ///
+    /// Note that all the setters affecting `isolation` are
+    /// mutually exclusive.
+    pub fn set_priority<T: std::convert::Into<crate::model::app_profile::Priority>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.isolation =
+            std::option::Option::Some(crate::model::app_profile::Isolation::Priority(v.into()));
+        self
+    }
+
+    /// Sets the value of [isolation][crate::model::AppProfile::isolation]
+    /// to hold a `StandardIsolation`.
+    ///
+    /// Note that all the setters affecting `isolation` are
+    /// mutually exclusive.
+    pub fn set_standard_isolation<
+        T: std::convert::Into<std::boxed::Box<crate::model::app_profile::StandardIsolation>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.isolation = std::option::Option::Some(
+            crate::model::app_profile::Isolation::StandardIsolation(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [isolation][crate::model::AppProfile::isolation]
+    /// to hold a `DataBoostIsolationReadOnly`.
+    ///
+    /// Note that all the setters affecting `isolation` are
+    /// mutually exclusive.
+    pub fn set_data_boost_isolation_read_only<
+        T: std::convert::Into<std::boxed::Box<crate::model::app_profile::DataBoostIsolationReadOnly>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.isolation = std::option::Option::Some(
+            crate::model::app_profile::Isolation::DataBoostIsolationReadOnly(v.into()),
+        );
         self
     }
 }
@@ -4822,6 +5259,46 @@ pub mod app_profile {
             v: T,
         ) -> Self {
             self.affinity = v.into();
+            self
+        }
+
+        /// The value of [affinity][crate::model::app_profile::MultiClusterRoutingUseAny::affinity]
+        /// if it holds a `RowAffinity`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_row_affinity(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::app_profile::multi_cluster_routing_use_any::RowAffinity>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.affinity.as_ref().and_then(|v| match v {
+                crate::model::app_profile::multi_cluster_routing_use_any::Affinity::RowAffinity(
+                    v,
+                ) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// Sets the value of [affinity][crate::model::app_profile::MultiClusterRoutingUseAny::affinity]
+        /// to hold a `RowAffinity`.
+        ///
+        /// Note that all the setters affecting `affinity` are
+        /// mutually exclusive.
+        pub fn set_row_affinity<
+            T: std::convert::Into<
+                std::boxed::Box<
+                    crate::model::app_profile::multi_cluster_routing_use_any::RowAffinity,
+                >,
+            >,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.affinity = std::option::Option::Some(
+                crate::model::app_profile::multi_cluster_routing_use_any::Affinity::RowAffinity(
+                    v.into(),
+                ),
+            );
             self
         }
     }
@@ -5231,6 +5708,33 @@ impl RestoreInfo {
         self.source_info = v.into();
         self
     }
+
+    /// The value of [source_info][crate::model::RestoreInfo::source_info]
+    /// if it holds a `BackupInfo`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_backup_info(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BackupInfo>> {
+        #[allow(unreachable_patterns)]
+        self.source_info.as_ref().and_then(|v| match v {
+            crate::model::restore_info::SourceInfo::BackupInfo(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [source_info][crate::model::RestoreInfo::source_info]
+    /// to hold a `BackupInfo`.
+    ///
+    /// Note that all the setters affecting `source_info` are
+    /// mutually exclusive.
+    pub fn set_backup_info<T: std::convert::Into<std::boxed::Box<crate::model::BackupInfo>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source_info =
+            std::option::Option::Some(crate::model::restore_info::SourceInfo::BackupInfo(v.into()));
+        self
+    }
 }
 
 impl wkt::message::Message for RestoreInfo {
@@ -5421,6 +5925,38 @@ impl Table {
         v: T,
     ) -> Self {
         self.automated_backup_config = v.into();
+        self
+    }
+
+    /// The value of [automated_backup_config][crate::model::Table::automated_backup_config]
+    /// if it holds a `AutomatedBackupPolicy`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_automated_backup_policy(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::table::AutomatedBackupPolicy>> {
+        #[allow(unreachable_patterns)]
+        self.automated_backup_config.as_ref().and_then(|v| match v {
+            crate::model::table::AutomatedBackupConfig::AutomatedBackupPolicy(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [automated_backup_config][crate::model::Table::automated_backup_config]
+    /// to hold a `AutomatedBackupPolicy`.
+    ///
+    /// Note that all the setters affecting `automated_backup_config` are
+    /// mutually exclusive.
+    pub fn set_automated_backup_policy<
+        T: std::convert::Into<std::boxed::Box<crate::model::table::AutomatedBackupPolicy>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.automated_backup_config = std::option::Option::Some(
+            crate::model::table::AutomatedBackupConfig::AutomatedBackupPolicy(v.into()),
+        );
         self
     }
 }
@@ -5718,6 +6254,38 @@ impl AuthorizedView {
         self.authorized_view = v.into();
         self
     }
+
+    /// The value of [authorized_view][crate::model::AuthorizedView::authorized_view]
+    /// if it holds a `SubsetView`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_subset_view(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::authorized_view::SubsetView>> {
+        #[allow(unreachable_patterns)]
+        self.authorized_view.as_ref().and_then(|v| match v {
+            crate::model::authorized_view::AuthorizedView::SubsetView(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [authorized_view][crate::model::AuthorizedView::authorized_view]
+    /// to hold a `SubsetView`.
+    ///
+    /// Note that all the setters affecting `authorized_view` are
+    /// mutually exclusive.
+    pub fn set_subset_view<
+        T: std::convert::Into<std::boxed::Box<crate::model::authorized_view::SubsetView>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.authorized_view = std::option::Option::Some(
+            crate::model::authorized_view::AuthorizedView::SubsetView(v.into()),
+        );
+        self
+    }
 }
 
 impl wkt::message::Message for AuthorizedView {
@@ -5951,6 +6519,104 @@ impl GcRule {
         v: T,
     ) -> Self {
         self.rule = v.into();
+        self
+    }
+
+    /// The value of [rule][crate::model::GcRule::rule]
+    /// if it holds a `MaxNumVersions`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_max_num_versions(&self) -> std::option::Option<&i32> {
+        #[allow(unreachable_patterns)]
+        self.rule.as_ref().and_then(|v| match v {
+            crate::model::gc_rule::Rule::MaxNumVersions(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [rule][crate::model::GcRule::rule]
+    /// if it holds a `MaxAge`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_max_age(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
+        #[allow(unreachable_patterns)]
+        self.rule.as_ref().and_then(|v| match v {
+            crate::model::gc_rule::Rule::MaxAge(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [rule][crate::model::GcRule::rule]
+    /// if it holds a `Intersection`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_intersection(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::gc_rule::Intersection>> {
+        #[allow(unreachable_patterns)]
+        self.rule.as_ref().and_then(|v| match v {
+            crate::model::gc_rule::Rule::Intersection(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [rule][crate::model::GcRule::rule]
+    /// if it holds a `Union`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_union(&self) -> std::option::Option<&std::boxed::Box<crate::model::gc_rule::Union>> {
+        #[allow(unreachable_patterns)]
+        self.rule.as_ref().and_then(|v| match v {
+            crate::model::gc_rule::Rule::Union(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [rule][crate::model::GcRule::rule]
+    /// to hold a `MaxNumVersions`.
+    ///
+    /// Note that all the setters affecting `rule` are
+    /// mutually exclusive.
+    pub fn set_max_num_versions<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.rule =
+            std::option::Option::Some(crate::model::gc_rule::Rule::MaxNumVersions(v.into()));
+        self
+    }
+
+    /// Sets the value of [rule][crate::model::GcRule::rule]
+    /// to hold a `MaxAge`.
+    ///
+    /// Note that all the setters affecting `rule` are
+    /// mutually exclusive.
+    pub fn set_max_age<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.rule = std::option::Option::Some(crate::model::gc_rule::Rule::MaxAge(v.into()));
+        self
+    }
+
+    /// Sets the value of [rule][crate::model::GcRule::rule]
+    /// to hold a `Intersection`.
+    ///
+    /// Note that all the setters affecting `rule` are
+    /// mutually exclusive.
+    pub fn set_intersection<
+        T: std::convert::Into<std::boxed::Box<crate::model::gc_rule::Intersection>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.rule = std::option::Option::Some(crate::model::gc_rule::Rule::Intersection(v.into()));
+        self
+    }
+
+    /// Sets the value of [rule][crate::model::GcRule::rule]
+    /// to hold a `Union`.
+    ///
+    /// Note that all the setters affecting `rule` are
+    /// mutually exclusive.
+    pub fn set_union<T: std::convert::Into<std::boxed::Box<crate::model::gc_rule::Union>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.rule = std::option::Option::Some(crate::model::gc_rule::Rule::Union(v.into()));
         self
     }
 }
@@ -6660,6 +7326,324 @@ impl Type {
         self.kind = v.into();
         self
     }
+
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `BytesType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_bytes_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Bytes>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::BytesType(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `StringType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_string_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::String>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::StringType(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `Int64Type`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_int64_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Int64>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::Int64Type(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `Float32Type`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_float32_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Float32>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::Float32Type(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `Float64Type`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_float64_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Float64>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::Float64Type(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `BoolType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_bool_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Bool>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::BoolType(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `TimestampType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_timestamp_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Timestamp>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::TimestampType(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `DateType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_date_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Date>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::DateType(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `AggregateType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_aggregate_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Aggregate>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::AggregateType(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `StructType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_struct_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Struct>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::StructType(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `ArrayType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_array_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Array>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::ArrayType(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `MapType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_map_type(&self) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Map>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::MapType(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [kind][crate::model::Type::kind]
+    /// to hold a `BytesType`.
+    ///
+    /// Note that all the setters affecting `kind` are
+    /// mutually exclusive.
+    pub fn set_bytes_type<T: std::convert::Into<std::boxed::Box<crate::model::r#type::Bytes>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.kind = std::option::Option::Some(crate::model::r#type::Kind::BytesType(v.into()));
+        self
+    }
+
+    /// Sets the value of [kind][crate::model::Type::kind]
+    /// to hold a `StringType`.
+    ///
+    /// Note that all the setters affecting `kind` are
+    /// mutually exclusive.
+    pub fn set_string_type<T: std::convert::Into<std::boxed::Box<crate::model::r#type::String>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.kind = std::option::Option::Some(crate::model::r#type::Kind::StringType(v.into()));
+        self
+    }
+
+    /// Sets the value of [kind][crate::model::Type::kind]
+    /// to hold a `Int64Type`.
+    ///
+    /// Note that all the setters affecting `kind` are
+    /// mutually exclusive.
+    pub fn set_int64_type<T: std::convert::Into<std::boxed::Box<crate::model::r#type::Int64>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.kind = std::option::Option::Some(crate::model::r#type::Kind::Int64Type(v.into()));
+        self
+    }
+
+    /// Sets the value of [kind][crate::model::Type::kind]
+    /// to hold a `Float32Type`.
+    ///
+    /// Note that all the setters affecting `kind` are
+    /// mutually exclusive.
+    pub fn set_float32_type<
+        T: std::convert::Into<std::boxed::Box<crate::model::r#type::Float32>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.kind = std::option::Option::Some(crate::model::r#type::Kind::Float32Type(v.into()));
+        self
+    }
+
+    /// Sets the value of [kind][crate::model::Type::kind]
+    /// to hold a `Float64Type`.
+    ///
+    /// Note that all the setters affecting `kind` are
+    /// mutually exclusive.
+    pub fn set_float64_type<
+        T: std::convert::Into<std::boxed::Box<crate::model::r#type::Float64>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.kind = std::option::Option::Some(crate::model::r#type::Kind::Float64Type(v.into()));
+        self
+    }
+
+    /// Sets the value of [kind][crate::model::Type::kind]
+    /// to hold a `BoolType`.
+    ///
+    /// Note that all the setters affecting `kind` are
+    /// mutually exclusive.
+    pub fn set_bool_type<T: std::convert::Into<std::boxed::Box<crate::model::r#type::Bool>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.kind = std::option::Option::Some(crate::model::r#type::Kind::BoolType(v.into()));
+        self
+    }
+
+    /// Sets the value of [kind][crate::model::Type::kind]
+    /// to hold a `TimestampType`.
+    ///
+    /// Note that all the setters affecting `kind` are
+    /// mutually exclusive.
+    pub fn set_timestamp_type<
+        T: std::convert::Into<std::boxed::Box<crate::model::r#type::Timestamp>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.kind = std::option::Option::Some(crate::model::r#type::Kind::TimestampType(v.into()));
+        self
+    }
+
+    /// Sets the value of [kind][crate::model::Type::kind]
+    /// to hold a `DateType`.
+    ///
+    /// Note that all the setters affecting `kind` are
+    /// mutually exclusive.
+    pub fn set_date_type<T: std::convert::Into<std::boxed::Box<crate::model::r#type::Date>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.kind = std::option::Option::Some(crate::model::r#type::Kind::DateType(v.into()));
+        self
+    }
+
+    /// Sets the value of [kind][crate::model::Type::kind]
+    /// to hold a `AggregateType`.
+    ///
+    /// Note that all the setters affecting `kind` are
+    /// mutually exclusive.
+    pub fn set_aggregate_type<
+        T: std::convert::Into<std::boxed::Box<crate::model::r#type::Aggregate>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.kind = std::option::Option::Some(crate::model::r#type::Kind::AggregateType(v.into()));
+        self
+    }
+
+    /// Sets the value of [kind][crate::model::Type::kind]
+    /// to hold a `StructType`.
+    ///
+    /// Note that all the setters affecting `kind` are
+    /// mutually exclusive.
+    pub fn set_struct_type<T: std::convert::Into<std::boxed::Box<crate::model::r#type::Struct>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.kind = std::option::Option::Some(crate::model::r#type::Kind::StructType(v.into()));
+        self
+    }
+
+    /// Sets the value of [kind][crate::model::Type::kind]
+    /// to hold a `ArrayType`.
+    ///
+    /// Note that all the setters affecting `kind` are
+    /// mutually exclusive.
+    pub fn set_array_type<T: std::convert::Into<std::boxed::Box<crate::model::r#type::Array>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.kind = std::option::Option::Some(crate::model::r#type::Kind::ArrayType(v.into()));
+        self
+    }
+
+    /// Sets the value of [kind][crate::model::Type::kind]
+    /// to hold a `MapType`.
+    ///
+    /// Note that all the setters affecting `kind` are
+    /// mutually exclusive.
+    pub fn set_map_type<T: std::convert::Into<std::boxed::Box<crate::model::r#type::Map>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.kind = std::option::Option::Some(crate::model::r#type::Kind::MapType(v.into()));
+        self
+    }
 }
 
 impl wkt::message::Message for Type {
@@ -6731,6 +7715,39 @@ pub mod r#type {
                 v: T,
             ) -> Self {
                 self.encoding = v.into();
+                self
+            }
+
+            /// The value of [encoding][crate::model::r#type::bytes::Encoding::encoding]
+            /// if it holds a `Raw`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn get_raw(
+                &self,
+            ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::bytes::encoding::Raw>>
+            {
+                #[allow(unreachable_patterns)]
+                self.encoding.as_ref().and_then(|v| match v {
+                    crate::model::r#type::bytes::encoding::Encoding::Raw(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
+            }
+
+            /// Sets the value of [encoding][crate::model::r#type::bytes::Encoding::encoding]
+            /// to hold a `Raw`.
+            ///
+            /// Note that all the setters affecting `encoding` are
+            /// mutually exclusive.
+            pub fn set_raw<
+                T: std::convert::Into<std::boxed::Box<crate::model::r#type::bytes::encoding::Raw>>,
+            >(
+                mut self,
+                v: T,
+            ) -> Self {
+                self.encoding = std::option::Option::Some(
+                    crate::model::r#type::bytes::encoding::Encoding::Raw(v.into()),
+                );
                 self
             }
         }
@@ -6834,6 +7851,78 @@ pub mod r#type {
                 v: T,
             ) -> Self {
                 self.encoding = v.into();
+                self
+            }
+
+            /// The value of [encoding][crate::model::r#type::string::Encoding::encoding]
+            /// if it holds a `Utf8Raw`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn get_utf8_raw(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<crate::model::r#type::string::encoding::Utf8Raw>,
+            > {
+                #[allow(unreachable_patterns)]
+                self.encoding.as_ref().and_then(|v| match v {
+                    crate::model::r#type::string::encoding::Encoding::Utf8Raw(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
+            }
+
+            /// The value of [encoding][crate::model::r#type::string::Encoding::encoding]
+            /// if it holds a `Utf8Bytes`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn get_utf8_bytes(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<crate::model::r#type::string::encoding::Utf8Bytes>,
+            > {
+                #[allow(unreachable_patterns)]
+                self.encoding.as_ref().and_then(|v| match v {
+                    crate::model::r#type::string::encoding::Encoding::Utf8Bytes(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
+            }
+
+            /// Sets the value of [encoding][crate::model::r#type::string::Encoding::encoding]
+            /// to hold a `Utf8Raw`.
+            ///
+            /// Note that all the setters affecting `encoding` are
+            /// mutually exclusive.
+            pub fn set_utf8_raw<
+                T: std::convert::Into<
+                    std::boxed::Box<crate::model::r#type::string::encoding::Utf8Raw>,
+                >,
+            >(
+                mut self,
+                v: T,
+            ) -> Self {
+                self.encoding = std::option::Option::Some(
+                    crate::model::r#type::string::encoding::Encoding::Utf8Raw(v.into()),
+                );
+                self
+            }
+
+            /// Sets the value of [encoding][crate::model::r#type::string::Encoding::encoding]
+            /// to hold a `Utf8Bytes`.
+            ///
+            /// Note that all the setters affecting `encoding` are
+            /// mutually exclusive.
+            pub fn set_utf8_bytes<
+                T: std::convert::Into<
+                    std::boxed::Box<crate::model::r#type::string::encoding::Utf8Bytes>,
+                >,
+            >(
+                mut self,
+                v: T,
+            ) -> Self {
+                self.encoding = std::option::Option::Some(
+                    crate::model::r#type::string::encoding::Encoding::Utf8Bytes(v.into()),
+                );
                 self
             }
         }
@@ -6957,6 +8046,42 @@ pub mod r#type {
                 v: T,
             ) -> Self {
                 self.encoding = v.into();
+                self
+            }
+
+            /// The value of [encoding][crate::model::r#type::int_64::Encoding::encoding]
+            /// if it holds a `BigEndianBytes`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn get_big_endian_bytes(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<crate::model::r#type::int_64::encoding::BigEndianBytes>,
+            > {
+                #[allow(unreachable_patterns)]
+                self.encoding.as_ref().and_then(|v| match v {
+                    crate::model::r#type::int_64::encoding::Encoding::BigEndianBytes(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
+            }
+
+            /// Sets the value of [encoding][crate::model::r#type::int_64::Encoding::encoding]
+            /// to hold a `BigEndianBytes`.
+            ///
+            /// Note that all the setters affecting `encoding` are
+            /// mutually exclusive.
+            pub fn set_big_endian_bytes<
+                T: std::convert::Into<
+                    std::boxed::Box<crate::model::r#type::int_64::encoding::BigEndianBytes>,
+                >,
+            >(
+                mut self,
+                v: T,
+            ) -> Self {
+                self.encoding = std::option::Option::Some(
+                    crate::model::r#type::int_64::encoding::Encoding::BigEndianBytes(v.into()),
+                );
                 self
             }
         }
@@ -7328,6 +8453,132 @@ pub mod r#type {
             v: T,
         ) -> Self {
             self.aggregator = v.into();
+            self
+        }
+
+        /// The value of [aggregator][crate::model::r#type::Aggregate::aggregator]
+        /// if it holds a `Sum`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_sum(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::aggregate::Sum>> {
+            #[allow(unreachable_patterns)]
+            self.aggregator.as_ref().and_then(|v| match v {
+                crate::model::r#type::aggregate::Aggregator::Sum(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// The value of [aggregator][crate::model::r#type::Aggregate::aggregator]
+        /// if it holds a `HllppUniqueCount`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_hllpp_unique_count(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::r#type::aggregate::HyperLogLogPlusPlusUniqueCount>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.aggregator.as_ref().and_then(|v| match v {
+                crate::model::r#type::aggregate::Aggregator::HllppUniqueCount(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// The value of [aggregator][crate::model::r#type::Aggregate::aggregator]
+        /// if it holds a `Max`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_max(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::aggregate::Max>> {
+            #[allow(unreachable_patterns)]
+            self.aggregator.as_ref().and_then(|v| match v {
+                crate::model::r#type::aggregate::Aggregator::Max(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// The value of [aggregator][crate::model::r#type::Aggregate::aggregator]
+        /// if it holds a `Min`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_min(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::aggregate::Min>> {
+            #[allow(unreachable_patterns)]
+            self.aggregator.as_ref().and_then(|v| match v {
+                crate::model::r#type::aggregate::Aggregator::Min(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// Sets the value of [aggregator][crate::model::r#type::Aggregate::aggregator]
+        /// to hold a `Sum`.
+        ///
+        /// Note that all the setters affecting `aggregator` are
+        /// mutually exclusive.
+        pub fn set_sum<
+            T: std::convert::Into<std::boxed::Box<crate::model::r#type::aggregate::Sum>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.aggregator = std::option::Option::Some(
+                crate::model::r#type::aggregate::Aggregator::Sum(v.into()),
+            );
+            self
+        }
+
+        /// Sets the value of [aggregator][crate::model::r#type::Aggregate::aggregator]
+        /// to hold a `HllppUniqueCount`.
+        ///
+        /// Note that all the setters affecting `aggregator` are
+        /// mutually exclusive.
+        pub fn set_hllpp_unique_count<
+            T: std::convert::Into<
+                std::boxed::Box<crate::model::r#type::aggregate::HyperLogLogPlusPlusUniqueCount>,
+            >,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.aggregator = std::option::Option::Some(
+                crate::model::r#type::aggregate::Aggregator::HllppUniqueCount(v.into()),
+            );
+            self
+        }
+
+        /// Sets the value of [aggregator][crate::model::r#type::Aggregate::aggregator]
+        /// to hold a `Max`.
+        ///
+        /// Note that all the setters affecting `aggregator` are
+        /// mutually exclusive.
+        pub fn set_max<
+            T: std::convert::Into<std::boxed::Box<crate::model::r#type::aggregate::Max>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.aggregator = std::option::Option::Some(
+                crate::model::r#type::aggregate::Aggregator::Max(v.into()),
+            );
+            self
+        }
+
+        /// Sets the value of [aggregator][crate::model::r#type::Aggregate::aggregator]
+        /// to hold a `Min`.
+        ///
+        /// Note that all the setters affecting `aggregator` are
+        /// mutually exclusive.
+        pub fn set_min<
+            T: std::convert::Into<std::boxed::Box<crate::model::r#type::aggregate::Min>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.aggregator = std::option::Option::Some(
+                crate::model::r#type::aggregate::Aggregator::Min(v.into()),
+            );
             self
         }
     }

--- a/src/generated/cloud/functions/v2/src/model.rs
+++ b/src/generated/cloud/functions/v2/src/model.rs
@@ -499,6 +499,72 @@ impl RepoSource {
         self.revision = v.into();
         self
     }
+
+    /// The value of [revision][crate::model::RepoSource::revision]
+    /// if it holds a `BranchName`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_branch_name(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.revision.as_ref().and_then(|v| match v {
+            crate::model::repo_source::Revision::BranchName(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [revision][crate::model::RepoSource::revision]
+    /// if it holds a `TagName`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_tag_name(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.revision.as_ref().and_then(|v| match v {
+            crate::model::repo_source::Revision::TagName(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [revision][crate::model::RepoSource::revision]
+    /// if it holds a `CommitSha`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_commit_sha(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.revision.as_ref().and_then(|v| match v {
+            crate::model::repo_source::Revision::CommitSha(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [revision][crate::model::RepoSource::revision]
+    /// to hold a `BranchName`.
+    ///
+    /// Note that all the setters affecting `revision` are
+    /// mutually exclusive.
+    pub fn set_branch_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.revision =
+            std::option::Option::Some(crate::model::repo_source::Revision::BranchName(v.into()));
+        self
+    }
+
+    /// Sets the value of [revision][crate::model::RepoSource::revision]
+    /// to hold a `TagName`.
+    ///
+    /// Note that all the setters affecting `revision` are
+    /// mutually exclusive.
+    pub fn set_tag_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.revision =
+            std::option::Option::Some(crate::model::repo_source::Revision::TagName(v.into()));
+        self
+    }
+
+    /// Sets the value of [revision][crate::model::RepoSource::revision]
+    /// to hold a `CommitSha`.
+    ///
+    /// Note that all the setters affecting `revision` are
+    /// mutually exclusive.
+    pub fn set_commit_sha<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.revision =
+            std::option::Option::Some(crate::model::repo_source::Revision::CommitSha(v.into()));
+        self
+    }
 }
 
 impl wkt::message::Message for RepoSource {
@@ -552,6 +618,82 @@ impl Source {
         v: T,
     ) -> Self {
         self.source = v.into();
+        self
+    }
+
+    /// The value of [source][crate::model::Source::source]
+    /// if it holds a `StorageSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_storage_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::StorageSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::source::Source::StorageSource(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [source][crate::model::Source::source]
+    /// if it holds a `RepoSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_repo_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::RepoSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::source::Source::RepoSource(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [source][crate::model::Source::source]
+    /// if it holds a `GitUri`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_git_uri(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::source::Source::GitUri(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [source][crate::model::Source::source]
+    /// to hold a `StorageSource`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_storage_source<
+        T: std::convert::Into<std::boxed::Box<crate::model::StorageSource>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source =
+            std::option::Option::Some(crate::model::source::Source::StorageSource(v.into()));
+        self
+    }
+
+    /// Sets the value of [source][crate::model::Source::source]
+    /// to hold a `RepoSource`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_repo_source<T: std::convert::Into<std::boxed::Box<crate::model::RepoSource>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source = std::option::Option::Some(crate::model::source::Source::RepoSource(v.into()));
+        self
+    }
+
+    /// Sets the value of [source][crate::model::Source::source]
+    /// to hold a `GitUri`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_git_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.source = std::option::Option::Some(crate::model::source::Source::GitUri(v.into()));
         self
     }
 }
@@ -825,6 +967,70 @@ impl BuildConfig {
         v: T,
     ) -> Self {
         self.runtime_update_policy = v.into();
+        self
+    }
+
+    /// The value of [runtime_update_policy][crate::model::BuildConfig::runtime_update_policy]
+    /// if it holds a `AutomaticUpdatePolicy`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_automatic_update_policy(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AutomaticUpdatePolicy>> {
+        #[allow(unreachable_patterns)]
+        self.runtime_update_policy.as_ref().and_then(|v| match v {
+            crate::model::build_config::RuntimeUpdatePolicy::AutomaticUpdatePolicy(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [runtime_update_policy][crate::model::BuildConfig::runtime_update_policy]
+    /// if it holds a `OnDeployUpdatePolicy`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_on_deploy_update_policy(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::OnDeployUpdatePolicy>> {
+        #[allow(unreachable_patterns)]
+        self.runtime_update_policy.as_ref().and_then(|v| match v {
+            crate::model::build_config::RuntimeUpdatePolicy::OnDeployUpdatePolicy(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [runtime_update_policy][crate::model::BuildConfig::runtime_update_policy]
+    /// to hold a `AutomaticUpdatePolicy`.
+    ///
+    /// Note that all the setters affecting `runtime_update_policy` are
+    /// mutually exclusive.
+    pub fn set_automatic_update_policy<
+        T: std::convert::Into<std::boxed::Box<crate::model::AutomaticUpdatePolicy>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.runtime_update_policy = std::option::Option::Some(
+            crate::model::build_config::RuntimeUpdatePolicy::AutomaticUpdatePolicy(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [runtime_update_policy][crate::model::BuildConfig::runtime_update_policy]
+    /// to hold a `OnDeployUpdatePolicy`.
+    ///
+    /// Note that all the setters affecting `runtime_update_policy` are
+    /// mutually exclusive.
+    pub fn set_on_deploy_update_policy<
+        T: std::convert::Into<std::boxed::Box<crate::model::OnDeployUpdatePolicy>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.runtime_update_policy = std::option::Option::Some(
+            crate::model::build_config::RuntimeUpdatePolicy::OnDeployUpdatePolicy(v.into()),
+        );
         self
     }
 }

--- a/src/generated/cloud/kms/v1/src/model.rs
+++ b/src/generated/cloud/kms/v1/src/model.rs
@@ -1849,6 +1849,34 @@ impl CryptoKey {
         self.rotation_schedule = v.into();
         self
     }
+
+    /// The value of [rotation_schedule][crate::model::CryptoKey::rotation_schedule]
+    /// if it holds a `RotationPeriod`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_rotation_period(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
+        #[allow(unreachable_patterns)]
+        self.rotation_schedule.as_ref().and_then(|v| match v {
+            crate::model::crypto_key::RotationSchedule::RotationPeriod(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [rotation_schedule][crate::model::CryptoKey::rotation_schedule]
+    /// to hold a `RotationPeriod`.
+    ///
+    /// Note that all the setters affecting `rotation_schedule` are
+    /// mutually exclusive.
+    pub fn set_rotation_period<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.rotation_schedule = std::option::Option::Some(
+            crate::model::crypto_key::RotationSchedule::RotationPeriod(v.into()),
+        );
+        self
+    }
 }
 
 impl wkt::message::Message for CryptoKey {
@@ -4688,6 +4716,31 @@ impl ImportCryptoKeyVersionRequest {
         self.wrapped_key_material = v.into();
         self
     }
+
+    /// The value of [wrapped_key_material][crate::model::ImportCryptoKeyVersionRequest::wrapped_key_material]
+    /// if it holds a `RsaAesWrappedKey`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_rsa_aes_wrapped_key(&self) -> std::option::Option<&bytes::Bytes> {
+        #[allow(unreachable_patterns)]
+        self.wrapped_key_material.as_ref().and_then(|v| match v {
+            crate::model::import_crypto_key_version_request::WrappedKeyMaterial::RsaAesWrappedKey(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [wrapped_key_material][crate::model::ImportCryptoKeyVersionRequest::wrapped_key_material]
+    /// to hold a `RsaAesWrappedKey`.
+    ///
+    /// Note that all the setters affecting `wrapped_key_material` are
+    /// mutually exclusive.
+    pub fn set_rsa_aes_wrapped_key<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
+        self.wrapped_key_material = std::option::Option::Some(
+            crate::model::import_crypto_key_version_request::WrappedKeyMaterial::RsaAesWrappedKey(
+                v.into(),
+            ),
+        );
+        self
+    }
 }
 
 impl wkt::message::Message for ImportCryptoKeyVersionRequest {
@@ -7382,6 +7435,69 @@ impl Digest {
         v: T,
     ) -> Self {
         self.digest = v.into();
+        self
+    }
+
+    /// The value of [digest][crate::model::Digest::digest]
+    /// if it holds a `Sha256`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_sha256(&self) -> std::option::Option<&bytes::Bytes> {
+        #[allow(unreachable_patterns)]
+        self.digest.as_ref().and_then(|v| match v {
+            crate::model::digest::Digest::Sha256(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [digest][crate::model::Digest::digest]
+    /// if it holds a `Sha384`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_sha384(&self) -> std::option::Option<&bytes::Bytes> {
+        #[allow(unreachable_patterns)]
+        self.digest.as_ref().and_then(|v| match v {
+            crate::model::digest::Digest::Sha384(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [digest][crate::model::Digest::digest]
+    /// if it holds a `Sha512`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_sha512(&self) -> std::option::Option<&bytes::Bytes> {
+        #[allow(unreachable_patterns)]
+        self.digest.as_ref().and_then(|v| match v {
+            crate::model::digest::Digest::Sha512(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [digest][crate::model::Digest::digest]
+    /// to hold a `Sha256`.
+    ///
+    /// Note that all the setters affecting `digest` are
+    /// mutually exclusive.
+    pub fn set_sha256<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
+        self.digest = std::option::Option::Some(crate::model::digest::Digest::Sha256(v.into()));
+        self
+    }
+
+    /// Sets the value of [digest][crate::model::Digest::digest]
+    /// to hold a `Sha384`.
+    ///
+    /// Note that all the setters affecting `digest` are
+    /// mutually exclusive.
+    pub fn set_sha384<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
+        self.digest = std::option::Option::Some(crate::model::digest::Digest::Sha384(v.into()));
+        self
+    }
+
+    /// Sets the value of [digest][crate::model::Digest::digest]
+    /// to hold a `Sha512`.
+    ///
+    /// Note that all the setters affecting `digest` are
+    /// mutually exclusive.
+    pub fn set_sha512<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
+        self.digest = std::option::Option::Some(crate::model::digest::Digest::Sha512(v.into()));
         self
     }
 }

--- a/src/generated/cloud/language/v2/src/model.rs
+++ b/src/generated/cloud/language/v2/src/model.rs
@@ -80,6 +80,49 @@ impl Document {
         self.source = v.into();
         self
     }
+
+    /// The value of [source][crate::model::Document::source]
+    /// if it holds a `Content`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_content(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::document::Source::Content(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [source][crate::model::Document::source]
+    /// if it holds a `GcsContentUri`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_gcs_content_uri(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::document::Source::GcsContentUri(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [source][crate::model::Document::source]
+    /// to hold a `Content`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_content<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.source = std::option::Option::Some(crate::model::document::Source::Content(v.into()));
+        self
+    }
+
+    /// Sets the value of [source][crate::model::Document::source]
+    /// to hold a `GcsContentUri`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_gcs_content_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.source =
+            std::option::Option::Some(crate::model::document::Source::GcsContentUri(v.into()));
+        self
+    }
 }
 
 impl wkt::message::Message for Document {

--- a/src/generated/cloud/run/v2/src/model.rs
+++ b/src/generated/cloud/run/v2/src/model.rs
@@ -125,6 +125,38 @@ impl SubmitBuildRequest {
         self
     }
 
+    /// The value of [source][crate::model::SubmitBuildRequest::source]
+    /// if it holds a `StorageSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_storage_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::StorageSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::submit_build_request::Source::StorageSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [source][crate::model::SubmitBuildRequest::source]
+    /// to hold a `StorageSource`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_storage_source<
+        T: std::convert::Into<std::boxed::Box<crate::model::StorageSource>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source = std::option::Option::Some(
+            crate::model::submit_build_request::Source::StorageSource(v.into()),
+        );
+        self
+    }
+
     /// Sets the value of `build_type`.
     pub fn set_build_type<
         T: std::convert::Into<std::option::Option<crate::model::submit_build_request::BuildType>>,
@@ -133,6 +165,72 @@ impl SubmitBuildRequest {
         v: T,
     ) -> Self {
         self.build_type = v.into();
+        self
+    }
+
+    /// The value of [build_type][crate::model::SubmitBuildRequest::build_type]
+    /// if it holds a `BuildpackBuild`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_buildpack_build(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::submit_build_request::BuildpacksBuild>>
+    {
+        #[allow(unreachable_patterns)]
+        self.build_type.as_ref().and_then(|v| match v {
+            crate::model::submit_build_request::BuildType::BuildpackBuild(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [build_type][crate::model::SubmitBuildRequest::build_type]
+    /// if it holds a `DockerBuild`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_docker_build(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::submit_build_request::DockerBuild>>
+    {
+        #[allow(unreachable_patterns)]
+        self.build_type.as_ref().and_then(|v| match v {
+            crate::model::submit_build_request::BuildType::DockerBuild(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [build_type][crate::model::SubmitBuildRequest::build_type]
+    /// to hold a `BuildpackBuild`.
+    ///
+    /// Note that all the setters affecting `build_type` are
+    /// mutually exclusive.
+    pub fn set_buildpack_build<
+        T: std::convert::Into<std::boxed::Box<crate::model::submit_build_request::BuildpacksBuild>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.build_type = std::option::Option::Some(
+            crate::model::submit_build_request::BuildType::BuildpackBuild(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [build_type][crate::model::SubmitBuildRequest::build_type]
+    /// to hold a `DockerBuild`.
+    ///
+    /// Note that all the setters affecting `build_type` are
+    /// mutually exclusive.
+    pub fn set_docker_build<
+        T: std::convert::Into<std::boxed::Box<crate::model::submit_build_request::DockerBuild>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.build_type = std::option::Option::Some(
+            crate::model::submit_build_request::BuildType::DockerBuild(v.into()),
+        );
         self
     }
 }
@@ -468,6 +566,85 @@ impl Condition {
         v: T,
     ) -> Self {
         self.reasons = v.into();
+        self
+    }
+
+    /// The value of [reasons][crate::model::Condition::reasons]
+    /// if it holds a `Reason`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_reason(&self) -> std::option::Option<&crate::model::condition::CommonReason> {
+        #[allow(unreachable_patterns)]
+        self.reasons.as_ref().and_then(|v| match v {
+            crate::model::condition::Reasons::Reason(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [reasons][crate::model::Condition::reasons]
+    /// if it holds a `RevisionReason`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_revision_reason(
+        &self,
+    ) -> std::option::Option<&crate::model::condition::RevisionReason> {
+        #[allow(unreachable_patterns)]
+        self.reasons.as_ref().and_then(|v| match v {
+            crate::model::condition::Reasons::RevisionReason(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [reasons][crate::model::Condition::reasons]
+    /// if it holds a `ExecutionReason`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_execution_reason(
+        &self,
+    ) -> std::option::Option<&crate::model::condition::ExecutionReason> {
+        #[allow(unreachable_patterns)]
+        self.reasons.as_ref().and_then(|v| match v {
+            crate::model::condition::Reasons::ExecutionReason(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [reasons][crate::model::Condition::reasons]
+    /// to hold a `Reason`.
+    ///
+    /// Note that all the setters affecting `reasons` are
+    /// mutually exclusive.
+    pub fn set_reason<T: std::convert::Into<crate::model::condition::CommonReason>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.reasons =
+            std::option::Option::Some(crate::model::condition::Reasons::Reason(v.into()));
+        self
+    }
+
+    /// Sets the value of [reasons][crate::model::Condition::reasons]
+    /// to hold a `RevisionReason`.
+    ///
+    /// Note that all the setters affecting `reasons` are
+    /// mutually exclusive.
+    pub fn set_revision_reason<T: std::convert::Into<crate::model::condition::RevisionReason>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.reasons =
+            std::option::Option::Some(crate::model::condition::Reasons::RevisionReason(v.into()));
+        self
+    }
+
+    /// Sets the value of [reasons][crate::model::Condition::reasons]
+    /// to hold a `ExecutionReason`.
+    ///
+    /// Note that all the setters affecting `reasons` are
+    /// mutually exclusive.
+    pub fn set_execution_reason<T: std::convert::Into<crate::model::condition::ExecutionReason>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.reasons =
+            std::option::Option::Some(crate::model::condition::Reasons::ExecutionReason(v.into()));
         self
     }
 }
@@ -2281,6 +2458,62 @@ impl Job {
         self.create_execution = v.into();
         self
     }
+
+    /// The value of [create_execution][crate::model::Job::create_execution]
+    /// if it holds a `StartExecutionToken`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_start_execution_token(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.create_execution.as_ref().and_then(|v| match v {
+            crate::model::job::CreateExecution::StartExecutionToken(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [create_execution][crate::model::Job::create_execution]
+    /// if it holds a `RunExecutionToken`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_run_execution_token(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.create_execution.as_ref().and_then(|v| match v {
+            crate::model::job::CreateExecution::RunExecutionToken(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [create_execution][crate::model::Job::create_execution]
+    /// to hold a `StartExecutionToken`.
+    ///
+    /// Note that all the setters affecting `create_execution` are
+    /// mutually exclusive.
+    pub fn set_start_execution_token<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.create_execution = std::option::Option::Some(
+            crate::model::job::CreateExecution::StartExecutionToken(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [create_execution][crate::model::Job::create_execution]
+    /// to hold a `RunExecutionToken`.
+    ///
+    /// Note that all the setters affecting `create_execution` are
+    /// mutually exclusive.
+    pub fn set_run_execution_token<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.create_execution = std::option::Option::Some(
+            crate::model::job::CreateExecution::RunExecutionToken(v.into()),
+        );
+        self
+    }
 }
 
 impl wkt::message::Message for Job {
@@ -2712,6 +2945,54 @@ impl EnvVar {
         self.values = v.into();
         self
     }
+
+    /// The value of [values][crate::model::EnvVar::values]
+    /// if it holds a `Value`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_value(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.values.as_ref().and_then(|v| match v {
+            crate::model::env_var::Values::Value(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [values][crate::model::EnvVar::values]
+    /// if it holds a `ValueSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_value_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::EnvVarSource>> {
+        #[allow(unreachable_patterns)]
+        self.values.as_ref().and_then(|v| match v {
+            crate::model::env_var::Values::ValueSource(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [values][crate::model::EnvVar::values]
+    /// to hold a `Value`.
+    ///
+    /// Note that all the setters affecting `values` are
+    /// mutually exclusive.
+    pub fn set_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.values = std::option::Option::Some(crate::model::env_var::Values::Value(v.into()));
+        self
+    }
+
+    /// Sets the value of [values][crate::model::EnvVar::values]
+    /// to hold a `ValueSource`.
+    ///
+    /// Note that all the setters affecting `values` are
+    /// mutually exclusive.
+    pub fn set_value_source<T: std::convert::Into<std::boxed::Box<crate::model::EnvVarSource>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.values =
+            std::option::Option::Some(crate::model::env_var::Values::ValueSource(v.into()));
+        self
+    }
 }
 
 impl wkt::message::Message for EnvVar {
@@ -2912,6 +3193,141 @@ impl Volume {
         v: T,
     ) -> Self {
         self.volume_type = v.into();
+        self
+    }
+
+    /// The value of [volume_type][crate::model::Volume::volume_type]
+    /// if it holds a `Secret`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_secret(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SecretVolumeSource>> {
+        #[allow(unreachable_patterns)]
+        self.volume_type.as_ref().and_then(|v| match v {
+            crate::model::volume::VolumeType::Secret(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [volume_type][crate::model::Volume::volume_type]
+    /// if it holds a `CloudSqlInstance`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_cloud_sql_instance(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudSqlInstance>> {
+        #[allow(unreachable_patterns)]
+        self.volume_type.as_ref().and_then(|v| match v {
+            crate::model::volume::VolumeType::CloudSqlInstance(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [volume_type][crate::model::Volume::volume_type]
+    /// if it holds a `EmptyDir`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_empty_dir(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::EmptyDirVolumeSource>> {
+        #[allow(unreachable_patterns)]
+        self.volume_type.as_ref().and_then(|v| match v {
+            crate::model::volume::VolumeType::EmptyDir(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [volume_type][crate::model::Volume::volume_type]
+    /// if it holds a `Nfs`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_nfs(&self) -> std::option::Option<&std::boxed::Box<crate::model::NFSVolumeSource>> {
+        #[allow(unreachable_patterns)]
+        self.volume_type.as_ref().and_then(|v| match v {
+            crate::model::volume::VolumeType::Nfs(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [volume_type][crate::model::Volume::volume_type]
+    /// if it holds a `Gcs`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_gcs(&self) -> std::option::Option<&std::boxed::Box<crate::model::GCSVolumeSource>> {
+        #[allow(unreachable_patterns)]
+        self.volume_type.as_ref().and_then(|v| match v {
+            crate::model::volume::VolumeType::Gcs(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [volume_type][crate::model::Volume::volume_type]
+    /// to hold a `Secret`.
+    ///
+    /// Note that all the setters affecting `volume_type` are
+    /// mutually exclusive.
+    pub fn set_secret<T: std::convert::Into<std::boxed::Box<crate::model::SecretVolumeSource>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.volume_type =
+            std::option::Option::Some(crate::model::volume::VolumeType::Secret(v.into()));
+        self
+    }
+
+    /// Sets the value of [volume_type][crate::model::Volume::volume_type]
+    /// to hold a `CloudSqlInstance`.
+    ///
+    /// Note that all the setters affecting `volume_type` are
+    /// mutually exclusive.
+    pub fn set_cloud_sql_instance<
+        T: std::convert::Into<std::boxed::Box<crate::model::CloudSqlInstance>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.volume_type =
+            std::option::Option::Some(crate::model::volume::VolumeType::CloudSqlInstance(v.into()));
+        self
+    }
+
+    /// Sets the value of [volume_type][crate::model::Volume::volume_type]
+    /// to hold a `EmptyDir`.
+    ///
+    /// Note that all the setters affecting `volume_type` are
+    /// mutually exclusive.
+    pub fn set_empty_dir<
+        T: std::convert::Into<std::boxed::Box<crate::model::EmptyDirVolumeSource>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.volume_type =
+            std::option::Option::Some(crate::model::volume::VolumeType::EmptyDir(v.into()));
+        self
+    }
+
+    /// Sets the value of [volume_type][crate::model::Volume::volume_type]
+    /// to hold a `Nfs`.
+    ///
+    /// Note that all the setters affecting `volume_type` are
+    /// mutually exclusive.
+    pub fn set_nfs<T: std::convert::Into<std::boxed::Box<crate::model::NFSVolumeSource>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.volume_type =
+            std::option::Option::Some(crate::model::volume::VolumeType::Nfs(v.into()));
+        self
+    }
+
+    /// Sets the value of [volume_type][crate::model::Volume::volume_type]
+    /// to hold a `Gcs`.
+    ///
+    /// Note that all the setters affecting `volume_type` are
+    /// mutually exclusive.
+    pub fn set_gcs<T: std::convert::Into<std::boxed::Box<crate::model::GCSVolumeSource>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.volume_type =
+            std::option::Option::Some(crate::model::volume::VolumeType::Gcs(v.into()));
         self
     }
 }
@@ -3359,6 +3775,84 @@ impl Probe {
         v: T,
     ) -> Self {
         self.probe_type = v.into();
+        self
+    }
+
+    /// The value of [probe_type][crate::model::Probe::probe_type]
+    /// if it holds a `HttpGet`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_http_get(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::HTTPGetAction>> {
+        #[allow(unreachable_patterns)]
+        self.probe_type.as_ref().and_then(|v| match v {
+            crate::model::probe::ProbeType::HttpGet(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [probe_type][crate::model::Probe::probe_type]
+    /// if it holds a `TcpSocket`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_tcp_socket(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::TCPSocketAction>> {
+        #[allow(unreachable_patterns)]
+        self.probe_type.as_ref().and_then(|v| match v {
+            crate::model::probe::ProbeType::TcpSocket(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [probe_type][crate::model::Probe::probe_type]
+    /// if it holds a `Grpc`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_grpc(&self) -> std::option::Option<&std::boxed::Box<crate::model::GRPCAction>> {
+        #[allow(unreachable_patterns)]
+        self.probe_type.as_ref().and_then(|v| match v {
+            crate::model::probe::ProbeType::Grpc(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [probe_type][crate::model::Probe::probe_type]
+    /// to hold a `HttpGet`.
+    ///
+    /// Note that all the setters affecting `probe_type` are
+    /// mutually exclusive.
+    pub fn set_http_get<T: std::convert::Into<std::boxed::Box<crate::model::HTTPGetAction>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.probe_type =
+            std::option::Option::Some(crate::model::probe::ProbeType::HttpGet(v.into()));
+        self
+    }
+
+    /// Sets the value of [probe_type][crate::model::Probe::probe_type]
+    /// to hold a `TcpSocket`.
+    ///
+    /// Note that all the setters affecting `probe_type` are
+    /// mutually exclusive.
+    pub fn set_tcp_socket<T: std::convert::Into<std::boxed::Box<crate::model::TCPSocketAction>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.probe_type =
+            std::option::Option::Some(crate::model::probe::ProbeType::TcpSocket(v.into()));
+        self
+    }
+
+    /// Sets the value of [probe_type][crate::model::Probe::probe_type]
+    /// to hold a `Grpc`.
+    ///
+    /// Note that all the setters affecting `probe_type` are
+    /// mutually exclusive.
+    pub fn set_grpc<T: std::convert::Into<std::boxed::Box<crate::model::GRPCAction>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.probe_type = std::option::Option::Some(crate::model::probe::ProbeType::Grpc(v.into()));
         self
     }
 }
@@ -6004,6 +6498,28 @@ impl TaskTemplate {
         self.retries = v.into();
         self
     }
+
+    /// The value of [retries][crate::model::TaskTemplate::retries]
+    /// if it holds a `MaxRetries`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_max_retries(&self) -> std::option::Option<&i32> {
+        #[allow(unreachable_patterns)]
+        self.retries.as_ref().and_then(|v| match v {
+            crate::model::task_template::Retries::MaxRetries(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [retries][crate::model::TaskTemplate::retries]
+    /// to hold a `MaxRetries`.
+    ///
+    /// Note that all the setters affecting `retries` are
+    /// mutually exclusive.
+    pub fn set_max_retries<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.retries =
+            std::option::Option::Some(crate::model::task_template::Retries::MaxRetries(v.into()));
+        self
+    }
 }
 
 impl wkt::message::Message for TaskTemplate {
@@ -6343,6 +6859,56 @@ impl BinaryAuthorization {
         v: T,
     ) -> Self {
         self.binauthz_method = v.into();
+        self
+    }
+
+    /// The value of [binauthz_method][crate::model::BinaryAuthorization::binauthz_method]
+    /// if it holds a `UseDefault`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_use_default(&self) -> std::option::Option<&bool> {
+        #[allow(unreachable_patterns)]
+        self.binauthz_method.as_ref().and_then(|v| match v {
+            crate::model::binary_authorization::BinauthzMethod::UseDefault(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [binauthz_method][crate::model::BinaryAuthorization::binauthz_method]
+    /// if it holds a `Policy`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_policy(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.binauthz_method.as_ref().and_then(|v| match v {
+            crate::model::binary_authorization::BinauthzMethod::Policy(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [binauthz_method][crate::model::BinaryAuthorization::binauthz_method]
+    /// to hold a `UseDefault`.
+    ///
+    /// Note that all the setters affecting `binauthz_method` are
+    /// mutually exclusive.
+    pub fn set_use_default<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.binauthz_method = std::option::Option::Some(
+            crate::model::binary_authorization::BinauthzMethod::UseDefault(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [binauthz_method][crate::model::BinaryAuthorization::binauthz_method]
+    /// to hold a `Policy`.
+    ///
+    /// Note that all the setters affecting `binauthz_method` are
+    /// mutually exclusive.
+    pub fn set_policy<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.binauthz_method = std::option::Option::Some(
+            crate::model::binary_authorization::BinauthzMethod::Policy(v.into()),
+        );
         self
     }
 }

--- a/src/generated/cloud/scheduler/v1/src/model.rs
+++ b/src/generated/cloud/scheduler/v1/src/model.rs
@@ -651,6 +651,87 @@ impl Job {
         self.target = v.into();
         self
     }
+
+    /// The value of [target][crate::model::Job::target]
+    /// if it holds a `PubsubTarget`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_pubsub_target(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PubsubTarget>> {
+        #[allow(unreachable_patterns)]
+        self.target.as_ref().and_then(|v| match v {
+            crate::model::job::Target::PubsubTarget(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [target][crate::model::Job::target]
+    /// if it holds a `AppEngineHttpTarget`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_app_engine_http_target(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AppEngineHttpTarget>> {
+        #[allow(unreachable_patterns)]
+        self.target.as_ref().and_then(|v| match v {
+            crate::model::job::Target::AppEngineHttpTarget(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [target][crate::model::Job::target]
+    /// if it holds a `HttpTarget`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_http_target(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::HttpTarget>> {
+        #[allow(unreachable_patterns)]
+        self.target.as_ref().and_then(|v| match v {
+            crate::model::job::Target::HttpTarget(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [target][crate::model::Job::target]
+    /// to hold a `PubsubTarget`.
+    ///
+    /// Note that all the setters affecting `target` are
+    /// mutually exclusive.
+    pub fn set_pubsub_target<T: std::convert::Into<std::boxed::Box<crate::model::PubsubTarget>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.target = std::option::Option::Some(crate::model::job::Target::PubsubTarget(v.into()));
+        self
+    }
+
+    /// Sets the value of [target][crate::model::Job::target]
+    /// to hold a `AppEngineHttpTarget`.
+    ///
+    /// Note that all the setters affecting `target` are
+    /// mutually exclusive.
+    pub fn set_app_engine_http_target<
+        T: std::convert::Into<std::boxed::Box<crate::model::AppEngineHttpTarget>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.target =
+            std::option::Option::Some(crate::model::job::Target::AppEngineHttpTarget(v.into()));
+        self
+    }
+
+    /// Sets the value of [target][crate::model::Job::target]
+    /// to hold a `HttpTarget`.
+    ///
+    /// Note that all the setters affecting `target` are
+    /// mutually exclusive.
+    pub fn set_http_target<T: std::convert::Into<std::boxed::Box<crate::model::HttpTarget>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.target = std::option::Option::Some(crate::model::job::Target::HttpTarget(v.into()));
+        self
+    }
 }
 
 impl wkt::message::Message for Job {
@@ -996,6 +1077,64 @@ impl HttpTarget {
         v: T,
     ) -> Self {
         self.authorization_header = v.into();
+        self
+    }
+
+    /// The value of [authorization_header][crate::model::HttpTarget::authorization_header]
+    /// if it holds a `OauthToken`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_oauth_token(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::OAuthToken>> {
+        #[allow(unreachable_patterns)]
+        self.authorization_header.as_ref().and_then(|v| match v {
+            crate::model::http_target::AuthorizationHeader::OauthToken(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [authorization_header][crate::model::HttpTarget::authorization_header]
+    /// if it holds a `OidcToken`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_oidc_token(&self) -> std::option::Option<&std::boxed::Box<crate::model::OidcToken>> {
+        #[allow(unreachable_patterns)]
+        self.authorization_header.as_ref().and_then(|v| match v {
+            crate::model::http_target::AuthorizationHeader::OidcToken(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [authorization_header][crate::model::HttpTarget::authorization_header]
+    /// to hold a `OauthToken`.
+    ///
+    /// Note that all the setters affecting `authorization_header` are
+    /// mutually exclusive.
+    pub fn set_oauth_token<T: std::convert::Into<std::boxed::Box<crate::model::OAuthToken>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.authorization_header = std::option::Option::Some(
+            crate::model::http_target::AuthorizationHeader::OauthToken(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [authorization_header][crate::model::HttpTarget::authorization_header]
+    /// to hold a `OidcToken`.
+    ///
+    /// Note that all the setters affecting `authorization_header` are
+    /// mutually exclusive.
+    pub fn set_oidc_token<T: std::convert::Into<std::boxed::Box<crate::model::OidcToken>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.authorization_header = std::option::Option::Some(
+            crate::model::http_target::AuthorizationHeader::OidcToken(v.into()),
+        );
         self
     }
 }

--- a/src/generated/cloud/secretmanager/v1/src/model.rs
+++ b/src/generated/cloud/secretmanager/v1/src/model.rs
@@ -294,6 +294,53 @@ impl Secret {
         self.expiration = v.into();
         self
     }
+
+    /// The value of [expiration][crate::model::Secret::expiration]
+    /// if it holds a `ExpireTime`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_expire_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
+        #[allow(unreachable_patterns)]
+        self.expiration.as_ref().and_then(|v| match v {
+            crate::model::secret::Expiration::ExpireTime(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [expiration][crate::model::Secret::expiration]
+    /// if it holds a `Ttl`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_ttl(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
+        #[allow(unreachable_patterns)]
+        self.expiration.as_ref().and_then(|v| match v {
+            crate::model::secret::Expiration::Ttl(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [expiration][crate::model::Secret::expiration]
+    /// to hold a `ExpireTime`.
+    ///
+    /// Note that all the setters affecting `expiration` are
+    /// mutually exclusive.
+    pub fn set_expire_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.expiration =
+            std::option::Option::Some(crate::model::secret::Expiration::ExpireTime(v.into()));
+        self
+    }
+
+    /// Sets the value of [expiration][crate::model::Secret::expiration]
+    /// to hold a `Ttl`.
+    ///
+    /// Note that all the setters affecting `expiration` are
+    /// mutually exclusive.
+    pub fn set_ttl<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(mut self, v: T) -> Self {
+        self.expiration =
+            std::option::Option::Some(crate::model::secret::Expiration::Ttl(v.into()));
+        self
+    }
 }
 
 impl wkt::message::Message for Secret {
@@ -597,6 +644,65 @@ impl Replication {
         self.replication = v.into();
         self
     }
+
+    /// The value of [replication][crate::model::Replication::replication]
+    /// if it holds a `Automatic`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_automatic(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::replication::Automatic>> {
+        #[allow(unreachable_patterns)]
+        self.replication.as_ref().and_then(|v| match v {
+            crate::model::replication::Replication::Automatic(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [replication][crate::model::Replication::replication]
+    /// if it holds a `UserManaged`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_user_managed(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::replication::UserManaged>> {
+        #[allow(unreachable_patterns)]
+        self.replication.as_ref().and_then(|v| match v {
+            crate::model::replication::Replication::UserManaged(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [replication][crate::model::Replication::replication]
+    /// to hold a `Automatic`.
+    ///
+    /// Note that all the setters affecting `replication` are
+    /// mutually exclusive.
+    pub fn set_automatic<
+        T: std::convert::Into<std::boxed::Box<crate::model::replication::Automatic>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.replication =
+            std::option::Option::Some(crate::model::replication::Replication::Automatic(v.into()));
+        self
+    }
+
+    /// Sets the value of [replication][crate::model::Replication::replication]
+    /// to hold a `UserManaged`.
+    ///
+    /// Note that all the setters affecting `replication` are
+    /// mutually exclusive.
+    pub fn set_user_managed<
+        T: std::convert::Into<std::boxed::Box<crate::model::replication::UserManaged>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.replication = std::option::Option::Some(
+            crate::model::replication::Replication::UserManaged(v.into()),
+        );
+        self
+    }
 }
 
 impl wkt::message::Message for Replication {
@@ -851,6 +957,72 @@ impl ReplicationStatus {
         v: T,
     ) -> Self {
         self.replication_status = v.into();
+        self
+    }
+
+    /// The value of [replication_status][crate::model::ReplicationStatus::replication_status]
+    /// if it holds a `Automatic`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_automatic(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::replication_status::AutomaticStatus>>
+    {
+        #[allow(unreachable_patterns)]
+        self.replication_status.as_ref().and_then(|v| match v {
+            crate::model::replication_status::ReplicationStatus::Automatic(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [replication_status][crate::model::ReplicationStatus::replication_status]
+    /// if it holds a `UserManaged`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_user_managed(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::replication_status::UserManagedStatus>>
+    {
+        #[allow(unreachable_patterns)]
+        self.replication_status.as_ref().and_then(|v| match v {
+            crate::model::replication_status::ReplicationStatus::UserManaged(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [replication_status][crate::model::ReplicationStatus::replication_status]
+    /// to hold a `Automatic`.
+    ///
+    /// Note that all the setters affecting `replication_status` are
+    /// mutually exclusive.
+    pub fn set_automatic<
+        T: std::convert::Into<std::boxed::Box<crate::model::replication_status::AutomaticStatus>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.replication_status = std::option::Option::Some(
+            crate::model::replication_status::ReplicationStatus::Automatic(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [replication_status][crate::model::ReplicationStatus::replication_status]
+    /// to hold a `UserManaged`.
+    ///
+    /// Note that all the setters affecting `replication_status` are
+    /// mutually exclusive.
+    pub fn set_user_managed<
+        T: std::convert::Into<std::boxed::Box<crate::model::replication_status::UserManagedStatus>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.replication_status = std::option::Option::Some(
+            crate::model::replication_status::ReplicationStatus::UserManaged(v.into()),
+        );
         self
     }
 }

--- a/src/generated/cloud/sql/v1/src/model.rs
+++ b/src/generated/cloud/sql/v1/src/model.rs
@@ -2668,8 +2668,34 @@ impl SqlInstancesVerifyExternalSyncSettingsRequest {
     }
 
     /// Sets the value of `sync_config`.
-    pub fn set_sync_config<T: std::convert::Into<std::option::Option<crate::model::sql_instances_verify_external_sync_settings_request::SyncConfig>>>(mut self, v: T) ->Self {
+    pub fn set_sync_config<T: std::convert::Into<std::option::Option<crate::model::sql_instances_verify_external_sync_settings_request::SyncConfig>>>(mut self, v: T) -> Self
+    {
         self.sync_config = v.into();
+        self
+    }
+
+    /// The value of [sync_config][crate::model::SqlInstancesVerifyExternalSyncSettingsRequest::sync_config]
+    /// if it holds a `MysqlSyncConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_mysql_sync_config(&self) -> std::option::Option<&std::boxed::Box<crate::model::MySqlSyncConfig>> {
+        #[allow(unreachable_patterns)]
+        self.sync_config.as_ref().and_then(|v| match v {
+            crate::model::sql_instances_verify_external_sync_settings_request::SyncConfig::MysqlSyncConfig(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [sync_config][crate::model::SqlInstancesVerifyExternalSyncSettingsRequest::sync_config]
+    /// to hold a `MysqlSyncConfig`.
+    ///
+    /// Note that all the setters affecting `sync_config` are
+    /// mutually exclusive.
+    pub fn set_mysql_sync_config<T: std::convert::Into<std::boxed::Box<crate::model::MySqlSyncConfig>>>(mut self, v: T) -> Self {
+        self.sync_config = std::option::Option::Some(
+            crate::model::sql_instances_verify_external_sync_settings_request::SyncConfig::MysqlSyncConfig(
+                v.into()
+            )
+        );
         self
     }
 }
@@ -2830,8 +2856,34 @@ impl SqlInstancesStartExternalSyncRequest {
     }
 
     /// Sets the value of `sync_config`.
-    pub fn set_sync_config<T: std::convert::Into<std::option::Option<crate::model::sql_instances_start_external_sync_request::SyncConfig>>>(mut self, v: T) ->Self {
+    pub fn set_sync_config<T: std::convert::Into<std::option::Option<crate::model::sql_instances_start_external_sync_request::SyncConfig>>>(mut self, v: T) -> Self
+    {
         self.sync_config = v.into();
+        self
+    }
+
+    /// The value of [sync_config][crate::model::SqlInstancesStartExternalSyncRequest::sync_config]
+    /// if it holds a `MysqlSyncConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_mysql_sync_config(&self) -> std::option::Option<&std::boxed::Box<crate::model::MySqlSyncConfig>> {
+        #[allow(unreachable_patterns)]
+        self.sync_config.as_ref().and_then(|v| match v {
+            crate::model::sql_instances_start_external_sync_request::SyncConfig::MysqlSyncConfig(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [sync_config][crate::model::SqlInstancesStartExternalSyncRequest::sync_config]
+    /// to hold a `MysqlSyncConfig`.
+    ///
+    /// Note that all the setters affecting `sync_config` are
+    /// mutually exclusive.
+    pub fn set_mysql_sync_config<T: std::convert::Into<std::boxed::Box<crate::model::MySqlSyncConfig>>>(mut self, v: T) -> Self {
+        self.sync_config = std::option::Option::Some(
+            crate::model::sql_instances_start_external_sync_request::SyncConfig::MysqlSyncConfig(
+                v.into()
+            )
+        );
         self
     }
 }
@@ -6392,8 +6444,34 @@ impl Database {
     }
 
     /// Sets the value of `database_details`.
-    pub fn set_database_details<T: std::convert::Into<std::option::Option<crate::model::database::DatabaseDetails>>>(mut self, v: T) ->Self {
+    pub fn set_database_details<T: std::convert::Into<std::option::Option<crate::model::database::DatabaseDetails>>>(mut self, v: T) -> Self
+    {
         self.database_details = v.into();
+        self
+    }
+
+    /// The value of [database_details][crate::model::Database::database_details]
+    /// if it holds a `SqlserverDatabaseDetails`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_sqlserver_database_details(&self) -> std::option::Option<&std::boxed::Box<crate::model::SqlServerDatabaseDetails>> {
+        #[allow(unreachable_patterns)]
+        self.database_details.as_ref().and_then(|v| match v {
+            crate::model::database::DatabaseDetails::SqlserverDatabaseDetails(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [database_details][crate::model::Database::database_details]
+    /// to hold a `SqlserverDatabaseDetails`.
+    ///
+    /// Note that all the setters affecting `database_details` are
+    /// mutually exclusive.
+    pub fn set_sqlserver_database_details<T: std::convert::Into<std::boxed::Box<crate::model::SqlServerDatabaseDetails>>>(mut self, v: T) -> Self {
+        self.database_details = std::option::Option::Some(
+            crate::model::database::DatabaseDetails::SqlserverDatabaseDetails(
+                v.into()
+            )
+        );
         self
     }
 }
@@ -10860,8 +10938,34 @@ impl User {
     }
 
     /// Sets the value of `user_details`.
-    pub fn set_user_details<T: std::convert::Into<std::option::Option<crate::model::user::UserDetails>>>(mut self, v: T) ->Self {
+    pub fn set_user_details<T: std::convert::Into<std::option::Option<crate::model::user::UserDetails>>>(mut self, v: T) -> Self
+    {
         self.user_details = v.into();
+        self
+    }
+
+    /// The value of [user_details][crate::model::User::user_details]
+    /// if it holds a `SqlserverUserDetails`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_sqlserver_user_details(&self) -> std::option::Option<&std::boxed::Box<crate::model::SqlServerUserDetails>> {
+        #[allow(unreachable_patterns)]
+        self.user_details.as_ref().and_then(|v| match v {
+            crate::model::user::UserDetails::SqlserverUserDetails(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [user_details][crate::model::User::user_details]
+    /// to hold a `SqlserverUserDetails`.
+    ///
+    /// Note that all the setters affecting `user_details` are
+    /// mutually exclusive.
+    pub fn set_sqlserver_user_details<T: std::convert::Into<std::boxed::Box<crate::model::SqlServerUserDetails>>>(mut self, v: T) -> Self {
+        self.user_details = std::option::Option::Some(
+            crate::model::user::UserDetails::SqlserverUserDetails(
+                v.into()
+            )
+        );
         self
     }
 }

--- a/src/generated/cloud/translate/v3/src/model.rs
+++ b/src/generated/cloud/translate/v3/src/model.rs
@@ -871,6 +871,70 @@ impl ImportAdaptiveMtFileRequest {
         self.source = v.into();
         self
     }
+
+    /// The value of [source][crate::model::ImportAdaptiveMtFileRequest::source]
+    /// if it holds a `FileInputSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_file_input_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::FileInputSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::import_adaptive_mt_file_request::Source::FileInputSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [source][crate::model::ImportAdaptiveMtFileRequest::source]
+    /// if it holds a `GcsInputSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_gcs_input_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GcsInputSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::import_adaptive_mt_file_request::Source::GcsInputSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [source][crate::model::ImportAdaptiveMtFileRequest::source]
+    /// to hold a `FileInputSource`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_file_input_source<
+        T: std::convert::Into<std::boxed::Box<crate::model::FileInputSource>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source = std::option::Option::Some(
+            crate::model::import_adaptive_mt_file_request::Source::FileInputSource(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [source][crate::model::ImportAdaptiveMtFileRequest::source]
+    /// to hold a `GcsInputSource`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_gcs_input_source<
+        T: std::convert::Into<std::boxed::Box<crate::model::GcsInputSource>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source = std::option::Option::Some(
+            crate::model::import_adaptive_mt_file_request::Source::GcsInputSource(v.into()),
+        );
+        self
+    }
 }
 
 impl wkt::message::Message for ImportAdaptiveMtFileRequest {
@@ -1320,6 +1384,38 @@ pub mod dataset_input_config {
             self.source = v.into();
             self
         }
+
+        /// The value of [source][crate::model::dataset_input_config::InputFile::source]
+        /// if it holds a `GcsSource`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_gcs_source(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::GcsInputSource>> {
+            #[allow(unreachable_patterns)]
+            self.source.as_ref().and_then(|v| match v {
+                crate::model::dataset_input_config::input_file::Source::GcsSource(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// Sets the value of [source][crate::model::dataset_input_config::InputFile::source]
+        /// to hold a `GcsSource`.
+        ///
+        /// Note that all the setters affecting `source` are
+        /// mutually exclusive.
+        pub fn set_gcs_source<
+            T: std::convert::Into<std::boxed::Box<crate::model::GcsInputSource>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.source = std::option::Option::Some(
+                crate::model::dataset_input_config::input_file::Source::GcsSource(v.into()),
+            );
+            self
+        }
     }
 
     impl wkt::message::Message for InputFile {
@@ -1470,6 +1566,38 @@ impl DatasetOutputConfig {
         v: T,
     ) -> Self {
         self.destination = v.into();
+        self
+    }
+
+    /// The value of [destination][crate::model::DatasetOutputConfig::destination]
+    /// if it holds a `GcsDestination`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_gcs_destination(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GcsOutputDestination>> {
+        #[allow(unreachable_patterns)]
+        self.destination.as_ref().and_then(|v| match v {
+            crate::model::dataset_output_config::Destination::GcsDestination(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [destination][crate::model::DatasetOutputConfig::destination]
+    /// to hold a `GcsDestination`.
+    ///
+    /// Note that all the setters affecting `destination` are
+    /// mutually exclusive.
+    pub fn set_gcs_destination<
+        T: std::convert::Into<std::boxed::Box<crate::model::GcsOutputDestination>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.destination = std::option::Option::Some(
+            crate::model::dataset_output_config::Destination::GcsDestination(v.into()),
+        );
         self
     }
 }
@@ -2868,6 +2996,65 @@ impl GlossaryEntry {
         self.data = v.into();
         self
     }
+
+    /// The value of [data][crate::model::GlossaryEntry::data]
+    /// if it holds a `TermsPair`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_terms_pair(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::glossary_entry::GlossaryTermsPair>>
+    {
+        #[allow(unreachable_patterns)]
+        self.data.as_ref().and_then(|v| match v {
+            crate::model::glossary_entry::Data::TermsPair(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [data][crate::model::GlossaryEntry::data]
+    /// if it holds a `TermsSet`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_terms_set(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::glossary_entry::GlossaryTermsSet>> {
+        #[allow(unreachable_patterns)]
+        self.data.as_ref().and_then(|v| match v {
+            crate::model::glossary_entry::Data::TermsSet(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [data][crate::model::GlossaryEntry::data]
+    /// to hold a `TermsPair`.
+    ///
+    /// Note that all the setters affecting `data` are
+    /// mutually exclusive.
+    pub fn set_terms_pair<
+        T: std::convert::Into<std::boxed::Box<crate::model::glossary_entry::GlossaryTermsPair>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.data =
+            std::option::Option::Some(crate::model::glossary_entry::Data::TermsPair(v.into()));
+        self
+    }
+
+    /// Sets the value of [data][crate::model::GlossaryEntry::data]
+    /// to hold a `TermsSet`.
+    ///
+    /// Note that all the setters affecting `data` are
+    /// mutually exclusive.
+    pub fn set_terms_set<
+        T: std::convert::Into<std::boxed::Box<crate::model::glossary_entry::GlossaryTermsSet>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.data =
+            std::option::Option::Some(crate::model::glossary_entry::Data::TermsSet(v.into()));
+        self
+    }
 }
 
 impl wkt::message::Message for GlossaryEntry {
@@ -3578,6 +3765,31 @@ impl DetectLanguageRequest {
         self.source = v.into();
         self
     }
+
+    /// The value of [source][crate::model::DetectLanguageRequest::source]
+    /// if it holds a `Content`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_content(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::detect_language_request::Source::Content(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [source][crate::model::DetectLanguageRequest::source]
+    /// to hold a `Content`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_content<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.source = std::option::Option::Some(
+            crate::model::detect_language_request::Source::Content(v.into()),
+        );
+        self
+    }
 }
 
 impl wkt::message::Message for DetectLanguageRequest {
@@ -3890,6 +4102,31 @@ impl InputConfig {
         self.source = v.into();
         self
     }
+
+    /// The value of [source][crate::model::InputConfig::source]
+    /// if it holds a `GcsSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_gcs_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::input_config::Source::GcsSource(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [source][crate::model::InputConfig::source]
+    /// to hold a `GcsSource`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source =
+            std::option::Option::Some(crate::model::input_config::Source::GcsSource(v.into()));
+        self
+    }
 }
 
 impl wkt::message::Message for InputConfig {
@@ -3982,6 +4219,38 @@ impl OutputConfig {
         v: T,
     ) -> Self {
         self.destination = v.into();
+        self
+    }
+
+    /// The value of [destination][crate::model::OutputConfig::destination]
+    /// if it holds a `GcsDestination`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_gcs_destination(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GcsDestination>> {
+        #[allow(unreachable_patterns)]
+        self.destination.as_ref().and_then(|v| match v {
+            crate::model::output_config::Destination::GcsDestination(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [destination][crate::model::OutputConfig::destination]
+    /// to hold a `GcsDestination`.
+    ///
+    /// Note that all the setters affecting `destination` are
+    /// mutually exclusive.
+    pub fn set_gcs_destination<
+        T: std::convert::Into<std::boxed::Box<crate::model::GcsDestination>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.destination = std::option::Option::Some(
+            crate::model::output_config::Destination::GcsDestination(v.into()),
+        );
         self
     }
 }
@@ -4126,6 +4395,57 @@ impl DocumentInputConfig {
         self.source = v.into();
         self
     }
+
+    /// The value of [source][crate::model::DocumentInputConfig::source]
+    /// if it holds a `Content`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_content(&self) -> std::option::Option<&bytes::Bytes> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::document_input_config::Source::Content(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [source][crate::model::DocumentInputConfig::source]
+    /// if it holds a `GcsSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_gcs_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::document_input_config::Source::GcsSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [source][crate::model::DocumentInputConfig::source]
+    /// to hold a `Content`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_content<T: std::convert::Into<bytes::Bytes>>(mut self, v: T) -> Self {
+        self.source = std::option::Option::Some(
+            crate::model::document_input_config::Source::Content(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [source][crate::model::DocumentInputConfig::source]
+    /// to hold a `GcsSource`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source = std::option::Option::Some(
+            crate::model::document_input_config::Source::GcsSource(v.into()),
+        );
+        self
+    }
 }
 
 impl wkt::message::Message for DocumentInputConfig {
@@ -4203,6 +4523,38 @@ impl DocumentOutputConfig {
         v: T,
     ) -> Self {
         self.destination = v.into();
+        self
+    }
+
+    /// The value of [destination][crate::model::DocumentOutputConfig::destination]
+    /// if it holds a `GcsDestination`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_gcs_destination(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GcsDestination>> {
+        #[allow(unreachable_patterns)]
+        self.destination.as_ref().and_then(|v| match v {
+            crate::model::document_output_config::Destination::GcsDestination(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [destination][crate::model::DocumentOutputConfig::destination]
+    /// to hold a `GcsDestination`.
+    ///
+    /// Note that all the setters affecting `destination` are
+    /// mutually exclusive.
+    pub fn set_gcs_destination<
+        T: std::convert::Into<std::boxed::Box<crate::model::GcsDestination>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.destination = std::option::Option::Some(
+            crate::model::document_output_config::Destination::GcsDestination(v.into()),
+        );
         self
     }
 }
@@ -5023,6 +5375,34 @@ impl GlossaryInputConfig {
         self.source = v.into();
         self
     }
+
+    /// The value of [source][crate::model::GlossaryInputConfig::source]
+    /// if it holds a `GcsSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_gcs_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::glossary_input_config::Source::GcsSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [source][crate::model::GlossaryInputConfig::source]
+    /// to hold a `GcsSource`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source = std::option::Option::Some(
+            crate::model::glossary_input_config::Source::GcsSource(v.into()),
+        );
+        self
+    }
 }
 
 impl wkt::message::Message for GlossaryInputConfig {
@@ -5159,6 +5539,65 @@ impl Glossary {
         v: T,
     ) -> Self {
         self.languages = v.into();
+        self
+    }
+
+    /// The value of [languages][crate::model::Glossary::languages]
+    /// if it holds a `LanguagePair`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_language_pair(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::glossary::LanguageCodePair>> {
+        #[allow(unreachable_patterns)]
+        self.languages.as_ref().and_then(|v| match v {
+            crate::model::glossary::Languages::LanguagePair(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [languages][crate::model::Glossary::languages]
+    /// if it holds a `LanguageCodesSet`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_language_codes_set(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::glossary::LanguageCodesSet>> {
+        #[allow(unreachable_patterns)]
+        self.languages.as_ref().and_then(|v| match v {
+            crate::model::glossary::Languages::LanguageCodesSet(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [languages][crate::model::Glossary::languages]
+    /// to hold a `LanguagePair`.
+    ///
+    /// Note that all the setters affecting `languages` are
+    /// mutually exclusive.
+    pub fn set_language_pair<
+        T: std::convert::Into<std::boxed::Box<crate::model::glossary::LanguageCodePair>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.languages =
+            std::option::Option::Some(crate::model::glossary::Languages::LanguagePair(v.into()));
+        self
+    }
+
+    /// Sets the value of [languages][crate::model::Glossary::languages]
+    /// to hold a `LanguageCodesSet`.
+    ///
+    /// Note that all the setters affecting `languages` are
+    /// mutually exclusive.
+    pub fn set_language_codes_set<
+        T: std::convert::Into<std::boxed::Box<crate::model::glossary::LanguageCodesSet>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.languages = std::option::Option::Some(
+            crate::model::glossary::Languages::LanguageCodesSet(v.into()),
+        );
         self
     }
 }
@@ -6339,6 +6778,34 @@ impl BatchDocumentInputConfig {
         self.source = v.into();
         self
     }
+
+    /// The value of [source][crate::model::BatchDocumentInputConfig::source]
+    /// if it holds a `GcsSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_gcs_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::batch_document_input_config::Source::GcsSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [source][crate::model::BatchDocumentInputConfig::source]
+    /// to hold a `GcsSource`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source = std::option::Option::Some(
+            crate::model::batch_document_input_config::Source::GcsSource(v.into()),
+        );
+        self
+    }
 }
 
 impl wkt::message::Message for BatchDocumentInputConfig {
@@ -6404,6 +6871,38 @@ impl BatchDocumentOutputConfig {
         v: T,
     ) -> Self {
         self.destination = v.into();
+        self
+    }
+
+    /// The value of [destination][crate::model::BatchDocumentOutputConfig::destination]
+    /// if it holds a `GcsDestination`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_gcs_destination(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GcsDestination>> {
+        #[allow(unreachable_patterns)]
+        self.destination.as_ref().and_then(|v| match v {
+            crate::model::batch_document_output_config::Destination::GcsDestination(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [destination][crate::model::BatchDocumentOutputConfig::destination]
+    /// to hold a `GcsDestination`.
+    ///
+    /// Note that all the setters affecting `destination` are
+    /// mutually exclusive.
+    pub fn set_gcs_destination<
+        T: std::convert::Into<std::boxed::Box<crate::model::GcsDestination>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.destination = std::option::Option::Some(
+            crate::model::batch_document_output_config::Destination::GcsDestination(v.into()),
+        );
         self
     }
 }

--- a/src/generated/cloud/webrisk/v1/src/model.rs
+++ b/src/generated/cloud/webrisk/v1/src/model.rs
@@ -956,6 +956,63 @@ pub mod threat_info {
             self.value = v.into();
             self
         }
+
+        /// The value of [value][crate::model::threat_info::Confidence::value]
+        /// if it holds a `Score`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_score(&self) -> std::option::Option<&f32> {
+            #[allow(unreachable_patterns)]
+            self.value.as_ref().and_then(|v| match v {
+                crate::model::threat_info::confidence::Value::Score(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// The value of [value][crate::model::threat_info::Confidence::value]
+        /// if it holds a `Level`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_level(
+            &self,
+        ) -> std::option::Option<&crate::model::threat_info::confidence::ConfidenceLevel> {
+            #[allow(unreachable_patterns)]
+            self.value.as_ref().and_then(|v| match v {
+                crate::model::threat_info::confidence::Value::Level(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// Sets the value of [value][crate::model::threat_info::Confidence::value]
+        /// to hold a `Score`.
+        ///
+        /// Note that all the setters affecting `value` are
+        /// mutually exclusive.
+        pub fn set_score<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
+            self.value = std::option::Option::Some(
+                crate::model::threat_info::confidence::Value::Score(v.into()),
+            );
+            self
+        }
+
+        /// Sets the value of [value][crate::model::threat_info::Confidence::value]
+        /// to hold a `Level`.
+        ///
+        /// Note that all the setters affecting `value` are
+        /// mutually exclusive.
+        pub fn set_level<
+            T: std::convert::Into<crate::model::threat_info::confidence::ConfidenceLevel>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.value = std::option::Option::Some(
+                crate::model::threat_info::confidence::Value::Level(v.into()),
+            );
+            self
+        }
     }
 
     impl wkt::message::Message for Confidence {

--- a/src/generated/cloud/workflows/v1/src/model.rs
+++ b/src/generated/cloud/workflows/v1/src/model.rs
@@ -262,6 +262,28 @@ impl Workflow {
         self.source_code = v.into();
         self
     }
+
+    /// The value of [source_code][crate::model::Workflow::source_code]
+    /// if it holds a `SourceContents`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_source_contents(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.source_code.as_ref().and_then(|v| match v {
+            crate::model::workflow::SourceCode::SourceContents(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [source_code][crate::model::Workflow::source_code]
+    /// to hold a `SourceContents`.
+    ///
+    /// Note that all the setters affecting `source_code` are
+    /// mutually exclusive.
+    pub fn set_source_contents<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.source_code =
+            std::option::Option::Some(crate::model::workflow::SourceCode::SourceContents(v.into()));
+        self
+    }
 }
 
 impl wkt::message::Message for Workflow {

--- a/src/generated/container/v1/src/model.rs
+++ b/src/generated/container/v1/src/model.rs
@@ -2008,8 +2008,34 @@ pub mod containerd_config {
             }
 
             /// Sets the value of `certificate_config`.
-            pub fn set_certificate_config<T: std::convert::Into<std::option::Option<crate::model::containerd_config::private_registry_access_config::certificate_authority_domain_config::CertificateConfig>>>(mut self, v: T) ->Self{
+            pub fn set_certificate_config<T: std::convert::Into<std::option::Option<crate::model::containerd_config::private_registry_access_config::certificate_authority_domain_config::CertificateConfig>>>(mut self, v: T) -> Self
+            {
                 self.certificate_config = v.into();
+                self
+            }
+
+            /// The value of [certificate_config][crate::model::containerd_config::private_registry_access_config::CertificateAuthorityDomainConfig::certificate_config]
+            /// if it holds a `GcpSecretManagerCertificateConfig`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn get_gcp_secret_manager_certificate_config(&self) -> std::option::Option<&std::boxed::Box<crate::model::containerd_config::private_registry_access_config::certificate_authority_domain_config::GCPSecretManagerCertificateConfig>>{
+                #[allow(unreachable_patterns)]
+                self.certificate_config.as_ref().and_then(|v| match v {
+                    crate::model::containerd_config::private_registry_access_config::certificate_authority_domain_config::CertificateConfig::GcpSecretManagerCertificateConfig(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
+            }
+
+            /// Sets the value of [certificate_config][crate::model::containerd_config::private_registry_access_config::CertificateAuthorityDomainConfig::certificate_config]
+            /// to hold a `GcpSecretManagerCertificateConfig`.
+            ///
+            /// Note that all the setters affecting `certificate_config` are
+            /// mutually exclusive.
+            pub fn set_gcp_secret_manager_certificate_config<T: std::convert::Into<std::boxed::Box<crate::model::containerd_config::private_registry_access_config::certificate_authority_domain_config::GCPSecretManagerCertificateConfig>>>(mut self, v: T) -> Self{
+                self.certificate_config = std::option::Option::Some(
+                    crate::model::containerd_config::private_registry_access_config::certificate_authority_domain_config::CertificateConfig::GcpSecretManagerCertificateConfig(
+                        v.into()
+                    )
+                );
                 self
             }
         }
@@ -7482,6 +7508,84 @@ pub mod operation_progress {
             self.value = v.into();
             self
         }
+
+        /// The value of [value][crate::model::operation_progress::Metric::value]
+        /// if it holds a `IntValue`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_int_value(&self) -> std::option::Option<&i64> {
+            #[allow(unreachable_patterns)]
+            self.value.as_ref().and_then(|v| match v {
+                crate::model::operation_progress::metric::Value::IntValue(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// The value of [value][crate::model::operation_progress::Metric::value]
+        /// if it holds a `DoubleValue`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_double_value(&self) -> std::option::Option<&f64> {
+            #[allow(unreachable_patterns)]
+            self.value.as_ref().and_then(|v| match v {
+                crate::model::operation_progress::metric::Value::DoubleValue(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// The value of [value][crate::model::operation_progress::Metric::value]
+        /// if it holds a `StringValue`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_string_value(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.value.as_ref().and_then(|v| match v {
+                crate::model::operation_progress::metric::Value::StringValue(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// Sets the value of [value][crate::model::operation_progress::Metric::value]
+        /// to hold a `IntValue`.
+        ///
+        /// Note that all the setters affecting `value` are
+        /// mutually exclusive.
+        pub fn set_int_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+            self.value = std::option::Option::Some(
+                crate::model::operation_progress::metric::Value::IntValue(v.into()),
+            );
+            self
+        }
+
+        /// Sets the value of [value][crate::model::operation_progress::Metric::value]
+        /// to hold a `DoubleValue`.
+        ///
+        /// Note that all the setters affecting `value` are
+        /// mutually exclusive.
+        pub fn set_double_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+            self.value = std::option::Option::Some(
+                crate::model::operation_progress::metric::Value::DoubleValue(v.into()),
+            );
+            self
+        }
+
+        /// Sets the value of [value][crate::model::operation_progress::Metric::value]
+        /// to hold a `StringValue`.
+        ///
+        /// Note that all the setters affecting `value` are
+        /// mutually exclusive.
+        pub fn set_string_value<T: std::convert::Into<std::string::String>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.value = std::option::Option::Some(
+                crate::model::operation_progress::metric::Value::StringValue(v.into()),
+            );
+            self
+        }
     }
 
     impl wkt::message::Message for Metric {
@@ -9751,6 +9855,42 @@ impl BlueGreenSettings {
         self.rollout_policy = v.into();
         self
     }
+
+    /// The value of [rollout_policy][crate::model::BlueGreenSettings::rollout_policy]
+    /// if it holds a `StandardRolloutPolicy`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_standard_rollout_policy(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::blue_green_settings::StandardRolloutPolicy>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.rollout_policy.as_ref().and_then(|v| match v {
+            crate::model::blue_green_settings::RolloutPolicy::StandardRolloutPolicy(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [rollout_policy][crate::model::BlueGreenSettings::rollout_policy]
+    /// to hold a `StandardRolloutPolicy`.
+    ///
+    /// Note that all the setters affecting `rollout_policy` are
+    /// mutually exclusive.
+    pub fn set_standard_rollout_policy<
+        T: std::convert::Into<
+            std::boxed::Box<crate::model::blue_green_settings::StandardRolloutPolicy>,
+        >,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.rollout_policy = std::option::Option::Some(
+            crate::model::blue_green_settings::RolloutPolicy::StandardRolloutPolicy(v.into()),
+        );
+        self
+    }
 }
 
 impl wkt::message::Message for BlueGreenSettings {
@@ -9805,6 +9945,56 @@ pub mod blue_green_settings {
             v: T,
         ) -> Self {
             self.update_batch_size = v.into();
+            self
+        }
+
+        /// The value of [update_batch_size][crate::model::blue_green_settings::StandardRolloutPolicy::update_batch_size]
+        /// if it holds a `BatchPercentage`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_batch_percentage(&self) -> std::option::Option<&f32> {
+            #[allow(unreachable_patterns)]
+            self.update_batch_size.as_ref().and_then(|v| match v {
+                crate::model::blue_green_settings::standard_rollout_policy::UpdateBatchSize::BatchPercentage(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// The value of [update_batch_size][crate::model::blue_green_settings::StandardRolloutPolicy::update_batch_size]
+        /// if it holds a `BatchNodeCount`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_batch_node_count(&self) -> std::option::Option<&i32> {
+            #[allow(unreachable_patterns)]
+            self.update_batch_size.as_ref().and_then(|v| match v {
+                crate::model::blue_green_settings::standard_rollout_policy::UpdateBatchSize::BatchNodeCount(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// Sets the value of [update_batch_size][crate::model::blue_green_settings::StandardRolloutPolicy::update_batch_size]
+        /// to hold a `BatchPercentage`.
+        ///
+        /// Note that all the setters affecting `update_batch_size` are
+        /// mutually exclusive.
+        pub fn set_batch_percentage<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
+            self.update_batch_size = std::option::Option::Some(
+                crate::model::blue_green_settings::standard_rollout_policy::UpdateBatchSize::BatchPercentage(
+                    v.into()
+                )
+            );
+            self
+        }
+
+        /// Sets the value of [update_batch_size][crate::model::blue_green_settings::StandardRolloutPolicy::update_batch_size]
+        /// to hold a `BatchNodeCount`.
+        ///
+        /// Note that all the setters affecting `update_batch_size` are
+        /// mutually exclusive.
+        pub fn set_batch_node_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.update_batch_size = std::option::Option::Some(
+                crate::model::blue_green_settings::standard_rollout_policy::UpdateBatchSize::BatchNodeCount(
+                    v.into()
+                )
+            );
             self
         }
     }
@@ -10850,6 +11040,70 @@ impl MaintenanceWindow {
         self.policy = v.into();
         self
     }
+
+    /// The value of [policy][crate::model::MaintenanceWindow::policy]
+    /// if it holds a `DailyMaintenanceWindow`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_daily_maintenance_window(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DailyMaintenanceWindow>> {
+        #[allow(unreachable_patterns)]
+        self.policy.as_ref().and_then(|v| match v {
+            crate::model::maintenance_window::Policy::DailyMaintenanceWindow(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [policy][crate::model::MaintenanceWindow::policy]
+    /// if it holds a `RecurringWindow`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_recurring_window(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::RecurringTimeWindow>> {
+        #[allow(unreachable_patterns)]
+        self.policy.as_ref().and_then(|v| match v {
+            crate::model::maintenance_window::Policy::RecurringWindow(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [policy][crate::model::MaintenanceWindow::policy]
+    /// to hold a `DailyMaintenanceWindow`.
+    ///
+    /// Note that all the setters affecting `policy` are
+    /// mutually exclusive.
+    pub fn set_daily_maintenance_window<
+        T: std::convert::Into<std::boxed::Box<crate::model::DailyMaintenanceWindow>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.policy = std::option::Option::Some(
+            crate::model::maintenance_window::Policy::DailyMaintenanceWindow(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [policy][crate::model::MaintenanceWindow::policy]
+    /// to hold a `RecurringWindow`.
+    ///
+    /// Note that all the setters affecting `policy` are
+    /// mutually exclusive.
+    pub fn set_recurring_window<
+        T: std::convert::Into<std::boxed::Box<crate::model::RecurringTimeWindow>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.policy = std::option::Option::Some(
+            crate::model::maintenance_window::Policy::RecurringWindow(v.into()),
+        );
+        self
+    }
 }
 
 impl wkt::message::Message for MaintenanceWindow {
@@ -10922,6 +11176,38 @@ impl TimeWindow {
         v: T,
     ) -> Self {
         self.options = v.into();
+        self
+    }
+
+    /// The value of [options][crate::model::TimeWindow::options]
+    /// if it holds a `MaintenanceExclusionOptions`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_maintenance_exclusion_options(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::MaintenanceExclusionOptions>> {
+        #[allow(unreachable_patterns)]
+        self.options.as_ref().and_then(|v| match v {
+            crate::model::time_window::Options::MaintenanceExclusionOptions(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [options][crate::model::TimeWindow::options]
+    /// to hold a `MaintenanceExclusionOptions`.
+    ///
+    /// Note that all the setters affecting `options` are
+    /// mutually exclusive.
+    pub fn set_maintenance_exclusion_options<
+        T: std::convert::Into<std::boxed::Box<crate::model::MaintenanceExclusionOptions>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.options = std::option::Option::Some(
+            crate::model::time_window::Options::MaintenanceExclusionOptions(v.into()),
+        );
         self
     }
 }

--- a/src/generated/devtools/cloudbuild/v2/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/model.rs
@@ -350,6 +350,162 @@ impl Connection {
         self.connection_config = v.into();
         self
     }
+
+    /// The value of [connection_config][crate::model::Connection::connection_config]
+    /// if it holds a `GithubConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_github_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GitHubConfig>> {
+        #[allow(unreachable_patterns)]
+        self.connection_config.as_ref().and_then(|v| match v {
+            crate::model::connection::ConnectionConfig::GithubConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [connection_config][crate::model::Connection::connection_config]
+    /// if it holds a `GithubEnterpriseConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_github_enterprise_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GitHubEnterpriseConfig>> {
+        #[allow(unreachable_patterns)]
+        self.connection_config.as_ref().and_then(|v| match v {
+            crate::model::connection::ConnectionConfig::GithubEnterpriseConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [connection_config][crate::model::Connection::connection_config]
+    /// if it holds a `GitlabConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_gitlab_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GitLabConfig>> {
+        #[allow(unreachable_patterns)]
+        self.connection_config.as_ref().and_then(|v| match v {
+            crate::model::connection::ConnectionConfig::GitlabConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [connection_config][crate::model::Connection::connection_config]
+    /// if it holds a `BitbucketDataCenterConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_bitbucket_data_center_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BitbucketDataCenterConfig>> {
+        #[allow(unreachable_patterns)]
+        self.connection_config.as_ref().and_then(|v| match v {
+            crate::model::connection::ConnectionConfig::BitbucketDataCenterConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [connection_config][crate::model::Connection::connection_config]
+    /// if it holds a `BitbucketCloudConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_bitbucket_cloud_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BitbucketCloudConfig>> {
+        #[allow(unreachable_patterns)]
+        self.connection_config.as_ref().and_then(|v| match v {
+            crate::model::connection::ConnectionConfig::BitbucketCloudConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [connection_config][crate::model::Connection::connection_config]
+    /// to hold a `GithubConfig`.
+    ///
+    /// Note that all the setters affecting `connection_config` are
+    /// mutually exclusive.
+    pub fn set_github_config<T: std::convert::Into<std::boxed::Box<crate::model::GitHubConfig>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.connection_config = std::option::Option::Some(
+            crate::model::connection::ConnectionConfig::GithubConfig(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [connection_config][crate::model::Connection::connection_config]
+    /// to hold a `GithubEnterpriseConfig`.
+    ///
+    /// Note that all the setters affecting `connection_config` are
+    /// mutually exclusive.
+    pub fn set_github_enterprise_config<
+        T: std::convert::Into<std::boxed::Box<crate::model::GitHubEnterpriseConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.connection_config = std::option::Option::Some(
+            crate::model::connection::ConnectionConfig::GithubEnterpriseConfig(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [connection_config][crate::model::Connection::connection_config]
+    /// to hold a `GitlabConfig`.
+    ///
+    /// Note that all the setters affecting `connection_config` are
+    /// mutually exclusive.
+    pub fn set_gitlab_config<T: std::convert::Into<std::boxed::Box<crate::model::GitLabConfig>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.connection_config = std::option::Option::Some(
+            crate::model::connection::ConnectionConfig::GitlabConfig(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [connection_config][crate::model::Connection::connection_config]
+    /// to hold a `BitbucketDataCenterConfig`.
+    ///
+    /// Note that all the setters affecting `connection_config` are
+    /// mutually exclusive.
+    pub fn set_bitbucket_data_center_config<
+        T: std::convert::Into<std::boxed::Box<crate::model::BitbucketDataCenterConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.connection_config = std::option::Option::Some(
+            crate::model::connection::ConnectionConfig::BitbucketDataCenterConfig(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [connection_config][crate::model::Connection::connection_config]
+    /// to hold a `BitbucketCloudConfig`.
+    ///
+    /// Note that all the setters affecting `connection_config` are
+    /// mutually exclusive.
+    pub fn set_bitbucket_cloud_config<
+        T: std::convert::Into<std::boxed::Box<crate::model::BitbucketCloudConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.connection_config = std::option::Option::Some(
+            crate::model::connection::ConnectionConfig::BitbucketCloudConfig(v.into()),
+        );
+        self
+    }
 }
 
 impl wkt::message::Message for Connection {

--- a/src/generated/devtools/cloudtrace/v2/src/model.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/model.rs
@@ -354,6 +354,72 @@ pub mod span {
             self.value = v.into();
             self
         }
+
+        /// The value of [value][crate::model::span::TimeEvent::value]
+        /// if it holds a `Annotation`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_annotation(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::span::time_event::Annotation>>
+        {
+            #[allow(unreachable_patterns)]
+            self.value.as_ref().and_then(|v| match v {
+                crate::model::span::time_event::Value::Annotation(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// The value of [value][crate::model::span::TimeEvent::value]
+        /// if it holds a `MessageEvent`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_message_event(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::span::time_event::MessageEvent>>
+        {
+            #[allow(unreachable_patterns)]
+            self.value.as_ref().and_then(|v| match v {
+                crate::model::span::time_event::Value::MessageEvent(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// Sets the value of [value][crate::model::span::TimeEvent::value]
+        /// to hold a `Annotation`.
+        ///
+        /// Note that all the setters affecting `value` are
+        /// mutually exclusive.
+        pub fn set_annotation<
+            T: std::convert::Into<std::boxed::Box<crate::model::span::time_event::Annotation>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.value = std::option::Option::Some(
+                crate::model::span::time_event::Value::Annotation(v.into()),
+            );
+            self
+        }
+
+        /// Sets the value of [value][crate::model::span::TimeEvent::value]
+        /// to hold a `MessageEvent`.
+        ///
+        /// Note that all the setters affecting `value` are
+        /// mutually exclusive.
+        pub fn set_message_event<
+            T: std::convert::Into<std::boxed::Box<crate::model::span::time_event::MessageEvent>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.value = std::option::Option::Some(
+                crate::model::span::time_event::Value::MessageEvent(v.into()),
+            );
+            self
+        }
     }
 
     impl wkt::message::Message for TimeEvent {
@@ -800,6 +866,79 @@ impl AttributeValue {
         v: T,
     ) -> Self {
         self.value = v.into();
+        self
+    }
+
+    /// The value of [value][crate::model::AttributeValue::value]
+    /// if it holds a `StringValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_string_value(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::TruncatableString>> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::attribute_value::Value::StringValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [value][crate::model::AttributeValue::value]
+    /// if it holds a `IntValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_int_value(&self) -> std::option::Option<&i64> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::attribute_value::Value::IntValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [value][crate::model::AttributeValue::value]
+    /// if it holds a `BoolValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_bool_value(&self) -> std::option::Option<&bool> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::attribute_value::Value::BoolValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [value][crate::model::AttributeValue::value]
+    /// to hold a `StringValue`.
+    ///
+    /// Note that all the setters affecting `value` are
+    /// mutually exclusive.
+    pub fn set_string_value<
+        T: std::convert::Into<std::boxed::Box<crate::model::TruncatableString>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.value =
+            std::option::Option::Some(crate::model::attribute_value::Value::StringValue(v.into()));
+        self
+    }
+
+    /// Sets the value of [value][crate::model::AttributeValue::value]
+    /// to hold a `IntValue`.
+    ///
+    /// Note that all the setters affecting `value` are
+    /// mutually exclusive.
+    pub fn set_int_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.value =
+            std::option::Option::Some(crate::model::attribute_value::Value::IntValue(v.into()));
+        self
+    }
+
+    /// Sets the value of [value][crate::model::AttributeValue::value]
+    /// to hold a `BoolValue`.
+    ///
+    /// Note that all the setters affecting `value` are
+    /// mutually exclusive.
+    pub fn set_bool_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.value =
+            std::option::Option::Some(crate::model::attribute_value::Value::BoolValue(v.into()));
         self
     }
 }

--- a/src/generated/iam/admin/v1/src/model.rs
+++ b/src/generated/iam/admin/v1/src/model.rs
@@ -2523,6 +2523,34 @@ impl LintPolicyRequest {
         self.lint_object = v.into();
         self
     }
+
+    /// The value of [lint_object][crate::model::LintPolicyRequest::lint_object]
+    /// if it holds a `Condition`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_condition(&self) -> std::option::Option<&std::boxed::Box<gtype::model::Expr>> {
+        #[allow(unreachable_patterns)]
+        self.lint_object.as_ref().and_then(|v| match v {
+            crate::model::lint_policy_request::LintObject::Condition(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [lint_object][crate::model::LintPolicyRequest::lint_object]
+    /// to hold a `Condition`.
+    ///
+    /// Note that all the setters affecting `lint_object` are
+    /// mutually exclusive.
+    pub fn set_condition<T: std::convert::Into<std::boxed::Box<gtype::model::Expr>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.lint_object = std::option::Option::Some(
+            crate::model::lint_policy_request::LintObject::Condition(v.into()),
+        );
+        self
+    }
 }
 
 impl wkt::message::Message for LintPolicyRequest {

--- a/src/generated/iam/v2/src/model.rs
+++ b/src/generated/iam/v2/src/model.rs
@@ -384,6 +384,30 @@ impl PolicyRule {
         self.kind = v.into();
         self
     }
+
+    /// The value of [kind][crate::model::PolicyRule::kind]
+    /// if it holds a `DenyRule`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_deny_rule(&self) -> std::option::Option<&std::boxed::Box<crate::model::DenyRule>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::policy_rule::Kind::DenyRule(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [kind][crate::model::PolicyRule::kind]
+    /// to hold a `DenyRule`.
+    ///
+    /// Note that all the setters affecting `kind` are
+    /// mutually exclusive.
+    pub fn set_deny_rule<T: std::convert::Into<std::boxed::Box<crate::model::DenyRule>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.kind = std::option::Option::Some(crate::model::policy_rule::Kind::DenyRule(v.into()));
+        self
+    }
 }
 
 impl wkt::message::Message for PolicyRule {

--- a/src/generated/longrunning/src/model.rs
+++ b/src/generated/longrunning/src/model.rs
@@ -95,6 +95,52 @@ impl Operation {
         self.result = v.into();
         self
     }
+
+    /// The value of [result][crate::model::Operation::result]
+    /// if it holds a `Error`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_error(&self) -> std::option::Option<&std::boxed::Box<rpc::model::Status>> {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::operation::Result::Error(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [result][crate::model::Operation::result]
+    /// if it holds a `Response`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_response(&self) -> std::option::Option<&std::boxed::Box<wkt::Any>> {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::operation::Result::Response(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [result][crate::model::Operation::result]
+    /// to hold a `Error`.
+    ///
+    /// Note that all the setters affecting `result` are
+    /// mutually exclusive.
+    pub fn set_error<T: std::convert::Into<std::boxed::Box<rpc::model::Status>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.result = std::option::Option::Some(crate::model::operation::Result::Error(v.into()));
+        self
+    }
+
+    /// Sets the value of [result][crate::model::Operation::result]
+    /// to hold a `Response`.
+    ///
+    /// Note that all the setters affecting `result` are
+    /// mutually exclusive.
+    pub fn set_response<T: std::convert::Into<std::boxed::Box<wkt::Any>>>(mut self, v: T) -> Self {
+        self.result =
+            std::option::Option::Some(crate::model::operation::Result::Response(v.into()));
+        self
+    }
 }
 
 impl wkt::message::Message for Operation {

--- a/src/generated/monitoring/dashboard/v1/src/model.rs
+++ b/src/generated/monitoring/dashboard/v1/src/model.rs
@@ -842,6 +842,112 @@ impl Dashboard {
         self.layout = v.into();
         self
     }
+
+    /// The value of [layout][crate::model::Dashboard::layout]
+    /// if it holds a `GridLayout`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_grid_layout(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GridLayout>> {
+        #[allow(unreachable_patterns)]
+        self.layout.as_ref().and_then(|v| match v {
+            crate::model::dashboard::Layout::GridLayout(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [layout][crate::model::Dashboard::layout]
+    /// if it holds a `MosaicLayout`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_mosaic_layout(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::MosaicLayout>> {
+        #[allow(unreachable_patterns)]
+        self.layout.as_ref().and_then(|v| match v {
+            crate::model::dashboard::Layout::MosaicLayout(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [layout][crate::model::Dashboard::layout]
+    /// if it holds a `RowLayout`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_row_layout(&self) -> std::option::Option<&std::boxed::Box<crate::model::RowLayout>> {
+        #[allow(unreachable_patterns)]
+        self.layout.as_ref().and_then(|v| match v {
+            crate::model::dashboard::Layout::RowLayout(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [layout][crate::model::Dashboard::layout]
+    /// if it holds a `ColumnLayout`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_column_layout(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ColumnLayout>> {
+        #[allow(unreachable_patterns)]
+        self.layout.as_ref().and_then(|v| match v {
+            crate::model::dashboard::Layout::ColumnLayout(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [layout][crate::model::Dashboard::layout]
+    /// to hold a `GridLayout`.
+    ///
+    /// Note that all the setters affecting `layout` are
+    /// mutually exclusive.
+    pub fn set_grid_layout<T: std::convert::Into<std::boxed::Box<crate::model::GridLayout>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.layout =
+            std::option::Option::Some(crate::model::dashboard::Layout::GridLayout(v.into()));
+        self
+    }
+
+    /// Sets the value of [layout][crate::model::Dashboard::layout]
+    /// to hold a `MosaicLayout`.
+    ///
+    /// Note that all the setters affecting `layout` are
+    /// mutually exclusive.
+    pub fn set_mosaic_layout<T: std::convert::Into<std::boxed::Box<crate::model::MosaicLayout>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.layout =
+            std::option::Option::Some(crate::model::dashboard::Layout::MosaicLayout(v.into()));
+        self
+    }
+
+    /// Sets the value of [layout][crate::model::Dashboard::layout]
+    /// to hold a `RowLayout`.
+    ///
+    /// Note that all the setters affecting `layout` are
+    /// mutually exclusive.
+    pub fn set_row_layout<T: std::convert::Into<std::boxed::Box<crate::model::RowLayout>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.layout =
+            std::option::Option::Some(crate::model::dashboard::Layout::RowLayout(v.into()));
+        self
+    }
+
+    /// Sets the value of [layout][crate::model::Dashboard::layout]
+    /// to hold a `ColumnLayout`.
+    ///
+    /// Note that all the setters affecting `layout` are
+    /// mutually exclusive.
+    pub fn set_column_layout<T: std::convert::Into<std::boxed::Box<crate::model::ColumnLayout>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.layout =
+            std::option::Option::Some(crate::model::dashboard::Layout::ColumnLayout(v.into()));
+        self
+    }
 }
 
 impl wkt::message::Message for Dashboard {
@@ -932,6 +1038,31 @@ impl DashboardFilter {
         v: T,
     ) -> Self {
         self.default_value = v.into();
+        self
+    }
+
+    /// The value of [default_value][crate::model::DashboardFilter::default_value]
+    /// if it holds a `StringValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_string_value(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.default_value.as_ref().and_then(|v| match v {
+            crate::model::dashboard_filter::DefaultValue::StringValue(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [default_value][crate::model::DashboardFilter::default_value]
+    /// to hold a `StringValue`.
+    ///
+    /// Note that all the setters affecting `default_value` are
+    /// mutually exclusive.
+    pub fn set_string_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.default_value = std::option::Option::Some(
+            crate::model::dashboard_filter::DefaultValue::StringValue(v.into()),
+        );
         self
     }
 }
@@ -1794,6 +1925,126 @@ impl TimeSeriesQuery {
         self.source = v.into();
         self
     }
+
+    /// The value of [source][crate::model::TimeSeriesQuery::source]
+    /// if it holds a `TimeSeriesFilter`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_time_series_filter(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::TimeSeriesFilter>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::time_series_query::Source::TimeSeriesFilter(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [source][crate::model::TimeSeriesQuery::source]
+    /// if it holds a `TimeSeriesFilterRatio`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_time_series_filter_ratio(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::TimeSeriesFilterRatio>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::time_series_query::Source::TimeSeriesFilterRatio(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [source][crate::model::TimeSeriesQuery::source]
+    /// if it holds a `TimeSeriesQueryLanguage`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_time_series_query_language(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::time_series_query::Source::TimeSeriesQueryLanguage(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [source][crate::model::TimeSeriesQuery::source]
+    /// if it holds a `PrometheusQuery`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_prometheus_query(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::time_series_query::Source::PrometheusQuery(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [source][crate::model::TimeSeriesQuery::source]
+    /// to hold a `TimeSeriesFilter`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_time_series_filter<
+        T: std::convert::Into<std::boxed::Box<crate::model::TimeSeriesFilter>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source = std::option::Option::Some(
+            crate::model::time_series_query::Source::TimeSeriesFilter(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [source][crate::model::TimeSeriesQuery::source]
+    /// to hold a `TimeSeriesFilterRatio`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_time_series_filter_ratio<
+        T: std::convert::Into<std::boxed::Box<crate::model::TimeSeriesFilterRatio>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source = std::option::Option::Some(
+            crate::model::time_series_query::Source::TimeSeriesFilterRatio(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [source][crate::model::TimeSeriesQuery::source]
+    /// to hold a `TimeSeriesQueryLanguage`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_time_series_query_language<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source = std::option::Option::Some(
+            crate::model::time_series_query::Source::TimeSeriesQueryLanguage(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [source][crate::model::TimeSeriesQuery::source]
+    /// to hold a `PrometheusQuery`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_prometheus_query<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source = std::option::Option::Some(
+            crate::model::time_series_query::Source::PrometheusQuery(v.into()),
+        );
+        self
+    }
 }
 
 impl wkt::message::Message for TimeSeriesQuery {
@@ -1892,6 +2143,70 @@ impl TimeSeriesFilter {
         self.output_filter = v.into();
         self
     }
+
+    /// The value of [output_filter][crate::model::TimeSeriesFilter::output_filter]
+    /// if it holds a `PickTimeSeriesFilter`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_pick_time_series_filter(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PickTimeSeriesFilter>> {
+        #[allow(unreachable_patterns)]
+        self.output_filter.as_ref().and_then(|v| match v {
+            crate::model::time_series_filter::OutputFilter::PickTimeSeriesFilter(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [output_filter][crate::model::TimeSeriesFilter::output_filter]
+    /// if it holds a `StatisticalTimeSeriesFilter`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_statistical_time_series_filter(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::StatisticalTimeSeriesFilter>> {
+        #[allow(unreachable_patterns)]
+        self.output_filter.as_ref().and_then(|v| match v {
+            crate::model::time_series_filter::OutputFilter::StatisticalTimeSeriesFilter(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [output_filter][crate::model::TimeSeriesFilter::output_filter]
+    /// to hold a `PickTimeSeriesFilter`.
+    ///
+    /// Note that all the setters affecting `output_filter` are
+    /// mutually exclusive.
+    pub fn set_pick_time_series_filter<
+        T: std::convert::Into<std::boxed::Box<crate::model::PickTimeSeriesFilter>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.output_filter = std::option::Option::Some(
+            crate::model::time_series_filter::OutputFilter::PickTimeSeriesFilter(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [output_filter][crate::model::TimeSeriesFilter::output_filter]
+    /// to hold a `StatisticalTimeSeriesFilter`.
+    ///
+    /// Note that all the setters affecting `output_filter` are
+    /// mutually exclusive.
+    pub fn set_statistical_time_series_filter<
+        T: std::convert::Into<std::boxed::Box<crate::model::StatisticalTimeSeriesFilter>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.output_filter = std::option::Option::Some(
+            crate::model::time_series_filter::OutputFilter::StatisticalTimeSeriesFilter(v.into()),
+        );
+        self
+    }
 }
 
 impl wkt::message::Message for TimeSeriesFilter {
@@ -1988,6 +2303,72 @@ impl TimeSeriesFilterRatio {
         v: T,
     ) -> Self {
         self.output_filter = v.into();
+        self
+    }
+
+    /// The value of [output_filter][crate::model::TimeSeriesFilterRatio::output_filter]
+    /// if it holds a `PickTimeSeriesFilter`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_pick_time_series_filter(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PickTimeSeriesFilter>> {
+        #[allow(unreachable_patterns)]
+        self.output_filter.as_ref().and_then(|v| match v {
+            crate::model::time_series_filter_ratio::OutputFilter::PickTimeSeriesFilter(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [output_filter][crate::model::TimeSeriesFilterRatio::output_filter]
+    /// if it holds a `StatisticalTimeSeriesFilter`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_statistical_time_series_filter(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::StatisticalTimeSeriesFilter>> {
+        #[allow(unreachable_patterns)]
+        self.output_filter.as_ref().and_then(|v| match v {
+            crate::model::time_series_filter_ratio::OutputFilter::StatisticalTimeSeriesFilter(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [output_filter][crate::model::TimeSeriesFilterRatio::output_filter]
+    /// to hold a `PickTimeSeriesFilter`.
+    ///
+    /// Note that all the setters affecting `output_filter` are
+    /// mutually exclusive.
+    pub fn set_pick_time_series_filter<
+        T: std::convert::Into<std::boxed::Box<crate::model::PickTimeSeriesFilter>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.output_filter = std::option::Option::Some(
+            crate::model::time_series_filter_ratio::OutputFilter::PickTimeSeriesFilter(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [output_filter][crate::model::TimeSeriesFilterRatio::output_filter]
+    /// to hold a `StatisticalTimeSeriesFilter`.
+    ///
+    /// Note that all the setters affecting `output_filter` are
+    /// mutually exclusive.
+    pub fn set_statistical_time_series_filter<
+        T: std::convert::Into<std::boxed::Box<crate::model::StatisticalTimeSeriesFilter>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.output_filter = std::option::Option::Some(
+            crate::model::time_series_filter_ratio::OutputFilter::StatisticalTimeSeriesFilter(
+                v.into(),
+            ),
+        );
         self
     }
 }
@@ -2481,6 +2862,89 @@ impl Scorecard {
         v: T,
     ) -> Self {
         self.data_view = v.into();
+        self
+    }
+
+    /// The value of [data_view][crate::model::Scorecard::data_view]
+    /// if it holds a `GaugeView`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_gauge_view(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::scorecard::GaugeView>> {
+        #[allow(unreachable_patterns)]
+        self.data_view.as_ref().and_then(|v| match v {
+            crate::model::scorecard::DataView::GaugeView(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [data_view][crate::model::Scorecard::data_view]
+    /// if it holds a `SparkChartView`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_spark_chart_view(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::scorecard::SparkChartView>> {
+        #[allow(unreachable_patterns)]
+        self.data_view.as_ref().and_then(|v| match v {
+            crate::model::scorecard::DataView::SparkChartView(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [data_view][crate::model::Scorecard::data_view]
+    /// if it holds a `BlankView`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_blank_view(&self) -> std::option::Option<&std::boxed::Box<wkt::Empty>> {
+        #[allow(unreachable_patterns)]
+        self.data_view.as_ref().and_then(|v| match v {
+            crate::model::scorecard::DataView::BlankView(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [data_view][crate::model::Scorecard::data_view]
+    /// to hold a `GaugeView`.
+    ///
+    /// Note that all the setters affecting `data_view` are
+    /// mutually exclusive.
+    pub fn set_gauge_view<
+        T: std::convert::Into<std::boxed::Box<crate::model::scorecard::GaugeView>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.data_view =
+            std::option::Option::Some(crate::model::scorecard::DataView::GaugeView(v.into()));
+        self
+    }
+
+    /// Sets the value of [data_view][crate::model::Scorecard::data_view]
+    /// to hold a `SparkChartView`.
+    ///
+    /// Note that all the setters affecting `data_view` are
+    /// mutually exclusive.
+    pub fn set_spark_chart_view<
+        T: std::convert::Into<std::boxed::Box<crate::model::scorecard::SparkChartView>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.data_view =
+            std::option::Option::Some(crate::model::scorecard::DataView::SparkChartView(v.into()));
+        self
+    }
+
+    /// Sets the value of [data_view][crate::model::Scorecard::data_view]
+    /// to hold a `BlankView`.
+    ///
+    /// Note that all the setters affecting `data_view` are
+    /// mutually exclusive.
+    pub fn set_blank_view<T: std::convert::Into<std::boxed::Box<wkt::Empty>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.data_view =
+            std::option::Option::Some(crate::model::scorecard::DataView::BlankView(v.into()));
         self
     }
 }
@@ -3333,6 +3797,348 @@ impl Widget {
         v: T,
     ) -> Self {
         self.content = v.into();
+        self
+    }
+
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `XyChart`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_xy_chart(&self) -> std::option::Option<&std::boxed::Box<crate::model::XyChart>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::XyChart(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `Scorecard`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_scorecard(&self) -> std::option::Option<&std::boxed::Box<crate::model::Scorecard>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::Scorecard(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `Text`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_text(&self) -> std::option::Option<&std::boxed::Box<crate::model::Text>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::Text(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `Blank`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_blank(&self) -> std::option::Option<&std::boxed::Box<wkt::Empty>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::Blank(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `AlertChart`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_alert_chart(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AlertChart>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::AlertChart(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `TimeSeriesTable`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_time_series_table(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::TimeSeriesTable>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::TimeSeriesTable(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `CollapsibleGroup`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_collapsible_group(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CollapsibleGroup>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::CollapsibleGroup(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `LogsPanel`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_logs_panel(&self) -> std::option::Option<&std::boxed::Box<crate::model::LogsPanel>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::LogsPanel(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `IncidentList`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_incident_list(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::IncidentList>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::IncidentList(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `PieChart`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_pie_chart(&self) -> std::option::Option<&std::boxed::Box<crate::model::PieChart>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::PieChart(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `ErrorReportingPanel`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_error_reporting_panel(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ErrorReportingPanel>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::ErrorReportingPanel(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `SectionHeader`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_section_header(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SectionHeader>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::SectionHeader(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `SingleViewGroup`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_single_view_group(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SingleViewGroup>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::SingleViewGroup(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [content][crate::model::Widget::content]
+    /// to hold a `XyChart`.
+    ///
+    /// Note that all the setters affecting `content` are
+    /// mutually exclusive.
+    pub fn set_xy_chart<T: std::convert::Into<std::boxed::Box<crate::model::XyChart>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.content = std::option::Option::Some(crate::model::widget::Content::XyChart(v.into()));
+        self
+    }
+
+    /// Sets the value of [content][crate::model::Widget::content]
+    /// to hold a `Scorecard`.
+    ///
+    /// Note that all the setters affecting `content` are
+    /// mutually exclusive.
+    pub fn set_scorecard<T: std::convert::Into<std::boxed::Box<crate::model::Scorecard>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.content =
+            std::option::Option::Some(crate::model::widget::Content::Scorecard(v.into()));
+        self
+    }
+
+    /// Sets the value of [content][crate::model::Widget::content]
+    /// to hold a `Text`.
+    ///
+    /// Note that all the setters affecting `content` are
+    /// mutually exclusive.
+    pub fn set_text<T: std::convert::Into<std::boxed::Box<crate::model::Text>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.content = std::option::Option::Some(crate::model::widget::Content::Text(v.into()));
+        self
+    }
+
+    /// Sets the value of [content][crate::model::Widget::content]
+    /// to hold a `Blank`.
+    ///
+    /// Note that all the setters affecting `content` are
+    /// mutually exclusive.
+    pub fn set_blank<T: std::convert::Into<std::boxed::Box<wkt::Empty>>>(mut self, v: T) -> Self {
+        self.content = std::option::Option::Some(crate::model::widget::Content::Blank(v.into()));
+        self
+    }
+
+    /// Sets the value of [content][crate::model::Widget::content]
+    /// to hold a `AlertChart`.
+    ///
+    /// Note that all the setters affecting `content` are
+    /// mutually exclusive.
+    pub fn set_alert_chart<T: std::convert::Into<std::boxed::Box<crate::model::AlertChart>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.content =
+            std::option::Option::Some(crate::model::widget::Content::AlertChart(v.into()));
+        self
+    }
+
+    /// Sets the value of [content][crate::model::Widget::content]
+    /// to hold a `TimeSeriesTable`.
+    ///
+    /// Note that all the setters affecting `content` are
+    /// mutually exclusive.
+    pub fn set_time_series_table<
+        T: std::convert::Into<std::boxed::Box<crate::model::TimeSeriesTable>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.content =
+            std::option::Option::Some(crate::model::widget::Content::TimeSeriesTable(v.into()));
+        self
+    }
+
+    /// Sets the value of [content][crate::model::Widget::content]
+    /// to hold a `CollapsibleGroup`.
+    ///
+    /// Note that all the setters affecting `content` are
+    /// mutually exclusive.
+    pub fn set_collapsible_group<
+        T: std::convert::Into<std::boxed::Box<crate::model::CollapsibleGroup>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.content =
+            std::option::Option::Some(crate::model::widget::Content::CollapsibleGroup(v.into()));
+        self
+    }
+
+    /// Sets the value of [content][crate::model::Widget::content]
+    /// to hold a `LogsPanel`.
+    ///
+    /// Note that all the setters affecting `content` are
+    /// mutually exclusive.
+    pub fn set_logs_panel<T: std::convert::Into<std::boxed::Box<crate::model::LogsPanel>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.content =
+            std::option::Option::Some(crate::model::widget::Content::LogsPanel(v.into()));
+        self
+    }
+
+    /// Sets the value of [content][crate::model::Widget::content]
+    /// to hold a `IncidentList`.
+    ///
+    /// Note that all the setters affecting `content` are
+    /// mutually exclusive.
+    pub fn set_incident_list<T: std::convert::Into<std::boxed::Box<crate::model::IncidentList>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.content =
+            std::option::Option::Some(crate::model::widget::Content::IncidentList(v.into()));
+        self
+    }
+
+    /// Sets the value of [content][crate::model::Widget::content]
+    /// to hold a `PieChart`.
+    ///
+    /// Note that all the setters affecting `content` are
+    /// mutually exclusive.
+    pub fn set_pie_chart<T: std::convert::Into<std::boxed::Box<crate::model::PieChart>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.content = std::option::Option::Some(crate::model::widget::Content::PieChart(v.into()));
+        self
+    }
+
+    /// Sets the value of [content][crate::model::Widget::content]
+    /// to hold a `ErrorReportingPanel`.
+    ///
+    /// Note that all the setters affecting `content` are
+    /// mutually exclusive.
+    pub fn set_error_reporting_panel<
+        T: std::convert::Into<std::boxed::Box<crate::model::ErrorReportingPanel>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.content =
+            std::option::Option::Some(crate::model::widget::Content::ErrorReportingPanel(v.into()));
+        self
+    }
+
+    /// Sets the value of [content][crate::model::Widget::content]
+    /// to hold a `SectionHeader`.
+    ///
+    /// Note that all the setters affecting `content` are
+    /// mutually exclusive.
+    pub fn set_section_header<
+        T: std::convert::Into<std::boxed::Box<crate::model::SectionHeader>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.content =
+            std::option::Option::Some(crate::model::widget::Content::SectionHeader(v.into()));
+        self
+    }
+
+    /// Sets the value of [content][crate::model::Widget::content]
+    /// to hold a `SingleViewGroup`.
+    ///
+    /// Note that all the setters affecting `content` are
+    /// mutually exclusive.
+    pub fn set_single_view_group<
+        T: std::convert::Into<std::boxed::Box<crate::model::SingleViewGroup>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.content =
+            std::option::Option::Some(crate::model::widget::Content::SingleViewGroup(v.into()));
         self
     }
 }

--- a/src/generated/spanner/admin/database/v1/src/model.rs
+++ b/src/generated/spanner/admin/database/v1/src/model.rs
@@ -1612,6 +1612,36 @@ impl BackupScheduleSpec {
         self.schedule_spec = v.into();
         self
     }
+
+    /// The value of [schedule_spec][crate::model::BackupScheduleSpec::schedule_spec]
+    /// if it holds a `CronSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_cron_spec(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CrontabSpec>> {
+        #[allow(unreachable_patterns)]
+        self.schedule_spec.as_ref().and_then(|v| match v {
+            crate::model::backup_schedule_spec::ScheduleSpec::CronSpec(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [schedule_spec][crate::model::BackupScheduleSpec::schedule_spec]
+    /// to hold a `CronSpec`.
+    ///
+    /// Note that all the setters affecting `schedule_spec` are
+    /// mutually exclusive.
+    pub fn set_cron_spec<T: std::convert::Into<std::boxed::Box<crate::model::CrontabSpec>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.schedule_spec = std::option::Option::Some(
+            crate::model::backup_schedule_spec::ScheduleSpec::CronSpec(v.into()),
+        );
+        self
+    }
 }
 
 impl wkt::message::Message for BackupScheduleSpec {
@@ -1741,6 +1771,70 @@ impl BackupSchedule {
         v: T,
     ) -> Self {
         self.backup_type_spec = v.into();
+        self
+    }
+
+    /// The value of [backup_type_spec][crate::model::BackupSchedule::backup_type_spec]
+    /// if it holds a `FullBackupSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_full_backup_spec(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::FullBackupSpec>> {
+        #[allow(unreachable_patterns)]
+        self.backup_type_spec.as_ref().and_then(|v| match v {
+            crate::model::backup_schedule::BackupTypeSpec::FullBackupSpec(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [backup_type_spec][crate::model::BackupSchedule::backup_type_spec]
+    /// if it holds a `IncrementalBackupSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_incremental_backup_spec(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::IncrementalBackupSpec>> {
+        #[allow(unreachable_patterns)]
+        self.backup_type_spec.as_ref().and_then(|v| match v {
+            crate::model::backup_schedule::BackupTypeSpec::IncrementalBackupSpec(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [backup_type_spec][crate::model::BackupSchedule::backup_type_spec]
+    /// to hold a `FullBackupSpec`.
+    ///
+    /// Note that all the setters affecting `backup_type_spec` are
+    /// mutually exclusive.
+    pub fn set_full_backup_spec<
+        T: std::convert::Into<std::boxed::Box<crate::model::FullBackupSpec>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.backup_type_spec = std::option::Option::Some(
+            crate::model::backup_schedule::BackupTypeSpec::FullBackupSpec(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [backup_type_spec][crate::model::BackupSchedule::backup_type_spec]
+    /// to hold a `IncrementalBackupSpec`.
+    ///
+    /// Note that all the setters affecting `backup_type_spec` are
+    /// mutually exclusive.
+    pub fn set_incremental_backup_spec<
+        T: std::convert::Into<std::boxed::Box<crate::model::IncrementalBackupSpec>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.backup_type_spec = std::option::Option::Some(
+            crate::model::backup_schedule::BackupTypeSpec::IncrementalBackupSpec(v.into()),
+        );
         self
     }
 }
@@ -2359,6 +2453,33 @@ impl RestoreInfo {
         v: T,
     ) -> Self {
         self.source_info = v.into();
+        self
+    }
+
+    /// The value of [source_info][crate::model::RestoreInfo::source_info]
+    /// if it holds a `BackupInfo`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_backup_info(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BackupInfo>> {
+        #[allow(unreachable_patterns)]
+        self.source_info.as_ref().and_then(|v| match v {
+            crate::model::restore_info::SourceInfo::BackupInfo(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [source_info][crate::model::RestoreInfo::source_info]
+    /// to hold a `BackupInfo`.
+    ///
+    /// Note that all the setters affecting `source_info` are
+    /// mutually exclusive.
+    pub fn set_backup_info<T: std::convert::Into<std::boxed::Box<crate::model::BackupInfo>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source_info =
+            std::option::Option::Some(crate::model::restore_info::SourceInfo::BackupInfo(v.into()));
         self
     }
 }
@@ -3687,6 +3808,31 @@ impl RestoreDatabaseRequest {
         self.source = v.into();
         self
     }
+
+    /// The value of [source][crate::model::RestoreDatabaseRequest::source]
+    /// if it holds a `Backup`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_backup(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::restore_database_request::Source::Backup(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [source][crate::model::RestoreDatabaseRequest::source]
+    /// to hold a `Backup`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_backup<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.source = std::option::Option::Some(
+            crate::model::restore_database_request::Source::Backup(v.into()),
+        );
+        self
+    }
 }
 
 impl wkt::message::Message for RestoreDatabaseRequest {
@@ -3953,6 +4099,36 @@ impl RestoreDatabaseMetadata {
         v: T,
     ) -> Self {
         self.source_info = v.into();
+        self
+    }
+
+    /// The value of [source_info][crate::model::RestoreDatabaseMetadata::source_info]
+    /// if it holds a `BackupInfo`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_backup_info(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BackupInfo>> {
+        #[allow(unreachable_patterns)]
+        self.source_info.as_ref().and_then(|v| match v {
+            crate::model::restore_database_metadata::SourceInfo::BackupInfo(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [source_info][crate::model::RestoreDatabaseMetadata::source_info]
+    /// to hold a `BackupInfo`.
+    ///
+    /// Note that all the setters affecting `source_info` are
+    /// mutually exclusive.
+    pub fn set_backup_info<T: std::convert::Into<std::boxed::Box<crate::model::BackupInfo>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source_info = std::option::Option::Some(
+            crate::model::restore_database_metadata::SourceInfo::BackupInfo(v.into()),
+        );
         self
     }
 }

--- a/src/generated/spanner/admin/instance/v1/src/model.rs
+++ b/src/generated/spanner/admin/instance/v1/src/model.rs
@@ -653,6 +653,56 @@ impl ReplicaComputeCapacity {
         self.compute_capacity = v.into();
         self
     }
+
+    /// The value of [compute_capacity][crate::model::ReplicaComputeCapacity::compute_capacity]
+    /// if it holds a `NodeCount`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_node_count(&self) -> std::option::Option<&i32> {
+        #[allow(unreachable_patterns)]
+        self.compute_capacity.as_ref().and_then(|v| match v {
+            crate::model::replica_compute_capacity::ComputeCapacity::NodeCount(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [compute_capacity][crate::model::ReplicaComputeCapacity::compute_capacity]
+    /// if it holds a `ProcessingUnits`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_processing_units(&self) -> std::option::Option<&i32> {
+        #[allow(unreachable_patterns)]
+        self.compute_capacity.as_ref().and_then(|v| match v {
+            crate::model::replica_compute_capacity::ComputeCapacity::ProcessingUnits(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [compute_capacity][crate::model::ReplicaComputeCapacity::compute_capacity]
+    /// to hold a `NodeCount`.
+    ///
+    /// Note that all the setters affecting `compute_capacity` are
+    /// mutually exclusive.
+    pub fn set_node_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.compute_capacity = std::option::Option::Some(
+            crate::model::replica_compute_capacity::ComputeCapacity::NodeCount(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [compute_capacity][crate::model::ReplicaComputeCapacity::compute_capacity]
+    /// to hold a `ProcessingUnits`.
+    ///
+    /// Note that all the setters affecting `compute_capacity` are
+    /// mutually exclusive.
+    pub fn set_processing_units<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.compute_capacity = std::option::Option::Some(
+            crate::model::replica_compute_capacity::ComputeCapacity::ProcessingUnits(v.into()),
+        );
+        self
+    }
 }
 
 impl wkt::message::Message for ReplicaComputeCapacity {
@@ -805,6 +855,56 @@ pub mod autoscaling_config {
             self
         }
 
+        /// The value of [min_limit][crate::model::autoscaling_config::AutoscalingLimits::min_limit]
+        /// if it holds a `MinNodes`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_min_nodes(&self) -> std::option::Option<&i32> {
+            #[allow(unreachable_patterns)]
+            self.min_limit.as_ref().and_then(|v| match v {
+                crate::model::autoscaling_config::autoscaling_limits::MinLimit::MinNodes(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// The value of [min_limit][crate::model::autoscaling_config::AutoscalingLimits::min_limit]
+        /// if it holds a `MinProcessingUnits`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_min_processing_units(&self) -> std::option::Option<&i32> {
+            #[allow(unreachable_patterns)]
+            self.min_limit.as_ref().and_then(|v| match v {
+                crate::model::autoscaling_config::autoscaling_limits::MinLimit::MinProcessingUnits(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// Sets the value of [min_limit][crate::model::autoscaling_config::AutoscalingLimits::min_limit]
+        /// to hold a `MinNodes`.
+        ///
+        /// Note that all the setters affecting `min_limit` are
+        /// mutually exclusive.
+        pub fn set_min_nodes<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.min_limit = std::option::Option::Some(
+                crate::model::autoscaling_config::autoscaling_limits::MinLimit::MinNodes(v.into()),
+            );
+            self
+        }
+
+        /// Sets the value of [min_limit][crate::model::autoscaling_config::AutoscalingLimits::min_limit]
+        /// to hold a `MinProcessingUnits`.
+        ///
+        /// Note that all the setters affecting `min_limit` are
+        /// mutually exclusive.
+        pub fn set_min_processing_units<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.min_limit = std::option::Option::Some(
+                crate::model::autoscaling_config::autoscaling_limits::MinLimit::MinProcessingUnits(
+                    v.into(),
+                ),
+            );
+            self
+        }
+
         /// Sets the value of `max_limit`.
         pub fn set_max_limit<
             T: std::convert::Into<
@@ -815,6 +915,56 @@ pub mod autoscaling_config {
             v: T,
         ) -> Self {
             self.max_limit = v.into();
+            self
+        }
+
+        /// The value of [max_limit][crate::model::autoscaling_config::AutoscalingLimits::max_limit]
+        /// if it holds a `MaxNodes`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_max_nodes(&self) -> std::option::Option<&i32> {
+            #[allow(unreachable_patterns)]
+            self.max_limit.as_ref().and_then(|v| match v {
+                crate::model::autoscaling_config::autoscaling_limits::MaxLimit::MaxNodes(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// The value of [max_limit][crate::model::autoscaling_config::AutoscalingLimits::max_limit]
+        /// if it holds a `MaxProcessingUnits`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn get_max_processing_units(&self) -> std::option::Option<&i32> {
+            #[allow(unreachable_patterns)]
+            self.max_limit.as_ref().and_then(|v| match v {
+                crate::model::autoscaling_config::autoscaling_limits::MaxLimit::MaxProcessingUnits(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
+        /// Sets the value of [max_limit][crate::model::autoscaling_config::AutoscalingLimits::max_limit]
+        /// to hold a `MaxNodes`.
+        ///
+        /// Note that all the setters affecting `max_limit` are
+        /// mutually exclusive.
+        pub fn set_max_nodes<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.max_limit = std::option::Option::Some(
+                crate::model::autoscaling_config::autoscaling_limits::MaxLimit::MaxNodes(v.into()),
+            );
+            self
+        }
+
+        /// Sets the value of [max_limit][crate::model::autoscaling_config::AutoscalingLimits::max_limit]
+        /// to hold a `MaxProcessingUnits`.
+        ///
+        /// Note that all the setters affecting `max_limit` are
+        /// mutually exclusive.
+        pub fn set_max_processing_units<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.max_limit = std::option::Option::Some(
+                crate::model::autoscaling_config::autoscaling_limits::MaxLimit::MaxProcessingUnits(
+                    v.into(),
+                ),
+            );
             self
         }
     }
@@ -2908,6 +3058,56 @@ impl InstancePartition {
         v: T,
     ) -> Self {
         self.compute_capacity = v.into();
+        self
+    }
+
+    /// The value of [compute_capacity][crate::model::InstancePartition::compute_capacity]
+    /// if it holds a `NodeCount`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_node_count(&self) -> std::option::Option<&i32> {
+        #[allow(unreachable_patterns)]
+        self.compute_capacity.as_ref().and_then(|v| match v {
+            crate::model::instance_partition::ComputeCapacity::NodeCount(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [compute_capacity][crate::model::InstancePartition::compute_capacity]
+    /// if it holds a `ProcessingUnits`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_processing_units(&self) -> std::option::Option<&i32> {
+        #[allow(unreachable_patterns)]
+        self.compute_capacity.as_ref().and_then(|v| match v {
+            crate::model::instance_partition::ComputeCapacity::ProcessingUnits(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [compute_capacity][crate::model::InstancePartition::compute_capacity]
+    /// to hold a `NodeCount`.
+    ///
+    /// Note that all the setters affecting `compute_capacity` are
+    /// mutually exclusive.
+    pub fn set_node_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.compute_capacity = std::option::Option::Some(
+            crate::model::instance_partition::ComputeCapacity::NodeCount(v.into()),
+        );
+        self
+    }
+
+    /// Sets the value of [compute_capacity][crate::model::InstancePartition::compute_capacity]
+    /// to hold a `ProcessingUnits`.
+    ///
+    /// Note that all the setters affecting `compute_capacity` are
+    /// mutually exclusive.
+    pub fn set_processing_units<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.compute_capacity = std::option::Option::Some(
+            crate::model::instance_partition::ComputeCapacity::ProcessingUnits(v.into()),
+        );
         self
     }
 }

--- a/src/generated/type/src/model.rs
+++ b/src/generated/type/src/model.rs
@@ -395,6 +395,56 @@ impl DateTime {
         self.time_offset = v.into();
         self
     }
+
+    /// The value of [time_offset][crate::model::DateTime::time_offset]
+    /// if it holds a `UtcOffset`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_utc_offset(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
+        #[allow(unreachable_patterns)]
+        self.time_offset.as_ref().and_then(|v| match v {
+            crate::model::date_time::TimeOffset::UtcOffset(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [time_offset][crate::model::DateTime::time_offset]
+    /// if it holds a `TimeZone`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_time_zone(&self) -> std::option::Option<&std::boxed::Box<crate::model::TimeZone>> {
+        #[allow(unreachable_patterns)]
+        self.time_offset.as_ref().and_then(|v| match v {
+            crate::model::date_time::TimeOffset::TimeZone(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [time_offset][crate::model::DateTime::time_offset]
+    /// to hold a `UtcOffset`.
+    ///
+    /// Note that all the setters affecting `time_offset` are
+    /// mutually exclusive.
+    pub fn set_utc_offset<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.time_offset =
+            std::option::Option::Some(crate::model::date_time::TimeOffset::UtcOffset(v.into()));
+        self
+    }
+
+    /// Sets the value of [time_offset][crate::model::DateTime::time_offset]
+    /// to hold a `TimeZone`.
+    ///
+    /// Note that all the setters affecting `time_offset` are
+    /// mutually exclusive.
+    pub fn set_time_zone<T: std::convert::Into<std::boxed::Box<crate::model::TimeZone>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.time_offset =
+            std::option::Option::Some(crate::model::date_time::TimeOffset::TimeZone(v.into()));
+        self
+    }
 }
 
 impl wkt::message::Message for DateTime {
@@ -934,6 +984,57 @@ impl PhoneNumber {
         v: T,
     ) -> Self {
         self.kind = v.into();
+        self
+    }
+
+    /// The value of [kind][crate::model::PhoneNumber::kind]
+    /// if it holds a `E164Number`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_e164_number(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::phone_number::Kind::E164Number(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// The value of [kind][crate::model::PhoneNumber::kind]
+    /// if it holds a `ShortCode`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn get_short_code(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::phone_number::ShortCode>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::phone_number::Kind::ShortCode(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
+    /// Sets the value of [kind][crate::model::PhoneNumber::kind]
+    /// to hold a `E164Number`.
+    ///
+    /// Note that all the setters affecting `kind` are
+    /// mutually exclusive.
+    pub fn set_e164_number<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.kind =
+            std::option::Option::Some(crate::model::phone_number::Kind::E164Number(v.into()));
+        self
+    }
+
+    /// Sets the value of [kind][crate::model::PhoneNumber::kind]
+    /// to hold a `ShortCode`.
+    ///
+    /// Note that all the setters affecting `kind` are
+    /// mutually exclusive.
+    pub fn set_short_code<
+        T: std::convert::Into<std::boxed::Box<crate::model::phone_number::ShortCode>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.kind =
+            std::option::Option::Some(crate::model::phone_number::Kind::ShortCode(v.into()));
         self
     }
 }


### PR DESCRIPTION
Generate methods to set and get each oneof branch. Including the
`IntoIterator<>` adapters for repeated fields.

Part of the work for #845
