### PR TITLE
feat(generator/rust): even more generous URLs

### DIFF
--- a/generator/internal/language/rust.go
+++ b/generator/internal/language/rust.go
@@ -51,9 +51,9 @@ var rustTemplates embed.FS
 var commentUrlRegex = regexp.MustCompile(
 	`` + // `go fmt` is annoying
 		`https?://` + // Accept either https or http.
-		`([A-Za-z0-9\.\-]+\.)+` + // Be generous in accepting most of the authority (hostname)
+		`([A-Za-z0-9\.\-_]+\.)+` + // Be generous in accepting most of the authority (hostname)
 		`[a-zA-Z]{2,63}` + // The root domain is far more strict
-		`(/[-a-zA-Z0-9@:%_\+.~#?&/=]*)?`) // Accept just about anything on the query and URL fragments
+		`(/[-a-zA-Z0-9@:%_\+.~#?&/={}\$]*)?`) // Accept just about anything on the query and URL fragments
 
 func newRustCodec(options map[string]string) (*rustCodec, error) {
 	year, _, _ := time.Now().Date()

--- a/src/generated/iam/admin/v1/src/model.rs
+++ b/src/generated/iam/admin/v1/src/model.rs
@@ -1655,14 +1655,14 @@ pub struct ListRolesRequest {
     ///   [custom
     ///   roles](https://cloud.google.com/iam/docs/understanding-custom-roles).
     ///   Example request URL:
-    ///   `<https://iam.googleapis.com/v1/projects/>{PROJECT_ID}/roles`
+    ///   `<https://iam.googleapis.com/v1/projects/{PROJECT_ID}/roles>`
     ///
     /// * [`organizations.roles.list()`](https://cloud.google.com/iam/reference/rest/v1/organizations.roles/list):
     ///   `organizations/{ORGANIZATION_ID}`. This method lists all
     ///   organization-level [custom
     ///   roles](https://cloud.google.com/iam/docs/understanding-custom-roles).
     ///   Example request URL:
-    ///   `<https://iam.googleapis.com/v1/organizations/>{ORGANIZATION_ID}/roles`
+    ///   `<https://iam.googleapis.com/v1/organizations/{ORGANIZATION_ID}/roles>`
     ///
     ///
     /// Note: Wildcard (*) values are invalid; you must specify a complete project
@@ -1800,21 +1800,21 @@ pub struct GetRoleRequest {
     ///   [predefined
     ///   roles](https://cloud.google.com/iam/docs/understanding-roles#predefined_roles)
     ///   in Cloud IAM. Example request URL:
-    ///   `<https://iam.googleapis.com/v1/roles/>{ROLE_NAME}`
+    ///   `<https://iam.googleapis.com/v1/roles/{ROLE_NAME}>`
     ///
     /// * [`projects.roles.get()`](https://cloud.google.com/iam/reference/rest/v1/projects.roles/get):
     ///   `projects/{PROJECT_ID}/roles/{CUSTOM_ROLE_ID}`. This method returns only
     ///   [custom
     ///   roles](https://cloud.google.com/iam/docs/understanding-custom-roles) that
     ///   have been created at the project level. Example request URL:
-    ///   `<https://iam.googleapis.com/v1/projects/>{PROJECT_ID}/roles/{CUSTOM_ROLE_ID}`
+    ///   `<https://iam.googleapis.com/v1/projects/{PROJECT_ID}/roles/{CUSTOM_ROLE_ID}>`
     ///
     /// * [`organizations.roles.get()`](https://cloud.google.com/iam/reference/rest/v1/organizations.roles/get):
     ///   `organizations/{ORGANIZATION_ID}/roles/{CUSTOM_ROLE_ID}`. This method
     ///   returns only [custom
     ///   roles](https://cloud.google.com/iam/docs/understanding-custom-roles) that
     ///   have been created at the organization level. Example request URL:
-    ///   `<https://iam.googleapis.com/v1/organizations/>{ORGANIZATION_ID}/roles/{CUSTOM_ROLE_ID}`
+    ///   `<https://iam.googleapis.com/v1/organizations/{ORGANIZATION_ID}/roles/{CUSTOM_ROLE_ID}>`
     ///
     ///
     /// Note: Wildcard (*) values are invalid; you must specify a complete project
@@ -1855,14 +1855,14 @@ pub struct CreateRoleRequest {
     ///   [custom
     ///   roles](https://cloud.google.com/iam/docs/understanding-custom-roles).
     ///   Example request URL:
-    ///   `<https://iam.googleapis.com/v1/projects/>{PROJECT_ID}/roles`
+    ///   `<https://iam.googleapis.com/v1/projects/{PROJECT_ID}/roles>`
     ///
     /// * [`organizations.roles.create()`](https://cloud.google.com/iam/reference/rest/v1/organizations.roles/create):
     ///   `organizations/{ORGANIZATION_ID}`. This method creates organization-level
     ///   [custom
     ///   roles](https://cloud.google.com/iam/docs/understanding-custom-roles).
     ///   Example request URL:
-    ///   `<https://iam.googleapis.com/v1/organizations/>{ORGANIZATION_ID}/roles`
+    ///   `<https://iam.googleapis.com/v1/organizations/{ORGANIZATION_ID}/roles>`
     ///
     ///
     /// Note: Wildcard (*) values are invalid; you must specify a complete project
@@ -1930,14 +1930,14 @@ pub struct UpdateRoleRequest {
     ///   [custom
     ///   roles](https://cloud.google.com/iam/docs/understanding-custom-roles) that
     ///   have been created at the project level. Example request URL:
-    ///   `<https://iam.googleapis.com/v1/projects/>{PROJECT_ID}/roles/{CUSTOM_ROLE_ID}`
+    ///   `<https://iam.googleapis.com/v1/projects/{PROJECT_ID}/roles/{CUSTOM_ROLE_ID}>`
     ///
     /// * [`organizations.roles.patch()`](https://cloud.google.com/iam/reference/rest/v1/organizations.roles/patch):
     ///   `organizations/{ORGANIZATION_ID}/roles/{CUSTOM_ROLE_ID}`. This method
     ///   updates only [custom
     ///   roles](https://cloud.google.com/iam/docs/understanding-custom-roles) that
     ///   have been created at the organization level. Example request URL:
-    ///   `<https://iam.googleapis.com/v1/organizations/>{ORGANIZATION_ID}/roles/{CUSTOM_ROLE_ID}`
+    ///   `<https://iam.googleapis.com/v1/organizations/{ORGANIZATION_ID}/roles/{CUSTOM_ROLE_ID}>`
     ///
     ///
     /// Note: Wildcard (*) values are invalid; you must specify a complete project
@@ -2004,14 +2004,14 @@ pub struct DeleteRoleRequest {
     ///   [custom
     ///   roles](https://cloud.google.com/iam/docs/understanding-custom-roles) that
     ///   have been created at the project level. Example request URL:
-    ///   `<https://iam.googleapis.com/v1/projects/>{PROJECT_ID}/roles/{CUSTOM_ROLE_ID}`
+    ///   `<https://iam.googleapis.com/v1/projects/{PROJECT_ID}/roles/{CUSTOM_ROLE_ID}>`
     ///
     /// * [`organizations.roles.delete()`](https://cloud.google.com/iam/reference/rest/v1/organizations.roles/delete):
     ///   `organizations/{ORGANIZATION_ID}/roles/{CUSTOM_ROLE_ID}`. This method
     ///   deletes only [custom
     ///   roles](https://cloud.google.com/iam/docs/understanding-custom-roles) that
     ///   have been created at the organization level. Example request URL:
-    ///   `<https://iam.googleapis.com/v1/organizations/>{ORGANIZATION_ID}/roles/{CUSTOM_ROLE_ID}`
+    ///   `<https://iam.googleapis.com/v1/organizations/{ORGANIZATION_ID}/roles/{CUSTOM_ROLE_ID}>`
     ///
     ///
     /// Note: Wildcard (*) values are invalid; you must specify a complete project
@@ -2063,14 +2063,14 @@ pub struct UndeleteRoleRequest {
     ///   only [custom
     ///   roles](https://cloud.google.com/iam/docs/understanding-custom-roles) that
     ///   have been created at the project level. Example request URL:
-    ///   `<https://iam.googleapis.com/v1/projects/>{PROJECT_ID}/roles/{CUSTOM_ROLE_ID}`
+    ///   `<https://iam.googleapis.com/v1/projects/{PROJECT_ID}/roles/{CUSTOM_ROLE_ID}>`
     ///
     /// * [`organizations.roles.undelete()`](https://cloud.google.com/iam/reference/rest/v1/organizations.roles/undelete):
     ///   `organizations/{ORGANIZATION_ID}/roles/{CUSTOM_ROLE_ID}`. This method
     ///   undeletes only [custom
     ///   roles](https://cloud.google.com/iam/docs/understanding-custom-roles) that
     ///   have been created at the organization level. Example request URL:
-    ///   `<https://iam.googleapis.com/v1/organizations/>{ORGANIZATION_ID}/roles/{CUSTOM_ROLE_ID}`
+    ///   `<https://iam.googleapis.com/v1/organizations/{ORGANIZATION_ID}/roles/{CUSTOM_ROLE_ID}>`
     ///
     ///
     /// Note: Wildcard (*) values are invalid; you must specify a complete project


### PR DESCRIPTION
Part of the work for #827 where we can find:


```
      // Example: "https://my_domain.com/playbook?name=${resource.name}"
```
https://github.com/googleapis/googleapis/blob/89a0f8e22df3d09eb1a283a32cb3772ad2553fce/google/monitoring/v3/alert.proto#L63
 