### PR TITLE
fix(auth): SA cred missing claims

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,6 +687,7 @@ dependencies = [
  "http",
  "mockall",
  "rand",
+ "regex",
  "reqwest",
  "rsa",
  "rustls",

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -41,11 +41,12 @@ derive_builder = "0.20.2"
 [dev-dependencies]
 axum        = "0.8.1"
 mockall     = "0.13.1"
+rand        = "0.8.5"
+regex       = "1.11.1"
+rsa         = { version = "0.9.7", features = ["pem"] }
 scoped-env  = "2.1.0"
 serial_test = "3.2.0"
 tempfile    = "3.14.0"
 test-case   = "3.3.1"
 tokio       = { version = "1.42", features = ["macros", "rt-multi-thread", "test-util"] }
 tokio-test  = "0.4.4"
-rsa         = { version = "0.9.7", features = ["pem"] }
-rand        = "0.8.5"

--- a/src/auth/src/credentials/util/jws.rs
+++ b/src/auth/src/credentials/util/jws.rs
@@ -71,8 +71,8 @@ impl JwsClaims {
 pub struct JwsHeader<'a> {
     pub alg: &'a str,
     pub typ: &'a str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub kid: Option<&'a str>,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    pub kid: &'a str,
 }
 
 impl JwsHeader<'_> {
@@ -200,7 +200,7 @@ mod tests {
         let header = JwsHeader {
             alg: "RS256",
             typ: "JWT",
-            kid: Some("some_key_id"),
+            kid: "some_key_id",
         };
         let encoded = header.encode().unwrap();
         let decoded = String::from_utf8(
@@ -221,7 +221,7 @@ mod tests {
         let header = JwsHeader {
             alg: "RS256",
             typ: "JWT",
-            kid: None,
+            kid: "",
         };
         let encoded = header.encode().unwrap();
         let decoded = String::from_utf8(


### PR DESCRIPTION
Part of the work for #679 

We were missing the ...
- `kid` claim, which is equal to the `private_key_id`,  if there is one.
- `sub` claim which is the subject aka principal aka SA email.

Found by local integration testing.

Verify the values  of the claims we set in a unit test.