### PR TITLE
docs(generator): update README.md

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -35,7 +35,7 @@ options should be already configured in a `.sidekick.toml` file.
 
 ```bash
 cd generator
-go run github.com/googleapis/google-cloud-rust/generator/sidekick@latest generate -project-root=.. \
+go run cmd/sidekick/main.go generate -project-root=.. \
   -specification-format openapi \
   -specification-source generator/testdata/openapi/secretmanager_openapi_v1.json \
   -service-config generator/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml \


### PR DESCRIPTION
- update command-line  for the openapi example in the readme

W/o this change I saw the error below; but perhaps this is a local config error on my part.

```
go: github.com/googleapis/google-cloud-rust/generator/sidekick@latest:
  module github.com/googleapis/google-cloud-rust/generator@latest found (v0.0.0-20250129204245-87fd1ddc5475),
  but does not contain package github.com/googleapis/google-cloud-rust/generator/sidekick
```
