### PR TITLE
impl(auth): sa creds default crypto provider

### DIFF
--- a/src/auth/src/credentials/service_account_credential.rs
+++ b/src/auth/src/credentials/service_account_credential.rs
@@ -115,10 +115,10 @@ impl TokenProvider for ServiceAccountTokenProvider {
 impl ServiceAccountTokenProvider {
     // Creates a signer using the private key stored in the service account file.
     fn signer(&self, private_key: &String) -> Result<Box<dyn Signer>> {
-        let crypto_provider = CryptoProvider::get_default()
-            .ok_or_else(|| CredentialError::non_retryable("unable to get crypto provider"))?;
-
-        let key_provider = crypto_provider.key_provider;
+        let key_provider = CryptoProvider::get_default().map_or_else(
+            || rustls::crypto::aws_lc_rs::default_provider().key_provider,
+            |p| p.key_provider,
+        );
 
         let private_key = rustls_pemfile::read_one(&mut private_key.as_bytes())
             .map_err(CredentialError::non_retryable)?
@@ -308,7 +308,6 @@ mod test {
 
     #[tokio::test]
     async fn get_service_account_token_pkcs1_key_failure() -> TestResult {
-        let _ = CryptoProvider::install_default(rustls::crypto::aws_lc_rs::default_provider());
         let mut service_account_info = get_mock_service_account();
         service_account_info.private_key = generate_pkcs1_key();
         let token_provider = ServiceAccountTokenProvider {
@@ -344,7 +343,6 @@ mod test {
 
     #[tokio::test]
     async fn get_service_account_token_pkcs8_key_success() -> TestResult {
-        let _ = CryptoProvider::install_default(rustls::crypto::aws_lc_rs::default_provider());
         let mut service_account_info = get_mock_service_account();
         service_account_info.private_key = generate_pkcs8_key();
         let token_provider = ServiceAccountTokenProvider {
@@ -377,7 +375,6 @@ mod test {
 
     #[tokio::test]
     async fn get_service_account_token_invalid_key_failure() -> TestResult {
-        let _ = CryptoProvider::install_default(rustls::crypto::aws_lc_rs::default_provider());
         let mut service_account_info = get_mock_service_account();
         let pem_data = "-----BEGIN PRIVATE KEY-----\nMIGkAg==\n-----END PRIVATE KEY-----";
         service_account_info.private_key = pem_data.to_string();
@@ -392,7 +389,6 @@ mod test {
 
     #[test]
     fn signer_failure() -> TestResult {
-        let _ = CryptoProvider::install_default(rustls::crypto::aws_lc_rs::default_provider());
         let tp = ServiceAccountTokenProvider {
             service_account_info: get_mock_service_account(),
         };


### PR DESCRIPTION
Part of the work for #679 

If an application sets a default crypto provider, use that. Otherwise use a default one.

This reduces the need for boilerplate code in applications which should lead to a better customer experience.

## Code Cleanliness

I am open to suggestions on how to make the `map_or_else` better. One is a `CryptoProvider`, the other is an `&Arc<CryptoProvider>`. I feel like I want to say the following, but couldn't figure it out.

```rs
let crypto_provider = ...;
let key_provider = crypto_provider.key_provider;
```

## Testing?

"Why are there no unit tests that check that we use a custom crypto provider if the application sets one?", you ask.

`CryptoProvider::install_default()` can only be called once per process. If you try to call it again, it fails. Previously, we were just eating up this error.

`cargo test` runs in a single process. So injecting a custom `CryptoProvider` effects all other tests. That sounds like a bad idea.

The tests under `src/auth/tests/...` get compiled into their own binaries. So we could eventually add a test there. We cannot do that until SA creds are exposed somehow in our public API. (But also, we don't want to expose them until we solve this defaulting problem.)

I did write a unit test (using internal types). Here it is, in case we want it later:

```rs
    #[test]
    fn uses_installed_crypto_provider() -> TestResult {
        use rustls::crypto::KeyProvider;

        const CUSTOM_ERROR: &str = "An error message so specific that it could only have been written by a developer of Google's Rust Auth SDK for the `uses_installed_crypto_provider` unit test.";

        #[derive(Debug)]
        struct FakeKeyProvider {}

        impl KeyProvider for FakeKeyProvider {
            fn load_private_key(
                &self,
                _key_der: rustls::pki_types::PrivateKeyDer<'static>,
            ) -> std::result::Result<std::sync::Arc<dyn rustls::sign::SigningKey>, rustls::Error>
            {
                Err(rustls::Error::General(CUSTOM_ERROR.to_string()))
            }
            fn fips(&self) -> bool {
                true
            }
        }

        // We need a type with a static lifetime because of the constraints on `PrivateKeyDer`
        static FAKE_KEY_PROVIDER: FakeKeyProvider = FakeKeyProvider {};

        // It is easier to grab some `CryptoProvider` and replace its `key_provider` than construct a fake `CryptoProvider` from scratch.
        let mut cp = rustls::crypto::aws_lc_rs::default_provider();
        cp.key_provider = &FAKE_KEY_PROVIDER;

        // Install our custom `CryptoProvider`.
        CryptoProvider::install_default(cp).unwrap();

        let mut service_account_info = get_mock_service_account();
        service_account_info.private_key = generate_pkcs8_key();
        let tp = ServiceAccountTokenProvider {
            service_account_info,
        };

        let signer = tp.signer(&tp.service_account_info.private_key);
        let e = signer.err().unwrap();
        assert!(e.to_string().contains(CUSTOM_ERROR), "{e}");

        Ok(())
    }
```