### PR TITLE
cleanup(auth): remove accidental debug statement

### DIFF
--- a/src/auth/src/credentials/service_account_credential.rs
+++ b/src/auth/src/credentials/service_account_credential.rs
@@ -351,7 +351,6 @@ mod test {
             service_account_info,
         };
         let token = token_provider.get_token().await?;
-        println!("DEBUG TOKEN: {}", token.token);
         let re =
             regex::Regex::new(r"(?<header>[^\.]+)\.(?<claims>[^\.]+)\.(?<sig>[^\.]+)").unwrap();
         let captures = re.captures(&token.token).ok_or_else(|| {


### PR DESCRIPTION
I did not mean to commit this print statement. Note that we would log the `token.token` later if it is in an unexpected format.