### PR TITLE
ci(auth): add SA integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auth-integration-tests"
+version = "0.0.0"
+dependencies = [
+ "gcp-sdk-auth",
+ "gcp-sdk-gax",
+ "gcp-sdk-secretmanager-v1",
+ "scoped-env",
+ "serial_test",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ resolver = "2"
 
 members = [
   "src/auth",
+  "src/auth/integration-tests",
   "src/base",
   "src/gax",
   "src/generated/api",

--- a/src/auth/.gcb/integration.yaml
+++ b/src/auth/.gcb/integration.yaml
@@ -16,12 +16,12 @@ options:
   dynamic_substitutions: true
   substitutionOption: 'ALLOW_LOOSE'
   logging: CLOUD_LOGGING_ONLY
+  env:
+    - GOOGLE_CLOUD_PROJECT=${PROJECT_ID}
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'
 steps:
   - name: 'rust:1.84-bookworm'
     script: |
       #!/usr/bin/env bash
       set -e
-      # TODO(#806) - For now, we just build the code. Eventually we will run
-      # real integration tests.
-      cargo build -p gcp-sdk-auth
+      cargo test --features run-integration-tests -p auth-integration-tests

--- a/src/auth/integration-tests/Cargo.toml
+++ b/src/auth/integration-tests/Cargo.toml
@@ -1,0 +1,34 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name              = "auth-integration-tests"
+description       = "Integration tests for gcp-sdk-auth."
+version           = "0.0.0"
+edition.workspace = true
+publish           = false
+
+[features]
+run-integration-tests = []
+
+[dependencies]
+
+[dev-dependencies]
+auth          = { path = "../../../src/auth", package = "gcp-sdk-auth" }
+gax           = { path = "../../../src/gax", package = "gcp-sdk-gax" }
+scoped-env    = "2.1.0"
+secretmanager = { path = "../../../src/generated/cloud/secretmanager/v1", package = "gcp-sdk-secretmanager-v1" }
+serial_test   = "3.2.0"
+tempfile      = "3.14.0"
+tokio         = { version = "1.42", features = ["full", "macros"] }

--- a/src/auth/integration-tests/tests/driver.rs
+++ b/src/auth/integration-tests/tests/driver.rs
@@ -1,0 +1,76 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(all(test, feature = "run-integration-tests"))]
+mod driver {
+    use auth::credentials::create_access_token_credential;
+    use gax::error::Error;
+    use gax::options::ClientConfig as Config;
+    use scoped_env::ScopedEnv;
+    use secretmanager::client::SecretManagerService;
+
+    type Result<T> = std::result::Result<T, gax::error::Error>;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[serial_test::serial]
+    async fn service_account() -> Result<()> {
+        // Create a SecretManager client. When running on GCB, this loads MDS
+        // credentials for our `integration-test-runner` service account.
+        let client = SecretManagerService::new().await?;
+
+        // Load the ADC json for the principal under test, in this case, a
+        // service account.
+        let response = client
+            .access_secret_version(
+                "projects/rust-auth-testing/secrets/test-sa-creds-json/versions/latest",
+            )
+            .send()
+            .await
+            ?;
+        let adc_json = response
+            .payload
+            .expect("missing payload in test-sa-creds-json response")
+            .data;
+
+        // Write the ADC to a temporary file
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let path = file.into_temp_path();
+        std::fs::write(&path, adc_json).expect("Unable to write to temporary file.");
+
+        // Create credentials for the principal under test.
+        let _e = ScopedEnv::set("GOOGLE_APPLICATION_CREDENTIALS", path.to_str().unwrap());
+        let creds = create_access_token_credential()
+            .await
+            .map_err(Error::authentication)?;
+
+        // Construct a new SecretManager client using the credentials.
+        let config = Config::new().set_credential(creds);
+        let client = SecretManagerService::new_with_config(config).await?;
+
+        // Access a secret, which only this principal has permissions to do.
+        let response = client
+            .access_secret_version(
+                "projects/rust-auth-testing/secrets/test-sa-creds-secret/versions/latest",
+            )
+            .send()
+            .await?;
+        let secret = response
+            .payload
+            .expect("missing payload in test-sa-creds-secret response")
+            .data;
+        assert_eq!(secret, "service_account");
+
+        Ok(())
+    }
+}

--- a/src/auth/integration-tests/tests/driver.rs
+++ b/src/auth/integration-tests/tests/driver.rs
@@ -36,8 +36,7 @@ mod driver {
                 "projects/rust-auth-testing/secrets/test-sa-creds-json/versions/latest",
             )
             .send()
-            .await
-            ?;
+            .await?;
         let adc_json = response
             .payload
             .expect("missing payload in test-sa-creds-json response")


### PR DESCRIPTION
Part of the work for #806 

Add a package for `auth-integration-tests`. Right now it is one test, guarded by the `run-integration-tests` feature.

Update auth's `cloudbuild.yaml` to run the tests in this new package.

Add a test that verifies SA credentials. Hopefully the code makes it clear what we are doing. I will wait to refactor until we have another test.

I will take a TODO to abstract the project ID, and add a README for running the integration tests locally.