### PR TITLE
cleanup(generator): use annotations for methods

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -104,8 +104,10 @@ type Method struct {
 	ID string
 	// InputType is the input to the Method
 	InputTypeID string
+	InputType   *Message
 	// OutputType is the output of the Method
 	OutputTypeID string
+	OutputType   *Message
 	// PathInfo information about the HTTP request
 	PathInfo *PathInfo
 	// IsPageable is true if the method conforms to standard defined by
@@ -117,6 +119,8 @@ type Method struct {
 	ServerSideStreaming bool
 	// For methods returning long-running operations
 	OperationInfo *OperationInfo
+	// Language specific annotations
+	Codec any
 }
 
 // Normalized request path information.
@@ -154,6 +158,10 @@ type OperationInfo struct {
 	// The result type. This is the expected type when the long running
 	// operation completes successfully.
 	ResponseTypeID string
+	// The method.
+	Method *Method
+	// Language specific annotations
+	Codec any
 }
 
 // A path segment is either a string literal (such as "projects") or a field

--- a/generator/internal/api/xref_test.go
+++ b/generator/internal/api/xref_test.go
@@ -51,7 +51,9 @@ func TestCrossReferenceOneOfs(t *testing.T) {
 		OneOfs: []*OneOf{group0, group1},
 	}
 	model := NewTestAPI([]*Message{message}, []*Enum{}, []*Service{})
-	CrossReference(model)
+	if err := CrossReference(model); err != nil {
+		t.Fatal(err)
+	}
 
 	for _, test := range []struct {
 		field *Field
@@ -67,5 +69,38 @@ func TestCrossReferenceOneOfs(t *testing.T) {
 			t.Errorf("mismatched group for %s, got=%v, want=%v", test.field.Name, test.field.Group, test.oneof)
 		}
 
+	}
+}
+
+func TestCrossReferenceMethod(t *testing.T) {
+	request := &Message{
+		Name: "Request",
+		ID:   ".test.Request",
+	}
+	response := &Message{
+		Name: "Response",
+		ID:   ".test.Response",
+	}
+	method := &Method{
+		Name:         "GetResource",
+		ID:           ".test.Service.GetResource",
+		InputTypeID:  ".test.Request",
+		OutputTypeID: ".test.Response",
+	}
+	service := &Service{
+		Name:    "Service",
+		ID:      ".test.Service",
+		Methods: []*Method{method},
+	}
+
+	model := NewTestAPI([]*Message{request, response}, []*Enum{}, []*Service{service})
+	if err := CrossReference(model); err != nil {
+		t.Fatal(err)
+	}
+	if method.InputType != request {
+		t.Errorf("mismatched input type, got=%v, want=%v", method.InputType, request)
+	}
+	if method.OutputType != response {
+		t.Errorf("mismatched output type, got=%v, want=%v", method.OutputType, response)
 	}
 }

--- a/generator/internal/golang/templates/client.go.mustache
+++ b/generator/internal/golang/templates/client.go.mustache
@@ -95,10 +95,10 @@ func (c *Client) {{ServiceName}}() *{{ServiceName}}{
 {{#DocLines}}
 // {{{.}}}
 {{/DocLines}}
-func (s *{{ServiceName}}) {{NameToCamel}}(ctx context.Context, req *{{InputTypeName}}) (*{{OutputTypeName}}, error) {
-    out := new({{OutputTypeName}})
+func (s *{{Codec.ServiceName}}) {{Codec.Name}}(ctx context.Context, req *{{InputTypeName}}) (*{{OutputType.Codec.Name}}, error) {
+    out := new({{OutputType.Codec.Name}})
     {{#PathInfo.Codec.HasBody}}
-    reqBody, err := json.Marshal(req{{BodyAccessor}})
+    reqBody, err := json.Marshal(req{{Codec.BodyAccessor}})
     if err != nil {
         return nil, err
     }

--- a/generator/internal/rust/rusttemplate.go
+++ b/generator/internal/rust/rusttemplate.go
@@ -332,7 +332,7 @@ func partitionFields(fields []*api.Field, state *api.APIState) fieldPartition {
 }
 
 // annotateMessage annotates the message, its fields, its nested
-// mesages, and its nested enums.
+// messages, and its nested enums.
 func annotateMessage(m *api.Message, state *api.APIState, deserializeWithDefaults bool, modulePath, sourceSpecificationPackageName string, packageMapping map[string]*packagez) {
 	for _, f := range m.Fields {
 		annotateField(f, m, state, modulePath, sourceSpecificationPackageName, packageMapping)

--- a/generator/internal/rust/rusttemplate.go
+++ b/generator/internal/rust/rusttemplate.go
@@ -52,7 +52,7 @@ type templateData struct {
 }
 
 type service struct {
-	Methods             []*method
+	Methods             []*api.Method
 	NameToSnake         string
 	NameToPascal        string
 	ServiceNameToPascal string
@@ -87,23 +87,17 @@ type messageAnnotation struct {
 	HasSyntheticFields bool
 }
 
-type method struct {
-	NameToSnake         string
-	NameToCamel         string
-	NameToPascal        string
+type methodAnnotation struct {
+	Name                string
+	BuilderName         string
 	DocLines            []string
-	InputTypeName       string
-	OutputTypeName      string
 	PathInfo            *api.PathInfo
 	PathParams          []*api.Field
 	QueryParams         []*api.Field
 	BodyAccessor        string
-	IsPageable          bool
 	ServiceNameToPascal string
 	ServiceNameToCamel  string
 	ServiceNameToSnake  string
-	InputTypeID         string
-	InputType           *api.Message
 	OperationInfo       *operationInfo
 }
 
@@ -214,6 +208,20 @@ func newTemplateData(model *api.API, c *codec, outdir string) (*templateData, er
 	for _, m := range model.Messages {
 		annotateMessage(m, model.State, c.deserializeWithdDefaults, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping)
 	}
+	for _, s := range model.Services {
+		for _, m := range s.Methods {
+			if !generateMethod(m) {
+				continue
+			}
+			annotateMethod(m, s, model.State, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping, packageNamespace)
+			if m := m.InputType; m != nil {
+				annotateMessage(m, model.State, c.deserializeWithdDefaults, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping)
+			}
+			if m := m.OutputType; m != nil {
+				annotateMessage(m, model.State, c.deserializeWithdDefaults, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping)
+			}
+		}
+	}
 	data := &templateData{
 		Name:             model.Name,
 		Title:            model.Title,
@@ -233,7 +241,7 @@ func newTemplateData(model *api.API, c *codec, outdir string) (*templateData, er
 			return ""
 		}(),
 		Services: language.MapSlice(model.Services, func(s *api.Service) *service {
-			return newService(s, model, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping, packageNamespace)
+			return newService(s, model, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping)
 		}),
 		Messages:          model.Messages,
 		Enums:             model.Enums,
@@ -262,33 +270,23 @@ func newTemplateData(model *api.API, c *codec, outdir string) (*templateData, er
 	data.ExternPackages = externPackages(c.extraPackages)
 	addStreamingFeature(data, model, c.extraPackages)
 
-	for _, s := range data.Services {
-		for _, method := range s.Methods {
-			if m, ok := model.State.MessageByID[method.InputTypeID]; ok {
-				annotateMessage(m, model.State, c.deserializeWithdDefaults, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping)
-				method.InputType = m
-			}
-		}
-	}
 	return data, nil
 }
 
-func newService(s *api.Service, model *api.API, modulePath, sourceSpecificationPackageName string, packageMapping map[string]*packagez, packageNamespace string) *service {
+func newService(s *api.Service, model *api.API, modulePath, sourceSpecificationPackageName string, packageMapping map[string]*packagez) *service {
 	// Some codecs skip some methods.
 	methods := language.FilterSlice(s.Methods, func(m *api.Method) bool {
 		return generateMethod(m)
 	})
 	hasLROs := false
-	for _, m := range s.Methods {
+	for _, m := range methods {
 		if m.OperationInfo != nil {
 			hasLROs = true
 			break
 		}
 	}
 	return &service{
-		Methods: language.MapSlice(methods, func(m *api.Method) *method {
-			return newMethod(m, s, model.State, modulePath, sourceSpecificationPackageName, packageMapping, packageNamespace)
-		}),
+		Methods:             methods,
 		NameToSnake:         toSnake(s.Name),
 		NameToPascal:        toPascal(s.Name),
 		ServiceNameToPascal: toPascal(s.Name), // Alias for clarity
@@ -333,12 +331,10 @@ func partitionFields(fields []*api.Field, state *api.APIState) fieldPartition {
 	}
 }
 
+// annotateMessage annotates the message, its fields, its nested
+// mesages, and its nested enums.
 func annotateMessage(m *api.Message, state *api.APIState, deserializeWithDefaults bool, modulePath, sourceSpecificationPackageName string, packageMapping map[string]*packagez) {
-	hasSyntheticFields := false
 	for _, f := range m.Fields {
-		if f.Synthetic {
-			hasSyntheticFields = true
-		}
 		annotateField(f, m, state, modulePath, sourceSpecificationPackageName, packageMapping)
 	}
 	for _, f := range m.OneOfs {
@@ -350,7 +346,13 @@ func annotateMessage(m *api.Message, state *api.APIState, deserializeWithDefault
 	for _, child := range m.Messages {
 		annotateMessage(child, state, deserializeWithDefaults, modulePath, sourceSpecificationPackageName, packageMapping)
 	}
-
+	hasSyntheticFields := false
+	for _, f := range m.Fields {
+		if f.Synthetic {
+			hasSyntheticFields = true
+			break
+		}
+	}
 	basicFields := language.FilterSlice(m.Fields, func(f *api.Field) bool {
 		return !f.IsOneOf
 	})
@@ -371,7 +373,7 @@ func annotateMessage(m *api.Message, state *api.APIState, deserializeWithDefault
 	}
 }
 
-func newMethod(m *api.Method, s *api.Service, state *api.APIState, modulePath, sourceSpecificationPackageName string, packageMapping map[string]*packagez, packageNamespace string) *method {
+func annotateMethod(m *api.Method, s *api.Service, state *api.APIState, modulePath, sourceSpecificationPackageName string, packageMapping map[string]*packagez, packageNamespace string) {
 	pathInfoAnnotation := &pathInfoAnnotation{
 		Method:        m.PathInfo.Verb,
 		MethodToLower: strings.ToLower(m.PathInfo.Verb),
@@ -382,27 +384,22 @@ func newMethod(m *api.Method, s *api.Service, state *api.APIState, modulePath, s
 	pathInfoAnnotation.HasPathArgs = len(pathInfoAnnotation.PathArgs) > 0
 
 	m.PathInfo.Codec = pathInfoAnnotation
-	method := &method{
+	annotation := &methodAnnotation{
+		Name:                strcase.ToSnake(m.Name),
+		BuilderName:         toPascal(m.Name),
 		BodyAccessor:        bodyAccessor(m),
 		DocLines:            formatDocComments(m.Documentation, state, modulePath, sourceSpecificationPackageName, packageMapping),
 		PathInfo:            m.PathInfo,
-		InputTypeName:       methodInOutTypeName(m.InputTypeID, state, modulePath, sourceSpecificationPackageName, packageMapping),
-		NameToCamel:         strcase.ToCamel(m.Name),
-		NameToPascal:        toPascal(m.Name),
-		NameToSnake:         strcase.ToSnake(m.Name),
-		OutputTypeName:      methodInOutTypeName(m.OutputTypeID, state, modulePath, sourceSpecificationPackageName, packageMapping),
 		PathParams:          language.PathParams(m, state),
 		QueryParams:         language.QueryParams(m, state),
-		IsPageable:          m.IsPageable,
 		ServiceNameToPascal: toPascal(s.Name),
 		ServiceNameToCamel:  toCamel(s.Name),
 		ServiceNameToSnake:  toSnake(s.Name),
-		InputTypeID:         m.InputTypeID,
 	}
 	if m.OperationInfo != nil {
 		metadataType := methodInOutTypeName(m.OperationInfo.MetadataTypeID, state, modulePath, sourceSpecificationPackageName, packageMapping)
 		responseType := methodInOutTypeName(m.OperationInfo.ResponseTypeID, state, modulePath, sourceSpecificationPackageName, packageMapping)
-		method.OperationInfo = &operationInfo{
+		m.OperationInfo.Codec = &operationInfo{
 			MetadataType:       metadataType,
 			ResponseType:       responseType,
 			MetadataTypeInDocs: strings.TrimPrefix(metadataType, "crate::"),
@@ -410,7 +407,7 @@ func newMethod(m *api.Method, s *api.Service, state *api.APIState, modulePath, s
 			PackageNamespace:   packageNamespace,
 		}
 	}
-	return method
+	m.Codec = annotation
 }
 
 func annotateOneOf(oneof *api.OneOf, message *api.Message, state *api.APIState, modulePath, sourceSpecificationPackageName string, packageMapping map[string]*packagez) {

--- a/generator/internal/rust/templates/crate/src/builders.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/builders.rs.mustache
@@ -43,19 +43,19 @@ pub mod {{NameToSnake}} {
     }
 
     {{#Methods}}
-    /// The request builder for a {{ServiceNameToPascal}}::{{NameToSnake}} call.
+    /// The request builder for a {{Codec.ServiceNameToPascal}}::{{Codec.Name}} call.
     #[derive(Clone, Debug)]
-    pub struct {{NameToPascal}}(RequestBuilder<{{InputTypeName}}>);
+    pub struct {{Codec.BuilderName}}(RequestBuilder<{{InputType.Codec.QualifiedName}}>);
 
-    impl {{NameToPascal}} {
-        pub(crate) fn new(stub: Arc<dyn crate::stubs::dynamic::{{ServiceNameToPascal}}>) -> Self {
+    impl {{Codec.BuilderName}} {
+        pub(crate) fn new(stub: Arc<dyn crate::stubs::dynamic::{{Codec.ServiceNameToPascal}}>) -> Self {
             Self(
                 RequestBuilder::new(stub)
             )
         }
 
         /// Sets the full request, replacing any prior values.
-        pub fn with_request<V: Into<{{InputTypeName}}>>(mut self, v: V) -> Self {
+        pub fn with_request<V: Into<{{InputType.Codec.QualifiedName}}>>(mut self, v: V) -> Self {
             self.0.request = v.into();
             self
         }
@@ -72,22 +72,22 @@ pub mod {{NameToSnake}} {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [{{NameToSnake}}][crate::client::{{ServiceNameToPascal}}::{{NameToSnake}}].
+        /// on [{{Method.Codec.Name}}][crate::client::{{Method.Codec.ServiceNameToPascal}}::{{Method.Codec.Name}}].
         {{/OperationInfo}}
-        pub async fn send(self) -> Result<{{OutputTypeName}}> {
+        pub async fn send(self) -> Result<{{OutputType.Codec.QualifiedName}}> {
             {{!
                 In rare cases `self.0.stub.foo` is ambiguous: we are calling
                 via `Arc<dyn T>` which implements `T` but also implements other
                 traits (e.g. `std::clone::Clone`) making the call ambiguous.
                 Using `*self.0.stub` makes the call not-ambiguous.
             }}
-            (*self.0.stub).{{NameToSnake}}(self.0.request, self.0.options).await
+            (*self.0.stub).{{Codec.Name}}(self.0.request, self.0.options).await
         }
         {{#IsPageable}}
 
         /// Streams the responses back.
         #[cfg(feature = "unstable-stream")]
-        pub async fn stream(self) -> gax::paginator::Paginator<{{OutputTypeName}}, gax::error::Error> {
+        pub async fn stream(self) -> gax::paginator::Paginator<{{OutputType.Codec.QualifiedName}}, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
                 let builder = self.clone();
@@ -99,12 +99,12 @@ pub mod {{NameToSnake}} {
         {{/IsPageable}}
         {{#OperationInfo}}
 
-        /// Creates a [Poller][lro::Poller] to work with `{{NameToSnake}}`.
+        /// Creates a [Poller][lro::Poller] to work with `{{Method.Codec.Name}}`.
         pub fn poller(
             self
-        ) -> impl lro::Poller<{{ResponseType}}, {{MetadataType}}>
+        ) -> impl lro::Poller<{{Codec.ResponseType}}, {{Codec.MetadataType}}>
         {
-            type Operation = lro::Operation<{{ResponseType}}, {{MetadataType}}>;
+            type Operation = lro::Operation<{{Codec.ResponseType}}, {{Codec.MetadataType}}>;
             let polling_policy = self.0.stub.get_polling_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
 
@@ -176,7 +176,7 @@ pub mod {{NameToSnake}} {
         {{/InputType.OneOfs}}
     }
 
-    impl gax::options::RequestBuilder for {{NameToPascal}} {
+    impl gax::options::RequestBuilder for {{Codec.BuilderName}} {
         fn request_options(&mut self) -> &mut gax::options::RequestOptions {
             &mut self.0.options
         }

--- a/generator/internal/rust/templates/crate/src/client.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/client.rs.mustache
@@ -87,9 +87,9 @@ impl {{NameToPascal}} {
     }
 
     {{#Methods}}
-    {{#DocLines}}
+    {{#Codec.DocLines}}
     {{{.}}}
-    {{/DocLines}}
+    {{/Codec.DocLines}}
     {{#OperationInfo}}
     ///
     /// # Long running operations
@@ -115,8 +115,8 @@ impl {{NameToPascal}} {
     /// # use gax::Result;
     /// # use {{PackageNamespace}}::model;
     /// async fn wait(
-    ///     mut poller: impl lro::Poller<{{ResponseTypeInDocs}}, {{MetadataTypeInDocs}}>
-    /// ) -> Result<{{ResponseTypeInDocs}}> {
+    ///     mut poller: impl lro::Poller<{{Codec.ResponseTypeInDocs}}, {{Codec.MetadataTypeInDocs}}>
+    /// ) -> Result<{{Codec.ResponseTypeInDocs}}> {
     ///     poller.until_done().await
     /// }
     /// ```
@@ -133,8 +133,8 @@ impl {{NameToPascal}} {
     /// # use gax::Result;
     /// # use {{PackageNamespace}}::model;
     /// async fn wait(
-    ///     mut poller: impl lro::Poller<{{ResponseTypeInDocs}}, {{MetadataTypeInDocs}}>
-    /// ) -> Result<{{ResponseTypeInDocs}}> {
+    ///     mut poller: impl lro::Poller<{{Codec.ResponseTypeInDocs}}, {{Codec.MetadataTypeInDocs}}>
+    /// ) -> Result<{{Codec.ResponseTypeInDocs}}> {
     ///     while let Some(p) = poller.poll().await {
     ///         match p {
     ///             lro::PollingResult::Completed(r) => { return r; },
@@ -154,11 +154,11 @@ impl {{NameToPascal}} {
     /// the operation.
     ///
     /// If the `done` field is `true`, the operation has completed. The `result`
-    /// field contains the final response, this will be a [{{ResponseType}}] (as
+    /// field contains the final response, this will be a [{{Codec.ResponseType}}] (as
     /// an [Any]), or the error (as a `Status`).
     ///
     /// If the `done` field is `false`, the operation has not completed.  The
-    /// operation may also include a [{{MetadataType}}] value in the `metadata`
+    /// operation may also include a [{{Codec.MetadataType}}] value in the `metadata`
     /// field. This value would also be encoded as an [Any]. The metadata may
     /// include information about how much progress the LRO has made.
     ///
@@ -169,8 +169,8 @@ impl {{NameToPascal}} {
     /// long-running operation failed. Long-running operation failures return
     /// the error status in the [result] field.
     ///
-    /// [send()]: crate::builders::{{ServiceNameToSnake}}::{{NameToPascal}}::send
-    /// [poller()]: crate::builders::{{ServiceNameToSnake}}::{{NameToPascal}}::poller
+    /// [send()]: crate::builders::{{Method.Codec.ServiceNameToSnake}}::{{Method.Codec.BuilderName}}::send
+    /// [poller()]: crate::builders::{{Method.Codec.ServiceNameToSnake}}::{{Method.Codec.BuilderName}}::poller
     /// [until_done()]: lro::Poller::until_done
     /// [PollingPolicy]: gax::polling_policy::PollingPolicy
     /// [PollingBackoffPolicy]: gax::polling_backoff_policy::PollingBackoffPolicy
@@ -181,17 +181,17 @@ impl {{NameToPascal}} {
     /// [result]: longrunning::model::Operation::result
     /// [Any]: wkt::Any
     {{/OperationInfo}}
-    pub fn {{NameToSnake}}(
+    pub fn {{Codec.Name}}(
         &self,
-        {{#PathParams}}
+        {{#Codec.PathParams}}
         {{{Codec.FieldName}}}: impl Into<{{{Codec.PrimitiveFieldType}}}>,
-        {{/PathParams}}
-    ) -> crate::builders::{{ServiceNameToSnake}}::{{NameToPascal}}
+        {{/Codec.PathParams}}
+    ) -> crate::builders::{{Codec.ServiceNameToSnake}}::{{Codec.BuilderName}}
     {
-        crate::builders::{{ServiceNameToSnake}}::{{NameToPascal}}::new(self.inner.clone())
-        {{#PathParams}}
+        crate::builders::{{Codec.ServiceNameToSnake}}::{{Codec.BuilderName}}::new(self.inner.clone())
+        {{#Codec.PathParams}}
             .set_{{Codec.SetterName}} ( {{Codec.FieldName}}.into() )
-        {{/PathParams}}
+        {{/Codec.PathParams}}
     }
 
     {{/Methods}}

--- a/generator/internal/rust/templates/crate/src/stubs.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/stubs.rs.mustache
@@ -53,13 +53,13 @@ pub(crate) mod dynamic;
 pub trait {{NameToPascal}}: std::fmt::Debug + Send + Sync {
     {{#Methods}}
 
-    /// Implements [crate::client::{{ServiceNameToPascal}}::{{NameToSnake}}].
-    fn {{NameToSnake}}(
+    /// Implements [crate::client::{{ServiceNameToPascal}}::{{Codec.Name}}].
+    fn {{Codec.Name}}(
         &self,
-        _req: {{InputTypeName}},
+        _req: {{InputType.Codec.QualifiedName}},
         _options: gax::options::RequestOptions
-    ) -> impl std::future::Future<Output = crate::Result<{{OutputTypeName}}>> + Send {
-        std::future::ready::<crate::Result<{{OutputTypeName}}>>(Err(Error::other("unimplemented")))
+    ) -> impl std::future::Future<Output = crate::Result<{{OutputType.Codec.QualifiedName}}>> + Send {
+        std::future::ready::<crate::Result<{{OutputType.Codec.QualifiedName}}>>(Err(Error::other("unimplemented")))
     }
     {{/Methods}}
     {{#HasLROs}}

--- a/generator/internal/rust/templates/crate/src/stubs/dynamic.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/stubs/dynamic.rs.mustache
@@ -27,11 +27,11 @@ use std::sync::Arc;
 #[async_trait::async_trait]
 pub trait {{NameToPascal}}: std::fmt::Debug + Send + Sync {
     {{#Methods}}
-    async fn {{NameToSnake}}(
+    async fn {{Codec.Name}}(
         &self,
-        req: {{InputTypeName}},
+        req: {{InputType.Codec.QualifiedName}},
         options: gax::options::RequestOptions
-    ) -> crate::Result<{{OutputTypeName}}>;
+    ) -> crate::Result<{{OutputType.Codec.QualifiedName}}>;
 
     {{/Methods}}
     {{#HasLROs}}
@@ -52,12 +52,12 @@ pub trait {{NameToPascal}}: std::fmt::Debug + Send + Sync {
 impl<T: crate::stubs::{{NameToPascal}}> {{NameToPascal}} for T {
     {{#Methods}}
     /// Forwards the call to the implementation provided by `T`.
-    async fn {{NameToSnake}}(
+    async fn {{Codec.Name}}(
         &self,
-        req: {{InputTypeName}},
+        req: {{InputType.Codec.QualifiedName}},
         options: gax::options::RequestOptions
-    ) -> crate::Result<{{OutputTypeName}}> {
-        T::{{NameToSnake}}(self, req, options).await
+    ) -> crate::Result<{{OutputType.Codec.QualifiedName}}> {
+        T::{{Codec.Name}}(self, req, options).await
     }
 
     {{/Methods}}

--- a/generator/internal/rust/templates/crate/src/tracing.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/tracing.rs.mustache
@@ -40,12 +40,12 @@ impl<T> crate::stubs::{{NameToPascal}} for {{NameToPascal}}<T>
 where T: crate::stubs::{{NameToPascal}} + std::fmt::Debug + Send + Sync {
     {{#Methods}}
     #[tracing::instrument(ret)]
-    async fn {{NameToSnake}}(
+    async fn {{Codec.Name}}(
         &self,
-        req: {{InputTypeName}},
+        req: {{InputType.Codec.QualifiedName}},
         options: gax::options::RequestOptions
-    ) -> Result<{{OutputTypeName}}> {
-        self.inner.{{NameToSnake}}(req, options).await
+    ) -> Result<{{OutputType.Codec.QualifiedName}}> {
+        self.inner.{{Codec.Name}}(req, options).await
     }
 
     {{/Methods}}

--- a/generator/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/transport.rs.mustache
@@ -49,11 +49,11 @@ impl {{NameToPascal}} {
 
 impl crate::stubs::{{NameToPascal}} for {{NameToPascal}} {
     {{#Methods}}
-    async fn {{NameToSnake}}(
+    async fn {{Codec.Name}}(
         &self,
-        req: {{InputTypeName}},
+        req: {{InputType.Codec.QualifiedName}},
         options: gax::options::RequestOptions,
-    ) -> Result<{{OutputTypeName}}> {
+    ) -> Result<{{OutputType.Codec.QualifiedName}}> {
         let options = options.set_default_idempotency(reqwest::Method::{{PathInfo.Codec.Method}}.is_idempotent());
         let builder = self
             .inner
@@ -73,12 +73,12 @@ impl crate::stubs::{{NameToPascal}} for {{NameToPascal}} {
             )
             .query(&[("alt", "json")])
             .header("x-goog-api-client", reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER));
-        {{#QueryParams}}
+        {{#Codec.QueryParams}}
         {{{Codec.AddQueryParameter}}}
-        {{/QueryParams}}
+        {{/Codec.QueryParams}}
         self.inner.execute(
             builder,
-            {{#PathInfo.Codec.HasBody}}Some(req{{BodyAccessor}}){{/PathInfo.Codec.HasBody}}
+            {{#PathInfo.Codec.HasBody}}Some(req{{Codec.BodyAccessor}}){{/PathInfo.Codec.HasBody}}
             {{^PathInfo.Codec.HasBody}}None::<gax::http_client::NoBody>{{/PathInfo.Codec.HasBody}},
             options,
         ).await

--- a/generator/internal/sidekick/refresh.go
+++ b/generator/internal/sidekick/refresh.go
@@ -71,7 +71,9 @@ func refreshDir(rootConfig *config.Config, cmdLine *CommandLine, output string) 
 		return nil
 	}
 	api.LabelRecursiveFields(model)
-	api.CrossReference(model)
+	if err := api.CrossReference(model); err != nil {
+		return err
+	}
 
 	switch config.General.Language {
 	case "rust":


### PR DESCRIPTION
Continue the work to refactor the `*template.go` files, using
annotations on the original model to store language specific data.

Part of the work for #653 