### PR TITLE
docs: reorder a couple of steps for lib generation

### DIFF
--- a/doc/contributor/howto-guide-generated-code-maintenance.md
+++ b/doc/contributor/howto-guide-generated-code-maintenance.md
@@ -36,14 +36,14 @@ go -C generator/ run ./cmd/sidekick generate \
 Add the files to `git`, compile them, and run the tests:
 
 ```bash
-git add src/generated/cloud/websecurityscanner/v1
 cargo fmt && cargo build && cargo test && cargo doc
+git add src/generated/cloud/websecurityscanner/v1
 ```
 
 Commit all these changes and send a PR to merge them.
 
 ```bash
-git commit -m"feat(websecurityscanner): generate library" .
+git commit -m "feat(websecurityscanner): generate library"
 ```
 
 ## Update the code with new googleapis protos


### PR DESCRIPTION
Just recently ran though this playbook and it was almost perfect for me. Just reorderd that `git add` to after the cargo commands because `cargo fmt` will cause a diff. Also a couple other small cleanups.