### PR TITLE
fix(generator/golang): fix testing and regressions

### DIFF
--- a/generator/internal/golang/golang.go
+++ b/generator/internal/golang/golang.go
@@ -40,8 +40,11 @@ func Generate(model *api.API, outdir string, options map[string]string) error {
 		return err
 	}
 	provider := templatesProvider()
-	generatedFiles := language.WalkTemplatesDir(goTemplates, "templates")
-	return language.GenerateFromRoot(outdir, data, provider, generatedFiles)
+	return language.GenerateFromRoot(outdir, data, provider, generatedFiles())
+}
+
+func generatedFiles() []language.GeneratedFile {
+	return language.WalkTemplatesDir(goTemplates, "templates")
 }
 
 func loadWellKnownTypes(s *api.APIState) {

--- a/generator/internal/golang/golang.go
+++ b/generator/internal/golang/golang.go
@@ -40,7 +40,7 @@ func Generate(model *api.API, outdir string, options map[string]string) error {
 		return err
 	}
 	provider := templatesProvider()
-	generatedFiles := language.WalkTemplatesDir(goTemplates, "templates/go")
+	generatedFiles := language.WalkTemplatesDir(goTemplates, "templates")
 	return language.GenerateFromRoot(outdir, data, provider, generatedFiles)
 }
 

--- a/generator/internal/golang/golang_test.go
+++ b/generator/internal/golang/golang_test.go
@@ -27,6 +27,13 @@ type goCaseConvertTest struct {
 	Expected string
 }
 
+func TestGo_GeneratedFiles(t *testing.T) {
+	files := generatedFiles()
+	if len(files) == 0 {
+		t.Errorf("expected a non-empty list of template files from generatedFiles()")
+	}
+}
+
 func TestGo_ToPascal(t *testing.T) {
 	var pascalConvertTests = []goCaseConvertTest{
 		{"foo_bar", "FooBar"},

--- a/generator/internal/golang/gotemplate.go
+++ b/generator/internal/golang/gotemplate.go
@@ -42,7 +42,8 @@ type templateData struct {
 }
 
 type serviceAnnotations struct {
-	Name        string
+	FieldName   string
+	StructName  string
 	DocLines    []string
 	DefaultHost string
 }
@@ -58,15 +59,14 @@ type messageAnnotation struct {
 }
 
 type methodAnnotation struct {
-	Name                string
-	NameToPascal        string
-	DocLines            []string
-	PathParams          []*api.Field
-	QueryParams         []*api.Field
-	BodyAccessor        string
-	ServiceNameToPascal string
-	ServiceNameToCamel  string
-	OperationInfo       *operationInfo
+	Name              string
+	NameToPascal      string
+	DocLines          []string
+	PathParams        []*api.Field
+	QueryParams       []*api.Field
+	BodyAccessor      string
+	ServiceStructName string
+	OperationInfo     *operationInfo
 }
 
 type pathInfoAnnotation struct {
@@ -196,7 +196,8 @@ func annotateService(s *api.Service, state *api.APIState) {
 		annotateMethod(m, s, state)
 	}
 	ann := &serviceAnnotations{
-		Name:        toPascal(s.Name),
+		FieldName:   strcase.ToLowerCamel(s.Name),
+		StructName:  s.Name,
 		DocLines:    formatDocComments(s.Documentation, state),
 		DefaultHost: s.DefaultHost,
 	}
@@ -231,13 +232,13 @@ func annotateMethod(m *api.Method, s *api.Service, state *api.APIState) {
 	}
 	m.PathInfo.Codec = pathInfoAnnotation
 	annotation := &methodAnnotation{
-		BodyAccessor:        bodyAccessor(m),
-		DocLines:            formatDocComments(m.Documentation, state),
-		Name:                strcase.ToCamel(m.Name),
-		NameToPascal:        toPascal(m.Name),
-		PathParams:          language.PathParams(m, state),
-		QueryParams:         language.QueryParams(m, state),
-		ServiceNameToPascal: toPascal(s.Name),
+		BodyAccessor:      bodyAccessor(m),
+		DocLines:          formatDocComments(m.Documentation, state),
+		Name:              strcase.ToCamel(m.Name),
+		NameToPascal:      toPascal(m.Name),
+		PathParams:        language.PathParams(m, state),
+		QueryParams:       language.QueryParams(m, state),
+		ServiceStructName: s.Name,
 	}
 	if m.OperationInfo != nil {
 		annotation.OperationInfo = &operationInfo{

--- a/generator/internal/golang/templates/client.go.mustache
+++ b/generator/internal/golang/templates/client.go.mustache
@@ -49,7 +49,7 @@ type Client struct {
     hc *http.Client
     opts *Options
     {{#Services}}
-    {{NameToCamel}} *{{ServiceName}}
+    {{Codec.FieldName}} *{{Codec.StructName}}
     {{/Services}}
 }
 
@@ -76,26 +76,26 @@ func (c *Client) token(ctx context.Context) (string, error) {
 }
 
 {{#Services}}
-{{#DocLines}}
+{{#Codec.DocLines}}
 // {{{.}}}
-{{/DocLines}}
-type {{ServiceName}} struct {
+{{/Codec.DocLines}}
+type {{Codec.StructName}} struct {
     client *Client
     baseURL   string
 }
 
-{{#DocLines}}
+{{#Codec.DocLines}}
 // {{{.}}}
-{{/DocLines}}
-func (c *Client) {{ServiceName}}() *{{ServiceName}}{
-    return &{{ServiceName}}{client: c, baseURL: defaultHost}
+{{/Codec.DocLines}}
+func (c *Client) {{Codec.StructName}}() *{{Codec.StructName}}{
+    return &{{Codec.StructName}}{client: c, baseURL: defaultHost}
 }
 
 {{#Methods}}
-{{#DocLines}}
+{{#Codec.DocLines}}
 // {{{.}}}
-{{/DocLines}}
-func (s *{{Codec.ServiceName}}) {{Codec.Name}}(ctx context.Context, req *{{InputTypeName}}) (*{{OutputType.Codec.Name}}, error) {
+{{/Codec.DocLines}}
+func (s *{{Codec.ServiceStructName}}) {{Codec.Name}}(ctx context.Context, req *{{InputType.Codec.Name}}) (*{{OutputType.Codec.Name}}, error) {
     out := new({{OutputType.Codec.Name}})
     {{#PathInfo.Codec.HasBody}}
     reqBody, err := json.Marshal(req{{Codec.BodyAccessor}})


### PR DESCRIPTION
I broke the golang generator in #895: it found no templates and
therefore generated no code and nothing changed in the golden files.
Then I introduced regressions in #905 and #912. This restores the
testing and fixes the golden files.