### PR TITLE
feat(generator/rust): re-export Result and Error

### DIFF
--- a/generator/internal/rust/templates/crate/src/lib.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/lib.rs.mustache
@@ -37,7 +37,8 @@ limitations under the License.
 pub mod model;
 
 {{#HasServices}}
-pub(crate) use gax::Result;
+pub use gax::Result;
+pub use gax::error::Error;
 
 {{! Google APIs often use angle brackets for <PLACEHOLDERS>, rustdoc does not like those. }}
 #[allow(rustdoc::invalid_html_tags)]

--- a/generator/testdata/rust/openapi/golden/src/lib.rs
+++ b/generator/testdata/rust/openapi/golden/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::Result;
+pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/generator/testdata/rust/protobuf/golden/iam/v1/src/lib.rs
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::Result;
+pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/generator/testdata/rust/protobuf/golden/location/src/lib.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::Result;
+pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/lib.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::Result;
+pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/gax/src/lib.rs
+++ b/src/gax/src/lib.rs
@@ -30,7 +30,7 @@
 //! change both if needed.
 //! </div>
 
-/// An alias of [std::result::Result] where the error is always [crate::error::Error].
+/// An alias of [std::result::Result] where the error is always [Error][crate::error::Error].
 ///
 /// This is the result type used by all functions wrapping RPCs.
 pub type Result<T> = std::result::Result<T, crate::error::Error>;

--- a/src/generated/bigtable/admin/v2/src/lib.rs
+++ b/src/generated/bigtable/admin/v2/src/lib.rs
@@ -31,7 +31,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/cloud/functions/v2/src/lib.rs
+++ b/src/generated/cloud/functions/v2/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/cloud/kms/v1/src/lib.rs
+++ b/src/generated/cloud/kms/v1/src/lib.rs
@@ -33,7 +33,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/cloud/language/v2/src/lib.rs
+++ b/src/generated/cloud/language/v2/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/cloud/location/src/lib.rs
+++ b/src/generated/cloud/location/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/cloud/resourcemanager/v3/src/lib.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/lib.rs
@@ -36,7 +36,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/cloud/run/v2/src/lib.rs
+++ b/src/generated/cloud/run/v2/src/lib.rs
@@ -35,7 +35,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/cloud/scheduler/v1/src/lib.rs
+++ b/src/generated/cloud/scheduler/v1/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/cloud/secretmanager/v1/src/lib.rs
+++ b/src/generated/cloud/secretmanager/v1/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/cloud/sql/v1/src/lib.rs
+++ b/src/generated/cloud/sql/v1/src/lib.rs
@@ -38,7 +38,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::Result;
+pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/cloud/tasks/v2/src/lib.rs
+++ b/src/generated/cloud/tasks/v2/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/cloud/translate/v3/src/lib.rs
+++ b/src/generated/cloud/translate/v3/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/cloud/vpcaccess/v1/src/lib.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/cloud/webrisk/v1/src/lib.rs
+++ b/src/generated/cloud/webrisk/v1/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/cloud/workflows/v1/src/lib.rs
+++ b/src/generated/cloud/workflows/v1/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/container/v1/src/lib.rs
+++ b/src/generated/container/v1/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/devtools/cloudbuild/v1/src/lib.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/devtools/cloudbuild/v2/src/lib.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/devtools/cloudtrace/v2/src/lib.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/iam/admin/v1/src/lib.rs
+++ b/src/generated/iam/admin/v1/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/iam/credentials/v1/src/lib.rs
+++ b/src/generated/iam/credentials/v1/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/iam/v1/src/lib.rs
+++ b/src/generated/iam/v1/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/iam/v2/src/lib.rs
+++ b/src/generated/iam/v2/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/longrunning/src/lib.rs
+++ b/src/generated/longrunning/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/monitoring/dashboard/v1/src/lib.rs
+++ b/src/generated/monitoring/dashboard/v1/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/monitoring/metricsscope/v1/src/lib.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/monitoring/v3/src/lib.rs
+++ b/src/generated/monitoring/v3/src/lib.rs
@@ -37,7 +37,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/openapi-validation/src/lib.rs
+++ b/src/generated/openapi-validation/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/privacy/dlp/v2/src/lib.rs
+++ b/src/generated/privacy/dlp/v2/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/spanner/admin/database/v1/src/lib.rs
+++ b/src/generated/spanner/admin/database/v1/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]

--- a/src/generated/spanner/admin/instance/v1/src/lib.rs
+++ b/src/generated/spanner/admin/instance/v1/src/lib.rs
@@ -30,7 +30,8 @@
 /// The messages and enums that are part of this client library.
 pub mod model;
 
-pub(crate) use gax::Result;
+pub use gax::error::Error;
+pub use gax::Result;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]


### PR DESCRIPTION
Application developers may need to name these types when using a
generated client. Re-exporting the types makes it possible to name
them unambiguously, something that may be hard (or impossible?) in
complex applications where there may be more than one version of `gax`.

Fixes #903
