### PR TITLE
ci(auth): terraform for SA integration tests

### DIFF
--- a/src/auth/.gcb/builds/grants/main.tf
+++ b/src/auth/.gcb/builds/grants/main.tf
@@ -31,6 +31,6 @@ resource "google_storage_bucket_iam_member" "sa-can-read-build-tarballs" {
   member = "serviceAccount:${data.google_service_account.integration-test-runner.email}"
 }
 
-output "runner" {
-  value = data.google_service_account.integration-test-runner.id
+output "test_runner" {
+  value = data.google_service_account.integration-test-runner
 }

--- a/src/auth/.gcb/builds/main.tf
+++ b/src/auth/.gcb/builds/main.tf
@@ -46,11 +46,19 @@ module "grants" {
   project     = var.project
 }
 
+# Set up for the service account integration test.
+module "service_account_test" {
+  depends_on  = [module.grants]
+  source      = "./service_account_test"
+  project     = var.project
+  test_runner = module.grants.test_runner
+}
+
 # Create the GCB triggers.
 module "triggers" {
-  depends_on      = [module.services, module.resources, module.grants]
-  source          = "./triggers"
-  project         = var.project
-  region          = var.region
-  service_account = module.grants.runner
+  depends_on  = [module.services, module.resources, module.grants]
+  source      = "./triggers"
+  project     = var.project
+  region      = var.region
+  test_runner = module.grants.test_runner
 }

--- a/src/auth/.gcb/builds/service_account_test/main.tf
+++ b/src/auth/.gcb/builds/service_account_test/main.tf
@@ -1,0 +1,83 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project" {}
+variable "test_runner" {}
+
+data "google_project" "project" {
+}
+
+# The service account we use as our principal for testing service account credentials.
+data "google_service_account" "test-sa-creds-principal" {
+  account_id = "test-sa-creds"
+}
+
+# Generate a key for the test service account credentials.
+resource "google_service_account_key" "test-sa-creds-principal-key" {
+  service_account_id = data.google_service_account.test-sa-creds-principal.name
+}
+
+# This secret stores the ADC json for the principal testing service account credentials.
+resource "google_secret_manager_secret" "test-sa-creds-json-secret" {
+  secret_id   = "test-sa-creds-json"
+  replication {
+    auto {}
+  }
+}
+
+# Store the test service account key in secret manager.
+resource "google_secret_manager_secret_version" "test-sa-creds-json-secret-version" {
+  secret      = google_secret_manager_secret.test-sa-creds-json-secret.id
+  secret_data = base64decode(google_service_account_key.test-sa-creds-principal-key.private_key)
+}
+
+# The integration test runner needs access to the service account key secret
+resource "google_secret_manager_secret_iam_member" "test-sa-creds-json-secret-member" {
+  project = "${var.project}"
+  secret_id = google_secret_manager_secret.test-sa-creds-json-secret.id
+  role = "roles/secretmanager.secretAccessor"
+  member = "serviceAccount:${var.test_runner.email}"
+}
+
+# The "secret" that will be accessed by the principal testing service account
+# credentials.
+#
+# Note that this is not really a "secret", in that we are not trying to hide its
+# contents.
+#
+# In order to validate our credential types, we need a GCP resource we can set
+# fine-grained ACL on. We have picked Secret Manager secrets for this purpose.
+#
+resource "google_secret_manager_secret" "test-sa-creds-secret" {
+  secret_id = "test-sa-creds-secret"
+  replication {
+    auto {}
+  }
+}
+
+# Add a value to the secret.
+resource "google_secret_manager_secret_version" "test-sa-creds-secret-version" {
+  secret      = google_secret_manager_secret.test-sa-creds-secret.id
+
+  # We do not care that the value is public. We are just testing ACLs.
+  secret_data = "service_account"
+}
+
+# Set up secret permissions for service account credentials.
+resource "google_secret_manager_secret_iam_member" "test-sa-creds-secret-member" {
+  project = "${var.project}"
+  secret_id = google_secret_manager_secret.test-sa-creds-secret.id
+  role = "roles/secretmanager.secretAccessor"
+  member = "serviceAccount:${data.google_service_account.test-sa-creds-principal.email}"
+}

--- a/src/auth/.gcb/builds/services/main.tf
+++ b/src/auth/.gcb/builds/services/main.tf
@@ -25,3 +25,15 @@ resource "google_project_service" "cloudbuild" {
 
   disable_dependent_services = true
 }
+
+resource "google_project_service" "secretmanager" {
+  project = var.project
+  service = "secretmanager.googleapis.com"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+
+  disable_dependent_services = true
+}

--- a/src/auth/.gcb/builds/triggers/main.tf
+++ b/src/auth/.gcb/builds/triggers/main.tf
@@ -14,7 +14,7 @@
 
 variable "project" {}
 variable "region" {}
-variable "service_account" {}
+variable "test_runner" {}
 
 locals {
   # Google Cloud Build installs an application on the GitHub organization or
@@ -86,7 +86,7 @@ resource "google_cloudbuild_trigger" "pull-request" {
   filename = "src/auth/.gcb/${each.key}.yaml"
   tags     = ["pull-request", "name:${each.key}"]
 
-  service_account = var.service_account
+  service_account = var.test_runner.id
 
   repository_event_config {
     repository = google_cloudbuildv2_repository.main.id
@@ -106,7 +106,7 @@ resource "google_cloudbuild_trigger" "post-merge" {
   filename = "src/auth/.gcb/${each.key}.yaml"
   tags     = ["post-merge", "push", "name:${each.key}"]
 
-  service_account = var.service_account
+  service_account = var.test_runner.id
 
   repository_event_config {
     repository = google_cloudbuildv2_repository.main.id


### PR DESCRIPTION
Part of the work for #806 

Add the terraform configuration needed to set up the service account integration test.

I think it is cleaner to keep the setup for each test in its own module. (vs. splitting it across `resources/` and `grants/`).

I am considering flattening the structure of `resources/` and `grants/`.