### PR TITLE
feat(generator): model auto-populated fields

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -316,6 +316,17 @@ type Field struct {
 	// containing message. That triggers slightly different code generation for
 	// some languages.
 	Recursive bool
+	// AutoPopulated is true if the field meets the requirements in AIP-4235.
+	// That is:
+	// - It has Typez == STRING_TYPE
+	// - For Protobuf, has the `google.api.field_behavior = REQUIRED` annotation
+	// - For Protobuf, has the `google.api.field_info.format = UUID4` annotation
+	// - For OpenAPI, it is a required field
+	// - For OpenAPI, it has format == "uuid"
+	// - In the service config file, it is listed in the
+	//   `google.api.MethodSettings.auto_populated_fields` entry in
+	//   `google.api.Publishing.method_settings`
+	AutoPopulated bool
 	// For fields that are part of a OneOf, the group of fields that makes the
 	// OneOf.
 	Group *OneOf

--- a/generator/internal/parser/auto_populated.go
+++ b/generator/internal/parser/auto_populated.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/generator/internal/parser/auto_populated.go
+++ b/generator/internal/parser/auto_populated.go
@@ -1,0 +1,63 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"github.com/googleapis/google-cloud-rust/generator/internal/api"
+	"google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/genproto/googleapis/api/serviceconfig"
+)
+
+// updateAutoPopulatedFields resets any fields that do not conform to
+// [AIP-4235](https://google.aip.dev/client-libraries/4235) as
+// *not* auto-populated.
+//
+// The first phases of the parser has no knowledge of the service config
+// settings and marks any fields that *might* be auto-populated (having the
+// right type and annotations) as `AutoPopulated: true`. This phase applies the
+// service configuration settings.
+func updateAutoPopulatedFields(serviceConfig *serviceconfig.Service, model *api.API) {
+	if serviceConfig == nil {
+		return
+	}
+	for _, m := range serviceConfig.GetPublishing().GetMethodSettings() {
+		selector := m.GetSelector()
+		method, ok := model.State.MethodByID[selector]
+		if !ok {
+			continue
+		}
+		message, ok := model.State.MessageByID[method.InputTypeID]
+		if !ok {
+			continue
+		}
+		for _, field := range message.Fields {
+			if !field.AutoPopulated {
+				continue
+			}
+			if !inAutoPopulatedList(field.Name, m) {
+				field.AutoPopulated = false
+			}
+		}
+	}
+}
+
+func inAutoPopulatedList(name string, method *annotations.MethodSettings) bool {
+	for _, n := range method.GetAutoPopulatedFields() {
+		if name == n {
+			return true
+		}
+	}
+	return false
+}

--- a/generator/internal/parser/openapi.go
+++ b/generator/internal/parser/openapi.go
@@ -125,6 +125,7 @@ func makeAPIForOpenAPI(serviceConfig *serviceconfig.Service, model *libopenapi.D
 		return nil, err
 	}
 	updateMethodPagination(result)
+	updateAutoPopulatedFields(serviceConfig, result)
 	return result, nil
 }
 
@@ -341,6 +342,9 @@ func makeRequestMessage(a *api.API, operation *v3.Operation, packageName, templa
 			Typez:         typez,
 			TypezID:       typezID,
 			Synthetic:     true,
+		}
+		if typez == api.STRING_TYPE && schema.Format == "uuid" && !field.Optional {
+			field.AutoPopulated = true
 		}
 		addFieldIfNew(message, field)
 	}
@@ -646,6 +650,8 @@ func scalarTypeForNumberFormats(messageName, name string, schema *base.Schema) (
 func scalarTypeForStringFormats(messageName, name string, schema *base.Schema) (api.Typez, string, error) {
 	switch schema.Format {
 	case "":
+		return api.STRING_TYPE, "string", nil
+	case "uuid":
 		return api.STRING_TYPE, "string", nil
 	case "byte":
 		return api.BYTES_TYPE, "bytes", nil

--- a/generator/internal/parser/protobuf.go
+++ b/generator/internal/parser/protobuf.go
@@ -353,6 +353,7 @@ func makeAPIForProtobuf(serviceConfig *serviceconfig.Service, req *pluginpb.Code
 		result.Name = strings.TrimSuffix(serviceConfig.Name, ".googleapis.com")
 	}
 	updateMethodPagination(result)
+	updateAutoPopulatedFields(serviceConfig, result)
 	return result
 }
 
@@ -511,12 +512,13 @@ func processMessage(state *api.APIState, m *descriptorpb.DescriptorProto, mFQN, 
 	for _, mf := range m.Field {
 		isProtoOptional := mf.Proto3Optional != nil && *mf.Proto3Optional
 		field := &api.Field{
-			Name:     mf.GetName(),
-			ID:       mFQN + "." + mf.GetName(),
-			JSONName: mf.GetJsonName(),
-			Optional: isProtoOptional,
-			Repeated: mf.Label != nil && *mf.Label == descriptorpb.FieldDescriptorProto_LABEL_REPEATED,
-			IsOneOf:  mf.OneofIndex != nil && !isProtoOptional,
+			Name:          mf.GetName(),
+			ID:            mFQN + "." + mf.GetName(),
+			JSONName:      mf.GetJsonName(),
+			Optional:      isProtoOptional,
+			Repeated:      mf.Label != nil && *mf.Label == descriptorpb.FieldDescriptorProto_LABEL_REPEATED,
+			IsOneOf:       mf.OneofIndex != nil && !isProtoOptional,
+			AutoPopulated: protobufIsAutoPopulated(mf),
 		}
 		normalizeTypes(state, mf, field)
 		message.Fields = append(message.Fields, field)

--- a/generator/internal/parser/protobuf_annotations.go
+++ b/generator/internal/parser/protobuf_annotations.go
@@ -139,3 +139,29 @@ func parseDefaultHost(m proto.Message) string {
 	}
 	return defaultHost
 }
+
+func protobufIsAutoPopulated(field *descriptorpb.FieldDescriptorProto) bool {
+	if field.GetType() != descriptorpb.FieldDescriptorProto_TYPE_STRING {
+		return false
+	}
+	extensionId := annotations.E_FieldInfo
+	if !proto.HasExtension(field.GetOptions(), extensionId) {
+		return false
+	}
+	fieldInfo := proto.GetExtension(field.GetOptions(), extensionId).(*annotations.FieldInfo)
+	if fieldInfo.GetFormat() != annotations.FieldInfo_UUID4 {
+		return false
+	}
+	extensionId = annotations.E_FieldBehavior
+	if !proto.HasExtension(field.GetOptions(), extensionId) {
+		return false
+	}
+	fieldBehavior := proto.GetExtension(field.GetOptions(), extensionId).([]annotations.FieldBehavior)
+	for _, b := range fieldBehavior {
+		if b == annotations.FieldBehavior_REQUIRED {
+			return true
+		}
+	}
+
+	return false
+}

--- a/generator/internal/parser/testdata/auto_populated.proto
+++ b/generator/internal/parser/testdata/auto_populated.proto
@@ -1,0 +1,115 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package test;
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
+import "google/api/field_info.proto";
+import "google/api/resource.proto";
+
+// A service to unit test the protobuf parser.
+service TestService {
+  option (google.api.default_host) = "test.googleapis.com";
+  option (google.api.oauth_scopes) =
+      "https://www.googleapis.com/auth/cloud-platform";
+
+  // Creates a new Foo resource.
+  rpc CreateFoo(CreateFooRequest) returns (Foo) {
+    option (google.api.http) = {
+      post: "/v1/{parent=projects/*}/foos"
+      body: "foo"
+    };
+  }
+}
+
+// The resource message.
+message Foo {
+  option (google.api.resource) = {
+    type: "test.googleapis.com/Foo"
+    pattern: "projects/{project}/foos/{foo}"
+  };
+
+  // Output only. The resource name of the resource, in the format
+  // `projects/{project}/foos/{foo}`.
+  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The contents.
+  string content = 2;
+}
+
+// A request to create a `Foo` resource.
+message CreateFooRequest {
+  // Required. The resource name of the project.
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "cloudresourcemanager.googleapis.com/Project"
+    }
+  ];
+
+  // Required. This must be unique within the project.
+  string foo_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. A [Foo][test.Foo] with initial field values.
+  Foo foo = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // Required. This is an auto-populated field. The remaining fields almost
+  // meet the requirements to be auto-populated, but fail for the reasons
+  // implied by their name.
+  string request_id = 4 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_info).format = UUID4
+  ];
+
+  optional string request_id_optional = 5 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_info).format = UUID4
+  ];
+
+  bytes not_request_id_bad_type = 6 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_info).format = UUID4
+  ];
+
+  string not_request_id_missing_field_behavior = 7 [
+    (google.api.field_info).format = UUID4
+  ];
+
+  string not_request_id_bad_field_behavior = 8 [
+    (google.api.field_behavior) = OPTIONAL,
+    (google.api.field_info).format = UUID4
+  ];
+
+  string not_request_id_missing_field_info = 9 [
+    (google.api.field_behavior) = REQUIRED
+  ];
+
+  string not_request_id_missing_field_info_format = 10 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_info).referenced_types = {type_name: "*"}
+  ];
+
+  string not_request_id_bad_field_info_format = 11 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_info).format = IPV6
+  ];
+
+  string not_request_id_missing_service_config = 12 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_info).format = UUID4
+  ];
+}

--- a/generator/internal/parser/testdata/auto_populated_openapi.json
+++ b/generator/internal/parser/testdata/auto_populated_openapi.json
@@ -1,0 +1,95 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Test API",
+        "version": "v1"
+    },
+    "paths": {
+        "/v1/projects/{project}/foos": {
+            "post": {
+                "operationId": "CreateFoo",
+                "parameters": [
+                    {
+                        "name": "project",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "fooId",
+                        "description": "Test-only Description",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "requestId",
+                        "description": "Test-only Description",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "name": "notRequestIdMissingFormat",
+                        "description": "Test-only Description",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "notRequestIdOptional",
+                        "description": "Test-only Description",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "name": "notRequestIdMissingServiceConfig",
+                        "description": "Test-only Description",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Foo"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Foo": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "readOnly": true,
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/generator/testdata/googleapis/google/api/field_info.proto
+++ b/generator/testdata/googleapis/google/api/field_info.proto
@@ -1,0 +1,106 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+import "google/protobuf/descriptor.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
+option java_multiple_files = true;
+option java_outer_classname = "FieldInfoProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+extend google.protobuf.FieldOptions {
+  // Rich semantic descriptor of an API field beyond the basic typing.
+  //
+  // Examples:
+  //
+  //     string request_id = 1 [(google.api.field_info).format = UUID4];
+  //     string old_ip_address = 2 [(google.api.field_info).format = IPV4];
+  //     string new_ip_address = 3 [(google.api.field_info).format = IPV6];
+  //     string actual_ip_address = 4 [
+  //       (google.api.field_info).format = IPV4_OR_IPV6
+  //     ];
+  //     google.protobuf.Any generic_field = 5 [
+  //       (google.api.field_info).referenced_types = {type_name: "ActualType"},
+  //       (google.api.field_info).referenced_types = {type_name: "OtherType"},
+  //     ];
+  //     google.protobuf.Any generic_user_input = 5 [
+  //       (google.api.field_info).referenced_types = {type_name: "*"},
+  //     ];
+  google.api.FieldInfo field_info = 291403980;
+}
+
+// Rich semantic information of an API field beyond basic typing.
+message FieldInfo {
+  // The standard format of a field value. The supported formats are all backed
+  // by either an RFC defined by the IETF or a Google-defined AIP.
+  enum Format {
+    // Default, unspecified value.
+    FORMAT_UNSPECIFIED = 0;
+
+    // Universally Unique Identifier, version 4, value as defined by
+    // https://datatracker.ietf.org/doc/html/rfc4122. The value may be
+    // normalized to entirely lowercase letters. For example, the value
+    // `F47AC10B-58CC-0372-8567-0E02B2C3D479` would be normalized to
+    // `f47ac10b-58cc-0372-8567-0e02b2c3d479`.
+    UUID4 = 1;
+
+    // Internet Protocol v4 value as defined by [RFC
+    // 791](https://datatracker.ietf.org/doc/html/rfc791). The value may be
+    // condensed, with leading zeros in each octet stripped. For example,
+    // `001.022.233.040` would be condensed to `1.22.233.40`.
+    IPV4 = 2;
+
+    // Internet Protocol v6 value as defined by [RFC
+    // 2460](https://datatracker.ietf.org/doc/html/rfc2460). The value may be
+    // normalized to entirely lowercase letters with zeros compressed, following
+    // [RFC 5952](https://datatracker.ietf.org/doc/html/rfc5952). For example,
+    // the value `2001:0DB8:0::0` would be normalized to `2001:db8::`.
+    IPV6 = 3;
+
+    // An IP address in either v4 or v6 format as described by the individual
+    // values defined herein. See the comments on the IPV4 and IPV6 types for
+    // allowed normalizations of each.
+    IPV4_OR_IPV6 = 4;
+  }
+
+  // The standard format of a field value. This does not explicitly configure
+  // any API consumer, just documents the API's format for the field it is
+  // applied to.
+  Format format = 1;
+
+  // The type(s) that the annotated, generic field may represent.
+  //
+  // Currently, this must only be used on fields of type `google.protobuf.Any`.
+  // Supporting other generic types may be considered in the future.
+  repeated TypeReference referenced_types = 2;
+}
+
+// A reference to a message type, for use in [FieldInfo][google.api.FieldInfo].
+message TypeReference {
+  // The name of the type that the annotated, generic field may represent.
+  // If the type is in the same protobuf package, the value can be the simple
+  // message name e.g., `"MyMessage"`. Otherwise, the value must be the
+  // fully-qualified message name e.g., `"google.library.v1.Book"`.
+  //
+  // If the type(s) are unknown to the service (e.g. the field accepts generic
+  // user input), use the wildcard `"*"` to denote this behavior.
+  //
+  // See [AIP-202](https://google.aip.dev/202#type-references) for more details.
+  string type_name = 1;
+}


### PR DESCRIPTION
Add an annotation to the fields so we can implement AIP-4235: automatically
populate fields in the request message.

Part of the work for #439 - we do not use the annotation in any mustache template