### PR TITLE
test(generator): `json_name` annotations work

### DIFF
--- a/generator/internal/parser/protobuf_test.go
+++ b/generator/internal/parser/protobuf_test.go
@@ -621,6 +621,40 @@ func TestProtobuf_WellKnownTypeFields(t *testing.T) {
 	})
 }
 
+func TestProtobuf_JsonName(t *testing.T) {
+	test := makeAPIForProtobuf(nil, newTestCodeGeneratorRequest(t, "json_name.proto"))
+	message, ok := test.State.MessageByID[".test.Request"]
+	if !ok {
+		t.Fatalf("Cannot find message %s in API State", ".test.Request")
+	}
+	checkMessage(t, message, &api.Message{
+		Name:          "Request",
+		Package:       "test",
+		ID:            ".test.Request",
+		Documentation: "A test message.",
+		Fields: []*api.Field{
+			{
+				Name:     "parent",
+				JSONName: "parent",
+				ID:       ".test.Request.parent",
+				Typez:    api.STRING_TYPE,
+			},
+			{
+				Name:     "public_key",
+				JSONName: "public_key",
+				ID:       ".test.Request.public_key",
+				Typez:    api.STRING_TYPE,
+			},
+			{
+				Name:     "read_time",
+				JSONName: "readTime",
+				ID:       ".test.Request.read_time",
+				Typez:    api.INT32_TYPE,
+			},
+		},
+	})
+}
+
 func TestProtobuf_MapFields(t *testing.T) {
 	test := makeAPIForProtobuf(nil, newTestCodeGeneratorRequest(t, "map_fields.proto"))
 	message, ok := test.State.MessageByID[".test.Fake"]

--- a/generator/internal/parser/testdata/json_name.proto
+++ b/generator/internal/parser/testdata/json_name.proto
@@ -1,0 +1,29 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package test;
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+
+// A test message.
+message Request {
+  string parent = 1;
+
+  string public_key = 2 [json_name = "public_key"];
+  int32 read_time = 3;
+}

--- a/generator/internal/rust/rusttemplate_test.go
+++ b/generator/internal/rust/rusttemplate_test.go
@@ -240,3 +240,94 @@ func Test_RustEnumAnnotations(t *testing.T) {
 		t.Errorf("mismatch in enum annotations (-want, +got)\n:%s", diff)
 	}
 }
+
+func Test_JsonNameAnnotations(t *testing.T) {
+	parent := &api.Field{
+		Name:     "parent",
+		JSONName: "parent",
+		ID:       ".test.Request.parent",
+		Typez:    api.STRING_TYPE,
+	}
+	publicKey := &api.Field{
+		Name:     "public_key",
+		JSONName: "public_key",
+		ID:       ".test.Request.public_key",
+		Typez:    api.STRING_TYPE,
+	}
+	readTime := &api.Field{
+		Name:     "read_time",
+		JSONName: "readTime",
+		ID:       ".test.Request.read_time",
+		Typez:    api.INT32_TYPE,
+	}
+	message := &api.Message{
+		Name:          "Request",
+		Package:       "test",
+		ID:            ".test.Request",
+		Documentation: "A test message.",
+		Fields:        []*api.Field{parent, publicKey, readTime},
+	}
+	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
+	api.CrossReference(model)
+	codec, err := newCodec(map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = annotateModel(model, codec, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(&fieldAnnotations{
+		FieldName:     "parent",
+		SetterName:    "parent",
+		BranchName:    "Parent",
+		FQMessageName: "crate::model::Request",
+		DocLines:      nil,
+		Attributes: []string{
+			`#[serde(skip_serializing_if = "std::string::String::is_empty")]`,
+		},
+		FieldType:          "std::string::String",
+		PrimitiveFieldType: "std::string::String",
+		AddQueryParameter:  `let builder = builder.query(&[("parent", &req.parent)]);`,
+		KeyType:            "",
+		ValueType:          "",
+	}, parent.Codec); diff != "" {
+		t.Errorf("mismatch in field annotations (-want, +got)\n:%s", diff)
+	}
+
+	if diff := cmp.Diff(&fieldAnnotations{
+		FieldName:     "public_key",
+		SetterName:    "public_key",
+		BranchName:    "PublicKey",
+		FQMessageName: "crate::model::Request",
+		DocLines:      nil,
+		Attributes: []string{
+			`#[serde(rename = "public_key")]`,
+			`#[serde(skip_serializing_if = "std::string::String::is_empty")]`,
+		},
+		FieldType:          "std::string::String",
+		PrimitiveFieldType: "std::string::String",
+		AddQueryParameter:  `let builder = builder.query(&[("public_key", &req.public_key)]);`,
+		KeyType:            "",
+		ValueType:          "",
+	}, publicKey.Codec); diff != "" {
+		t.Errorf("mismatch in field annotations (-want, +got)\n:%s", diff)
+	}
+
+	if diff := cmp.Diff(&fieldAnnotations{
+		FieldName:          "read_time",
+		SetterName:         "read_time",
+		BranchName:         "ReadTime",
+		FQMessageName:      "crate::model::Request",
+		DocLines:           nil,
+		Attributes:         []string{},
+		FieldType:          "i32",
+		PrimitiveFieldType: "i32",
+		AddQueryParameter:  `let builder = builder.query(&[("readTime", &req.read_time)]);`,
+		KeyType:            "",
+		ValueType:          "",
+	}, readTime.Codec); diff != "" {
+		t.Errorf("mismatch in field annotations (-want, +got)\n:%s", diff)
+	}
+}


### PR DESCRIPTION
If the `json_name` annotation is present, then we capture it in the
AST and the Rust generator outputs the right attributes for JSON
serialization *and* the right query parameter code.

Fixes #97
