### PR TITLE
test(generator/go): add an integration test for golang generation

### DIFF
--- a/.github/workflows/generator_go.yaml
+++ b/.github/workflows/generator_go.yaml
@@ -14,14 +14,12 @@
 
 name: "Client Generator: Go"
 permissions: read-all
-
 # Run CI on pushes to the main branch and on PRs against main.
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
-
+    branches: [main]
 jobs:
   generator-build:
     runs-on: ubuntu-24.04
@@ -45,10 +43,10 @@ jobs:
       - run: go get
       - run: go test
         working-directory: generator/internal/golang
-
       - name: Generate Go API
         run: >-
           go run cmd/sidekick/main.go generate -project-root=..
+
             -specification-format=openapi
             -specification-source=generator/testdata/openapi/secretmanager_openapi_v1.json
             -service-config=generator/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml
@@ -58,7 +56,7 @@ jobs:
             -language=go
             -output=generator/testdata/go/openapi/golden
 
-      # TODO(devoncarew): Commented out as the generated code does not currently build.
-      # - name: Validate generation
-      #   working-directory: testdata/go/openapi/golden
-      #   run: go build
+# TODO(devoncarew): Commented out as the generated code does not currently build.
+# - name: Validate generation
+#   working-directory: testdata/go/openapi/golden
+#   run: go build

--- a/.github/workflows/generator_go.yaml
+++ b/.github/workflows/generator_go.yaml
@@ -44,16 +44,7 @@ jobs:
       - run: go test
         working-directory: generator/internal/golang
       - name: Generate Go API
-        run: >-
-          go run cmd/sidekick/main.go generate -project-root=..
-            -specification-format=openapi
-            -specification-source=generator/testdata/openapi/secretmanager_openapi_v1.json
-            -service-config=generator/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml
-            -codec-option=go-package-name=secretmanager
-            -codec-option=package:wkt=package=types,path=types,source=google.protobuf
-            -codec-option=package:gax=package=gax,path=gax,feature=unstable-sdk-client
-            -language=go
-            -output=generator/testdata/go/openapi/golden
+        run: go run cmd/sidekick/main.go generate -project-root=.. -specification-format=openapi -specification-source=generator/testdata/openapi/secretmanager_openapi_v1.json -service-config=generator/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml -codec-option=go-package-name=secretmanager -codec-option=package:wkt=package=types,path=types,source=google.protobuf -codec-option=package:gax=package=gax,path=gax,feature=unstable-sdk-client -language=go -output=generator/testdata/go/openapi/golden
 
 # TODO(devoncarew): Commented out as the generated code does not currently build.
 # - name: Validate generation

--- a/.github/workflows/generator_go.yaml
+++ b/.github/workflows/generator_go.yaml
@@ -15,7 +15,12 @@
 name: "Client Generator: Go"
 permissions: read-all
 
-on: [push, pull_request]
+# Run CI on pushes to the main branch and on PRs against main.
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   generator-build:
@@ -39,7 +44,7 @@ jobs:
           go-version: '1.23'
       - run: go get
       - run: go test
-        working-directory: internal/golang
+        working-directory: generator/internal/golang
 
       - name: Generate Go API
         run: >-

--- a/.github/workflows/generator_go.yaml
+++ b/.github/workflows/generator_go.yaml
@@ -46,7 +46,6 @@ jobs:
       - name: Generate Go API
         run: >-
           go run cmd/sidekick/main.go generate -project-root=..
-
             -specification-format=openapi
             -specification-source=generator/testdata/openapi/secretmanager_openapi_v1.json
             -service-config=generator/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml

--- a/.github/workflows/generator_go.yaml
+++ b/.github/workflows/generator_go.yaml
@@ -55,5 +55,5 @@ jobs:
 
       # TODO(devoncarew): Commented out as the generated code does not currently build.
       # - name: Validate generation
-      #   working-directory: testdata/rust/openapi/golden
+      #   working-directory: testdata/go/openapi/golden
       #   run: go build

--- a/.github/workflows/generator_go.yaml
+++ b/.github/workflows/generator_go.yaml
@@ -1,0 +1,59 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Client Generator: Go"
+permissions: read-all
+
+on: [push, pull_request]
+
+jobs:
+  generator-build:
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: generator
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install protoc
+        run: |
+          set -e
+          curl -fSSL -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protoc-28.3-linux-x86_64.zip
+          cd /usr/local
+          sudo unzip -x /tmp/protoc.zip
+          protoc --version
+      - run: go install golang.org/x/tools/cmd/goimports@latest
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+      - run: go get
+      - run: go test
+        working-directory: internal/golang
+
+      - name: Generate Go API
+        run: >-
+          go run cmd/sidekick/main.go generate -project-root=..
+            -specification-format=openapi
+            -specification-source=generator/testdata/openapi/secretmanager_openapi_v1.json
+            -service-config=generator/testdata/googleapis/google/cloud/secretmanager/v1/secretmanager_v1.yaml
+            -codec-option=go-package-name=secretmanager
+            -codec-option=package:wkt=package=types,path=types,source=google.protobuf
+            -codec-option=package:gax=package=gax,path=gax,feature=unstable-sdk-client
+            -language=go
+            -output=generator/testdata/go/openapi/golden
+
+      # TODO(devoncarew): Commented out as the generated code does not currently build.
+      # - name: Validate generation
+      #   working-directory: testdata/rust/openapi/golden
+      #   run: go build

--- a/generator/internal/golang/golang_test.go
+++ b/generator/internal/golang/golang_test.go
@@ -15,6 +15,9 @@
 package golang
 
 import (
+	"io/fs"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -170,5 +173,24 @@ func TestGo_ValidateMessageMismatch(t *testing.T) {
 		[]*api.Service{{Name: "s1", Package: "p1"}, {Name: "s2", Package: "p2"}})
 	if err := validateModel(test, "p1"); err == nil {
 		t.Errorf("expected an error in API validation got=%s", sourceSpecificationPackageName)
+	}
+}
+
+func TestGo_TemplatesAvailable(t *testing.T) {
+	var count = 0
+	fs.WalkDir(goTemplates, "templates", func(path string, d fs.DirEntry, err error) error {
+		if filepath.Ext(path) != ".mustache" {
+			return nil
+		}
+		if strings.Count(d.Name(), ".") == 1 {
+			// skip partials
+			return nil
+		}
+		count++
+		return nil
+	})
+
+	if count == 0 {
+		t.Errorf("no go templates found")
 	}
 }

--- a/generator/internal/golang/templates/go.mod.mustache
+++ b/generator/internal/golang/templates/go.mod.mustache
@@ -16,3 +16,10 @@ limitations under the License.
 module {{Codec.PackageName}}
 
 go 1.23.2
+
+require (
+	cloud.google.com/go/auth v0.14.1 // indirect
+	cloud.google.com/go/compute/metadata v0.6.0 // indirect
+	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
+	golang.org/x/sys v0.29.0 // indirect
+)

--- a/generator/internal/golang/templates/go.mod.mustache
+++ b/generator/internal/golang/templates/go.mod.mustache
@@ -18,7 +18,6 @@ module {{Codec.PackageName}}
 go 1.23.2
 
 require (
-	cloud.google.com/go/auth v0.14.1 // indirect
 	cloud.google.com/go/compute/metadata v0.6.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
 	golang.org/x/sys v0.29.0 // indirect


### PR DESCRIPTION
- add an integration test for golang generation

When looking at adding a Dart backend, I'd copied the Go one (from a few days ago), but noticed that it was no longer working; the templates directory location had changed as well as several of the mustache variable names. This PR adds an integration test for the golang generator as a github workflow. It's not 100% functional, as the generation code doesn't `go build`:

```
# secretmanager
./client.go:1112:5: undefined: Metadata
./client.go:1147:17: undefined: Time
./client.go:1168:17: undefined: Time
./client.go:1171:10: undefined: Duration
./client.go:1213:24: undefined: Duration
...
```

but perhaps this test is useful as a start? The fixes are probably pretty straightforward for someone w/ more go experience.
