### PR TITLE
chore(deps): update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: "gomod"
     directory: "/generator"
     schedule:


### PR DESCRIPTION
- have dependabot send one PR for all github actions changes (instead of one PR per updated action)

We use this config for the dart-lang repos in order to reduce the number of dependabot PRs.