### PR TITLE
ci: test gax with features disabled

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -38,6 +38,8 @@ jobs:
       - name: Display rustc version
         run: rustc --version
       - run: cargo test
+      - name: Test gax with features disabled
+        run: cargo test -p gcp-sdk-gax
   coverage:
     runs-on: ubuntu-24.04
     strategy:
@@ -86,6 +88,9 @@ jobs:
       - run: cargo clippy -- --deny warnings
       - run: cargo fmt
       - run: cargo doc
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+      - run: cargo doc -p gcp-sdk-gax
         env:
           RUSTDOCFLAGS: "-D warnings"
       - run: git diff --exit-code

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -37,9 +37,9 @@ jobs:
         run: cargo version
       - name: Display rustc version
         run: rustc --version
-      - run: cargo test
       - name: Test gax with features disabled
         run: cargo build -p gcp-sdk-gax
+      - run: cargo test
   coverage:
     runs-on: ubuntu-24.04
     strategy:

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -39,7 +39,7 @@ jobs:
         run: rustc --version
       - run: cargo test
       - name: Test gax with features disabled
-        run: cargo test -p gcp-sdk-gax
+        run: cargo build -p gcp-sdk-gax
   coverage:
     runs-on: ubuntu-24.04
     strategy:

--- a/src/gax/src/polling_policy.rs
+++ b/src/gax/src/polling_policy.rs
@@ -185,7 +185,7 @@ impl PollingPolicy for Aip194Strict {
         }
 
         if let Some(http) = error.as_inner::<crate::error::HttpError>() {
-            return if http.status_code() == http::StatusCode::SERVICE_UNAVAILABLE {
+            return if http.status_code() == reqwest::StatusCode::SERVICE_UNAVAILABLE {
                 LoopState::Continue(error)
             } else {
                 LoopState::Permanent(error)

--- a/src/gax/src/polling_policy.rs
+++ b/src/gax/src/polling_policy.rs
@@ -185,7 +185,7 @@ impl PollingPolicy for Aip194Strict {
         }
 
         if let Some(http) = error.as_inner::<crate::error::HttpError>() {
-            return if http.status_code() == reqwest::StatusCode::SERVICE_UNAVAILABLE {
+            return if http.status_code() == http::StatusCode::SERVICE_UNAVAILABLE {
                 LoopState::Continue(error)
             } else {
                 LoopState::Permanent(error)


### PR DESCRIPTION
The normal `cargo test` enables all the features needed by other crates,
including generated libraries. Running `cargo test -p gcp-sdk-gax`
verifies the library builds on its own.