### PR TITLE
fix(generator/rust): set next_page token when streaming

### DIFF
--- a/generator/internal/rust/templates/crate/src/builders.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/builders.rs.mustache
@@ -90,8 +90,8 @@ pub mod {{Codec.ModuleName}} {
         pub async fn stream(self) -> gax::paginator::Paginator<{{OutputType.Codec.QualifiedName}}, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/generator/testdata/rust/openapi/golden/src/builders.rs
+++ b/generator/testdata/rust/openapi/golden/src/builders.rs
@@ -70,8 +70,8 @@ pub mod secret_manager_service {
         pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListLocationsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -188,8 +188,8 @@ pub mod secret_manager_service {
         pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListSecretsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -312,8 +312,8 @@ pub mod secret_manager_service {
         pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListSecretsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -902,8 +902,8 @@ pub mod secret_manager_service {
         pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListSecretVersionsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -979,8 +979,8 @@ pub mod secret_manager_service {
         pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListSecretVersionsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/generator/testdata/rust/protobuf/golden/location/src/builders.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/builders.rs
@@ -70,8 +70,8 @@ pub mod locations {
         pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListLocationsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/builders.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/builders.rs
@@ -70,8 +70,8 @@ pub mod secret_manager_service {
         pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListSecretsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -376,8 +376,8 @@ pub mod secret_manager_service {
         pub async fn stream(self) -> gax::paginator::Paginator<crate::model::ListSecretVersionsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -822,8 +822,8 @@ pub mod secret_manager_service {
         pub async fn stream(self) -> gax::paginator::Paginator<location::model::ListLocationsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/api/servicemanagement/v1/src/builders.rs
+++ b/src/generated/api/servicemanagement/v1/src/builders.rs
@@ -75,8 +75,8 @@ pub mod service_manager {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -434,8 +434,8 @@ pub mod service_manager {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -717,8 +717,8 @@ pub mod service_manager {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1148,8 +1148,8 @@ pub mod service_manager {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/api/serviceusage/v1/src/builders.rs
+++ b/src/generated/api/serviceusage/v1/src/builders.rs
@@ -297,8 +297,8 @@ pub mod service_usage {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -525,8 +525,8 @@ pub mod service_usage {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/bigtable/admin/v2/src/builders.rs
+++ b/src/generated/bigtable/admin/v2/src/builders.rs
@@ -1046,8 +1046,8 @@ pub mod bigtable_instance_admin {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1429,8 +1429,8 @@ pub mod bigtable_instance_admin {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1515,8 +1515,8 @@ pub mod bigtable_instance_admin {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1911,8 +1911,8 @@ pub mod bigtable_table_admin {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2345,8 +2345,8 @@ pub mod bigtable_table_admin {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2988,8 +2988,8 @@ pub mod bigtable_table_admin {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -3326,8 +3326,8 @@ pub mod bigtable_table_admin {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -3766,8 +3766,8 @@ pub mod bigtable_table_admin {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/cloud/accessapproval/v1/src/builders.rs
+++ b/src/generated/cloud/accessapproval/v1/src/builders.rs
@@ -78,8 +78,8 @@ pub mod access_approval {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/cloud/apigateway/v1/src/builders.rs
+++ b/src/generated/cloud/apigateway/v1/src/builders.rs
@@ -75,8 +75,8 @@ pub mod api_gateway_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -454,8 +454,8 @@ pub mod api_gateway_service {
         ) -> gax::paginator::Paginator<crate::model::ListApisResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -826,8 +826,8 @@ pub mod api_gateway_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1220,8 +1220,8 @@ pub mod api_gateway_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/cloud/apigeeconnect/v1/src/builders.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/builders.rs
@@ -75,8 +75,8 @@ pub mod connection_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/cloud/assuredworkloads/v1/src/builders.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/builders.rs
@@ -370,8 +370,8 @@ pub mod assured_workloads_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -447,8 +447,8 @@ pub mod assured_workloads_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/cloud/functions/v2/src/builders.rs
+++ b/src/generated/cloud/functions/v2/src/builders.rs
@@ -122,8 +122,8 @@ pub mod function_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -613,8 +613,8 @@ pub mod function_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -854,8 +854,8 @@ pub mod function_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/cloud/kms/inventory/v1/src/builders.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/builders.rs
@@ -75,8 +75,8 @@ pub mod key_dashboard_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -222,8 +222,8 @@ pub mod key_tracking_service {
         > {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/cloud/kms/v1/src/builders.rs
+++ b/src/generated/cloud/kms/v1/src/builders.rs
@@ -211,8 +211,8 @@ pub mod autokey {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -288,8 +288,8 @@ pub mod autokey {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -786,8 +786,8 @@ pub mod autokey_admin {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1138,8 +1138,8 @@ pub mod ekm_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1518,8 +1518,8 @@ pub mod ekm_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1867,8 +1867,8 @@ pub mod key_management_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1947,8 +1947,8 @@ pub mod key_management_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2039,8 +2039,8 @@ pub mod key_management_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2128,8 +2128,8 @@ pub mod key_management_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -3630,8 +3630,8 @@ pub mod key_management_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/cloud/location/src/builders.rs
+++ b/src/generated/cloud/location/src/builders.rs
@@ -75,8 +75,8 @@ pub mod locations {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/cloud/resourcemanager/v3/src/builders.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/builders.rs
@@ -116,8 +116,8 @@ pub mod folders {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -190,8 +190,8 @@ pub mod folders {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -951,8 +951,8 @@ pub mod organizations {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1294,8 +1294,8 @@ pub mod projects {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1368,8 +1368,8 @@ pub mod projects {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2087,8 +2087,8 @@ pub mod tag_bindings {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2331,8 +2331,8 @@ pub mod tag_bindings {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2645,8 +2645,8 @@ pub mod tag_holds {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2789,8 +2789,8 @@ pub mod tag_keys {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -3452,8 +3452,8 @@ pub mod tag_values {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/cloud/run/v2/src/builders.rs
+++ b/src/generated/cloud/run/v2/src/builders.rs
@@ -166,8 +166,8 @@ pub mod builds {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -445,8 +445,8 @@ pub mod executions {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -698,8 +698,8 @@ pub mod executions {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1068,8 +1068,8 @@ pub mod jobs {
         ) -> gax::paginator::Paginator<crate::model::ListJobsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1582,8 +1582,8 @@ pub mod jobs {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1861,8 +1861,8 @@ pub mod revisions {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2026,8 +2026,8 @@ pub mod revisions {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2402,8 +2402,8 @@ pub mod services {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2831,8 +2831,8 @@ pub mod services {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -3109,8 +3109,8 @@ pub mod tasks {
         ) -> gax::paginator::Paginator<crate::model::ListTasksResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -3186,8 +3186,8 @@ pub mod tasks {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/cloud/scheduler/v1/src/builders.rs
+++ b/src/generated/cloud/scheduler/v1/src/builders.rs
@@ -74,8 +74,8 @@ pub mod cloud_scheduler {
         ) -> gax::paginator::Paginator<crate::model::ListJobsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -443,8 +443,8 @@ pub mod cloud_scheduler {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/cloud/secretmanager/v1/src/builders.rs
+++ b/src/generated/cloud/secretmanager/v1/src/builders.rs
@@ -75,8 +75,8 @@ pub mod secret_manager_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -402,8 +402,8 @@ pub mod secret_manager_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -881,8 +881,8 @@ pub mod secret_manager_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/cloud/tasks/v2/src/builders.rs
+++ b/src/generated/cloud/tasks/v2/src/builders.rs
@@ -75,8 +75,8 @@ pub mod cloud_tasks {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -620,8 +620,8 @@ pub mod cloud_tasks {
         ) -> gax::paginator::Paginator<crate::model::ListTasksResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -885,8 +885,8 @@ pub mod cloud_tasks {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/cloud/translate/v3/src/builders.rs
+++ b/src/generated/cloud/translate/v3/src/builders.rs
@@ -1015,8 +1015,8 @@ pub mod translation_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1259,8 +1259,8 @@ pub mod translation_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1600,8 +1600,8 @@ pub mod translation_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1896,8 +1896,8 @@ pub mod translation_service {
         > {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2203,8 +2203,8 @@ pub mod translation_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2278,8 +2278,8 @@ pub mod translation_service {
         > {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2518,8 +2518,8 @@ pub mod translation_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2679,8 +2679,8 @@ pub mod translation_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2873,8 +2873,8 @@ pub mod translation_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2991,8 +2991,8 @@ pub mod translation_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/cloud/vpcaccess/v1/src/builders.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/builders.rs
@@ -210,8 +210,8 @@ pub mod vpc_access_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -357,8 +357,8 @@ pub mod vpc_access_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -434,8 +434,8 @@ pub mod vpc_access_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/cloud/webrisk/v1/src/builders.rs
+++ b/src/generated/cloud/webrisk/v1/src/builders.rs
@@ -402,8 +402,8 @@ pub mod web_risk_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/cloud/workflows/v1/src/builders.rs
+++ b/src/generated/cloud/workflows/v1/src/builders.rs
@@ -75,8 +75,8 @@ pub mod workflows {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -466,8 +466,8 @@ pub mod workflows {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -584,8 +584,8 @@ pub mod workflows {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/container/v1/src/builders.rs
+++ b/src/generated/container/v1/src/builders.rs
@@ -2393,8 +2393,8 @@ pub mod cluster_manager {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/devtools/artifactregistry/v1/src/builders.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/builders.rs
@@ -78,8 +78,8 @@ pub mod artifact_registry {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -196,8 +196,8 @@ pub mod artifact_registry {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -308,8 +308,8 @@ pub mod artifact_registry {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -420,8 +420,8 @@ pub mod artifact_registry {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -727,8 +727,8 @@ pub mod artifact_registry {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1080,8 +1080,8 @@ pub mod artifact_registry {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1277,8 +1277,8 @@ pub mod artifact_registry {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1642,8 +1642,8 @@ pub mod artifact_registry {
         ) -> gax::paginator::Paginator<crate::model::ListFilesResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1888,8 +1888,8 @@ pub mod artifact_registry {
         ) -> gax::paginator::Paginator<crate::model::ListTagsResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2197,8 +2197,8 @@ pub mod artifact_registry {
         ) -> gax::paginator::Paginator<crate::model::ListRulesResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2811,8 +2811,8 @@ pub mod artifact_registry {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -3105,8 +3105,8 @@ pub mod artifact_registry {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/devtools/cloudbuild/v1/src/builders.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/builders.rs
@@ -222,8 +222,8 @@ pub mod cloud_build {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -649,8 +649,8 @@ pub mod cloud_build {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1368,8 +1368,8 @@ pub mod cloud_build {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/devtools/cloudbuild/v2/src/builders.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/builders.rs
@@ -213,8 +213,8 @@ pub mod repository_manager {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -719,8 +719,8 @@ pub mod repository_manager {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -976,8 +976,8 @@ pub mod repository_manager {
         > {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/iam/admin/v1/src/builders.rs
+++ b/src/generated/iam/admin/v1/src/builders.rs
@@ -78,8 +78,8 @@ pub mod iam {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1193,8 +1193,8 @@ pub mod iam {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1266,8 +1266,8 @@ pub mod iam {
         ) -> gax::paginator::Paginator<crate::model::ListRolesResponse, gax::error::Error> {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1597,8 +1597,8 @@ pub mod iam {
         > {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/iam/v2/src/builders.rs
+++ b/src/generated/iam/v2/src/builders.rs
@@ -75,8 +75,8 @@ pub mod policies {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/longrunning/src/builders.rs
+++ b/src/generated/longrunning/src/builders.rs
@@ -75,8 +75,8 @@ pub mod operations {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/monitoring/dashboard/v1/src/builders.rs
+++ b/src/generated/monitoring/dashboard/v1/src/builders.rs
@@ -131,8 +131,8 @@ pub mod dashboards_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/monitoring/v3/src/builders.rs
+++ b/src/generated/monitoring/v3/src/builders.rs
@@ -78,8 +78,8 @@ pub mod alert_policy_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -378,8 +378,8 @@ pub mod group_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -652,8 +652,8 @@ pub mod group_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -768,8 +768,8 @@ pub mod metric_service {
         > {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -891,8 +891,8 @@ pub mod metric_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1112,8 +1112,8 @@ pub mod metric_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1379,8 +1379,8 @@ pub mod notification_channel_service {
         > {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1504,8 +1504,8 @@ pub mod notification_channel_service {
         > {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1996,8 +1996,8 @@ pub mod query_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2193,8 +2193,8 @@ pub mod service_monitoring_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2489,8 +2489,8 @@ pub mod service_monitoring_service {
         > {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2754,8 +2754,8 @@ pub mod snooze_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2953,8 +2953,8 @@ pub mod uptime_check_service {
         > {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -3237,8 +3237,8 @@ pub mod uptime_check_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/openapi-validation/src/builders.rs
+++ b/src/generated/openapi-validation/src/builders.rs
@@ -75,8 +75,8 @@ pub mod secret_manager_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -202,8 +202,8 @@ pub mod secret_manager_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -343,8 +343,8 @@ pub mod secret_manager_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -997,8 +997,8 @@ pub mod secret_manager_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1093,8 +1093,8 @@ pub mod secret_manager_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/privacy/dlp/v2/src/builders.rs
+++ b/src/generated/privacy/dlp/v2/src/builders.rs
@@ -643,8 +643,8 @@ pub mod dlp_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -953,8 +953,8 @@ pub mod dlp_service {
         > {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1302,8 +1302,8 @@ pub mod dlp_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1650,8 +1650,8 @@ pub mod dlp_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1830,8 +1830,8 @@ pub mod dlp_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2219,8 +2219,8 @@ pub mod dlp_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2350,8 +2350,8 @@ pub mod dlp_service {
         > {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2433,8 +2433,8 @@ pub mod dlp_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2518,8 +2518,8 @@ pub mod dlp_service {
         > {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -2649,8 +2649,8 @@ pub mod dlp_service {
         > {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -3141,8 +3141,8 @@ pub mod dlp_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -3218,8 +3218,8 @@ pub mod dlp_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/spanner/admin/database/v1/src/builders.rs
+++ b/src/generated/spanner/admin/database/v1/src/builders.rs
@@ -75,8 +75,8 @@ pub mod database_admin {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1099,8 +1099,8 @@ pub mod database_admin {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1284,8 +1284,8 @@ pub mod database_admin {
         > {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1361,8 +1361,8 @@ pub mod database_admin {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1438,8 +1438,8 @@ pub mod database_admin {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1770,8 +1770,8 @@ pub mod database_admin {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1841,8 +1841,8 @@ pub mod database_admin {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/spanner/admin/instance/v1/src/builders.rs
+++ b/src/generated/spanner/admin/instance/v1/src/builders.rs
@@ -78,8 +78,8 @@ pub mod instance_admin {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -462,8 +462,8 @@ pub mod instance_admin {
         > {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -536,8 +536,8 @@ pub mod instance_admin {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -624,8 +624,8 @@ pub mod instance_admin {
         > {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1455,8 +1455,8 @@ pub mod instance_admin {
         > {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -1629,8 +1629,8 @@ pub mod instance_admin {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)

--- a/src/generated/storagetransfer/v1/src/builders.rs
+++ b/src/generated/storagetransfer/v1/src/builders.rs
@@ -286,8 +286,8 @@ pub mod storage_transfer_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -726,8 +726,8 @@ pub mod storage_transfer_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)
@@ -844,8 +844,8 @@ pub mod storage_transfer_service {
         {
             let token = gax::paginator::extract_token(&self.0.request.page_token);
             let execute = move |token: String| {
-                let builder = self.clone();
-                builder.0.request.clone().set_page_token(token);
+                let mut builder = self.clone();
+                builder.0.request = builder.0.request.set_page_token(token);
                 builder.send()
             };
             gax::paginator::Paginator::new(token, execute)


### PR DESCRIPTION
Modify the builder to set the page token when iterating over a stream, rather than modifying a cloned request.

Part of the work for #976 

