### PR TITLE
ci(auth): add build cache

### DIFF
--- a/src/auth/.gcb/integration.yaml
+++ b/src/auth/.gcb/integration.yaml
@@ -18,9 +18,23 @@ options:
   logging: CLOUD_LOGGING_ONLY
   env:
     - GOOGLE_CLOUD_PROJECT=${PROJECT_ID}
+    - SCCACHE_GCS_BUCKET=${PROJECT_ID}-build-cache
+    - SCCACHE_GCS_RW_MODE=READ_WRITE
+    - SCCACHE_GCS_KEY_PREFIX=sccache/integration
+    - RUSTC_WRAPPER=/workspace/.bin/sccache
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'
 steps:
-  - name: 'rust:1.84-bookworm'
+  - id: 'Set up build cache'
+    name: 'gcr.io/cloud-builders/curl'
+    script: |
+      #!/usr/bin/env bash
+      set -e
+      mkdir -p .bin
+      curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.9.1/sccache-v0.9.1-x86_64-unknown-linux-musl.tar.gz |
+        tar -C /workspace/.bin -zxf - --strip-components=1
+      chmod 755 /workspace/.bin/sccache
+  - id: 'Run auth integration tests'
+    name: 'rust:1.84-bookworm'
     script: |
       #!/usr/bin/env bash
       set -e


### PR DESCRIPTION
Fixes #806 

Add a build cache for the rust auth integration tests.

A bit of a YOLO, but I trust in my abilities to `Ctrl` + `C`, `Ctrl` + `V`. The first run of the `auth-integration` build should populate the cache. I will probably restart it to see if the build time drops before requesting review.

**Update**: it seems to work.

![image](https://github.com/user-attachments/assets/72891b6b-cdc3-474f-94c4-632b4f1baa44)
