### PR TITLE
chore(sidekick): freeze package names and change default prefix

### DIFF
--- a/generator/internal/rust/rust.go
+++ b/generator/internal/rust/rust.go
@@ -1501,7 +1501,7 @@ func packageName(api *api.API, packageNameOverride string) string {
 	if name == "" {
 		name = api.Name
 	}
-	return "gcp-sdk-" + name
+	return "google-cloud-" + name
 }
 
 func validateModel(api *api.API, sourceSpecificationPackageName string) error {

--- a/generator/internal/rust/rust_test.go
+++ b/generator/internal/rust/rust_test.go
@@ -158,11 +158,11 @@ func TestRust_PackageName(t *testing.T) {
 		Name:        "test-only-name",
 		PackageName: "google.cloud.service.v3",
 	})
-	rustPackageNameImpl(t, "gcp-sdk-service-v3", nil, &api.API{
+	rustPackageNameImpl(t, "google-cloud-service-v3", nil, &api.API{
 		Name:        "test-only-name",
 		PackageName: "google.cloud.service.v3",
 	})
-	rustPackageNameImpl(t, "gcp-sdk-type", nil, &api.API{
+	rustPackageNameImpl(t, "google-cloud-type", nil, &api.API{
 		Name:        "type",
 		PackageName: "",
 	})

--- a/generator/internal/rust/rusttemplate_test.go
+++ b/generator/internal/rust/rusttemplate_test.go
@@ -36,7 +36,7 @@ func TestPackageNames(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "gcp_sdk_workflows_v1"
+	want := "google_cloud_workflows_v1"
 	if got.PackageNamespace != want {
 		t.Errorf("mismatched package namespace, want=%s, got=%s", want, got.PackageNamespace)
 	}

--- a/src/generated/api/servicemanagement/v1/.sidekick.toml
+++ b/src/generated/api/servicemanagement/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/api/servicemanagement/v1/servicemanagement_v1.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-api-servicemanagement-v1"

--- a/src/generated/api/serviceusage/v1/.sidekick.toml
+++ b/src/generated/api/serviceusage/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/api/serviceusage/v1/serviceusage_v1.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-api-serviceusage-v1"

--- a/src/generated/bigtable/admin/v2/.sidekick.toml
+++ b/src/generated/bigtable/admin/v2/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/bigtable/admin/v2/bigtableadmin_v2.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-bigtable-admin-v2"

--- a/src/generated/cloud/accessapproval/v1/.sidekick.toml
+++ b/src/generated/cloud/accessapproval/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/cloud/accessapproval/v1/accessapproval_v1.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-accessapproval-v1"

--- a/src/generated/cloud/apigateway/v1/.sidekick.toml
+++ b/src/generated/cloud/apigateway/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/cloud/apigateway/v1/apigateway_v1.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-apigateway-v1"

--- a/src/generated/cloud/apigeeconnect/v1/.sidekick.toml
+++ b/src/generated/cloud/apigeeconnect/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/cloud/apigeeconnect/v1/apigeeconnect_v1.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-apigeeconnect-v1"

--- a/src/generated/cloud/assuredworkloads/v1/.sidekick.toml
+++ b/src/generated/cloud/assuredworkloads/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/cloud/assuredworkloads/v1/assuredworkloads_v1.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-assuredworkloads-v1"

--- a/src/generated/cloud/essentialcontacts/v1/.sidekick.toml
+++ b/src/generated/cloud/essentialcontacts/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/cloud/essentialcontacts/v1/essentialcontacts_v1.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-essentialcontacts-v1"

--- a/src/generated/cloud/functions/v2/.sidekick.toml
+++ b/src/generated/cloud/functions/v2/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/cloud/functions/v2/cloudfunctions_v2.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-functions-v2"

--- a/src/generated/cloud/kms/inventory/v1/.sidekick.toml
+++ b/src/generated/cloud/kms/inventory/v1/.sidekick.toml
@@ -20,3 +20,4 @@ service-config = 'google/cloud/kms/inventory/v1/kmsinventory_v1.yaml'
 [codec]
 copyright-year = '2025'
 'package:kms' = 'package=gcp-sdk-kms-v1,source=google.cloud.kms.v1,path=src/generated/cloud/kms/v1,version=0.2'
+package-name-override = "gcp-sdk-kms-inventory-v1"

--- a/src/generated/cloud/kms/v1/.sidekick.toml
+++ b/src/generated/cloud/kms/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/cloud/kms/v1/cloudkms_v1.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-kms-v1"

--- a/src/generated/cloud/language/v2/.sidekick.toml
+++ b/src/generated/cloud/language/v2/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/cloud/language/v2/language_v2.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-language-v2"

--- a/src/generated/cloud/location/.sidekick.toml
+++ b/src/generated/cloud/location/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/cloud/location/cloud.yaml'
 [codec]
 copyright-year = '2024'
 'package:location' = 'ignore=true'
+package-name-override = "gcp-sdk-location"

--- a/src/generated/cloud/recaptchaenterprise/v1/.sidekick.toml
+++ b/src/generated/cloud/recaptchaenterprise/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/cloud/recaptchaenterprise/v1/recaptchaenterprise_v1.yam
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-recaptchaenterprise-v1"

--- a/src/generated/cloud/resourcemanager/v3/.sidekick.toml
+++ b/src/generated/cloud/resourcemanager/v3/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/cloud/resourcemanager/v3/cloudresourcemanager_v3.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-resourcemanager-v3"

--- a/src/generated/cloud/run/v2/.sidekick.toml
+++ b/src/generated/cloud/run/v2/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/cloud/run/v2/run_v2.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-run-v2"

--- a/src/generated/cloud/scheduler/v1/.sidekick.toml
+++ b/src/generated/cloud/scheduler/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/cloud/scheduler/v1/cloudscheduler_v1.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-scheduler-v1"

--- a/src/generated/cloud/secretmanager/v1/.sidekick.toml
+++ b/src/generated/cloud/secretmanager/v1/.sidekick.toml
@@ -18,3 +18,4 @@ service-config = 'google/cloud/secretmanager/v1/secretmanager_v1.yaml'
 
 [codec]
 copyright-year = '2024'
+package-name-override = "gcp-sdk-secretmanager-v1"

--- a/src/generated/cloud/sql/v1/.sidekick.toml
+++ b/src/generated/cloud/sql/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/cloud/sql/v1/sqladmin_v1.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-sql-v1"

--- a/src/generated/cloud/tasks/v2/.sidekick.toml
+++ b/src/generated/cloud/tasks/v2/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/cloud/tasks/v2/cloudtasks_v2.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-tasks-v2"

--- a/src/generated/cloud/translate/v3/.sidekick.toml
+++ b/src/generated/cloud/translate/v3/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/cloud/translate/v3/translate_v3.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-translation-v3"

--- a/src/generated/cloud/vpcaccess/v1/.sidekick.toml
+++ b/src/generated/cloud/vpcaccess/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/cloud/vpcaccess/v1/vpcaccess_v1.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-vpcaccess-v1"

--- a/src/generated/cloud/webrisk/v1/.sidekick.toml
+++ b/src/generated/cloud/webrisk/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/cloud/webrisk/v1/webrisk_v1.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-webrisk-v1"

--- a/src/generated/cloud/workflows/v1/.sidekick.toml
+++ b/src/generated/cloud/workflows/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/cloud/workflows/v1/workflows_v1.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-workflows-v1"

--- a/src/generated/container/v1/.sidekick.toml
+++ b/src/generated/container/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/container/v1/container_v1.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-container-v1"

--- a/src/generated/datastore/admin/v1/.sidekick.toml
+++ b/src/generated/datastore/admin/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/datastore/admin/v1/datastore_v1.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-datastore-admin-v1"

--- a/src/generated/devtools/artifactregistry/v1/.sidekick.toml
+++ b/src/generated/devtools/artifactregistry/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/devtools/artifactregistry/v1/artifactregistry_v1.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-devtools-artifactregistry-v1"

--- a/src/generated/devtools/cloudbuild/v1/.sidekick.toml
+++ b/src/generated/devtools/cloudbuild/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/devtools/cloudbuild/v1/cloudbuild_v1.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-devtools-cloudbuild-v1"

--- a/src/generated/devtools/cloudbuild/v2/.sidekick.toml
+++ b/src/generated/devtools/cloudbuild/v2/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/devtools/cloudbuild/v2/cloudbuild_v2.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-devtools-cloudbuild-v2"

--- a/src/generated/devtools/cloudtrace/v2/.sidekick.toml
+++ b/src/generated/devtools/cloudtrace/v2/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/devtools/cloudtrace/v2/cloudtrace_v2.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-devtools-cloudtrace-v2"

--- a/src/generated/iam/admin/v1/.sidekick.toml
+++ b/src/generated/iam/admin/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/iam/admin/v1/iam.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-iam-admin-v1"

--- a/src/generated/iam/credentials/v1/.sidekick.toml
+++ b/src/generated/iam/credentials/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/iam/credentials/v1/iamcredentials_v1.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-iam-credentials-v1"

--- a/src/generated/iam/v1/.sidekick.toml
+++ b/src/generated/iam/v1/.sidekick.toml
@@ -18,3 +18,4 @@ service-config = 'google/iam/v1/iam_meta_api.yaml'
 
 [codec]
 copyright-year = '2024'
+package-name-override = "gcp-sdk-iam-v1"

--- a/src/generated/iam/v2/.sidekick.toml
+++ b/src/generated/iam/v2/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/iam/v2/iam_v2.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-iam-v2"

--- a/src/generated/longrunning/.sidekick.toml
+++ b/src/generated/longrunning/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/longrunning/longrunning.yaml'
 [codec]
 copyright-year = '2024'
 'package:longrunning' = 'ignore=true'
+package-name-override = "gcp-sdk-longrunning"

--- a/src/generated/monitoring/dashboard/v1/.sidekick.toml
+++ b/src/generated/monitoring/dashboard/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/monitoring/dashboard/v1/monitoring.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-monitoring-dashboard-v1"

--- a/src/generated/monitoring/metricsscope/v1/.sidekick.toml
+++ b/src/generated/monitoring/metricsscope/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/monitoring/metricsscope/v1/monitoring.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-monitoring-metricsscope-v1"

--- a/src/generated/monitoring/v3/.sidekick.toml
+++ b/src/generated/monitoring/v3/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/monitoring/v3/monitoring.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-monitoring-v3"

--- a/src/generated/privacy/dlp/v2/.sidekick.toml
+++ b/src/generated/privacy/dlp/v2/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/privacy/dlp/v2/dlp_v2.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-privacy-dlp-v2"

--- a/src/generated/rpc/types/.sidekick.toml
+++ b/src/generated/rpc/types/.sidekick.toml
@@ -18,3 +18,4 @@ service-config = 'google/rpc/rpc_publish.yaml'
 
 [codec]
 copyright-year = '2024'
+package-name-override = "gcp-sdk-rpc"

--- a/src/generated/spanner/admin/database/v1/.sidekick.toml
+++ b/src/generated/spanner/admin/database/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/spanner/admin/database/v1/spanner.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-spanner-admin-database-v1"

--- a/src/generated/spanner/admin/instance/v1/.sidekick.toml
+++ b/src/generated/spanner/admin/instance/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/spanner/admin/instance/v1/spanner.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-spanner-admin-instance-v1"

--- a/src/generated/storagetransfer/v1/.sidekick.toml
+++ b/src/generated/storagetransfer/v1/.sidekick.toml
@@ -19,3 +19,4 @@ service-config = 'google/storagetransfer/v1/storagetransfer_v1.yaml'
 
 [codec]
 copyright-year = '2025'
+package-name-override = "gcp-sdk-storagetransfer-v1"

--- a/src/generated/type/.sidekick.toml
+++ b/src/generated/type/.sidekick.toml
@@ -18,3 +18,4 @@ service-config = 'google/type/type.yaml'
 
 [codec]
 copyright-year = '2024'
+package-name-override = "gcp-sdk-type"


### PR DESCRIPTION
Starting to migrate new libs to google-cloud prefix.

Updates: #987