### PR TITLE
docs: bootstrap user guide

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -20,6 +20,7 @@ coverage:
     patch: off
 # Ignore generated code that lives with handcrafted code.
 ignore:
+  - guide/samples
   - src/generated
   - src/wkt/src/generated
   - src/integration-tests

--- a/.gcb/integration.yaml
+++ b/.gcb/integration.yaml
@@ -40,3 +40,4 @@ steps:
       set -e
       cargo build
       cargo test --package integration-tests --features run-integration-tests
+      cargo test --package user-guide-samples --features run-integration-tests

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -67,6 +67,35 @@ jobs:
         with:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
+  docs:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        rust-version: ['1.84']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo
+          key: ${{ github.job }}-${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+      - name: Setup Rust ${{ matrix.rust-version }}
+        run: |
+          set -e
+          rustup toolchain install ${{ matrix.rust-version }}
+          cargo install mdbook
+      - name: Display Cargo version
+        run: cargo version
+      - name: Display rustc version
+        run: rustc --version
+      - run: mdbook build guide
+      - run: mdbook test guide
+      - run: cargo doc
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+      - run: cargo doc -p gcp-sdk-gax
+        env:
+          RUSTDOCFLAGS: "-D warnings"
   lint:
     runs-on: ubuntu-24.04
     strategy:
@@ -87,12 +116,6 @@ jobs:
         run: rustc --version
       - run: cargo clippy -- --deny warnings
       - run: cargo fmt
-      - run: cargo doc
-        env:
-          RUSTDOCFLAGS: "-D warnings"
-      - run: cargo doc -p gcp-sdk-gax
-        env:
-          RUSTDOCFLAGS: "-D warnings"
       - run: git diff --exit-code
   regenerate:
     # Verifies the generated code has not been tampered with. Or maybe that the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3556,6 +3556,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "user-guide-samples"
+version = "0.0.0"
+dependencies = [
+ "gcp-sdk-devtools-artifactregistry-v1",
+ "gcp-sdk-kms-v1",
+ "gcp-sdk-secretmanager-v1",
+ "tokio",
+]
+
+[[package]]
 name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3559,9 +3559,9 @@ dependencies = [
 name = "user-guide-samples"
 version = "0.0.0"
 dependencies = [
- "gcp-sdk-devtools-artifactregistry-v1",
  "gcp-sdk-kms-v1",
  "gcp-sdk-secretmanager-v1",
+ "google-cloud-devtools-artifactregistry-v1",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@
 resolver = "2"
 
 members = [
+  "guide/samples",
   "src/auth",
   "src/auth/integration-tests",
   "src/base",

--- a/doc/contributor/howto-guide-set-up-development-environment.md
+++ b/doc/contributor/howto-guide-set-up-development-environment.md
@@ -70,17 +70,17 @@ cargo build --package user-guide-samples
 
 and verify they run using the instructions in the [Integration Tests](#integration-tests) section.
 
-### Using `mdbook watch`
+### Using `mdbook serve`
 
-If you are working on the user guide you may find
+If you are working on the user guide you may find this handy:
 
 ```bash
-mdbook watch guide
+mdbook serve guide
 ```
 
-This will automatically rebuild the documentation when you save any of the
-`guide/src/*.md` files. You can then use a local browser to examine the rendered
-output.
+This will serve the documentation on a local HTTP server (usually at
+`http://localhost:3000/`). It will also automatically rebuild the documentation
+as you modify it.
 
 ## Getting code coverage locally
 

--- a/doc/contributor/howto-guide-set-up-development-environment.md
+++ b/doc/contributor/howto-guide-set-up-development-environment.md
@@ -40,6 +40,48 @@ cargo fmt && cargo clippy -- --deny warnings && cargo test
 git status # Shows any diffs created by `cargo fmt`
 ```
 
+## Generating the user guide
+
+We use [mdBook] to generate a user guide: a series of short "how-to" documents.
+Install the tool using `cargo install`:
+
+```bash
+cargo install mdbook
+```
+
+Then generate the documents with `mdbook build`:
+
+```bash
+mdbook build guide
+```
+
+You will find the generated book in `guide/book`. You can also test any code
+snippets in the documentation using:
+
+```bash
+mdbook test guide
+```
+
+Some of the samples are integration tests, you can verify they build using:
+
+```bash
+cargo build --package user-guide-samples
+```
+
+and verify they run using the instructions in the [Integration Tests](#integration-tests) section.
+
+### Using `mdbook watch`
+
+If you are working on the user guide you may find
+
+```bash
+mdbook watch guide
+```
+
+This will automatically rebuild the documentation when you save any of the
+`guide/src/*.md` files. You can then use a local browser to examine the rendered
+output.
+
 ## Getting code coverage locally
 
 ### Install coverage tools (once)
@@ -125,7 +167,7 @@ env \
     GOOGLE_CLOUD_RUST_TEST_SERVICE_ACCOUNT=rust-sdk-test@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com \
     GOOGLE_CLOUD_RUST_TEST_WORKFLOWS_RUNNER=rust-sdk-test@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com \
     GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT} \
-  cargo test --features run-integration-tests --package integration-tests
+  cargo test --features run-integration-tests --package integration-tests --package user-guide-samples
 ```
 
 There are (at the moment) six integration tests. All using secret manager. We

--- a/guide/.gitignore
+++ b/guide/.gitignore
@@ -1,0 +1,15 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+book

--- a/guide/book.toml
+++ b/guide/book.toml
@@ -1,0 +1,23 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[book]
+title        = "Google Cloud Client Libraries for Rust"
+authors      = ["Carlos O'Ryan"]
+language     = "en"
+multilingual = false
+src          = "src"
+
+[rust]
+edition = "2018"

--- a/guide/book.toml
+++ b/guide/book.toml
@@ -20,4 +20,4 @@ multilingual = false
 src          = "src"
 
 [rust]
-edition = "2018"
+edition = "2021"

--- a/guide/samples/Cargo.toml
+++ b/guide/samples/Cargo.toml
@@ -27,7 +27,7 @@ categories.workspace = true
 [dependencies]
 tokio = { version = "1.43", features = ["full", "macros"] }
 
-[dependencies.gcp-sdk-devtools-artifactregistry-v1]
+[dependencies.google-cloud-devtools-artifactregistry-v1]
 # TODO(#...) - update once the release is available
 # version = "0.3.0"
 features = ["unstable-stream"]

--- a/guide/samples/Cargo.toml
+++ b/guide/samples/Cargo.toml
@@ -1,0 +1,50 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name                 = "user-guide-samples"
+description          = "Samples for the User Guide"
+version              = "0.0.0"
+publish              = false
+edition.workspace    = true
+authors.workspace    = true
+license.workspace    = true
+repository.workspace = true
+keywords.workspace   = true
+categories.workspace = true
+
+[dependencies]
+tokio = { version = "1.43", features = ["full", "macros"] }
+
+[dependencies.gcp-sdk-devtools-artifactregistry-v1]
+# TODO(#...) - update once the release is available
+# version = "0.3.0"
+features = ["unstable-stream"]
+path     = "../../src/generated/devtools/artifactregistry/v1"
+
+[dependencies.gcp-sdk-kms-v1]
+version  = "0.2.0"
+features = ["unstable-stream"]
+path     = "../../src/generated/cloud/kms/v1"
+
+# ANCHOR: secretmanager
+[dependencies.gcp-sdk-secretmanager-v1]
+version  = "0.2.0"
+features = ["unstable-stream"]
+# ANCHOR_END: secretmanager
+path = "../../src/generated/cloud/secretmanager/v1"
+
+[features]
+run-integration-tests = []
+log-integration-tests = []

--- a/guide/samples/src/lib.rs
+++ b/guide/samples/src/lib.rs
@@ -1,0 +1,16 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This crate contains a number of guides showing how to use the
+//! Google Cloud Client Libraries for Rust.

--- a/guide/samples/tests/initialize_client.rs
+++ b/guide/samples/tests/initialize_client.rs
@@ -45,17 +45,6 @@ async fn initialize_client(project_id: &str) -> Result {
 }
 // [END test_only_snippet] ANCHOR_END: all
 
-#[tokio::main]
-async fn main() -> Result {
-    let args: Vec<String> = std::env::args().collect();
-    if args.len() < 2 {
-        println!("Usage: initialize_client <project-id>");
-        return Ok(());
-    }
-    initialize_client(&args[1]).await?;
-    Ok(())
-}
-
 #[cfg(all(test, feature = "run-integration-tests"))]
 mod test {
     use super::*;

--- a/guide/samples/tests/initialize_client.rs
+++ b/guide/samples/tests/initialize_client.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 // [START test_only_snippet] ANCHOR: all
-type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+pub type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
-async fn initialize_client(project_id: &str) -> Result {
+pub async fn initialize_client(project_id: &str) -> Result {
     // [START test_only] ANCHOR: use
     use gcp_sdk_secretmanager_v1::client::SecretManagerService;
     // [END test_only] ANCHOR_END: use

--- a/guide/samples/tests/initialize_client.rs
+++ b/guide/samples/tests/initialize_client.rs
@@ -1,0 +1,68 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START test_only_snippet] ANCHOR: all
+type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+async fn initialize_client(project_id: &str) -> Result {
+    // [START test_only] ANCHOR: use
+    use gcp_sdk_secretmanager_v1::client::SecretManagerService;
+    // [END test_only] ANCHOR_END: use
+
+    // Initialize a client with the default configuration. This is an
+    // asynchronous operation that may fail, as it requires acquiring an an
+    // access token.
+    // ANCHOR: new-client
+    let client = SecretManagerService::new().await?;
+    // ANCHOR_END: new-client
+
+    // Once initialized, use the client to make requests.
+    // ANCHOR: make-rpc
+    let mut items = client
+        .list_locations(format!("projects/{project_id}"))
+        .stream()
+        .await;
+    while let Some(page) = items.next().await {
+        let page = page?;
+        for location in page.locations {
+            println!("{}", location.name);
+        }
+    }
+    // ANCHOR_END: make-rpc
+
+    Ok(())
+}
+// [END test_only_snippet] ANCHOR_END: all
+
+#[tokio::main]
+async fn main() -> Result {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        println!("Usage: initialize_client <project-id>");
+        return Ok(());
+    }
+    initialize_client(&args[1]).await?;
+    Ok(())
+}
+
+#[cfg(all(test, feature = "run-integration-tests"))]
+mod test {
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn driver() -> Result {
+        let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").unwrap();
+        initialize_client(&project_id).await
+    }
+}

--- a/guide/samples/tests/list_resources.rs
+++ b/guide/samples/tests/list_resources.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use gcp_sdk_devtools_artifactregistry_v1::client::ArtifactRegistry;
+use google_cloud_devtools_artifactregistry_v1::client::ArtifactRegistry;
 use std::env;
 
 type Result = std::result::Result<(), Box<dyn std::error::Error>>;
@@ -44,13 +44,10 @@ async fn list_resources(project_id: &str) -> Result {
 async fn main() -> Result {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        println!("Usage: list_artifacts <project-id>");
+        println!("Usage: list_resources <project-id>");
         return Ok(());
     }
-    let project_id = &args[1];
-
-    list_resources(project_id).await?;
-
+    list_resources(&args[1]).await?;
     Ok(())
 }
 

--- a/guide/samples/tests/list_resources.rs
+++ b/guide/samples/tests/list_resources.rs
@@ -40,17 +40,6 @@ async fn list_resources(project_id: &str) -> Result {
     Ok(())
 }
 
-#[tokio::main]
-async fn main() -> Result {
-    let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        println!("Usage: list_resources <project-id>");
-        return Ok(());
-    }
-    list_resources(&args[1]).await?;
-    Ok(())
-}
-
 #[cfg(all(test, feature = "run-integration-tests"))]
 mod test {
     use super::*;

--- a/guide/samples/tests/list_resources.rs
+++ b/guide/samples/tests/list_resources.rs
@@ -1,0 +1,67 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use gcp_sdk_devtools_artifactregistry_v1::client::ArtifactRegistry;
+use std::env;
+
+type Result = std::result::Result<(), Box<dyn std::error::Error>>;
+
+async fn list_resources(project_id: &str) -> Result {
+    let client = ArtifactRegistry::new().await?;
+
+    let mut items = client
+        .list_repositories(format!("projects/{project_id}"))
+        .stream()
+        .await
+        .items();
+    while let Some(i) = items.next().await {
+        match i {
+            Ok(item) => {
+                println!("{item:?}");
+            }
+            Err(e) => {
+                println!("ERROR while iterating over the repositories {e}");
+                return Ok(());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        println!("Usage: list_artifacts <project-id>");
+        return Ok(());
+    }
+    let project_id = &args[1];
+
+    list_resources(project_id).await?;
+
+    Ok(())
+}
+
+#[cfg(all(test, feature = "run-integration-tests"))]
+mod test {
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn driver() -> Result {
+        let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").unwrap();
+        list_resources(&project_id).await?;
+        Ok(())
+    }
+}

--- a/guide/samples/tests/list_resources.rs
+++ b/guide/samples/tests/list_resources.rs
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use google_cloud_devtools_artifactregistry_v1::client::ArtifactRegistry;
-use std::env;
+pub type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
-type Result = std::result::Result<(), Box<dyn std::error::Error>>;
-
-async fn list_resources(project_id: &str) -> Result {
+pub async fn list_resources(project_id: &str) -> Result {
+    use google_cloud_devtools_artifactregistry_v1::client::ArtifactRegistry;
     let client = ArtifactRegistry::new().await?;
 
     let mut items = client

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -1,0 +1,20 @@
+<!-- 
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Summary
+
+- [Introduction](./introduction.md)
+- [How to initialize a client](./initialize_a_client.md)

--- a/guide/src/initialize_a_client.md
+++ b/guide/src/initialize_a_client.md
@@ -1,0 +1,76 @@
+<!-- 
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# How to initialize a client
+
+The Google Cloud Client Libraries for Rust use "clients" as the main
+abstraction to interface with specific services. Clients are implemented
+as Rust structs, with methods corresponding to each RPC offered by the
+service. In other words, to use a Google Cloud service using the Rust
+client libraries you need to first initialize a client.
+
+## Prerequisites
+
+In this guide we will initialize a client and then use the client to make
+a simple RPC. To make this guide concrete, we will use the
+[Secret Manager API]. The same structure applies to any other service in
+Google Cloud.
+
+We recommend you follow one of the "Getting Started" guides for Secret Manager
+before attempting to use the client library, such as how to [Create a secret].
+These guides cover service specific concepts in more detail, and provide
+detailed instructions with respect to project prerequisites than we can fit in
+this guide.
+
+We also recommend you follow the instructions in the
+[Authenticate for using client libraries] guide. This guide will show you how to
+login to configure the [Application Default Credentials] used in this guide.
+
+## Dependencies
+
+As it is usual with rust, you must declare the dependency in your
+`Cargo.toml` file. We use:
+
+```toml
+{{#include ../samples/Cargo.toml:secretmanager}}
+```
+
+The default initialization is designed to meet the requirements for most
+cases. You create a default client using `new()`:
+
+```rust,ignore,noplayground
+{{#include ../samples/tests/initialize_client.rs:new-client}}
+```
+
+Once successfully initialized, you can use this client to make RPCs:
+
+```rust,ignore,noplayground
+{{#include ../samples/tests/initialize_client.rs:make-rpc}}
+```
+
+______________________________________________________________________
+
+## Full Program
+
+Putting all this code together into a full program looks as follows:
+
+```rust,ignore,noplayground
+{{#include ../samples/tests/initialize_client.rs:all}}
+```
+
+[authenticate for using client libraries]: https://cloud.google.com/docs/authentication/client-libraries
+[create a secret]: https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets
+[secret manager api]: https://cloud.google.com/secret-manager

--- a/guide/src/introduction.md
+++ b/guide/src/introduction.md
@@ -1,0 +1,60 @@
+<!-- 
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Introduction
+
+The Google Cloud Client Libraries for Rust is a collection of Rust crates to
+interact with Google Cloud Services.
+
+This guide is organized as a series of small tutorials showing how to perform
+specific actions with the client libraries. Most Google Cloud services follow a
+series of guidelines, collectively known as the [AIPs](https://google.aip.dev).
+This makes the client libraries more from one service to the next. The functions
+to delete or list resources almost always have the same interface.
+
+## Audience
+
+This guide is intended for Rust developers that are familiar with the language
+and the Rust ecosystem. We will assume you know how to use Rust and its
+supporting toolchain.
+
+At the risk of being repetitive, most of the guides do not assume you have used
+any Google Service or client library before (in Rust or other language).
+However, the guides will prefer refer you to service specific tutorials to
+initialize their projects and services.
+
+## Service Specific Documentation
+
+These guides are not intended as tutorials for each services or extended guides
+on how to design Rust applications to work on Google Cloud. They are starting
+points to get you productive with the client libraries for Rust.
+
+We recommend you read the service documentation at <https://cloud.google.com> to
+learn more each service. If you need guidance on how to design your application
+for Google Cloud the [Cloud Architecture Center] may have what you are looking
+for.
+
+## Reporting Bugs
+
+We welcome bugs about the client libraries or their documentation. Please use
+[GitHub Issues](https://github.com/googleapis/google-cloud-rust/issues).
+
+## License
+
+The client libraries source and their documentation are release under the
+[Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+[cloud architecture center]: https://cloud.google.com/architecture

--- a/guide/src/introduction.md
+++ b/guide/src/introduction.md
@@ -33,12 +33,12 @@ supporting toolchain.
 
 At the risk of being repetitive, most of the guides do not assume you have used
 any Google Service or client library before (in Rust or other language).
-However, the guides will prefer refer you to service specific tutorials to
+However, the guides will refer you to service specific tutorials to
 initialize their projects and services.
 
 ## Service Specific Documentation
 
-These guides are not intended as tutorials for each services or extended guides
+These guides are not intended as tutorials for each services or as extended guides
 on how to design Rust applications to work on Google Cloud. They are starting
 points to get you productive with the client libraries for Rust.
 


### PR DESCRIPTION
Create an initial `mdbook` with a simple tutorial showing how to initialize a
client.  Include the guide generation and testing of the code snippets *and*
the included samples into the CI build.

Part of the work for #574 