### PR TITLE
feat(generator): have mustache fail if there are unresolved template variables

### DIFF
--- a/generator/internal/language/generate.go
+++ b/generator/internal/language/generate.go
@@ -59,6 +59,7 @@ func GenerateFromRoot(outdir string, root any, provider TemplateProvider, genera
 			impl:    provider,
 			dirname: filepath.Dir(gen.TemplatePath),
 		}
+		mustache.AllowMissingVariables = false
 		s, err := mustache.RenderPartials(templateContents, &nestedProvider, root)
 		if err != nil {
 			errs = append(errs, err)


### PR DESCRIPTION
- have mustache fail if there are unresolved template variables

I found a flag on the cbroglie/mustache library to fast fail if there are variable references in the templates that don't resolve; likely useful to enable?
