### PR TITLE
chore(ci): have github workflows run fewer times

### DIFF
--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 name: Client Generator
-on: [push, pull_request]
-permissions:
-  contents: read
+permissions: read-all
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 jobs:
   generator-build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 name: Lint
-on: [push, pull_request]
+permissions: read-all
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 jobs:
   spell:
     runs-on: ubuntu-24.04

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 name: Rust SDK
-on: [push, pull_request]
+permissions: read-all
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 jobs:
   build:
     strategy:


### PR DESCRIPTION
- have github workflows run fewer times (just on PRs, or, pushes to main)

I noticed that most checks where running twice per PR; this should just run a workflow once per PR (or PR change), and once when that PR lands in main.
