### PR TITLE
fix(generator/rust): packages with only enums

### DIFF
--- a/generator/internal/golang/golang.go
+++ b/generator/internal/golang/golang.go
@@ -223,7 +223,7 @@ func validatePackageName(newPackage, elementName, sourceSpecificationPackageName
 	if sourceSpecificationPackageName == newPackage {
 		return nil
 	}
-	return fmt.Errorf("rust codec requires all top-level elements to be in the same package want=%s, got=%s for %s",
+	return fmt.Errorf("go codec requires all top-level elements to be in the same package want=%s, got=%s for %s",
 		sourceSpecificationPackageName, newPackage, elementName)
 }
 

--- a/generator/internal/rust/rusttemplate.go
+++ b/generator/internal/rust/rusttemplate.go
@@ -194,6 +194,8 @@ func annotateModel(model *api.API, c *codec, outdir string) (*modelAnnotations, 
 		c.sourceSpecificationPackageName = model.Services[0].Package
 	} else if len(model.Messages) > 0 {
 		c.sourceSpecificationPackageName = model.Messages[0].Package
+	} else if len(model.Enums) > 0 {
+		c.sourceSpecificationPackageName = model.Enums[0].Package
 	}
 	if err := validateModel(model, c.sourceSpecificationPackageName); err != nil {
 		return nil, err


### PR DESCRIPTION
Another fix for packages without a service config file. The package
may only contain enums, so we cannot determine the source package name
from the services or the messages.

Motivated by #1014
