### PR TITLE
feat(generator/rust): xref links take 2 or 7

### DIFF
--- a/generator/internal/api/scopes.go
+++ b/generator/internal/api/scopes.go
@@ -1,0 +1,73 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import "strings"
+
+// Each element of the model (services, messages, enums) has a series of
+// "scopes" associated with it. These are the relative names for symbols
+// in the context of the element.
+//
+// This is intended for discovery of relative and absolute cross-reference links
+// in the documentation.
+//
+// For example, with a proto specification like:
+//
+// ```proto
+// package .test.v1;
+//
+// message M {
+//   message Child {
+//     string f1 = 1;
+//   }
+//   string f1 = 1;
+//   Child f2 = 2;
+// }
+// ```
+//
+// In the context of `Child` we may say `[f1][]` and that is a cross-reference
+// link to `.test.v1.M.Child.f1`.  We may also refer to the same field as
+// `[Child.f1][]` or `[M.Child.f1][]` or even `[.test.v1.M.Child.f1]][]`.
+//
+// Meanwhile, in the context of `M` when we say `[f1][]` that refers to
+// `.test.v1.M.f1`.
+
+func (x *Service) Scopes() []string {
+	return []string{strings.TrimPrefix(x.ID, "."), x.Package}
+}
+
+func (x *Message) Scopes() []string {
+	localScope := strings.TrimPrefix(x.ID, ".")
+	if x.Parent == nil {
+		return []string{localScope, x.Package}
+	}
+	return append([]string{localScope}, x.Parent.Scopes()...)
+}
+
+func (x *Enum) Scopes() []string {
+	localScope := strings.TrimPrefix(x.ID, ".")
+	if x.Parent == nil {
+		return []string{localScope, x.Package}
+	}
+	return append([]string{localScope}, x.Parent.Scopes()...)
+}
+
+func (x *EnumValue) Scopes() []string {
+	localScope := strings.TrimPrefix(x.ID, ".")
+	if x.Parent == nil {
+		return []string{localScope}
+	}
+	return append([]string{localScope}, x.Parent.Scopes()...)
+}

--- a/generator/internal/rust/rust_test.go
+++ b/generator/internal/rust/rust_test.go
@@ -1637,7 +1637,7 @@ Maybe they wanted to show some JSON:
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	c := &codec{}
-	got := formatDocComments(input, model.State, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping)
+	got := formatDocComments(input, model.State, c.modulePath, []string{}, c.packageMapping)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
@@ -1663,7 +1663,7 @@ func TestRust_FormatDocCommentsBullets(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	c := createRustCodec()
-	got := formatDocComments(input, model.State, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping)
+	got := formatDocComments(input, model.State, c.modulePath, []string{}, c.packageMapping)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
@@ -1739,7 +1739,7 @@ block:
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	c := &codec{}
-	got := formatDocComments(input, model.State, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping)
+	got := formatDocComments(input, model.State, c.modulePath, []string{}, c.packageMapping)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
@@ -1760,7 +1760,7 @@ func TestRust_FormatDocCommentsImplicitBlockQuoteClosing(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	c := &codec{}
-	got := formatDocComments(input, model.State, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping)
+	got := formatDocComments(input, model.State, c.modulePath, []string{}, c.packageMapping)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
@@ -1787,7 +1787,7 @@ Second [example][].
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	c := &codec{}
-	got := formatDocComments(input, model.State, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping)
+	got := formatDocComments(input, model.State, c.modulePath, []string{}, c.packageMapping)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
@@ -1865,7 +1865,6 @@ func TestRust_FormatDocCommentsCrossLinks(t *testing.T) {
 			"google.protobuf": wkt,
 			"google.iam.v1":   iam,
 		},
-		sourceSpecificationPackageName: "test.v1",
 	}
 
 	// To test the mappings we need a fairly complex model.API instance. Create it
@@ -1873,7 +1872,7 @@ func TestRust_FormatDocCommentsCrossLinks(t *testing.T) {
 	model := makeApiForRustFormatDocCommentsCrossLinks()
 	loadWellKnownTypes(model.State)
 
-	got := formatDocComments(input, model.State, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping)
+	got := formatDocComments(input, model.State, c.modulePath, []string{"test.v1"}, c.packageMapping)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
@@ -1928,7 +1927,6 @@ func TestRust_FormatDocCommentsRelativeCrossLinks(t *testing.T) {
 			"google.protobuf": wkt,
 			"google.iam.v1":   iam,
 		},
-		sourceSpecificationPackageName: "test.v1",
 	}
 
 	// To test the mappings we need a fairly complex model.API instance. Create it
@@ -1936,7 +1934,7 @@ func TestRust_FormatDocCommentsRelativeCrossLinks(t *testing.T) {
 	model := makeApiForRustFormatDocCommentsCrossLinks()
 	loadWellKnownTypes(model.State)
 
-	got := formatDocComments(input, model.State, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping)
+	got := formatDocComments(input, model.State, c.modulePath, []string{"test.v1"}, c.packageMapping)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
@@ -1991,7 +1989,6 @@ implied enum value reference [SomeMessage.SomeEnum.ENUM_VALUE][]
 			"google.protobuf": wkt,
 			"google.iam.v1":   iam,
 		},
-		sourceSpecificationPackageName: "test.v1",
 	}
 
 	// To test the mappings we need a fairly complex model.API instance. Create it
@@ -1999,7 +1996,7 @@ implied enum value reference [SomeMessage.SomeEnum.ENUM_VALUE][]
 	model := makeApiForRustFormatDocCommentsCrossLinks()
 	loadWellKnownTypes(model.State)
 
-	got := formatDocComments(input, model.State, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping)
+	got := formatDocComments(input, model.State, c.modulePath, []string{"test.v1.Message", "test.v1"}, c.packageMapping)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
@@ -2034,7 +2031,7 @@ func TestRust_FormatDocCommentsHTMLTags(t *testing.T) {
 
 	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
 	c := &codec{}
-	got := formatDocComments(input, model.State, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping)
+	got := formatDocComments(input, model.State, c.modulePath, []string{}, c.packageMapping)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}
@@ -2192,7 +2189,7 @@ Hyperlink: <a href="https://hyperlink.com">Content</a>`
 	model := makeApiForRustFormatDocCommentsCrossLinks()
 	loadWellKnownTypes(model.State)
 
-	got := formatDocComments(input, model.State, c.modulePath, c.sourceSpecificationPackageName, c.packageMapping)
+	got := formatDocComments(input, model.State, c.modulePath, []string{}, c.packageMapping)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatch in FormatDocComments (-want, +got)\n:%s", diff)
 	}

--- a/src/wkt/protos/google/protobuf/api.proto
+++ b/src/wkt/protos/google/protobuf/api.proto
@@ -133,7 +133,7 @@ message Method {
 //
 // - If an http annotation is inherited, the path pattern will be
 //   modified as follows. Any version prefix will be replaced by the
-//   version of the including interface plus the [root][Mixin.root] path if
+//   version of the including interface plus the [root][] path if
 //   specified.
 //
 // Example of a simple mixin:

--- a/src/wkt/src/generated/mod.rs
+++ b/src/wkt/src/generated/mod.rs
@@ -265,7 +265,7 @@ impl wkt::message::Message for Method {
 ///
 /// - If an http annotation is inherited, the path pattern will be
 ///   modified as follows. Any version prefix will be replaced by the
-///   version of the including interface plus the [root][Mixin.root] path if
+///   version of the including interface plus the [root][] path if
 ///   specified.
 ///
 ///
@@ -341,7 +341,7 @@ impl wkt::message::Message for Method {
 /// }
 /// ```
 ///
-/// [Mixin.root]: crate::Mixin::root
+/// [root]: wkt::Mixin::root
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]


### PR DESCRIPTION
This deals with cross-reference links that reference a local (to a
message) field. For example, when a comment includes  `[root][]` to
reference a field named `root`.

This allows me to remove a local patch to `api.proto`, and is required
to (soon) use the protos directly from GitHub.

Motivated by #766
