### PR TITLE
feat(generator): support lists for proto files

### DIFF
--- a/generator/internal/parser/protobuf.go
+++ b/generator/internal/parser/protobuf.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/googleapis/google-cloud-rust/generator/internal/api"
@@ -127,15 +128,8 @@ func protoc(tempFile string, files []string, options map[string]string) ([]byte,
 
 func determineInputFiles(source string, options map[string]string) ([]string, error) {
 	// `config.Source` is relative to the `googleapis-root` (or `extra-protos-root`) if
-	// that is set. When it is a single file, this is easy, just return the
-	// filename and `protoc` will find it.
-
-	if strings.HasSuffix(source, ".proto") {
-		// If the source ends in `.proto` assume it is a single file and let
-		// protoc find it.
-		return []string{source}, nil
-	}
-
+	// that is set. It should always be a directory and by default all the
+	// the files in that directory are used.
 	for _, opt := range []string{"extra-protos-root", "googleapis-root"} {
 		location, ok := options[opt]
 		if !ok {
@@ -149,9 +143,25 @@ func determineInputFiles(source string, options map[string]string) ([]string, er
 			break
 		}
 	}
+	files := map[string]bool{}
+	if err := findFiles(files, source); err != nil {
+		return nil, err
+	}
+	applyIncludeList(files, source, options)
+	applyExcludeList(files, source, options)
+	var list []string
+	for name, ok := range files {
+		if ok {
+			list = append(list, name)
+		}
+	}
+	sort.Strings(list)
+	return list, nil
+}
+
+func findFiles(files map[string]bool, source string) error {
 	const maxDepth = 1
-	var files []string
-	err := filepath.Walk(source, func(path string, info os.FileInfo, err error) error {
+	return filepath.Walk(source, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -163,14 +173,34 @@ func determineInputFiles(source string, options map[string]string) ([]string, er
 			return nil
 		}
 		if filepath.Ext(path) == ".proto" {
-			files = append(files, path)
+			files[path] = true
 		}
 		return nil
 	})
-	if err != nil {
-		return nil, err
+}
+
+func applyIncludeList(files map[string]bool, sourceDirectory string, options map[string]string) {
+	list, ok := options["include-list"]
+	if !ok {
+		return
 	}
-	return files, err
+	// Ignore any discovered paths, only the paths from the include list apply.
+	for k := range files {
+		files[k] = false
+	}
+	for _, p := range strings.Split(list, ",") {
+		files[path.Join(sourceDirectory, p)] = true
+	}
+}
+
+func applyExcludeList(files map[string]bool, sourceDirectory string, options map[string]string) {
+	list, ok := options["exclude-list"]
+	if !ok {
+		return
+	}
+	for _, p := range strings.Split(list, ",") {
+		files[path.Join(sourceDirectory, p)] = false
+	}
 }
 
 func newCompilerVersion() *pluginpb.Version {

--- a/generator/internal/parser/protobuf.go
+++ b/generator/internal/parser/protobuf.go
@@ -127,6 +127,12 @@ func protoc(tempFile string, files []string, options map[string]string) ([]byte,
 }
 
 func determineInputFiles(source string, options map[string]string) ([]string, error) {
+	if _, ok := options["include-list"]; ok {
+		if _, ok := options["exclude-list"]; ok {
+			return nil, fmt.Errorf("cannot use both `exclude-list` and `include-list` in the source options")
+		}
+	}
+
 	// `config.Source` is relative to the `googleapis-root` (or `extra-protos-root`) if
 	// that is set. It should always be a directory and by default all the
 	// the files in that directory are used.
@@ -185,9 +191,7 @@ func applyIncludeList(files map[string]bool, sourceDirectory string, options map
 		return
 	}
 	// Ignore any discovered paths, only the paths from the include list apply.
-	for k := range files {
-		files[k] = false
-	}
+	clear(files)
 	for _, p := range strings.Split(list, ",") {
 		files[path.Join(sourceDirectory, p)] = true
 	}
@@ -199,7 +203,7 @@ func applyExcludeList(files map[string]bool, sourceDirectory string, options map
 		return
 	}
 	for _, p := range strings.Split(list, ",") {
-		files[path.Join(sourceDirectory, p)] = false
+		delete(files, path.Join(sourceDirectory, p))
 	}
 }
 

--- a/generator/internal/parser/protobuf_test.go
+++ b/generator/internal/parser/protobuf_test.go
@@ -1474,8 +1474,9 @@ func newTestCodeGeneratorRequest(t *testing.T, filename string) *pluginpb.CodeGe
 	options := map[string]string{
 		"googleapis-root":   "../../testdata/googleapis",
 		"extra-protos-root": "testdata",
+		"include-list":      filename,
 	}
-	request, err := newCodeGeneratorRequest(filename, options)
+	request, err := newCodeGeneratorRequest("testdata", options)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/generator/internal/sidekick/sidekick_test.go
+++ b/generator/internal/sidekick/sidekick_test.go
@@ -203,13 +203,17 @@ func TestRustBootstrapWkt(t *testing.T) {
 		Source        string
 		ServiceConfig string
 		Name          string
-		ExtraOptions  map[string]string
+		SourceOptions map[string]string
+		CodecOptions  map[string]string
 	}
 	configs := []TestConfig{
 		{
-			Source: "google/protobuf/source_context.proto",
+			Source: "google/protobuf",
 			Name:   "wkt",
-			ExtraOptions: map[string]string{
+			SourceOptions: map[string]string{
+				"include-list": "source_context.proto",
+			},
+			CodecOptions: map[string]string{
 				"module-path": "crate",
 			},
 		},
@@ -231,7 +235,10 @@ func TestRustBootstrapWkt(t *testing.T) {
 				"generate-module": "true",
 			},
 		}
-		for k, v := range config.ExtraOptions {
+		for k, v := range config.SourceOptions {
+			cmdLine.Source[k] = v
+		}
+		for k, v := range config.CodecOptions {
 			cmdLine.Codec[k] = v
 		}
 		cmdGenerate, _, _ := cmdSidekick.lookup([]string{"generate"})

--- a/generator/testdata/rust/protobuf/golden/wkt/generated/wkt/.sidekick.toml
+++ b/generator/testdata/rust/protobuf/golden/wkt/generated/wkt/.sidekick.toml
@@ -15,10 +15,11 @@
 [general]
 language = 'rust'
 specification-format = 'protobuf'
-specification-source = 'google/protobuf/source_context.proto'
+specification-source = 'google/protobuf'
 
 [source]
 googleapis-root = 'testdata'
+include-list = 'source_context.proto'
 
 [codec]
 copyright-year = '2025'


### PR DESCRIPTION
Sometimes we want to generate client libraries or modules using only a subset
of the protos found in a given directory. This introduces configuration options
to only include explicitly listed files, and to exclude some files.

Motivated by #766
