### PR TITLE
feat(generator): support more `-root` options

### DIFF
--- a/generator/internal/parser/protobuf.go
+++ b/generator/internal/parser/protobuf.go
@@ -106,7 +106,7 @@ func protoc(tempFile string, files []string, options map[string]string) ([]byte,
 		"--retain_options",
 		"--descriptor_set_out", tempFile,
 	}
-	for _, name := range []string{"extra-protos-root", "googleapis-root"} {
+	for _, name := range SourceRoots(options) {
 		if path, ok := options[name]; ok {
 			args = append(args, "--proto_path")
 			args = append(args, path)
@@ -133,10 +133,10 @@ func determineInputFiles(source string, options map[string]string) ([]string, er
 		}
 	}
 
-	// `config.Source` is relative to the `googleapis-root` (or `extra-protos-root`) if
-	// that is set. It should always be a directory and by default all the
-	// the files in that directory are used.
-	for _, opt := range []string{"extra-protos-root", "googleapis-root"} {
+	// `config.Source` is relative to the `googleapis-root`,
+	// or `extra-protos-root`, when that is set. It should always be a directory
+	// and by default all the the files in that directory are used.
+	for _, opt := range SourceRoots(options) {
 		location, ok := options[opt]
 		if !ok {
 			// Ignore options that are not set

--- a/generator/internal/parser/service_config.go
+++ b/generator/internal/parser/service_config.go
@@ -54,7 +54,7 @@ func readServiceConfig(serviceConfigPath string) (*serviceconfig.Service, error)
 // path (or `extra-protos-root` when set). This finds the right path given a
 // configuration
 func findServiceConfigPath(serviceConfigFile string, options map[string]string) string {
-	for _, opt := range []string{"extra-protos-root", "googleapis-root"} {
+	for _, opt := range SourceRoots(options) {
 		dir, ok := options[opt]
 		if !ok {
 			// Ignore options that are not set

--- a/generator/internal/parser/source_roots.go
+++ b/generator/internal/parser/source_roots.go
@@ -1,0 +1,27 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import "strings"
+
+func SourceRoots(options map[string]string) []string {
+	var roots []string
+	for name := range options {
+		if strings.HasSuffix(name, "-root") {
+			roots = append(roots, name)
+		}
+	}
+	return roots
+}


### PR DESCRIPTION
We will need to add more `-root` options for the protobuf well-known
protos. And someday we may use `-root` for the discovery doc or OpenAPI
sources.

Part of the work for #766
