### PR TITLE
feat(generator/rust): re-export LRO poller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,7 +2386,6 @@ dependencies = [
  "gcp-sdk-longrunning",
  "google-cloud-iam-v1",
  "google-cloud-location",
- "google-cloud-lro",
  "google-cloud-secretmanager-v1",
  "google-cloud-wkt",
  "google-cloud-workflows-v1",

--- a/generator/internal/rust/templates/crate/src/lib.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/lib.rs.mustache
@@ -77,3 +77,7 @@ pub(crate) mod info {
 }
 
 {{/Codec.HasServices}}
+{{#Codec.HasLROs}}
+pub use lro::Poller;
+pub use lro::PollingResult;
+{{/Codec.HasLROs}}

--- a/src/generated/api/servicemanagement/v1/src/lib.rs
+++ b/src/generated/api/servicemanagement/v1/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/api/serviceusage/v1/src/lib.rs
+++ b/src/generated/api/serviceusage/v1/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/appengine/v1/src/lib.rs
+++ b/src/generated/appengine/v1/src/lib.rs
@@ -73,3 +73,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/bigtable/admin/v2/src/lib.rs
+++ b/src/generated/bigtable/admin/v2/src/lib.rs
@@ -67,3 +67,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/cloud/apigateway/v1/src/lib.rs
+++ b/src/generated/cloud/apigateway/v1/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/cloud/assuredworkloads/v1/src/lib.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/cloud/datacatalog/v1/src/lib.rs
+++ b/src/generated/cloud/datacatalog/v1/src/lib.rs
@@ -68,3 +68,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/cloud/datafusion/v1/src/lib.rs
+++ b/src/generated/cloud/datafusion/v1/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/cloud/deploy/v1/src/lib.rs
+++ b/src/generated/cloud/deploy/v1/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/cloud/eventarc/v1/src/lib.rs
+++ b/src/generated/cloud/eventarc/v1/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/cloud/functions/v2/src/lib.rs
+++ b/src/generated/cloud/functions/v2/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/cloud/kms/v1/src/lib.rs
+++ b/src/generated/cloud/kms/v1/src/lib.rs
@@ -69,3 +69,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/cloud/networkmanagement/v1/src/lib.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/lib.rs
@@ -67,3 +67,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/cloud/redis/v1/src/lib.rs
+++ b/src/generated/cloud/redis/v1/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/cloud/resourcemanager/v3/src/lib.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/lib.rs
@@ -72,3 +72,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/cloud/run/v2/src/lib.rs
+++ b/src/generated/cloud/run/v2/src/lib.rs
@@ -71,3 +71,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/cloud/translate/v3/src/lib.rs
+++ b/src/generated/cloud/translate/v3/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/cloud/videointelligence/v1/src/lib.rs
+++ b/src/generated/cloud/videointelligence/v1/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/cloud/vision/v1/src/lib.rs
+++ b/src/generated/cloud/vision/v1/src/lib.rs
@@ -67,3 +67,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/cloud/vpcaccess/v1/src/lib.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/cloud/webrisk/v1/src/lib.rs
+++ b/src/generated/cloud/webrisk/v1/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/cloud/workflows/v1/src/lib.rs
+++ b/src/generated/cloud/workflows/v1/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/datastore/admin/v1/src/lib.rs
+++ b/src/generated/datastore/admin/v1/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/devtools/artifactregistry/v1/src/lib.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/devtools/cloudbuild/v1/src/lib.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/devtools/cloudbuild/v2/src/lib.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/iam/v2/src/lib.rs
+++ b/src/generated/iam/v2/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/identity/accesscontextmanager/v1/src/lib.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/monitoring/metricsscope/v1/src/lib.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/spanner/admin/database/v1/src/lib.rs
+++ b/src/generated/spanner/admin/database/v1/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/spanner/admin/instance/v1/src/lib.rs
+++ b/src/generated/spanner/admin/instance/v1/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/generated/storagetransfer/v1/src/lib.rs
+++ b/src/generated/storagetransfer/v1/src/lib.rs
@@ -66,3 +66,6 @@ pub(crate) mod info {
         };
     }
 }
+
+pub use lro::Poller;
+pub use lro::PollingResult;

--- a/src/integration-tests/Cargo.toml
+++ b/src/integration-tests/Cargo.toml
@@ -31,7 +31,6 @@ gax                = { path = "../../src/gax", package = "gcp-sdk-gax" }
 iam_v1             = { path = "../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 loc                = { path = "../../src/generated/cloud/location", package = "google-cloud-location" }
 longrunning        = { path = "../../src/generated/longrunning", package = "gcp-sdk-longrunning" }
-lro                = { path = "../../src/lro", package = "google-cloud-lro" }
 rand               = "0.9"
 serde_json         = "1"
 tokio              = { version = "1.42", features = ["full", "macros"] }

--- a/src/integration-tests/src/workflows.rs
+++ b/src/integration-tests/src/workflows.rs
@@ -15,7 +15,7 @@
 use crate::Result;
 use gax::exponential_backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
 use gax::{error::Error, options::RequestOptionsBuilder};
-use lro::Poller;
+use wf::Poller;
 use rand::{distr::Alphanumeric, Rng};
 use std::time::Duration;
 
@@ -158,13 +158,13 @@ main:
     let mut backoff = Duration::from_millis(100);
     while let Some(status) = create.poll().await {
         match status {
-            lro::PollingResult::PollingError(e) => {
+            wf::PollingResult::PollingError(e) => {
                 println!("    error polling create LRO, continuing {e}");
             }
-            lro::PollingResult::InProgress(m) => {
+            wf::PollingResult::InProgress(m) => {
                 println!("    create LRO still in progress, metadata={m:?}");
             }
-            lro::PollingResult::Completed(r) => match r {
+            wf::PollingResult::Completed(r) => match r {
                 Err(e) => {
                     println!("    create LRO finished with error={e}\n\n");
                     return Err(e);
@@ -187,13 +187,13 @@ main:
     let mut backoff = Duration::from_millis(100);
     while let Some(status) = delete.poll().await {
         match status {
-            lro::PollingResult::PollingError(e) => {
+            wf::PollingResult::PollingError(e) => {
                 println!("    error polling delete LRO, continuing {e:?}");
             }
-            lro::PollingResult::InProgress(m) => {
+            wf::PollingResult::InProgress(m) => {
                 println!("    delete LRO still in progress, metadata={m:?}");
             }
-            lro::PollingResult::Completed(r) => {
+            wf::PollingResult::Completed(r) => {
                 println!("    delete LRO finished, result={r:?}");
                 let _ = r?;
             }

--- a/src/integration-tests/src/workflows.rs
+++ b/src/integration-tests/src/workflows.rs
@@ -15,9 +15,9 @@
 use crate::Result;
 use gax::exponential_backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
 use gax::{error::Error, options::RequestOptionsBuilder};
-use wf::Poller;
 use rand::{distr::Alphanumeric, Rng};
 use std::time::Duration;
+use wf::Poller;
 
 pub const WORKFLOW_ID_LENGTH: usize = 64;
 


### PR DESCRIPTION
Applications need to say `use ...::Poller` to use the `Poller` trait.
Since there may be multiple versions of the `lro` crate, we should
re-export the trait so applications may refer to "the same Poller that
crate ${crate} is using".

Motivated by #574, and related to #919 