### PR TITLE
feat(generator/protobuf): ignore more unused docs

### DIFF
--- a/generator/internal/parser/protobuf.go
+++ b/generator/internal/parser/protobuf.go
@@ -222,11 +222,19 @@ func newCompilerVersion() *pluginpb.Version {
 
 const (
 	// From https://pkg.go.dev/google.golang.org/protobuf/types/descriptorpb#FileDescriptorProto
-	fileDescriptorMessageType = 4
-	fileDescriptorEnumType    = 5
-	fileDescriptorService     = 6
-	fileDescriptorExtension   = 7
-	fileDescriptorOptions     = 8
+	fileDescriptorName             = 1
+	fileDescriptorPackage          = 2
+	fileDescriptorDependency       = 3
+	fileDescriptorMessageType      = 4
+	fileDescriptorEnumType         = 5
+	fileDescriptorService          = 6
+	fileDescriptorExtension        = 7
+	fileDescriptorOptions          = 8
+	fileDescriptorSourceCodeInfo   = 9
+	fileDescriptorPublicDependency = 10
+	fileDescriptorWeakDependency   = 11
+	fileDescriptorSyntax           = 12
+	fileDescriptorEdition          = 14
 
 	// From https://pkg.go.dev/google.golang.org/protobuf/types/descriptorpb#ServiceDescriptorProto
 	serviceDescriptorProtoMethod = 2
@@ -349,11 +357,14 @@ func makeAPIForProtobuf(serviceConfig *serviceconfig.Service, req *pluginpb.Code
 			case fileDescriptorService:
 				sFQN := fFQN + "." + f.GetService()[p[1]].GetName()
 				addServiceDocumentation(state, p[2:], loc.GetLeadingComments(), sFQN)
-			case fileDescriptorExtension, fileDescriptorOptions:
+			case fileDescriptorName, fileDescriptorPackage, fileDescriptorDependency,
+				fileDescriptorExtension, fileDescriptorOptions, fileDescriptorSourceCodeInfo,
+				fileDescriptorPublicDependency, fileDescriptorWeakDependency,
+				fileDescriptorSyntax, fileDescriptorEdition:
 				// We ignore this type of documentation because it produces no
 				// output in the generated code.
 			default:
-				slog.Warn("dropped unknown documentation type", "loc", p, "docs", loc.GetLeadingComments())
+				slog.Warn("dropped unknown documentation type", "loc", p, "docs", loc)
 			}
 		}
 		result.Services = append(result.Services, fileServices...)


### PR DESCRIPTION
It is possible to document more Protobuf elements that we do not use,
including `syntax` (which sometimes [is accidentally docummented]) and
`edition` and the package name.

[is accidentally documented]: https://github.com/googleapis/googleapis/blob/0a459af4362c0e41b9723dd4d7edc022c552db40/grafeas/v1/dsse_attestation.proto#L14

Motivated by #1070
