### PR TITLE
fix(generator/go): update a reference from NestedMessages => Messages

### DIFF
--- a/generator/internal/golang/templates/message.mustache
+++ b/generator/internal/golang/templates/message.mustache
@@ -27,9 +27,9 @@ type {{Codec.Name}} struct {
     {{Codec.Name}} {{Codec.FieldType}} `json:"{{JSONName}},omitempty"`
     {{/Fields}}
 }
-{{#NestedMessages}}
+{{#Messages}}
 {{> message}}
-{{/NestedMessages}}
+{{/Messages}}
 {{#Enums}}
 {{> enum}}
 {{/Enums}}


### PR DESCRIPTION
- update a reference from `NestedMessages` to `Messages`

I don't see `NestedMessages` populated in the model but do see `Messages` (as a field on Message). I'm guessing that the mustache library doesn't complain about undefined lists - treating them as empty lists? It would be great if we could get that library to fast-fail for more cases.
