### PR TITLE
feat(generator/dart): emit enums

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -295,8 +295,8 @@ type Field struct {
 	ID string
 	// Typez is the datatype of the field.
 	Typez Typez
-	// TypezID is the ID is the ID of the type the field refers to. This value
-	// is populated for message-like types only.
+	// TypezID is the ID of the type the field refers to. This value is populated
+	// for message-like types only.
 	TypezID string
 	// JSONName is the name of the field as it appears in JSON. Useful for
 	// serializing to JSON.

--- a/generator/internal/dart/dart.go
+++ b/generator/internal/dart/dart.go
@@ -136,29 +136,20 @@ func methodInOutTypeName(id string, s *api.APIState) string {
 
 func messageName(m *api.Message) string {
 	if m.Parent != nil {
-		return messageName(m.Parent) + "_" + strcase.ToCamel(m.Name)
+		return messageName(m.Parent) + "$" + strcase.ToCamel(m.Name)
 	}
 	return toPascal(m.Name)
 }
 
 func enumName(e *api.Enum) string {
 	if e.Parent != nil {
-		return messageName(e.Parent) + "_" + strcase.ToCamel(e.Name)
+		return messageName(e.Parent) + "$" + strcase.ToCamel(e.Name)
 	}
 	return strcase.ToCamel(e.Name)
 }
 
 func enumValueName(e *api.EnumValue) string {
-	var name string
-	if strings.ToUpper(e.Name) == e.Name {
-		name = e.Name
-	} else {
-		name = strcase.ToScreamingSnake(e.Name)
-	}
-	if e.Parent.Parent != nil {
-		return messageName(e.Parent.Parent) + "_" + name
-	}
-	return name
+	return strcase.ToLowerCamel(e.Name)
 }
 
 func bodyAccessor(m *api.Method) string {

--- a/generator/internal/dart/dart_test.go
+++ b/generator/internal/dart/dart_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/googleapis/google-cloud-rust/generator/internal/api"
+	"github.com/googleapis/google-cloud-rust/generator/internal/sample"
 )
 
 func TestDart_GeneratedFiles(t *testing.T) {
@@ -55,5 +56,103 @@ func TestDart_TemplatesAvailable(t *testing.T) {
 
 	if count == 0 {
 		t.Errorf("no dart templates found")
+	}
+}
+
+func TestDart_MessageNames(t *testing.T) {
+	r := sample.Replication()
+	a := sample.Automatic()
+	model := api.NewTestAPI([]*api.Message{r, a}, []*api.Enum{}, []*api.Service{})
+	model.PackageName = "test"
+	annotateModel(model, map[string]string{})
+
+	for _, test := range []struct {
+		message *api.Message
+		want    string
+	}{
+		{message: r, want: "Replication"},
+		{message: a, want: "Replication$Automatic"},
+	} {
+		t.Run(test.want, func(t *testing.T) {
+			if got := messageName(test.message); got != test.want {
+				t.Errorf("mismatched message name, got=%q, want=%q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestDart_EnumNames(t *testing.T) {
+	parent := &api.Message{
+		Name:    "SecretVersion",
+		ID:      ".test.SecretVersion",
+		Package: "test",
+		Fields: []*api.Field{
+			{
+				Name:     "automatic",
+				Typez:    api.MESSAGE_TYPE,
+				TypezID:  ".test.Automatic",
+				Optional: true,
+				Repeated: false,
+			},
+		},
+	}
+	nested := &api.Enum{
+		Name:    "State",
+		ID:      ".test.SecretVersion.State",
+		Parent:  parent,
+		Package: "test",
+	}
+	non_nested := &api.Enum{
+		Name:    "Code",
+		ID:      ".test.Code",
+		Package: "test",
+	}
+
+	model := api.NewTestAPI([]*api.Message{parent}, []*api.Enum{nested, non_nested}, []*api.Service{})
+	model.PackageName = "test"
+	annotateModel(model, map[string]string{})
+
+	for _, test := range []struct {
+		enum     *api.Enum
+		wantEnum string
+	}{
+		{non_nested, "Code"},
+		{nested, "SecretVersion$State"},
+	} {
+		if got := enumName(test.enum); got != test.wantEnum {
+			t.Errorf("c.enumName(%q) = %q; want = %s", test.enum.Name, got, test.wantEnum)
+		}
+	}
+}
+
+func TestDart_EnumValues(t *testing.T) {
+	enumValueSimple := &api.EnumValue{
+		Name: "NAME",
+		ID:   ".test.v1.SomeMessage.SomeEnum.NAME",
+	}
+	enumValueCompound := &api.EnumValue{
+		Name: "ENUM_VALUE",
+		ID:   ".test.v1.SomeMessage.SomeEnum.ENUM_VALUE",
+	}
+	someEnum := &api.Enum{
+		Name:    "SomeEnum",
+		ID:      ".test.v1.SomeMessage.SomeEnum",
+		Values:  []*api.EnumValue{enumValueSimple, enumValueCompound},
+		Package: "test.v1",
+	}
+	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{someEnum}, []*api.Service{})
+	model.PackageName = "test"
+	annotateModel(model, map[string]string{})
+
+	for _, test := range []struct {
+		value    *api.EnumValue
+		wantName string
+	}{
+		{enumValueSimple, "name"},
+		{enumValueCompound, "enumValue"},
+	} {
+		if got := enumValueName(test.value); got != test.wantName {
+			t.Errorf("c.enumName(%q) = %q; want = %s", test.value.Name, got, test.wantName)
+		}
 	}
 }

--- a/generator/internal/dart/darttemplate.go
+++ b/generator/internal/dart/darttemplate.go
@@ -38,6 +38,8 @@ type modelAnnotations struct {
 }
 
 type serviceAnnotations struct {
+	// The service name using Dart naming conventions.
+	Name        string
 	FieldName   string
 	StructName  string
 	DocLines    []string
@@ -98,7 +100,6 @@ type enumAnnotation struct {
 type enumValueAnnotation struct {
 	DocLines []string
 	Name     string
-	EnumType string
 }
 
 // annotateModel creates a struct used as input for Mustache templates.
@@ -155,7 +156,7 @@ func annotateModel(model *api.API, options map[string]string) (*modelAnnotations
 			}
 			return ""
 		}(),
-		DocLines: strings.Split(model.Description, "\n"),
+		DocLines: formatDocComments(model.Description, model.State),
 	}
 
 	model.Codec = ann
@@ -171,6 +172,7 @@ func annotateService(s *api.Service, state *api.APIState) {
 		annotateMethod(m, s, state)
 	}
 	ann := &serviceAnnotations{
+		Name:        s.Name,
 		FieldName:   strcase.ToLowerCamel(s.Name),
 		StructName:  s.Name,
 		DocLines:    formatDocComments(s.Documentation, state),
@@ -240,7 +242,7 @@ func annotateField(field *api.Field, state *api.APIState) {
 
 func annotateEnum(e *api.Enum, state *api.APIState) {
 	for _, ev := range e.Values {
-		annotateEnumValue(ev, e, state)
+		annotateEnumValue(ev, state)
 	}
 	e.Codec = &enumAnnotation{
 		Name:     enumName(e),
@@ -248,10 +250,9 @@ func annotateEnum(e *api.Enum, state *api.APIState) {
 	}
 }
 
-func annotateEnumValue(ev *api.EnumValue, e *api.Enum, state *api.APIState) {
+func annotateEnumValue(ev *api.EnumValue, state *api.APIState) {
 	ev.Codec = &enumValueAnnotation{
 		DocLines: formatDocComments(ev.Documentation, state),
 		Name:     enumValueName(ev),
-		EnumType: enumName(e),
 	}
 }

--- a/generator/internal/dart/templates/enum.mustache
+++ b/generator/internal/dart/templates/enum.mustache
@@ -22,10 +22,10 @@ class {{Codec.Name}} {
   {{#Codec.DocLines}}
   /// {{{.}}}
   {{/Codec.DocLines}}
-  static const {{Parent.Codec.Name}} {{Codec.Name}} = {{Parent.Codec.Name}}({{Number}});
+  static const {{Parent.Codec.Name}} {{Codec.Name}} = {{Parent.Codec.Name}}('{{Name}}');
 
   {{/Values}}
-  final int value;
+  final String value;
 
   const {{Codec.Name}}(this.value);
 }

--- a/generator/internal/dart/templates/enum.mustache
+++ b/generator/internal/dart/templates/enum.mustache
@@ -13,37 +13,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-// Copyright {{Codec.CopyrightYear}} Google LLC
-{{#Codec.BoilerPlate}}
-//{{{.}}}
-{{/Codec.BoilerPlate}}
 
-/// The Google Cloud client for the {{Title}}.
-///
-{{#Codec.DocLines}}
-/// {{{.}}}
-{{/Codec.DocLines}}
-library;
-
-{{#Services}}
 {{#Codec.DocLines}}
 /// {{{.}}}
 {{/Codec.DocLines}}
 class {{Codec.Name}} {
-  {{#Methods}}
-
+  {{#Values}}
   {{#Codec.DocLines}}
   /// {{{.}}}
   {{/Codec.DocLines}}
-  void {{Codec.Name}}() {
-    // TODO:
-  }
-  {{/Methods}}
+  static const {{Parent.Codec.Name}} {{Codec.Name}} = {{Parent.Codec.Name}}({{Number}});
+
+  {{/Values}}
+  final int value;
+
+  const {{Codec.Name}}(this.value);
 }
-{{/Services}}
-{{#Messages}}
-{{> message}}
-{{/Messages}}
-{{#Enums}}
-{{> enum}}
-{{/Enums}}

--- a/generator/internal/dart/templates/message.mustache
+++ b/generator/internal/dart/templates/message.mustache
@@ -13,37 +13,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-// Copyright {{Codec.CopyrightYear}} Google LLC
-{{#Codec.BoilerPlate}}
-//{{{.}}}
-{{/Codec.BoilerPlate}}
+{{^IsMap}}
 
-/// The Google Cloud client for the {{Title}}.
-///
-{{#Codec.DocLines}}
-/// {{{.}}}
-{{/Codec.DocLines}}
-library;
-
-{{#Services}}
 {{#Codec.DocLines}}
 /// {{{.}}}
 {{/Codec.DocLines}}
 class {{Codec.Name}} {
-  {{#Methods}}
-
-  {{#Codec.DocLines}}
-  /// {{{.}}}
-  {{/Codec.DocLines}}
-  void {{Codec.Name}}() {
-    // TODO:
-  }
-  {{/Methods}}
+  // TODO:
 }
-{{/Services}}
 {{#Messages}}
 {{> message}}
 {{/Messages}}
 {{#Enums}}
 {{> enum}}
 {{/Enums}}
+{{/IsMap}}

--- a/generator/testdata/dart/protobuf/golden/secretmanager/secretmanager.dart
+++ b/generator/testdata/dart/protobuf/golden/secretmanager/secretmanager.dart
@@ -174,25 +174,25 @@ class SecretVersion {
 /// it can be accessed.
 class SecretVersion$State {
   /// Not specified. This value is unused and invalid.
-  static const SecretVersion$State stateUnspecified = SecretVersion$State(0);
+  static const SecretVersion$State stateUnspecified = SecretVersion$State('STATE_UNSPECIFIED');
 
   /// The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] may be
   /// accessed.
-  static const SecretVersion$State enabled = SecretVersion$State(1);
+  static const SecretVersion$State enabled = SecretVersion$State('ENABLED');
 
   /// The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] may not
   /// be accessed, but the secret data is still available and can be placed
   /// back into the
   /// [ENABLED][google.cloud.secretmanager.v1.SecretVersion.State.ENABLED]
   /// state.
-  static const SecretVersion$State disabled = SecretVersion$State(2);
+  static const SecretVersion$State disabled = SecretVersion$State('DISABLED');
 
   /// The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] is
   /// destroyed and the secret data is no longer stored. A version may not
   /// leave this state once entered.
-  static const SecretVersion$State destroyed = SecretVersion$State(3);
+  static const SecretVersion$State destroyed = SecretVersion$State('DESTROYED');
 
-  final int value;
+  final String value;
 
   const SecretVersion$State(this.value);
 }

--- a/generator/testdata/dart/protobuf/golden/secretmanager/secretmanager.dart
+++ b/generator/testdata/dart/protobuf/golden/secretmanager/secretmanager.dart
@@ -169,8 +169,56 @@ class SecretVersion {
   // TODO:
 }
 
+/// The state of a
+/// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion], indicating if
+/// it can be accessed.
+class SecretVersion$State {
+  /// Not specified. This value is unused and invalid.
+  static const SecretVersion$State stateUnspecified = SecretVersion$State(0);
+
+  /// The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] may be
+  /// accessed.
+  static const SecretVersion$State enabled = SecretVersion$State(1);
+
+  /// The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] may not
+  /// be accessed, but the secret data is still available and can be placed
+  /// back into the
+  /// [ENABLED][google.cloud.secretmanager.v1.SecretVersion.State.ENABLED]
+  /// state.
+  static const SecretVersion$State disabled = SecretVersion$State(2);
+
+  /// The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] is
+  /// destroyed and the secret data is no longer stored. A version may not
+  /// leave this state once entered.
+  static const SecretVersion$State destroyed = SecretVersion$State(3);
+
+  final int value;
+
+  const SecretVersion$State(this.value);
+}
+
 /// A policy that defines the replication and encryption configuration of data.
 class Replication {
+  // TODO:
+}
+
+/// A replication policy that replicates the
+/// [Secret][google.cloud.secretmanager.v1.Secret] payload without any
+/// restrictions.
+class Replication$Automatic {
+  // TODO:
+}
+
+/// A replication policy that replicates the
+/// [Secret][google.cloud.secretmanager.v1.Secret] payload into the locations
+/// specified in [Secret.replication.user_managed.replicas][]
+class Replication$UserManaged {
+  // TODO:
+}
+
+/// Represents a Replica for this
+/// [Secret][google.cloud.secretmanager.v1.Secret].
+class Replication$UserManaged$Replica {
   // TODO:
 }
 
@@ -183,6 +231,32 @@ class CustomerManagedEncryption {
 /// The replication status of a
 /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
 class ReplicationStatus {
+  // TODO:
+}
+
+/// The replication status of a
+/// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] using
+/// automatic replication.
+/// 
+/// Only populated if the parent [Secret][google.cloud.secretmanager.v1.Secret]
+/// has an automatic replication policy.
+class ReplicationStatus$AutomaticStatus {
+  // TODO:
+}
+
+/// The replication status of a
+/// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] using
+/// user-managed replication.
+/// 
+/// Only populated if the parent [Secret][google.cloud.secretmanager.v1.Secret]
+/// has a user-managed replication policy.
+class ReplicationStatus$UserManagedStatus {
+  // TODO:
+}
+
+/// Describes the status of a user-managed replica for the
+/// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
+class ReplicationStatus$UserManagedStatus$ReplicaStatus {
   // TODO:
 }
 


### PR DESCRIPTION
Update the dart generator to emit enums:

- update the templates to emit enums
- update the templates to traverse into nested messages and enums
- general work towards https://github.com/googleapis/google-cloud-rust/issues/1034

This uses Dart classes to represent enums instead of actual language `enum`s. I assume this will work better with unknown values coming over the wire. And I'm assuming enum values over the wire will be represented by their int values (and not something like their SCREAMING_CAPS string name).

I'm using `'$'` to concatenate nested messages and enums. `'_'` and `''` are also reasonable; nothing's particularly idiomatic. Perhaps shorter names could be used if we determine there are no namespace conflicts in a library?
