### PR TITLE
feat(wkt): support `Any` inside an `Any`

### DIFF
--- a/generator/protojson/README.md
+++ b/generator/protojson/README.md
@@ -1,0 +1,5 @@
+# Test Protobuf to JSON encoding
+
+The documentation for the Protobuf to JSON encoding is not super clear or
+discoverable. In some cases it is easier to write a small golang test and verify
+the output looks like we expect.

--- a/generator/protojson/any_in_any_test.go
+++ b/generator/protojson/any_in_any_test.go
@@ -1,0 +1,82 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protojson
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+type Inner struct {
+	Typez string `json:"@type"`
+	Value string `json:"value"`
+}
+
+type Outer struct {
+	Typez string `json:"@type"`
+	Value Inner  `json:"value"`
+}
+
+func TestAnyInAny(t *testing.T) {
+	input := durationpb.New(123 * time.Second)
+	inner, err := anypb.New(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(inner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var gotInner Inner
+	if err := json.Unmarshal(blob, &gotInner); err != nil {
+		t.Fatal(err)
+	}
+	wantInner := Inner{
+		Typez: "type.googleapis.com/google.protobuf.Duration",
+		Value: "123s",
+	}
+	if diff := cmp.Diff(wantInner, gotInner); diff != "" {
+		t.Errorf("mismatched inner, (-want, +got)\n%s", diff)
+	}
+
+	anyz, err := anypb.New(inner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob, err = protojson.MarshalOptions{UseProtoNames: true}.Marshal(anyz)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var gotOuter Outer
+	if err := json.Unmarshal(blob, &gotOuter); err != nil {
+		t.Fatal(err)
+	}
+	wantOuter := Outer{
+		Typez: "type.googleapis.com/google.protobuf.Any",
+		Value: Inner{
+			Typez: "type.googleapis.com/google.protobuf.Duration",
+			Value: "123s",
+		},
+	}
+	if diff := cmp.Diff(wantOuter, gotOuter); diff != "" {
+		t.Errorf("mismatched inner, (-want, +got)\n%s", diff)
+	}
+}

--- a/src/wkt/src/duration.rs
+++ b/src/wkt/src/duration.rs
@@ -168,6 +168,12 @@ impl crate::message::Message for Duration {
     fn typename() -> &'static str {
         "type.googleapis.com/google.protobuf.Duration"
     }
+    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
+        crate::message::to_json_string(self)
+    }
+    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError> {
+        crate::message::from_value(map)
+    }
 }
 
 /// Converts a [Duration] to its [String] representation.

--- a/src/wkt/src/message.rs
+++ b/src/wkt/src/message.rs
@@ -14,12 +14,84 @@
 
 //! Define traits required of all messages.
 
+pub(crate) type Map = serde_json::Map<String, serde_json::Value>;
+use crate::AnyError as Error;
+
 /// A trait that must be implemented by all messages.
 ///
 /// Messages sent to and received from Google Cloud services may be wrapped in
 /// [Any][crate::any::Any]. `Any` uses a `@type` field to encoding the type
 /// name and then validates extraction and insertion against this type.
-pub trait Message {
+pub trait Message: serde::ser::Serialize + serde::de::DeserializeOwned {
     /// The typename of this message.
     fn typename() -> &'static str;
+
+    /// Store the value into a JSON object.
+    fn to_map(&self) -> Result<Map, Error> {
+        to_json_object(self)
+    }
+
+    /// Extract the value from a JSON object.
+    fn from_map(map: &Map) -> Result<Self, Error> {
+        serde_json::from_value::<Self>(serde_json::Value::Object(map.clone())).map_err(Error::deser)
+    }
+}
+
+pub(crate) fn to_json_object<T>(message: &T) -> Result<Map, Error>
+where
+    T: Message,
+{
+    use serde_json::Value;
+
+    let value = serde_json::to_value(message).map_err(Error::ser)?;
+    match value {
+        Value::Object(mut map) => {
+            map.insert(
+                "@type".to_string(),
+                Value::String(T::typename().to_string()),
+            );
+            Ok(map)
+        }
+        _ => Err(unexpected_json_type()),
+    }
+}
+
+pub(crate) fn to_json_string<T>(message: &T) -> Result<Map, Error>
+where
+    T: Message,
+{
+    use serde_json::Value;
+    let value = serde_json::to_value(message).map_err(Error::ser)?;
+    match value {
+        Value::String(s) => {
+            // Only a few well-known messages are serialized into something
+            // other than a object. In all cases, they are serialized using
+            // a small JSON object, with the string in the `value` field.
+            let map: Map = [("@type", T::typename().to_string()), ("value", s)]
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), Value::String(v)))
+                .collect();
+            Ok(map)
+        }
+        _ => Err(unexpected_json_type()),
+    }
+}
+
+pub(crate) fn from_value<T>(map: &Map) -> Result<T, Error>
+where
+    T: serde::de::DeserializeOwned,
+{
+     map
+        .get("value")
+        .map(|v| serde_json::from_value::<T>(v.clone()))
+        .ok_or_else(missing_value_field)?
+        .map_err(Error::deser)
+}
+
+fn missing_value_field() -> Error {
+    Error::deser("value field is missing")
+}
+
+fn unexpected_json_type() -> Error {
+    Error::ser("unexpected JSON type, only Object and String are supported")
 }

--- a/src/wkt/src/message.rs
+++ b/src/wkt/src/message.rs
@@ -81,8 +81,7 @@ pub(crate) fn from_value<T>(map: &Map) -> Result<T, Error>
 where
     T: serde::de::DeserializeOwned,
 {
-     map
-        .get("value")
+    map.get("value")
         .map(|v| serde_json::from_value::<T>(v.clone()))
         .ok_or_else(missing_value_field)?
         .map_err(Error::deser)

--- a/src/wkt/src/timestamp.rs
+++ b/src/wkt/src/timestamp.rs
@@ -169,6 +169,12 @@ impl crate::message::Message for Timestamp {
     fn typename() -> &'static str {
         "type.googleapis.com/google.protobuf.Timestamp"
     }
+    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
+        crate::message::to_json_string(self)
+    }
+    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError> {
+        crate::message::from_value(map)
+    }
 }
 
 use time::format_description::well_known::Rfc3339;

--- a/src/wkt/tests/any.rs
+++ b/src/wkt/tests/any.rs
@@ -55,3 +55,16 @@ fn roundtrip_duration() -> Result {
     assert_eq!(input, output);
     Ok(())
 }
+
+#[test]
+fn roundtrip_any() -> Result {
+    let input = Duration::new(12, 3456)?;
+    let inner = Any::try_from(&input)?;
+    let any = Any::try_from(&inner)?;
+    let json = serde_json::to_value(any)?;
+    let any = serde_json::from_value::<Any>(json)?;
+    let inner = any.try_into_message::<Any>()?;
+    let output = inner.try_into_message::<Duration>()?;
+    assert_eq!(input, output);
+    Ok(())
+}


### PR DESCRIPTION
Apparently some of our APIs like to store an `Any` object inside another `Any` object.

Fixes #1090
