### PR TITLE
fix(auth)!: stable token expiration type

### DIFF
--- a/src/auth/src/credentials/mds_credential.rs
+++ b/src/auth/src/credentials/mds_credential.rs
@@ -23,7 +23,6 @@ use reqwest::Client;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
-use time::OffsetDateTime;
 
 const METADATA_FLAVOR_VALUE: &str = "Google";
 const METADATA_FLAVOR: &str = "metadata-flavor";
@@ -157,7 +156,7 @@ impl TokenProvider for MDSAccessTokenProvider {
             token_type: response.token_type,
             expires_at: response
                 .expires_in
-                .map(|d| OffsetDateTime::now_utc() + Duration::from_secs(d)),
+                .map(|d| std::time::Instant::now() + Duration::from_secs(d)),
             metadata: None,
         };
         Ok(token)
@@ -371,7 +370,7 @@ mod test {
 
         let tp = MDSAccessTokenProvider { endpoint: endpoint };
         let mdsc = MDSCredential { token_provider: tp };
-        let now = OffsetDateTime::now_utc();
+        let now = std::time::Instant::now();
         let token = mdsc.get_token().await?;
         assert_eq!(token.token, "test-access-token");
         assert_eq!(token.token_type, "test-token-type");

--- a/src/auth/src/credentials/user_credential.rs
+++ b/src/auth/src/credentials/user_credential.rs
@@ -20,7 +20,6 @@ use http::header::{HeaderName, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 use reqwest::{Client, Method};
 use std::sync::Arc;
 use std::time::Duration;
-use time::OffsetDateTime;
 
 const OAUTH2_ENDPOINT: &str = "https://oauth2.googleapis.com/token";
 
@@ -101,7 +100,7 @@ impl TokenProvider for UserTokenProvider {
             token_type: response.token_type,
             expires_at: response
                 .expires_in
-                .map(|d| OffsetDateTime::now_utc() + Duration::from_secs(d)),
+                .map(|d| std::time::Instant::now() + Duration::from_secs(d)),
             metadata: None,
         };
         Ok(token)
@@ -539,7 +538,7 @@ mod test {
             token_provider,
             quota_project_id: None,
         };
-        let now = OffsetDateTime::now_utc();
+        let now = std::time::Instant::now();
         let token = uc.get_token().await?;
         assert_eq!(token.token, "test-access-token");
         assert_eq!(token.token_type, "test-token-type");

--- a/src/auth/src/token.rs
+++ b/src/auth/src/token.rs
@@ -31,7 +31,18 @@ pub struct Token {
     /// The instant at which the token expires.
     ///
     /// If `None`, the token does not expire or its expiration is unknown.
-    pub expires_at: Option<time::OffsetDateTime>,
+    ///
+    /// Note that the `Instant` is not valid across processes. It is
+    /// recommended to let the authentication library refresh tokens within a
+    /// process instead of handling expirations yourself. If you do need to
+    /// copy an expiration across processes, consider converting it to a
+    /// `time::OffsetDateTime` first:
+    ///
+    /// ```
+    /// # let expires_at = Some(std::time::Instant::now());
+    /// expires_at.map(|i| time::OffsetDateTime::now_utc() + (i - std::time::Instant::now()));
+    /// ```
+    pub expires_at: Option<std::time::Instant>,
 
     /// Optional metadata associated with the token.
     ///


### PR DESCRIPTION
Fixes #387

`time` crate is currently unstable. Use a `std::time::Instant` instead to represent the expiration timepoint.

Pro:
- `std` is stable.
- (not customer facing) `std::time::Instant` can be manipulated in a `tokio::test`, whereas `OffsetDateTime` cannot.

Con:
- `std::time::Instant` only means something within a process. It takes effort to copy it across processes.

I left a recommendation for customers to not interact with the expiration at all, and instead let the auth library do it. If they absolutely must, I left a hint for how to preserve the expiration across processes.