### PR TITLE
feat(sidekick): add message-name-override flag

### DIFF
--- a/generator/internal/api/overrides.go
+++ b/generator/internal/api/overrides.go
@@ -1,0 +1,23 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+func ApplyNameOverrides(model *API, msgNameOverrides map[string]string) {
+	for _, msg := range model.State.MessageByID {
+		if override, ok := msgNameOverrides[msg.ID]; ok {
+			msg.Name = override
+		}
+	}
+}

--- a/generator/internal/api/overrides_test.go
+++ b/generator/internal/api/overrides_test.go
@@ -1,0 +1,103 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestApplyNameOverrides(t *testing.T) {
+	tests := []struct {
+		name      string
+		api       *API
+		overrides map[string]string
+		want      *API
+	}{
+		{
+			name: "single override",
+			api: &API{
+				State: &APIState{
+					MessageByID: map[string]*Message{
+						"foo.bar.Baz": {ID: "foo.bar.Baz", Name: "Baz"},
+					},
+				},
+			},
+			overrides: map[string]string{
+				"foo.bar.Baz": "NewBaz",
+			},
+			want: &API{
+				State: &APIState{
+					MessageByID: map[string]*Message{
+						"foo.bar.Baz": {ID: "foo.bar.Baz", Name: "NewBaz"},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple overrides",
+			api: &API{
+				State: &APIState{
+					MessageByID: map[string]*Message{
+						"foo.bar.Baz":           {ID: "foo.bar.Baz", Name: "Baz"},
+						"foo.bar.Qux":           {ID: "foo.bar.Qux", Name: "Qux"},
+						"foo.bar.NotOverridden": {ID: "foo.bar.NotOverridden", Name: "NotOverridden"},
+					},
+				},
+			},
+			overrides: map[string]string{
+				"foo.bar.Baz": "NewBaz",
+				"foo.bar.Qux": "NewQux",
+			},
+			want: &API{
+				State: &APIState{
+					MessageByID: map[string]*Message{
+						"foo.bar.Baz":           {ID: "foo.bar.Baz", Name: "NewBaz"},
+						"foo.bar.Qux":           {ID: "foo.bar.Qux", Name: "NewQux"},
+						"foo.bar.NotOverridden": {ID: "foo.bar.NotOverridden", Name: "NotOverridden"},
+					},
+				},
+			},
+		},
+		{
+			name: "no overrides",
+			api: &API{
+				State: &APIState{
+					MessageByID: map[string]*Message{
+						"foo.bar.Baz": {ID: "foo.bar.Baz", Name: "Baz"},
+					},
+				},
+			},
+			overrides: map[string]string{},
+			want: &API{
+				State: &APIState{
+					MessageByID: map[string]*Message{
+						"foo.bar.Baz": {ID: "foo.bar.Baz", Name: "Baz"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ApplyNameOverrides(tt.api, tt.overrides)
+			if diff := cmp.Diff(tt.want, tt.api); diff != "" {
+				t.Errorf("ApplyNameOverrides(%+v, %+v) returned unexpected diff (-want +got):\n%s", tt.api, tt.overrides, diff)
+			}
+		})
+	}
+}

--- a/generator/internal/config/config_test.go
+++ b/generator/internal/config/config_test.go
@@ -106,10 +106,11 @@ func TestMergeLocalForGeneral(t *testing.T) {
 
 	local := Config{
 		General: GeneralConfig{
-			Language:            "local-language",
-			SpecificationFormat: "local-specification-format",
-			SpecificationSource: "local-specification-source",
-			ServiceConfig:       "local-service-config",
+			Language:             "local-language",
+			SpecificationFormat:  "local-specification-format",
+			SpecificationSource:  "local-specification-source",
+			ServiceConfig:        "local-service-config",
+			MessageNameOverrides: map[string]string{"a": "b"},
 		},
 	}
 
@@ -119,10 +120,11 @@ func TestMergeLocalForGeneral(t *testing.T) {
 	}
 	want := &Config{
 		General: GeneralConfig{
-			Language:            "local-language",
-			SpecificationFormat: "local-specification-format",
-			SpecificationSource: "local-specification-source",
-			ServiceConfig:       "local-service-config",
+			Language:             "local-language",
+			SpecificationFormat:  "local-specification-format",
+			SpecificationSource:  "local-specification-source",
+			ServiceConfig:        "local-service-config",
+			MessageNameOverrides: map[string]string{"a": "b"},
 		},
 		Codec:  map[string]string{},
 		Source: map[string]string{},
@@ -156,10 +158,11 @@ func TestMergeIgnoreRootSourceAndServiceConfig(t *testing.T) {
 	}
 	want := &Config{
 		General: GeneralConfig{
-			Language:            "local-language",
-			SpecificationFormat: "local-specification-format",
-			SpecificationSource: "",
-			ServiceConfig:       "",
+			Language:             "local-language",
+			SpecificationFormat:  "local-specification-format",
+			SpecificationSource:  "",
+			ServiceConfig:        "",
+			MessageNameOverrides: map[string]string{},
 		},
 		Codec:  map[string]string{},
 		Source: map[string]string{},
@@ -207,10 +210,11 @@ func TestMergeCodecAndSource(t *testing.T) {
 	}
 	want := &Config{
 		General: GeneralConfig{
-			Language:            "root-language",
-			SpecificationFormat: "root-specification-format",
-			SpecificationSource: "local-specification-source",
-			ServiceConfig:       "local-service-config",
+			Language:             "root-language",
+			SpecificationFormat:  "root-specification-format",
+			SpecificationSource:  "local-specification-source",
+			ServiceConfig:        "local-service-config",
+			MessageNameOverrides: map[string]string{},
 		},
 		Codec: map[string]string{
 			"codec-a": "root-a-value",

--- a/generator/internal/sidekick/cmdline.go
+++ b/generator/internal/sidekick/cmdline.go
@@ -16,26 +16,28 @@ package sidekick
 
 // CommandLine Represents the arguments received from the command line.
 type CommandLine struct {
-	Command             []string
-	ProjectRoot         string
-	SpecificationFormat string
-	SpecificationSource string
-	ServiceConfig       string
-	Source              map[string]string
-	Output              string
-	Language            string
-	Codec               map[string]string
-	DryRun              bool
+	Command              []string
+	ProjectRoot          string
+	SpecificationFormat  string
+	SpecificationSource  string
+	ServiceConfig        string
+	Source               map[string]string
+	Output               string
+	Language             string
+	Codec                map[string]string
+	DryRun               bool
+	MessageNameOverrides map[string]string
 }
 
 var (
-	flagProjectRoot string
-	format          string
-	source          string
-	serviceConfig   string
-	sourceOpts      = map[string]string{}
-	output          string
-	flagLanguage    string
-	codecOpts       = map[string]string{}
-	dryrun          bool
+	flagProjectRoot      string
+	format               string
+	source               string
+	serviceConfig        string
+	sourceOpts           = map[string]string{}
+	output               string
+	flagLanguage         string
+	codecOpts            = map[string]string{}
+	dryrun               bool
+	messageNameOverrides = map[string]string{}
 )

--- a/generator/internal/sidekick/cmdline_test.go
+++ b/generator/internal/sidekick/cmdline_test.go
@@ -23,7 +23,7 @@ import (
 
 func resetArgs() {
 	flagProjectRoot, format, source, serviceConfig, output, flagLanguage = "", "", "", "", "", ""
-	sourceOpts, codecOpts = map[string]string{}, map[string]string{}
+	sourceOpts, codecOpts, messageNameOverrides = map[string]string{}, map[string]string{}, map[string]string{}
 	dryrun = false
 }
 
@@ -42,6 +42,7 @@ func TestParseArgs(t *testing.T) {
 		"-codec-option", "package-name-override=secretmanager-golden-openapi",
 		"-codec-option", "package:wkt=package=google-cloud-wkt,path=src/wkt,source=google.protobuf",
 		"-codec-option", "package:gax=package=gcp-sdk-gax,path=src/gax,feature=unstable-sdk-client",
+		"-message-name-override", "foo.bar.Baz=NewBaz",
 	}
 	cmd, _, args := cmdSidekick.lookup(args)
 	if cmd.name() != "generate" {
@@ -69,6 +70,9 @@ func TestParseArgs(t *testing.T) {
 			"package:wkt":           "package=google-cloud-wkt,path=src/wkt,source=google.protobuf",
 			"package:gax":           "package=gcp-sdk-gax,path=src/gax,feature=unstable-sdk-client",
 		},
+		MessageNameOverrides: map[string]string{
+			"foo.bar.Baz": "NewBaz",
+		},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatched merged config (-want, +got):\n%s", diff)
@@ -86,10 +90,11 @@ func TestDefaults(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := &CommandLine{
-		Command:     args,
-		ProjectRoot: root,
-		Source:      map[string]string{},
-		Codec:       map[string]string{},
+		Command:              args,
+		ProjectRoot:          root,
+		Source:               map[string]string{},
+		Codec:                map[string]string{},
+		MessageNameOverrides: map[string]string{},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("mismatched merged config (-want, +got):\n%s", diff)

--- a/generator/internal/sidekick/command.go
+++ b/generator/internal/sidekick/command.go
@@ -137,16 +137,17 @@ func (c *command) parseCmdLine(args []string) (*CommandLine, error) {
 	}
 
 	return &CommandLine{
-		Command:             args,
-		ProjectRoot:         flagProjectRoot,
-		SpecificationFormat: format,
-		SpecificationSource: source,
-		ServiceConfig:       serviceConfig,
-		Source:              sourceOpts,
-		Language:            flagLanguage,
-		Output:              output,
-		Codec:               codecOpts,
-		DryRun:              dryrun,
+		Command:              args,
+		ProjectRoot:          flagProjectRoot,
+		SpecificationFormat:  format,
+		SpecificationSource:  source,
+		ServiceConfig:        serviceConfig,
+		Source:               sourceOpts,
+		Language:             flagLanguage,
+		Output:               output,
+		Codec:                codecOpts,
+		DryRun:               dryrun,
+		MessageNameOverrides: messageNameOverrides,
 	}, nil
 }
 

--- a/generator/internal/sidekick/generate.go
+++ b/generator/internal/sidekick/generate.go
@@ -41,10 +41,11 @@ Uses the configuration provided in the command line arguments, and saves it in a
 func generate(rootConfig *config.Config, cmdLine *CommandLine) error {
 	local := config.Config{
 		General: config.GeneralConfig{
-			Language:            cmdLine.Language,
-			SpecificationFormat: cmdLine.SpecificationFormat,
-			SpecificationSource: cmdLine.SpecificationSource,
-			ServiceConfig:       cmdLine.ServiceConfig,
+			Language:             cmdLine.Language,
+			SpecificationFormat:  cmdLine.SpecificationFormat,
+			SpecificationSource:  cmdLine.SpecificationSource,
+			ServiceConfig:        cmdLine.ServiceConfig,
+			MessageNameOverrides: cmdLine.MessageNameOverrides,
 		},
 		Source: maps.Clone(cmdLine.Source),
 		Codec:  maps.Clone(cmdLine.Codec),

--- a/generator/internal/sidekick/refresh.go
+++ b/generator/internal/sidekick/refresh.go
@@ -69,6 +69,7 @@ func refreshDir(rootConfig *config.Config, cmdLine *CommandLine, output string) 
 		return err
 	}
 	api.LabelRecursiveFields(model)
+	api.ApplyNameOverrides(model, config.General.MessageNameOverrides)
 	if err := api.CrossReference(model); err != nil {
 		return err
 	}

--- a/generator/internal/sidekick/refreshall.go
+++ b/generator/internal/sidekick/refreshall.go
@@ -47,6 +47,7 @@ func overrideSources(rootConfig *config.Config) (*config.Config, error) {
 	override := *rootConfig
 	override.Codec = maps.Clone(rootConfig.Codec)
 	override.Source = maps.Clone(rootConfig.Source)
+	override.General.MessageNameOverrides = maps.Clone(rootConfig.General.MessageNameOverrides)
 	for _, root := range parser.SourceRoots(rootConfig.Source) {
 		configPrefix := strings.TrimSuffix(root, "-root")
 		if _, ok := rootConfig.Source[root]; !ok {

--- a/generator/internal/sidekick/sidekick.go
+++ b/generator/internal/sidekick/sidekick.go
@@ -51,6 +51,14 @@ var cmdSidekick = newCommand(
 		}
 		codecOpts[components[0]] = components[1]
 		return nil
+	}).
+	addFlagFunc("message-name-override", "message name override", func(opt string) error {
+		components := strings.SplitN(opt, "=", 2)
+		if len(components) != 2 {
+			return fmt.Errorf("invalid message override, must be in key=value format (%s)", opt)
+		}
+		messageNameOverrides[components[0]] = components[1]
+		return nil
 	})
 
 // Run is the entry point for the sidekick logic. It expects args to be the command line arguments, minus the program name.
@@ -116,7 +124,7 @@ func runCommand(cmd *command, cmdLine *CommandLine) error {
 			return fmt.Errorf("could not change to project root [%s]: %w", cmdLine.ProjectRoot, err)
 		}
 	}
-	config, err := config.LoadConfig(cmdLine.Language, cmdLine.Source, cmdLine.Codec)
+	config, err := config.LoadConfig(cmdLine.Language, cmdLine.Source, cmdLine.Codec, cmdLine.MessageNameOverrides)
 	if err != nil {
 		return fmt.Errorf("could not load configuration: %w", err)
 	}


### PR DESCRIPTION
Add a flag to specify overriding of messages names. This can be useful for when there are conflicts within a given programming language.

Updates: #1122