### PR TITLE
feat(wkt): Support jiff From conversions for Duration and Timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2471,6 +2471,7 @@ dependencies = [
  "bytes",
  "chrono",
  "google-cloud-wkt",
+ "jiff",
  "serde",
  "serde_json",
  "serde_with",
@@ -2902,6 +2903,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "jiff"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba926fdd8e5b5e7f9700355b0831d8c416afe94b014b1023424037a187c9c582"
+dependencies = [
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3312,6 +3325,21 @@ name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "portable-atomic"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -24,12 +24,14 @@ repository.workspace = true
 version              = "0.1.1"
 
 [features]
-chrono = ["dep:chrono"]
-time   = []
+chrono   = ["dep:chrono"]
+jiff-0_2 = ["dep:jiff"]
+time     = []
 
 [dependencies]
 bytes      = { version = "1.10.0", features = ["serde"] }
 chrono     = { version = "0.4.39", optional = true }
+jiff       = { version = "0.2.0", default-features = false, features = ["std"], optional = true }
 serde      = { version = "1.0.217", features = ["serde_derive"] }
 serde_json = "1"
 serde_with = { version = "3.12.0", default-features = false, features = ["base64", "macros", "std"] }
@@ -39,4 +41,4 @@ time       = { version = "0.3.36", features = ["formatting", "parsing"] }
 [dev-dependencies]
 bytes     = { version = "1.10.0", features = ["serde"] }
 test-case = "3.3.1"
-wkt       = { path = ".", package = "google-cloud-wkt", features = ["chrono", "time"] }
+wkt       = { path = ".", package = "google-cloud-wkt", features = ["chrono", "jiff-0_2", "time"] }

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -24,9 +24,9 @@ repository.workspace = true
 version              = "0.1.1"
 
 [features]
-chrono   = ["dep:chrono"]
-jiff-0_2 = ["dep:jiff"]
-time     = []
+chrono = ["dep:chrono"]
+jiff   = ["dep:jiff"]
+time   = []
 
 [dependencies]
 bytes      = { version = "1.10.0", features = ["serde"] }
@@ -41,4 +41,4 @@ time       = { version = "0.3.36", features = ["formatting", "parsing"] }
 [dev-dependencies]
 bytes     = { version = "1.10.0", features = ["serde"] }
 test-case = "3.3.1"
-wkt       = { path = ".", package = "google-cloud-wkt", features = ["chrono", "jiff-0_2", "time"] }
+wkt       = { path = ".", package = "google-cloud-wkt", features = ["chrono", "jiff", "time"] }

--- a/src/wkt/src/duration.rs
+++ b/src/wkt/src/duration.rs
@@ -305,7 +305,7 @@ impl std::convert::From<Duration> for chrono::Duration {
 /// Converts from [jiff::SignedDuration] to [Duration].
 ///
 /// This conversion may fail if the [jiff::SignedDuration] value is out of range.
-#[cfg(feature = "jiff-0_2")]
+#[cfg(feature = "jiff")]
 impl std::convert::TryFrom<jiff::SignedDuration> for Duration {
     type Error = DurationError;
 
@@ -315,7 +315,7 @@ impl std::convert::TryFrom<jiff::SignedDuration> for Duration {
 }
 
 /// Converts from [Duration] to [jiff::SignedDuration].
-#[cfg(feature = "jiff-0_2")]
+#[cfg(feature = "jiff")]
 impl std::convert::From<Duration> for jiff::SignedDuration {
     fn from(value: Duration) -> Self {
         // Safety: The range of jiff::SignedDuration is larger than Duration,

--- a/src/wkt/src/timestamp.rs
+++ b/src/wkt/src/timestamp.rs
@@ -301,7 +301,7 @@ impl TryFrom<Timestamp> for chrono::DateTime<chrono::Utc> {
 /// Converts from [jiff::Timestamp] to [Timestamp].
 ///
 /// This conversion may fail if the [jiff::Timestamp] value is out of range.
-#[cfg(feature = "jiff-0_2")]
+#[cfg(feature = "jiff")]
 impl TryFrom<jiff::Timestamp> for Timestamp {
     type Error = TimestampError;
 
@@ -320,7 +320,7 @@ impl TryFrom<jiff::Timestamp> for Timestamp {
 /// Converts from [Timestamp] to [jiff::Timestamp].
 ///
 /// This conversion may fail if the [Timestamp] value is out of range.
-#[cfg(feature = "jiff-0_2")]
+#[cfg(feature = "jiff")]
 impl TryFrom<Timestamp> for jiff::Timestamp {
     type Error = jiff::Error;
 

--- a/src/wkt/src/timestamp.rs
+++ b/src/wkt/src/timestamp.rs
@@ -434,6 +434,12 @@ mod test {
     fn from_jiff_time_in_range(value: jiff::Timestamp, want: Timestamp) -> Result {
         let got = Timestamp::try_from(value)?;
         assert_eq!(got, want);
+
+        // Assert that both timestamps represent the same duration since (or before) the Epoch.
+        assert_eq!(
+            ((got.seconds as i128) * Timestamp::NS as i128) + got.nanos as i128,
+            value.as_duration().as_nanos()
+        );
         Ok(())
     }
 
@@ -444,8 +450,14 @@ mod test {
     #[test_case(Timestamp::new(-5, 500_000_000).unwrap(), jiff::Timestamp::new(-4, -500_000_000).unwrap() ; "negative seconds and nanos")]
     #[test_case(Timestamp::new(5, 500_000_000).unwrap(), jiff::Timestamp::new(5, 500_000_000).unwrap() ; "positive seconds and nanos")]
     fn to_jiff_time_in_range(value: Timestamp, want: jiff::Timestamp) -> Result {
-        let got = jiff::Timestamp::try_from(value)?;
+        let got = jiff::Timestamp::try_from(value.clone())?;
         assert_eq!(got, want);
+
+        // Assert that both timestamps represent the same duration since (or before) the Epoch.
+        assert_eq!(
+            ((value.seconds as i128) * Timestamp::NS as i128) + value.nanos as i128,
+            got.as_duration().as_nanos()
+        );
         Ok(())
     }
 


### PR DESCRIPTION
jiff is a promising time handling crate based on the design of the Temporal JavaScript API. It is planned for a long-term 1.0 version to be released later in the year.

This commit adds support for converting to and from `jiff::SignedDuration` and `jiff::Timestamp` for version 0.2.

To ease the transition between version 0.2 and 1.0, I've named the feature `jiff-0_2`, so that support for multiple versions could coexist. But if preferred, I can rename the feature to just `jiff`.

Fixes #1153 