### PR TITLE
fix(sidekick): allow nested modules with the same name as parent 

### DIFF
--- a/generator/internal/rust/templates/crate/src/lib.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/lib.rs.mustache
@@ -34,6 +34,7 @@ limitations under the License.
 {{/Codec.Services}}
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 {{#Codec.HasServices}}

--- a/generator/testdata/rust/openapi/golden/src/lib.rs
+++ b/generator/testdata/rust/openapi/golden/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [SecretManagerService](client/struct.SecretManagerService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::Result;

--- a/generator/testdata/rust/protobuf/golden/iam/v1/src/lib.rs
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [IAMPolicy](client/struct.IAMPolicy.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::Result;

--- a/generator/testdata/rust/protobuf/golden/location/src/lib.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [Locations](client/struct.Locations.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::Result;

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/lib.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [SecretManagerService](client/struct.SecretManagerService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::Result;

--- a/src/generated/api/servicecontrol/v1/src/lib.rs
+++ b/src/generated/api/servicecontrol/v1/src/lib.rs
@@ -29,6 +29,7 @@
 //! * [ServiceController](client/struct.ServiceController.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/api/servicecontrol/v2/src/lib.rs
+++ b/src/generated/api/servicecontrol/v2/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [ServiceController](client/struct.ServiceController.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/api/servicemanagement/v1/src/lib.rs
+++ b/src/generated/api/servicemanagement/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [ServiceManager](client/struct.ServiceManager.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/api/serviceusage/v1/src/lib.rs
+++ b/src/generated/api/serviceusage/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [ServiceUsage](client/struct.ServiceUsage.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/appengine/v1/src/lib.rs
+++ b/src/generated/appengine/v1/src/lib.rs
@@ -35,6 +35,7 @@
 //! * [DomainMappings](client/struct.DomainMappings.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/bigtable/admin/v2/src/lib.rs
+++ b/src/generated/bigtable/admin/v2/src/lib.rs
@@ -29,6 +29,7 @@
 //! * [BigtableTableAdmin](client/struct.BigtableTableAdmin.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/accessapproval/v1/src/lib.rs
+++ b/src/generated/cloud/accessapproval/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [AccessApproval](client/struct.AccessApproval.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/apigateway/v1/src/lib.rs
+++ b/src/generated/cloud/apigateway/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [ApiGatewayService](client/struct.ApiGatewayService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/apigeeconnect/v1/src/lib.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [ConnectionService](client/struct.ConnectionService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/assuredworkloads/v1/src/lib.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [AssuredWorkloadsService](client/struct.AssuredWorkloadsService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/bigquery/connection/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [ConnectionService](client/struct.ConnectionService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [DataTransferService](client/struct.DataTransferService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/bigquery/reservation/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [ReservationService](client/struct.ReservationService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/billing/v1/src/lib.rs
+++ b/src/generated/cloud/billing/v1/src/lib.rs
@@ -29,6 +29,7 @@
 //! * [CloudCatalog](client/struct.CloudCatalog.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/binaryauthorization/v1/src/lib.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/lib.rs
@@ -30,6 +30,7 @@
 //! * [ValidationHelperV1](client/struct.ValidationHelperV1.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/clouddms/v1/src/lib.rs
+++ b/src/generated/cloud/clouddms/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [DataMigrationService](client/struct.DataMigrationService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/contactcenterinsights/v1/src/lib.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [ContactCenterInsights](client/struct.ContactCenterInsights.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/datacatalog/v1/src/lib.rs
+++ b/src/generated/cloud/datacatalog/v1/src/lib.rs
@@ -30,6 +30,7 @@
 //! * [PolicyTagManagerSerialization](client/struct.PolicyTagManagerSerialization.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/datafusion/v1/src/lib.rs
+++ b/src/generated/cloud/datafusion/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [DataFusion](client/struct.DataFusion.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/dataproc/v1/src/lib.rs
+++ b/src/generated/cloud/dataproc/v1/src/lib.rs
@@ -35,6 +35,7 @@
 //! * [WorkflowTemplateService](client/struct.WorkflowTemplateService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/datastream/v1/src/lib.rs
+++ b/src/generated/cloud/datastream/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [Datastream](client/struct.Datastream.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/deploy/v1/src/lib.rs
+++ b/src/generated/cloud/deploy/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [CloudDeploy](client/struct.CloudDeploy.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/dialogflow/cx/v3/src/lib.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/lib.rs
@@ -44,6 +44,7 @@
 //! * [Webhooks](client/struct.Webhooks.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/documentai/v1/src/lib.rs
+++ b/src/generated/cloud/documentai/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [DocumentProcessorService](client/struct.DocumentProcessorService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/essentialcontacts/v1/src/lib.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [EssentialContactsService](client/struct.EssentialContactsService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/eventarc/v1/src/lib.rs
+++ b/src/generated/cloud/eventarc/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [Eventarc](client/struct.Eventarc.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/filestore/v1/src/lib.rs
+++ b/src/generated/cloud/filestore/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [CloudFilestoreManager](client/struct.CloudFilestoreManager.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/functions/v2/src/lib.rs
+++ b/src/generated/cloud/functions/v2/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [FunctionService](client/struct.FunctionService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/iap/v1/src/lib.rs
+++ b/src/generated/cloud/iap/v1/src/lib.rs
@@ -29,6 +29,7 @@
 //! * [IdentityAwareProxyOAuthService](client/struct.IdentityAwareProxyOAuthService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/ids/v1/src/lib.rs
+++ b/src/generated/cloud/ids/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [Ids](client/struct.Ids.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/kms/inventory/v1/src/lib.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/lib.rs
@@ -29,6 +29,7 @@
 //! * [KeyTrackingService](client/struct.KeyTrackingService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/kms/v1/src/lib.rs
+++ b/src/generated/cloud/kms/v1/src/lib.rs
@@ -31,6 +31,7 @@
 //! * [KeyManagementService](client/struct.KeyManagementService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/language/v2/src/lib.rs
+++ b/src/generated/cloud/language/v2/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [LanguageService](client/struct.LanguageService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/location/src/lib.rs
+++ b/src/generated/cloud/location/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [Locations](client/struct.Locations.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/managedidentities/v1/src/lib.rs
+++ b/src/generated/cloud/managedidentities/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [ManagedIdentitiesService](client/struct.ManagedIdentitiesService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/memcache/v1/src/lib.rs
+++ b/src/generated/cloud/memcache/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [CloudMemcache](client/struct.CloudMemcache.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/metastore/v1/src/lib.rs
+++ b/src/generated/cloud/metastore/v1/src/lib.rs
@@ -29,6 +29,7 @@
 //! * [DataprocMetastoreFederation](client/struct.DataprocMetastoreFederation.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/networkmanagement/v1/src/lib.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/lib.rs
@@ -29,6 +29,7 @@
 //! * [VpcFlowLogsService](client/struct.VpcFlowLogsService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/notebooks/v2/src/lib.rs
+++ b/src/generated/cloud/notebooks/v2/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [NotebookService](client/struct.NotebookService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/optimization/v1/src/lib.rs
+++ b/src/generated/cloud/optimization/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [FleetRouting](client/struct.FleetRouting.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/lib.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/lib.rs
@@ -29,6 +29,7 @@
 //! * [ImageVersions](client/struct.ImageVersions.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/orgpolicy/v2/src/lib.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [OrgPolicy](client/struct.OrgPolicy.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/oslogin/v1/src/lib.rs
+++ b/src/generated/cloud/oslogin/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [OsLoginService](client/struct.OsLoginService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/policytroubleshooter/v1/src/lib.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [IamChecker](client/struct.IamChecker.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/recaptchaenterprise/v1/src/lib.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [RecaptchaEnterpriseService](client/struct.RecaptchaEnterpriseService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/recommender/v1/src/lib.rs
+++ b/src/generated/cloud/recommender/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [Recommender](client/struct.Recommender.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/redis/cluster/v1/src/lib.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [CloudRedisCluster](client/struct.CloudRedisCluster.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/redis/v1/src/lib.rs
+++ b/src/generated/cloud/redis/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [CloudRedis](client/struct.CloudRedis.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/resourcemanager/v3/src/lib.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/lib.rs
@@ -34,6 +34,7 @@
 //! * [TagValues](client/struct.TagValues.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/run/v2/src/lib.rs
+++ b/src/generated/cloud/run/v2/src/lib.rs
@@ -33,6 +33,7 @@
 //! * [Tasks](client/struct.Tasks.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/scheduler/v1/src/lib.rs
+++ b/src/generated/cloud/scheduler/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [CloudScheduler](client/struct.CloudScheduler.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/secretmanager/v1/src/lib.rs
+++ b/src/generated/cloud/secretmanager/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [SecretManagerService](client/struct.SecretManagerService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/security/privateca/v1/src/lib.rs
+++ b/src/generated/cloud/security/privateca/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [CertificateAuthorityService](client/struct.CertificateAuthorityService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/securitycenter/v2/src/lib.rs
+++ b/src/generated/cloud/securitycenter/v2/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [SecurityCenter](client/struct.SecurityCenter.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/servicedirectory/v1/src/lib.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/lib.rs
@@ -29,6 +29,7 @@
 //! * [RegistrationService](client/struct.RegistrationService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/shell/v1/src/lib.rs
+++ b/src/generated/cloud/shell/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [CloudShellService](client/struct.CloudShellService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/speech/v2/src/lib.rs
+++ b/src/generated/cloud/speech/v2/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [Speech](client/struct.Speech.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/sql/v1/src/lib.rs
+++ b/src/generated/cloud/sql/v1/src/lib.rs
@@ -36,6 +36,7 @@
 //! * [SqlUsersService](client/struct.SqlUsersService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::Result;

--- a/src/generated/cloud/talent/v4/src/lib.rs
+++ b/src/generated/cloud/talent/v4/src/lib.rs
@@ -32,6 +32,7 @@
 //! * [TenantService](client/struct.TenantService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/tasks/v2/src/lib.rs
+++ b/src/generated/cloud/tasks/v2/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [CloudTasks](client/struct.CloudTasks.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/texttospeech/v1/src/lib.rs
+++ b/src/generated/cloud/texttospeech/v1/src/lib.rs
@@ -29,6 +29,7 @@
 //! * [TextToSpeechLongAudioSynthesize](client/struct.TextToSpeechLongAudioSynthesize.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/tpu/v2/src/lib.rs
+++ b/src/generated/cloud/tpu/v2/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [Tpu](client/struct.Tpu.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/translate/v3/src/lib.rs
+++ b/src/generated/cloud/translate/v3/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [TranslationService](client/struct.TranslationService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/video/transcoder/v1/src/lib.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [TranscoderService](client/struct.TranscoderService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/videointelligence/v1/src/lib.rs
+++ b/src/generated/cloud/videointelligence/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [VideoIntelligenceService](client/struct.VideoIntelligenceService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/vision/v1/src/lib.rs
+++ b/src/generated/cloud/vision/v1/src/lib.rs
@@ -29,6 +29,7 @@
 //! * [ProductSearch](client/struct.ProductSearch.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/vmmigration/v1/src/lib.rs
+++ b/src/generated/cloud/vmmigration/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [VmMigration](client/struct.VmMigration.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/vpcaccess/v1/src/lib.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [VpcAccessService](client/struct.VpcAccessService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/webrisk/v1/src/lib.rs
+++ b/src/generated/cloud/webrisk/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [WebRiskService](client/struct.WebRiskService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/websecurityscanner/v1/src/lib.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [WebSecurityScanner](client/struct.WebSecurityScanner.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/cloud/workflows/v1/src/lib.rs
+++ b/src/generated/cloud/workflows/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [Workflows](client/struct.Workflows.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/container/v1/src/lib.rs
+++ b/src/generated/container/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [ClusterManager](client/struct.ClusterManager.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/datastore/admin/v1/src/lib.rs
+++ b/src/generated/datastore/admin/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [DatastoreAdmin](client/struct.DatastoreAdmin.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/devtools/artifactregistry/v1/src/lib.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [ArtifactRegistry](client/struct.ArtifactRegistry.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/devtools/cloudbuild/v1/src/lib.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [CloudBuild](client/struct.CloudBuild.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/devtools/cloudbuild/v2/src/lib.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [RepositoryManager](client/struct.RepositoryManager.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/devtools/cloudtrace/v2/src/lib.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [TraceService](client/struct.TraceService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/grafeas/v1/src/lib.rs
+++ b/src/generated/grafeas/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [Grafeas](client/struct.Grafeas.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/iam/admin/v1/src/lib.rs
+++ b/src/generated/iam/admin/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [Iam](client/struct.Iam.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/iam/credentials/v1/src/lib.rs
+++ b/src/generated/iam/credentials/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [IAMCredentials](client/struct.IAMCredentials.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/iam/v1/src/lib.rs
+++ b/src/generated/iam/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [IAMPolicy](client/struct.IAMPolicy.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/iam/v2/src/lib.rs
+++ b/src/generated/iam/v2/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [Policies](client/struct.Policies.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/identity/accesscontextmanager/v1/src/lib.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [AccessContextManager](client/struct.AccessContextManager.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/logging/v2/src/lib.rs
+++ b/src/generated/logging/v2/src/lib.rs
@@ -30,6 +30,7 @@
 //! * [MetricsServiceV2](client/struct.MetricsServiceV2.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/longrunning/src/lib.rs
+++ b/src/generated/longrunning/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [Operations](client/struct.Operations.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/monitoring/dashboard/v1/src/lib.rs
+++ b/src/generated/monitoring/dashboard/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [DashboardsService](client/struct.DashboardsService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/monitoring/metricsscope/v1/src/lib.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [MetricsScopes](client/struct.MetricsScopes.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/monitoring/v3/src/lib.rs
+++ b/src/generated/monitoring/v3/src/lib.rs
@@ -35,6 +35,7 @@
 //! * [UptimeCheckService](client/struct.UptimeCheckService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/openapi-validation/src/lib.rs
+++ b/src/generated/openapi-validation/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [SecretManagerService](client/struct.SecretManagerService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/privacy/dlp/v2/src/lib.rs
+++ b/src/generated/privacy/dlp/v2/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [DlpService](client/struct.DlpService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/spanner/admin/database/v1/src/lib.rs
+++ b/src/generated/spanner/admin/database/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [DatabaseAdmin](client/struct.DatabaseAdmin.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/spanner/admin/instance/v1/src/lib.rs
+++ b/src/generated/spanner/admin/instance/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [InstanceAdmin](client/struct.InstanceAdmin.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;

--- a/src/generated/storagetransfer/v1/src/lib.rs
+++ b/src/generated/storagetransfer/v1/src/lib.rs
@@ -28,6 +28,7 @@
 //! * [StorageTransferService](client/struct.StorageTransferService.html)
 
 /// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 pub use gax::error::Error;


### PR DESCRIPTION
There are some services, retail, which have a type named Model.
When generating some of the helpers we then create a mod named
model which clippy gets angry about. This allow macro tells clippy
it is alright.

Updates: #1122