### PR TITLE
feat(auth): clone for `CredentialError`

### DIFF
--- a/src/auth/src/errors.rs
+++ b/src/auth/src/errors.rs
@@ -75,6 +75,13 @@ impl std::error::Error for CredentialError {
     }
 }
 
+impl Clone for CredentialError {
+    fn clone(&self) -> CredentialError {
+        let source = format!("{}", self.source);
+        CredentialError::new(self.is_retryable, source.into())
+    }
+}
+
 const RETRYABLE_MSG: &str = "but future attempts may succeed";
 const NON_RETRYABLE_MSG: &str = "and future attempts will not succeed";
 
@@ -148,5 +155,22 @@ mod test {
         let got = format!("{e}");
         assert!(got.contains("test-only-err-123"), "{got}");
         assert!(got.contains(NON_RETRYABLE_MSG), "{got}");
+    }
+
+    #[test]
+    fn clone() {
+        let orig = CredentialError::retryable("fail");
+        let clone = orig.clone();
+
+        let msg = format!("{orig}");
+        let msg2 = format!("{clone}");
+        assert_eq!(msg, msg2);
+
+        let orig = CredentialError::non_retryable("fail");
+        let clone = orig.clone();
+
+        let msg = format!("{orig}");
+        let msg2 = format!("{clone}");
+        assert_eq!(msg, msg2);
     }
 }


### PR DESCRIPTION
Part of the work for #1210 

In the token cache, if we have N waiters for a single request, and that request errors, we want to give that error to each of the waiters. That means we need our errors to be clone-able.

We do not want to use an `Arc` instead of a `Box` to hold the error `source`. Some `source`s do not fit in an `Arc`.

We can stream the error message, and copy that into a new `CredentialError`.

If the error message is the same, the `CredentialError` is the same, as far as I am concerned.