### PR TITLE
docs: use Google guidelines on titles style

### DIFF
--- a/guide/src/configuring_polling_policies.md
+++ b/guide/src/configuring_polling_policies.md
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Configuring Polling Policies
+# Configuring polling policies
 
 The Google Cloud Client Libraries for Rust provide helper functions to simplify
 waiting and monitoring the progress of

--- a/guide/src/initialize_a_client.md
+++ b/guide/src/initialize_a_client.md
@@ -63,7 +63,7 @@ Once successfully initialized, you can use this client to make RPCs:
 
 ______________________________________________________________________
 
-## Full Program
+## Full program
 
 Putting all this code together into a full program looks as follows:
 

--- a/guide/src/introduction.md
+++ b/guide/src/introduction.md
@@ -36,7 +36,7 @@ any Google Service or client library before (in Rust or other language).
 However, the guides will refer you to service specific tutorials to
 initialize their projects and services.
 
-## Service Specific Documentation
+## Service specific documentation
 
 These guides are not intended as tutorials for each services or as extended guides
 on how to design Rust applications to work on Google Cloud. They are starting
@@ -47,7 +47,7 @@ learn more each service. If you need guidance on how to design your application
 for Google Cloud the [Cloud Architecture Center] may have what you are looking
 for.
 
-## Reporting Bugs
+## Reporting bugs
 
 We welcome bugs about the client libraries or their documentation. Please use
 [GitHub Issues](https://github.com/googleapis/google-cloud-rust/issues).

--- a/guide/src/setting_up_rust_on_cloud_shell.md
+++ b/guide/src/setting_up_rust_on_cloud_shell.md
@@ -1,3 +1,19 @@
+<!-- 
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Setting up Rust on Cloud Shell
 
 Cloud Shell is a great environment to run small examples and tests.
@@ -66,3 +82,4 @@ Cloud Shell is a great environment to run small examples and tests.
 
 [cloud shell]: https://cloud.google.com/shell
 [rustup]: https://rust-lang.github.io/rustup/
+[tokio]: https://crates.io/crates/tokio

--- a/guide/src/setting_up_your_development_environment.md
+++ b/guide/src/setting_up_your_development_environment.md
@@ -1,3 +1,19 @@
+<!-- 
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Setting up your development environment
 
 Prepare your environment for [Rust] app development and deployment on
@@ -115,3 +131,4 @@ Note: The source of the Cloud Client Libraries for Rust is
 [google cloud cli]: https://cloud.google.com/sdk/
 [rust]: https://www.rust-lang.org/
 [rust-getting-started]: https://www.rust-lang.org/learn/get-started
+[tokio]: https://crates.io/crates/tokio


### PR DESCRIPTION
The titles are not supposed to capitalize each word, except product
names (and other proper names, presumably).

Also add some missing boilerplate.