### PR TITLE
fix(mustache): allow missing variables for mustache

### DIFF
--- a/generator/internal/language/generate.go
+++ b/generator/internal/language/generate.go
@@ -59,7 +59,6 @@ func GenerateFromRoot(outdir string, root any, provider TemplateProvider, genera
 			impl:    provider,
 			dirname: filepath.Dir(gen.TemplatePath),
 		}
-		mustache.AllowMissingVariables = false
 		s, err := mustache.RenderPartials(templateContents, &nestedProvider, root)
 		if err != nil {
 			errs = append(errs, err)


### PR DESCRIPTION
- switch back to allowing missing variables for mustache

Currently, when this fails the error does not contain any positional information (which template? which line?). This is much harder to debug than just substituting an empty string and letting downstream systems fail (static analysis / compilation).
