### PR TITLE
fix(generator): default to root config language

### DIFF
--- a/generator/internal/sidekick/cmdline_test.go
+++ b/generator/internal/sidekick/cmdline_test.go
@@ -36,7 +36,7 @@ func TestParseArgs(t *testing.T) {
 		"-specification-source", specificationSource,
 		"-service-config", secretManagerServiceConfig,
 		"-source-option", fmt.Sprintf("googleapis-root=%s", googleapisRoot),
-		"-language", "rust",
+		"-language", "not-rust",
 		"-output", outputDir,
 		"-codec-option", "copyright-year=2024",
 		"-codec-option", "package-name-override=secretmanager-golden-openapi",
@@ -61,7 +61,7 @@ func TestParseArgs(t *testing.T) {
 		Source: map[string]string{
 			"googleapis-root": googleapisRoot,
 		},
-		Language: "rust",
+		Language: "not-rust",
 		Output:   outputDir,
 		Codec: map[string]string{
 			"copyright-year":        "2024",

--- a/generator/internal/sidekick/command.go
+++ b/generator/internal/sidekick/command.go
@@ -89,8 +89,8 @@ func (c *command) addFlagBool(p *bool, name string, value bool, usage string) *c
 	return c
 }
 
-func (c *command) addFlagString(p *string, name string, value string, usage string) *command {
-	c.flags.StringVar(p, name, value, usage)
+func (c *command) addFlagString(p *string, name string, usage string) *command {
+	c.flags.StringVar(p, name, "", usage)
 	return c
 }
 

--- a/generator/internal/sidekick/sidekick.go
+++ b/generator/internal/sidekick/sidekick.go
@@ -29,12 +29,12 @@ var cmdSidekick = newCommand(
 	``,
 	nil, // nil parent is only allowed for the root command
 	nil).
-	addFlagString(&flagProjectRoot, "project-root", "", "the root of the output project").
-	addFlagString(&format, "specification-format", "", "the specification format. Protobuf or OpenAPI v3.").
-	addFlagString(&source, "specification-source", "", "the path to the input data").
-	addFlagString(&serviceConfig, "service-config", "", "path to service config").
-	addFlagString(&output, "output", "", "the path within project-root to put generated files").
-	addFlagString(&flagLanguage, "language", "rust", "the generated language").
+	addFlagString(&flagProjectRoot, "project-root", "the root of the output project").
+	addFlagString(&format, "specification-format", "the specification format. Protobuf or OpenAPI v3.").
+	addFlagString(&source, "specification-source", "the path to the input data").
+	addFlagString(&serviceConfig, "service-config", "path to service config").
+	addFlagString(&output, "output", "the path within project-root to put generated files").
+	addFlagString(&flagLanguage, "language", "the generated language").
 	addFlagBool(&dryrun, "dry-run", false, "do a dry-run: load the configuration, but do not perform any changes.").
 	addFlagFunc("source-option", "source options", func(opt string) error {
 		components := strings.SplitN(opt, "=", 2)


### PR DESCRIPTION
The intention is to use the language configured in the top-level
`.sidekick.toml` file, with an opportunity to override via the
command-line or with a local `.sidekick.toml` file.

The actual implementation always overrode the language to `rust` because
it provided a default value for the command-line argument.

Motivated by #1324
