### PR TITLE
fix(generator): skip `generator/` in refreshall

### DIFF
--- a/generator/internal/sidekick/refreshall.go
+++ b/generator/internal/sidekick/refreshall.go
@@ -113,8 +113,8 @@ func findAllDirectories() ([]string, error) {
 		}
 		dir := filepath.Dir(path)
 		ignored := []string{
-			"target/package/",     // The output from `cargo package`
-			"generator/testdata/", // Testing
+			"target/package/", // The output from `cargo package`
+			"generator/",      // Testing
 		}
 		for _, candidate := range ignored {
 			if strings.Contains(dir, candidate) {


### PR DESCRIPTION
Part of the work for #1324
