### PR TITLE
cleanup: remove redundant `language` configuration

### DIFF
--- a/src/generated/api/apikeys/v2/.sidekick.toml
+++ b/src/generated/api/apikeys/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/api/apikeys/v2'
 service-config = 'google/api/apikeys/v2/apikeys_v2.yaml'
 

--- a/src/generated/api/servicecontrol/v1/.sidekick.toml
+++ b/src/generated/api/servicecontrol/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/api/servicecontrol/v1'
 service-config = 'google/api/servicecontrol/v1/servicecontrol.yaml'
 

--- a/src/generated/api/servicecontrol/v2/.sidekick.toml
+++ b/src/generated/api/servicecontrol/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/api/servicecontrol/v2'
 service-config = 'google/api/servicecontrol/v2/servicecontrol.yaml'
 

--- a/src/generated/api/servicemanagement/v1/.sidekick.toml
+++ b/src/generated/api/servicemanagement/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/api/servicemanagement/v1'
 service-config = 'google/api/servicemanagement/v1/servicemanagement_v1.yaml'
 

--- a/src/generated/api/serviceusage/v1/.sidekick.toml
+++ b/src/generated/api/serviceusage/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/api/serviceusage/v1'
 service-config = 'google/api/serviceusage/v1/serviceusage_v1.yaml'
 

--- a/src/generated/api/types/.sidekick.toml
+++ b/src/generated/api/types/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/api'
 service-config = 'google/api/serviceconfig.yaml'
 

--- a/src/generated/appengine/v1/.sidekick.toml
+++ b/src/generated/appengine/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/appengine/v1'
 service-config = 'google/appengine/v1/appengine_v1.yaml'
 

--- a/src/generated/apps/script/calendar/.sidekick.toml
+++ b/src/generated/apps/script/calendar/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/apps/script/type/calendar'
 
 [source]

--- a/src/generated/apps/script/docs/.sidekick.toml
+++ b/src/generated/apps/script/docs/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/apps/script/type/docs'
 
 [source]

--- a/src/generated/apps/script/drive/.sidekick.toml
+++ b/src/generated/apps/script/drive/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/apps/script/type/drive'
 
 [source]

--- a/src/generated/apps/script/gmail/.sidekick.toml
+++ b/src/generated/apps/script/gmail/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/apps/script/type/gmail'
 
 [source]

--- a/src/generated/apps/script/gtype/.sidekick.toml
+++ b/src/generated/apps/script/gtype/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/apps/script/type'
 
 [source]

--- a/src/generated/apps/script/sheets/.sidekick.toml
+++ b/src/generated/apps/script/sheets/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/apps/script/type/sheets'
 
 [source]

--- a/src/generated/apps/script/slides/.sidekick.toml
+++ b/src/generated/apps/script/slides/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/apps/script/type/slides'
 
 [source]

--- a/src/generated/bigtable/admin/v2/.sidekick.toml
+++ b/src/generated/bigtable/admin/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/bigtable/admin/v2'
 service-config = 'google/bigtable/admin/v2/bigtableadmin_v2.yaml'
 

--- a/src/generated/cloud/accessapproval/v1/.sidekick.toml
+++ b/src/generated/cloud/accessapproval/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/accessapproval/v1'
 service-config = 'google/cloud/accessapproval/v1/accessapproval_v1.yaml'
 

--- a/src/generated/cloud/advisorynotifications/v1/.sidekick.toml
+++ b/src/generated/cloud/advisorynotifications/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/advisorynotifications/v1'
 service-config = 'google/cloud/advisorynotifications/v1/advisorynotifications_v1.yaml'
 

--- a/src/generated/cloud/aiplatform/v1/.sidekick.toml
+++ b/src/generated/cloud/aiplatform/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/aiplatform/v1'
 service-config = 'google/cloud/aiplatform/v1/aiplatform_v1.yaml'
 

--- a/src/generated/cloud/alloydb/connectors/v1/.sidekick.toml
+++ b/src/generated/cloud/alloydb/connectors/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/alloydb/connectors/v1'
 service-config = 'google/cloud/alloydb/connectors/v1/connectors_v1.yaml'
 

--- a/src/generated/cloud/alloydb/v1/.sidekick.toml
+++ b/src/generated/cloud/alloydb/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/alloydb/v1'
 service-config = 'google/cloud/alloydb/v1/alloydb_v1.yaml'
 

--- a/src/generated/cloud/apigateway/v1/.sidekick.toml
+++ b/src/generated/cloud/apigateway/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/apigateway/v1'
 service-config = 'google/cloud/apigateway/v1/apigateway_v1.yaml'
 

--- a/src/generated/cloud/apigeeconnect/v1/.sidekick.toml
+++ b/src/generated/cloud/apigeeconnect/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/apigeeconnect/v1'
 service-config = 'google/cloud/apigeeconnect/v1/apigeeconnect_v1.yaml'
 

--- a/src/generated/cloud/apihub/v1/.sidekick.toml
+++ b/src/generated/cloud/apihub/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/apihub/v1'
 service-config = 'google/cloud/apihub/v1/apihub_v1.yaml'
 

--- a/src/generated/cloud/apphub/v1/.sidekick.toml
+++ b/src/generated/cloud/apphub/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/apphub/v1'
 service-config = 'google/cloud/apphub/v1/apphub_v1.yaml'
 

--- a/src/generated/cloud/asset/v1/.sidekick.toml
+++ b/src/generated/cloud/asset/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/asset/v1'
 service-config = 'google/cloud/asset/v1/cloudasset_v1.yaml'
 

--- a/src/generated/cloud/assuredworkloads/v1/.sidekick.toml
+++ b/src/generated/cloud/assuredworkloads/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 service-config = 'google/cloud/assuredworkloads/v1/assuredworkloads_v1.yaml'
 specification-source = 'google/cloud/assuredworkloads/v1'
 

--- a/src/generated/cloud/backupdr/v1/.sidekick.toml
+++ b/src/generated/cloud/backupdr/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/backupdr/v1'
 service-config = 'google/cloud/backupdr/v1/backupdr_v1.yaml'
 

--- a/src/generated/cloud/baremetalsolution/v2/.sidekick.toml
+++ b/src/generated/cloud/baremetalsolution/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/baremetalsolution/v2'
 service-config = 'google/cloud/baremetalsolution/v2/baremetalsolution_v2.yaml'
 

--- a/src/generated/cloud/beyondcorp/appconnections/v1/.sidekick.toml
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/beyondcorp/appconnections/v1'
 service-config = 'google/cloud/beyondcorp/appconnections/v1/beyondcorp_v1.yaml'
 

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/.sidekick.toml
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/beyondcorp/appconnectors/v1'
 service-config = 'google/cloud/beyondcorp/appconnectors/v1/beyondcorp_v1.yaml'
 

--- a/src/generated/cloud/beyondcorp/appgateways/v1/.sidekick.toml
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/beyondcorp/appgateways/v1'
 service-config = 'google/cloud/beyondcorp/appgateways/v1/beyondcorp_v1.yaml'
 

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/.sidekick.toml
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/beyondcorp/clientconnectorservices/v1'
 service-config = 'google/cloud/beyondcorp/clientconnectorservices/v1/beyondcorp_v1.yaml'
 

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/.sidekick.toml
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/beyondcorp/clientgateways/v1'
 service-config = 'google/cloud/beyondcorp/clientgateways/v1/beyondcorp_v1.yaml'
 

--- a/src/generated/cloud/bigquery/analyticshub/v1/.sidekick.toml
+++ b/src/generated/cloud/bigquery/analyticshub/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/bigquery/analyticshub/v1'
 service-config = 'google/cloud/bigquery/analyticshub/v1/analyticshub_v1.yaml'
 

--- a/src/generated/cloud/bigquery/connection/v1/.sidekick.toml
+++ b/src/generated/cloud/bigquery/connection/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/bigquery/connection/v1'
 service-config = 'google/cloud/bigquery/connection/v1/bigqueryconnection_v1.yaml'
 

--- a/src/generated/cloud/bigquery/datapolicies/v1/.sidekick.toml
+++ b/src/generated/cloud/bigquery/datapolicies/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/bigquery/datapolicies/v1'
 service-config = 'google/cloud/bigquery/datapolicies/v1/bigquerydatapolicy_v1.yaml'
 

--- a/src/generated/cloud/bigquery/datatransfer/v1/.sidekick.toml
+++ b/src/generated/cloud/bigquery/datatransfer/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/bigquery/datatransfer/v1'
 service-config = 'google/cloud/bigquery/datatransfer/v1/bigquerydatatransfer_v1.yaml'
 

--- a/src/generated/cloud/bigquery/migration/v2/.sidekick.toml
+++ b/src/generated/cloud/bigquery/migration/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/bigquery/migration/v2'
 service-config = 'google/cloud/bigquery/migration/v2/bigquerymigration_v2.yaml'
 

--- a/src/generated/cloud/bigquery/reservation/v1/.sidekick.toml
+++ b/src/generated/cloud/bigquery/reservation/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/bigquery/reservation/v1'
 service-config = 'google/cloud/bigquery/reservation/v1/bigqueryreservation_v1.yaml'
 

--- a/src/generated/cloud/billing/v1/.sidekick.toml
+++ b/src/generated/cloud/billing/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/billing/v1'
 service-config = 'google/cloud/billing/v1/cloudbilling_v1.yaml'
 

--- a/src/generated/cloud/binaryauthorization/v1/.sidekick.toml
+++ b/src/generated/cloud/binaryauthorization/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/binaryauthorization/v1'
 service-config = 'google/cloud/binaryauthorization/v1/binaryauthorization_v1.yaml'
 

--- a/src/generated/cloud/certificatemanager/v1/.sidekick.toml
+++ b/src/generated/cloud/certificatemanager/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/certificatemanager/v1'
 service-config = 'google/cloud/certificatemanager/v1/certificatemanager_v1.yaml'
 

--- a/src/generated/cloud/cloudcontrolspartner/v1/.sidekick.toml
+++ b/src/generated/cloud/cloudcontrolspartner/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/cloudcontrolspartner/v1'
 service-config = 'google/cloud/cloudcontrolspartner/v1/cloudcontrolspartner_v1.yaml'
 

--- a/src/generated/cloud/clouddms/v1/.sidekick.toml
+++ b/src/generated/cloud/clouddms/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/clouddms/v1'
 service-config = 'google/cloud/clouddms/v1/datamigration_v1.yaml'
 

--- a/src/generated/cloud/common/.sidekick.toml
+++ b/src/generated/cloud/common/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/common'
 service-config = 'google/cloud/common/common.yaml'
 

--- a/src/generated/cloud/confidentialcomputing/v1/.sidekick.toml
+++ b/src/generated/cloud/confidentialcomputing/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/confidentialcomputing/v1'
 service-config = 'google/cloud/confidentialcomputing/v1/confidentialcomputing_v1.yaml'
 

--- a/src/generated/cloud/config/v1/.sidekick.toml
+++ b/src/generated/cloud/config/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/config/v1'
 service-config = 'google/cloud/config/v1/config_v1.yaml'
 

--- a/src/generated/cloud/connectors/v1/.sidekick.toml
+++ b/src/generated/cloud/connectors/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/connectors/v1'
 service-config = 'google/cloud/connectors/v1/connectors_v1.yaml'
 

--- a/src/generated/cloud/contactcenterinsights/v1/.sidekick.toml
+++ b/src/generated/cloud/contactcenterinsights/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/contactcenterinsights/v1'
 service-config = 'google/cloud/contactcenterinsights/v1/contactcenterinsights_v1.yaml'
 

--- a/src/generated/cloud/datacatalog/lineage/v1/.sidekick.toml
+++ b/src/generated/cloud/datacatalog/lineage/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/datacatalog/lineage/v1'
 service-config = 'google/cloud/datacatalog/lineage/v1/datalineage_v1.yaml'
 

--- a/src/generated/cloud/datacatalog/v1/.sidekick.toml
+++ b/src/generated/cloud/datacatalog/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/datacatalog/v1'
 service-config = 'google/cloud/datacatalog/v1/datacatalog_v1.yaml'
 

--- a/src/generated/cloud/datafusion/v1/.sidekick.toml
+++ b/src/generated/cloud/datafusion/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/datafusion/v1'
 service-config = 'google/cloud/datafusion/v1/datafusion_v1.yaml'
 

--- a/src/generated/cloud/dataproc/v1/.sidekick.toml
+++ b/src/generated/cloud/dataproc/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/dataproc/v1'
 service-config = 'google/cloud/dataproc/v1/dataproc_v1.yaml'
 

--- a/src/generated/cloud/datastream/v1/.sidekick.toml
+++ b/src/generated/cloud/datastream/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/datastream/v1'
 service-config = 'google/cloud/datastream/v1/datastream_v1.yaml'
 

--- a/src/generated/cloud/deploy/v1/.sidekick.toml
+++ b/src/generated/cloud/deploy/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/deploy/v1'
 service-config = 'google/cloud/deploy/v1/clouddeploy_v1.yaml'
 

--- a/src/generated/cloud/developerconnect/v1/.sidekick.toml
+++ b/src/generated/cloud/developerconnect/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/developerconnect/v1'
 service-config = 'google/cloud/developerconnect/v1/developerconnect_v1.yaml'
 

--- a/src/generated/cloud/dialogflow/cx/v3/.sidekick.toml
+++ b/src/generated/cloud/dialogflow/cx/v3/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/dialogflow/cx/v3'
 service-config = 'google/cloud/dialogflow/cx/v3/dialogflow_v3.yaml'
 

--- a/src/generated/cloud/dialogflow/v2/.sidekick.toml
+++ b/src/generated/cloud/dialogflow/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/dialogflow/v2'
 service-config = 'google/cloud/dialogflow/v2/dialogflow_v2.yaml'
 

--- a/src/generated/cloud/discoveryengine/v1/.sidekick.toml
+++ b/src/generated/cloud/discoveryengine/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/discoveryengine/v1'
 service-config = 'google/cloud/discoveryengine/v1/discoveryengine_v1.yaml'
 

--- a/src/generated/cloud/documentai/v1/.sidekick.toml
+++ b/src/generated/cloud/documentai/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/documentai/v1'
 service-config = 'google/cloud/documentai/v1/documentai_v1.yaml'
 

--- a/src/generated/cloud/domains/v1/.sidekick.toml
+++ b/src/generated/cloud/domains/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/domains/v1'
 service-config = 'google/cloud/domains/v1/domains_v1.yaml'
 

--- a/src/generated/cloud/edgecontainer/v1/.sidekick.toml
+++ b/src/generated/cloud/edgecontainer/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/edgecontainer/v1'
 service-config = 'google/cloud/edgecontainer/v1/edgecontainer_v1.yaml'
 

--- a/src/generated/cloud/edgenetwork/v1/.sidekick.toml
+++ b/src/generated/cloud/edgenetwork/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/edgenetwork/v1'
 service-config = 'google/cloud/edgenetwork/v1/edgenetwork_v1.yaml'
 

--- a/src/generated/cloud/essentialcontacts/v1/.sidekick.toml
+++ b/src/generated/cloud/essentialcontacts/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/essentialcontacts/v1'
 service-config = 'google/cloud/essentialcontacts/v1/essentialcontacts_v1.yaml'
 

--- a/src/generated/cloud/eventarc/v1/.sidekick.toml
+++ b/src/generated/cloud/eventarc/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/eventarc/v1'
 service-config = 'google/cloud/eventarc/v1/eventarc_v1.yaml'
 

--- a/src/generated/cloud/filestore/v1/.sidekick.toml
+++ b/src/generated/cloud/filestore/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/filestore/v1'
 service-config = 'google/cloud/filestore/v1/file_v1.yaml'
 

--- a/src/generated/cloud/functions/v2/.sidekick.toml
+++ b/src/generated/cloud/functions/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/functions/v2'
 service-config = 'google/cloud/functions/v2/cloudfunctions_v2.yaml'
 

--- a/src/generated/cloud/gkebackup/v1/.sidekick.toml
+++ b/src/generated/cloud/gkebackup/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/gkebackup/v1'
 service-config = 'google/cloud/gkebackup/v1/gkebackup_v1.yaml'
 

--- a/src/generated/cloud/gkeconnect/gateway/v1/.sidekick.toml
+++ b/src/generated/cloud/gkeconnect/gateway/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/gkeconnect/gateway/v1'
 service-config = 'google/cloud/gkeconnect/gateway/v1/connectgateway_v1.yaml'
 

--- a/src/generated/cloud/gkehub/configmanagement/v1/.sidekick.toml
+++ b/src/generated/cloud/gkehub/configmanagement/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/gkehub/v1/configmanagement'
 
 [source]

--- a/src/generated/cloud/gkehub/multiclusteringress/v1/.sidekick.toml
+++ b/src/generated/cloud/gkehub/multiclusteringress/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/gkehub/v1/multiclusteringress'
 
 [source]

--- a/src/generated/cloud/gkehub/v1/.sidekick.toml
+++ b/src/generated/cloud/gkehub/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/gkehub/v1'
 service-config = 'google/cloud/gkehub/v1/gkehub_v1.yaml'
 

--- a/src/generated/cloud/gkemulticloud/v1/.sidekick.toml
+++ b/src/generated/cloud/gkemulticloud/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/gkemulticloud/v1'
 service-config = 'google/cloud/gkemulticloud/v1/gkemulticloud_v1.yaml'
 

--- a/src/generated/cloud/gsuiteaddons/v1/.sidekick.toml
+++ b/src/generated/cloud/gsuiteaddons/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/gsuiteaddons/v1'
 service-config = 'google/cloud/gsuiteaddons/v1/gsuiteaddons_v1.yaml'
 

--- a/src/generated/cloud/iap/v1/.sidekick.toml
+++ b/src/generated/cloud/iap/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/iap/v1'
 service-config = 'google/cloud/iap/v1/iap_v1.yaml'
 

--- a/src/generated/cloud/ids/v1/.sidekick.toml
+++ b/src/generated/cloud/ids/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/ids/v1'
 service-config = 'google/cloud/ids/v1/ids_v1.yaml'
 

--- a/src/generated/cloud/kms/inventory/v1/.sidekick.toml
+++ b/src/generated/cloud/kms/inventory/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/kms/inventory/v1'
 service-config = 'google/cloud/kms/inventory/v1/kmsinventory_v1.yaml'
 

--- a/src/generated/cloud/kms/v1/.sidekick.toml
+++ b/src/generated/cloud/kms/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/kms/v1'
 service-config = 'google/cloud/kms/v1/cloudkms_v1.yaml'
 

--- a/src/generated/cloud/language/v2/.sidekick.toml
+++ b/src/generated/cloud/language/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/language/v2'
 service-config = 'google/cloud/language/v2/language_v2.yaml'
 

--- a/src/generated/cloud/managedidentities/v1/.sidekick.toml
+++ b/src/generated/cloud/managedidentities/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/managedidentities/v1'
 service-config = 'google/cloud/managedidentities/v1/managedidentities_v1.yaml'
 

--- a/src/generated/cloud/memcache/v1/.sidekick.toml
+++ b/src/generated/cloud/memcache/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/memcache/v1'
 service-config = 'google/cloud/memcache/v1/memcache_v1.yaml'
 

--- a/src/generated/cloud/memorystore/v1/.sidekick.toml
+++ b/src/generated/cloud/memorystore/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/memorystore/v1'
 service-config = 'google/cloud/memorystore/v1/memorystore_v1.yaml'
 

--- a/src/generated/cloud/metastore/v1/.sidekick.toml
+++ b/src/generated/cloud/metastore/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/metastore/v1'
 service-config = 'google/cloud/metastore/v1/metastore_v1.yaml'
 

--- a/src/generated/cloud/migrationcenter/v1/.sidekick.toml
+++ b/src/generated/cloud/migrationcenter/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/migrationcenter/v1'
 service-config = 'google/cloud/migrationcenter/v1/migrationcenter_v1.yaml'
 

--- a/src/generated/cloud/modelarmor/v1/.sidekick.toml
+++ b/src/generated/cloud/modelarmor/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/modelarmor/v1'
 service-config = 'google/cloud/modelarmor/v1/modelarmor_v1.yaml'
 

--- a/src/generated/cloud/netapp/v1/.sidekick.toml
+++ b/src/generated/cloud/netapp/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/netapp/v1'
 service-config = 'google/cloud/netapp/v1/netapp_v1.yaml'
 

--- a/src/generated/cloud/networkconnectivity/v1/.sidekick.toml
+++ b/src/generated/cloud/networkconnectivity/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/networkconnectivity/v1'
 service-config = 'google/cloud/networkconnectivity/v1/networkconnectivity_v1.yaml'
 

--- a/src/generated/cloud/networkmanagement/v1/.sidekick.toml
+++ b/src/generated/cloud/networkmanagement/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/networkmanagement/v1'
 service-config = 'google/cloud/networkmanagement/v1/networkmanagement_v1.yaml'
 

--- a/src/generated/cloud/networksecurity/v1/.sidekick.toml
+++ b/src/generated/cloud/networksecurity/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/networksecurity/v1'
 service-config = 'google/cloud/networksecurity/v1/networksecurity_v1.yaml'
 

--- a/src/generated/cloud/networkservices/v1/.sidekick.toml
+++ b/src/generated/cloud/networkservices/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/networkservices/v1'
 service-config = 'google/cloud/networkservices/v1/networkservices_v1.yaml'
 

--- a/src/generated/cloud/notebooks/v2/.sidekick.toml
+++ b/src/generated/cloud/notebooks/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/notebooks/v2'
 service-config = 'google/cloud/notebooks/v2/notebooks_v2.yaml'
 

--- a/src/generated/cloud/optimization/v1/.sidekick.toml
+++ b/src/generated/cloud/optimization/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/optimization/v1'
 service-config = 'google/cloud/optimization/v1/cloudoptimization_v1.yaml'
 

--- a/src/generated/cloud/oracledatabase/v1/.sidekick.toml
+++ b/src/generated/cloud/oracledatabase/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/oracledatabase/v1'
 service-config = 'google/cloud/oracledatabase/v1/oracledatabase_v1.yaml'
 

--- a/src/generated/cloud/orchestration/airflow/service/v1/.sidekick.toml
+++ b/src/generated/cloud/orchestration/airflow/service/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/orchestration/airflow/service/v1'
 service-config = 'google/cloud/orchestration/airflow/service/v1/composer_v1.yaml'
 

--- a/src/generated/cloud/orgpolicy/v1/.sidekick.toml
+++ b/src/generated/cloud/orgpolicy/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/orgpolicy/v1'
 
 [source]

--- a/src/generated/cloud/orgpolicy/v2/.sidekick.toml
+++ b/src/generated/cloud/orgpolicy/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/orgpolicy/v2'
 service-config = 'google/cloud/orgpolicy/v2/orgpolicy_v2.yaml'
 

--- a/src/generated/cloud/osconfig/v1/.sidekick.toml
+++ b/src/generated/cloud/osconfig/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/osconfig/v1'
 service-config = 'google/cloud/osconfig/v1/osconfig_v1.yaml'
 

--- a/src/generated/cloud/oslogin/v1/.sidekick.toml
+++ b/src/generated/cloud/oslogin/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/oslogin/v1'
 service-config = 'google/cloud/oslogin/v1/oslogin_v1.yaml'
 

--- a/src/generated/cloud/parallelstore/v1/.sidekick.toml
+++ b/src/generated/cloud/parallelstore/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/parallelstore/v1'
 service-config = 'google/cloud/parallelstore/v1/parallelstore_v1.yaml'
 

--- a/src/generated/cloud/policysimulator/v1/.sidekick.toml
+++ b/src/generated/cloud/policysimulator/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/policysimulator/v1'
 service-config = 'google/cloud/policysimulator/v1/policysimulator_v1.yaml'
 

--- a/src/generated/cloud/policytroubleshooter/iam/v3/.sidekick.toml
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/policytroubleshooter/iam/v3'
 service-config = 'google/cloud/policytroubleshooter/iam/v3/policytroubleshooter_v3.yaml'
 

--- a/src/generated/cloud/policytroubleshooter/v1/.sidekick.toml
+++ b/src/generated/cloud/policytroubleshooter/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/policytroubleshooter/v1'
 service-config = 'google/cloud/policytroubleshooter/v1/policytroubleshooter_v1.yaml'
 

--- a/src/generated/cloud/privilegedaccessmanager/v1/.sidekick.toml
+++ b/src/generated/cloud/privilegedaccessmanager/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/privilegedaccessmanager/v1'
 service-config = 'google/cloud/privilegedaccessmanager/v1/privilegedaccessmanager_v1.yaml'
 

--- a/src/generated/cloud/rapidmigrationassessment/v1/.sidekick.toml
+++ b/src/generated/cloud/rapidmigrationassessment/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/rapidmigrationassessment/v1'
 service-config = 'google/cloud/rapidmigrationassessment/v1/rapidmigrationassessment_v1.yaml'
 

--- a/src/generated/cloud/recaptchaenterprise/v1/.sidekick.toml
+++ b/src/generated/cloud/recaptchaenterprise/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/recaptchaenterprise/v1'
 service-config = 'google/cloud/recaptchaenterprise/v1/recaptchaenterprise_v1.yaml'
 

--- a/src/generated/cloud/recommender/logging/v1/.sidekick.toml
+++ b/src/generated/cloud/recommender/logging/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/recommender/logging/v1'
 service-config = 'google/cloud/recommender/logging/v1/recommender.yaml'
 

--- a/src/generated/cloud/recommender/v1/.sidekick.toml
+++ b/src/generated/cloud/recommender/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/recommender/v1'
 service-config = 'google/cloud/recommender/v1/recommender_v1.yaml'
 

--- a/src/generated/cloud/redis/cluster/v1/.sidekick.toml
+++ b/src/generated/cloud/redis/cluster/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/redis/cluster/v1'
 service-config = 'google/cloud/redis/cluster/v1/redis_v1.yaml'
 

--- a/src/generated/cloud/redis/v1/.sidekick.toml
+++ b/src/generated/cloud/redis/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/redis/v1'
 service-config = 'google/cloud/redis/v1/redis_v1.yaml'
 

--- a/src/generated/cloud/resourcemanager/v3/.sidekick.toml
+++ b/src/generated/cloud/resourcemanager/v3/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/resourcemanager/v3'
 service-config = 'google/cloud/resourcemanager/v3/cloudresourcemanager_v3.yaml'
 

--- a/src/generated/cloud/retail/v2/.sidekick.toml
+++ b/src/generated/cloud/retail/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/retail/v2'
 service-config = 'google/cloud/retail/v2/retail_v2.yaml'
 

--- a/src/generated/cloud/run/v2/.sidekick.toml
+++ b/src/generated/cloud/run/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/run/v2'
 service-config = 'google/cloud/run/v2/run_v2.yaml'
 

--- a/src/generated/cloud/scheduler/v1/.sidekick.toml
+++ b/src/generated/cloud/scheduler/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/scheduler/v1'
 service-config = 'google/cloud/scheduler/v1/cloudscheduler_v1.yaml'
 

--- a/src/generated/cloud/securesourcemanager/v1/.sidekick.toml
+++ b/src/generated/cloud/securesourcemanager/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/securesourcemanager/v1'
 service-config = 'google/cloud/securesourcemanager/v1/securesourcemanager_v1.yaml'
 

--- a/src/generated/cloud/security/privateca/v1/.sidekick.toml
+++ b/src/generated/cloud/security/privateca/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/security/privateca/v1'
 service-config = 'google/cloud/security/privateca/v1/privateca_v1.yaml'
 

--- a/src/generated/cloud/security/publicca/v1/.sidekick.toml
+++ b/src/generated/cloud/security/publicca/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/security/publicca/v1'
 service-config = 'google/cloud/security/publicca/v1/publicca_v1.yaml'
 

--- a/src/generated/cloud/securitycenter/v2/.sidekick.toml
+++ b/src/generated/cloud/securitycenter/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/securitycenter/v2'
 service-config = 'google/cloud/securitycenter/v2/securitycenter_v2.yaml'
 

--- a/src/generated/cloud/securityposture/v1/.sidekick.toml
+++ b/src/generated/cloud/securityposture/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/securityposture/v1'
 service-config = 'google/cloud/securityposture/v1/securityposture_v1.yaml'
 

--- a/src/generated/cloud/servicedirectory/v1/.sidekick.toml
+++ b/src/generated/cloud/servicedirectory/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/servicedirectory/v1'
 service-config = 'google/cloud/servicedirectory/v1/servicedirectory_v1.yaml'
 

--- a/src/generated/cloud/servicehealth/v1/.sidekick.toml
+++ b/src/generated/cloud/servicehealth/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/servicehealth/v1'
 service-config = 'google/cloud/servicehealth/v1/servicehealth_v1.yaml'
 

--- a/src/generated/cloud/shell/v1/.sidekick.toml
+++ b/src/generated/cloud/shell/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/shell/v1'
 service-config = 'google/cloud/shell/v1/cloudshell_v1.yaml'
 

--- a/src/generated/cloud/speech/v2/.sidekick.toml
+++ b/src/generated/cloud/speech/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/speech/v2'
 service-config = 'google/cloud/speech/v2/speech_v2.yaml'
 

--- a/src/generated/cloud/sql/v1/.sidekick.toml
+++ b/src/generated/cloud/sql/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/sql/v1'
 service-config = 'google/cloud/sql/v1/sqladmin_v1.yaml'
 

--- a/src/generated/cloud/storageinsights/v1/.sidekick.toml
+++ b/src/generated/cloud/storageinsights/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/storageinsights/v1'
 service-config = 'google/cloud/storageinsights/v1/storageinsights_v1.yaml'
 

--- a/src/generated/cloud/support/v2/.sidekick.toml
+++ b/src/generated/cloud/support/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/support/v2'
 service-config = 'google/cloud/support/v2/cloudsupport_v2.yaml'
 

--- a/src/generated/cloud/talent/v4/.sidekick.toml
+++ b/src/generated/cloud/talent/v4/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/talent/v4'
 service-config = 'google/cloud/talent/v4/jobs_v4.yaml'
 

--- a/src/generated/cloud/tasks/v2/.sidekick.toml
+++ b/src/generated/cloud/tasks/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/tasks/v2'
 service-config = 'google/cloud/tasks/v2/cloudtasks_v2.yaml'
 

--- a/src/generated/cloud/telcoautomation/v1/.sidekick.toml
+++ b/src/generated/cloud/telcoautomation/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/telcoautomation/v1'
 service-config = 'google/cloud/telcoautomation/v1/telcoautomation_v1.yaml'
 

--- a/src/generated/cloud/texttospeech/v1/.sidekick.toml
+++ b/src/generated/cloud/texttospeech/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/texttospeech/v1'
 service-config = 'google/cloud/texttospeech/v1/texttospeech_v1.yaml'
 

--- a/src/generated/cloud/timeseriesinsights/v1/.sidekick.toml
+++ b/src/generated/cloud/timeseriesinsights/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/timeseriesinsights/v1'
 service-config = 'google/cloud/timeseriesinsights/v1/timeseriesinsights_v1.yaml'
 

--- a/src/generated/cloud/tpu/v2/.sidekick.toml
+++ b/src/generated/cloud/tpu/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/tpu/v2'
 service-config = 'google/cloud/tpu/v2/tpu_v2.yaml'
 

--- a/src/generated/cloud/translate/v3/.sidekick.toml
+++ b/src/generated/cloud/translate/v3/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/translate/v3'
 service-config = 'google/cloud/translate/v3/translate_v3.yaml'
 

--- a/src/generated/cloud/video/livestream/v1/.sidekick.toml
+++ b/src/generated/cloud/video/livestream/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/video/livestream/v1'
 service-config = 'google/cloud/video/livestream/v1/livestream_v1.yaml'
 

--- a/src/generated/cloud/video/stitcher/v1/.sidekick.toml
+++ b/src/generated/cloud/video/stitcher/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/video/stitcher/v1'
 service-config = 'google/cloud/video/stitcher/v1/videostitcher_v1.yaml'
 

--- a/src/generated/cloud/video/transcoder/v1/.sidekick.toml
+++ b/src/generated/cloud/video/transcoder/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/video/transcoder/v1'
 service-config = 'google/cloud/video/transcoder/v1/transcoder_v1.yaml'
 

--- a/src/generated/cloud/videointelligence/v1/.sidekick.toml
+++ b/src/generated/cloud/videointelligence/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/videointelligence/v1'
 service-config = 'google/cloud/videointelligence/v1/videointelligence_v1.yaml'
 

--- a/src/generated/cloud/vision/v1/.sidekick.toml
+++ b/src/generated/cloud/vision/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/vision/v1'
 service-config = 'google/cloud/vision/v1/vision_v1.yaml'
 

--- a/src/generated/cloud/vmmigration/v1/.sidekick.toml
+++ b/src/generated/cloud/vmmigration/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/vmmigration/v1'
 service-config = 'google/cloud/vmmigration/v1/vmmigration_v1.yaml'
 

--- a/src/generated/cloud/vmwareengine/v1/.sidekick.toml
+++ b/src/generated/cloud/vmwareengine/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/vmwareengine/v1'
 service-config = 'google/cloud/vmwareengine/v1/vmwareengine_v1.yaml'
 

--- a/src/generated/cloud/vpcaccess/v1/.sidekick.toml
+++ b/src/generated/cloud/vpcaccess/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/vpcaccess/v1'
 service-config = 'google/cloud/vpcaccess/v1/vpcaccess_v1.yaml'
 

--- a/src/generated/cloud/webrisk/v1/.sidekick.toml
+++ b/src/generated/cloud/webrisk/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/webrisk/v1'
 service-config = 'google/cloud/webrisk/v1/webrisk_v1.yaml'
 

--- a/src/generated/cloud/websecurityscanner/v1/.sidekick.toml
+++ b/src/generated/cloud/websecurityscanner/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/websecurityscanner/v1'
 service-config = 'google/cloud/websecurityscanner/v1/websecurityscanner_v1.yaml'
 

--- a/src/generated/cloud/workflows/executions/v1/.sidekick.toml
+++ b/src/generated/cloud/workflows/executions/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/workflows/executions/v1'
 service-config = 'google/cloud/workflows/executions/v1/workflowexecutions_v1.yaml'
 

--- a/src/generated/cloud/workflows/v1/.sidekick.toml
+++ b/src/generated/cloud/workflows/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/workflows/v1'
 service-config = 'google/cloud/workflows/v1/workflows_v1.yaml'
 

--- a/src/generated/cloud/workstations/v1/.sidekick.toml
+++ b/src/generated/cloud/workstations/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/workstations/v1'
 service-config = 'google/cloud/workstations/v1/workstations_v1.yaml'
 

--- a/src/generated/container/v1/.sidekick.toml
+++ b/src/generated/container/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/container/v1'
 service-config = 'google/container/v1/container_v1.yaml'
 

--- a/src/generated/datastore/admin/v1/.sidekick.toml
+++ b/src/generated/datastore/admin/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/datastore/admin/v1'
 service-config = 'google/datastore/admin/v1/datastore_v1.yaml'
 

--- a/src/generated/devtools/artifactregistry/v1/.sidekick.toml
+++ b/src/generated/devtools/artifactregistry/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/devtools/artifactregistry/v1'
 service-config = 'google/devtools/artifactregistry/v1/artifactregistry_v1.yaml'
 

--- a/src/generated/devtools/cloudbuild/v1/.sidekick.toml
+++ b/src/generated/devtools/cloudbuild/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/devtools/cloudbuild/v1'
 service-config = 'google/devtools/cloudbuild/v1/cloudbuild_v1.yaml'
 

--- a/src/generated/devtools/cloudbuild/v2/.sidekick.toml
+++ b/src/generated/devtools/cloudbuild/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/devtools/cloudbuild/v2'
 service-config = 'google/devtools/cloudbuild/v2/cloudbuild_v2.yaml'
 

--- a/src/generated/devtools/cloudprofiler/v2/.sidekick.toml
+++ b/src/generated/devtools/cloudprofiler/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/devtools/cloudprofiler/v2'
 service-config = 'google/devtools/cloudprofiler/v2/cloudprofiler_v2.yaml'
 

--- a/src/generated/devtools/cloudtrace/v2/.sidekick.toml
+++ b/src/generated/devtools/cloudtrace/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/devtools/cloudtrace/v2'
 service-config = 'google/devtools/cloudtrace/v2/cloudtrace_v2.yaml'
 

--- a/src/generated/devtools/containeranalysis/v1/.sidekick.toml
+++ b/src/generated/devtools/containeranalysis/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/devtools/containeranalysis/v1'
 service-config = 'google/devtools/containeranalysis/v1/containeranalysis_v1.yaml'
 

--- a/src/generated/grafeas/v1/.sidekick.toml
+++ b/src/generated/grafeas/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'grafeas/v1'
 service-config = 'grafeas/v1/grafeas_v1.yaml'
 

--- a/src/generated/iam/admin/v1/.sidekick.toml
+++ b/src/generated/iam/admin/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/iam/admin/v1'
 service-config = 'google/iam/admin/v1/iam.yaml'
 

--- a/src/generated/iam/credentials/v1/.sidekick.toml
+++ b/src/generated/iam/credentials/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/iam/credentials/v1'
 service-config = 'google/iam/credentials/v1/iamcredentials_v1.yaml'
 

--- a/src/generated/iam/v2/.sidekick.toml
+++ b/src/generated/iam/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/iam/v2'
 service-config = 'google/iam/v2/iam_v2.yaml'
 

--- a/src/generated/iam/v3/.sidekick.toml
+++ b/src/generated/iam/v3/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/iam/v3'
 service-config = 'google/iam/v3/iam_v3.yaml'
 

--- a/src/generated/identity/accesscontextmanager/type/.sidekick.toml
+++ b/src/generated/identity/accesscontextmanager/type/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/identity/accesscontextmanager/type'
 
 [source]

--- a/src/generated/identity/accesscontextmanager/v1/.sidekick.toml
+++ b/src/generated/identity/accesscontextmanager/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/identity/accesscontextmanager/v1'
 service-config = 'google/identity/accesscontextmanager/v1/accesscontextmanager_v1.yaml'
 

--- a/src/generated/logging/type/.sidekick.toml
+++ b/src/generated/logging/type/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/logging/type'
 
 [source]

--- a/src/generated/logging/v2/.sidekick.toml
+++ b/src/generated/logging/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/logging/v2'
 service-config = 'google/logging/v2/logging_v2.yaml'
 

--- a/src/generated/monitoring/dashboard/v1/.sidekick.toml
+++ b/src/generated/monitoring/dashboard/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/monitoring/dashboard/v1'
 service-config = 'google/monitoring/dashboard/v1/monitoring.yaml'
 

--- a/src/generated/monitoring/metricsscope/v1/.sidekick.toml
+++ b/src/generated/monitoring/metricsscope/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/monitoring/metricsscope/v1'
 service-config = 'google/monitoring/metricsscope/v1/monitoring.yaml'
 

--- a/src/generated/monitoring/v3/.sidekick.toml
+++ b/src/generated/monitoring/v3/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/monitoring/v3'
 service-config = 'google/monitoring/v3/monitoring.yaml'
 

--- a/src/generated/openapi-validation/.sidekick.toml
+++ b/src/generated/openapi-validation/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-format = 'openapi'
 specification-source = 'testdata/secretmanager_openapi_v1.json'
 service-config = 'google/cloud/secretmanager/v1/secretmanager_v1.yaml'

--- a/src/generated/oslogin/common/.sidekick.toml
+++ b/src/generated/oslogin/common/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/cloud/oslogin/common'
 
 [source]

--- a/src/generated/privacy/dlp/v2/.sidekick.toml
+++ b/src/generated/privacy/dlp/v2/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/privacy/dlp/v2'
 service-config = 'google/privacy/dlp/v2/dlp_v2.yaml'
 

--- a/src/generated/rpc/context/.sidekick.toml
+++ b/src/generated/rpc/context/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/rpc/context'
 
 [source]

--- a/src/generated/showcase/.not-working-sidekick.toml
+++ b/src/generated/showcase/.not-working-sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'schema/google/showcase/v1beta1'
 service-config = 'schema/google/showcase/v1beta1/showcase_v1beta1.yaml'
 

--- a/src/generated/spanner/admin/database/v1/.sidekick.toml
+++ b/src/generated/spanner/admin/database/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/spanner/admin/database/v1'
 service-config = 'google/spanner/admin/database/v1/spanner.yaml'
 

--- a/src/generated/spanner/admin/instance/v1/.sidekick.toml
+++ b/src/generated/spanner/admin/instance/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/spanner/admin/instance/v1'
 service-config = 'google/spanner/admin/instance/v1/spanner.yaml'
 

--- a/src/generated/storagetransfer/v1/.sidekick.toml
+++ b/src/generated/storagetransfer/v1/.sidekick.toml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 [general]
-language = 'rust'
 specification-source = 'google/storagetransfer/v1'
 service-config = 'google/storagetransfer/v1/storagetransfer_v1.yaml'
 


### PR DESCRIPTION
The value in the top-level `.sidekick.toml` is enough.

Fixes #1330