### PR TITLE
chore: match `google-cloud-longrunning` version

### DIFF
--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -63,6 +63,6 @@ disabled-rustdoc-warnings = "redundant_explicit_links,broken_intra_doc_links"
 'package:iam_v1'       = 'package=google-cloud-iam-v1,source=google.iam.v1,path=src/generated/iam/v1,version=0.2'
 'package:location'     = 'package=google-cloud-location,source=google.cloud.location,path=src/generated/cloud/location,version=0.2'
 'package:logging_type' = 'package=google-cloud-logging-type,source=google.logging.type,path=src/generated/logging/type,version=0.2'
-'package:longrunning'  = 'package=google-cloud-longrunning,source=google.longrunning,path=src/generated/longrunning,version=0.2'
+'package:longrunning'  = 'package=google-cloud-longrunning,source=google.longrunning,path=src/generated/longrunning,version=0.22'
 'package:rpc'          = 'package=google-cloud-rpc,source=google.rpc,path=src/generated/rpc/types,version=0.2'
 'package:rpc_context'  = 'package=google-cloud-rpc-context,source=google.rpc.context,path=src/generated/rpc/context,version=0.2'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2623,7 +2623,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-longrunning"
-version = "0.2.0"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/guide/samples/Cargo.toml
+++ b/guide/samples/Cargo.toml
@@ -30,7 +30,7 @@ name = "getting_started"
 [dependencies]
 tokio = { version = "1.43", features = ["full", "macros"] }
 # ANCHOR: longrunning
-google-cloud-longrunning = { version = "0.2.0", path = "../../src/generated/longrunning" }
+google-cloud-longrunning = { version = "0.22.0", path = "../../src/generated/longrunning" }
 # ANCHOR_END: longrunning
 # ANCHOR: gax
 google-cloud-gax = { version = "0.20.0", path = "../../src/gax" }

--- a/src/auth/README.md
+++ b/src/auth/README.md
@@ -10,6 +10,6 @@ APIs, documentation, missing features, bugs, etc.
 
 > This crate used to contain a different implementation, with a different
 > surface. [@yoshidan](https://github.com/yoshidan) generously donated the crate
-> name to google. Their crate continues to live as [gcloud-auth].
+> name to Google. Their crate continues to live as [gcloud-auth].
 
 [gcloud-auth]: https://crates.io/crates/gcloud-auth

--- a/src/gax/README.md
+++ b/src/gax/README.md
@@ -10,6 +10,6 @@ APIs, documentation, missing features, bugs, etc.
 
 > This crate used to contain a different implementation, with a different
 > surface. [@yoshidan](https://github.com/yoshidan) generously donated the crate
-> name to google. Their crate continues to live as [gcloud-gax].
+> name to Google. Their crate continues to live as [gcloud-gax].
 
 [gcloud-gax]: https://crates.io/crates/gcloud-gax

--- a/src/generated/api/apikeys/v2/Cargo.toml
+++ b/src/generated/api/apikeys/v2/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/api/servicemanagement/v1/Cargo.toml
+++ b/src/generated/api/servicemanagement/v1/Cargo.toml
@@ -32,7 +32,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/api/serviceusage/v1/Cargo.toml
+++ b/src/generated/api/serviceusage/v1/Cargo.toml
@@ -31,7 +31,7 @@ async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/appengine/v1/Cargo.toml
+++ b/src/generated/appengine/v1/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/bigtable/admin/v2/Cargo.toml
+++ b/src/generated/bigtable/admin/v2/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/aiplatform/v1/Cargo.toml
+++ b/src/generated/cloud/aiplatform/v1/Cargo.toml
@@ -34,7 +34,7 @@ gtype      = { version = "0.2", path = "../../../../../src/generated/type", pack
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/alloydb/v1/Cargo.toml
+++ b/src/generated/cloud/alloydb/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/apigateway/v1/Cargo.toml
+++ b/src/generated/cloud/apigateway/v1/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/apihub/v1/Cargo.toml
+++ b/src/generated/cloud/apihub/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/apphub/v1/Cargo.toml
+++ b/src/generated/cloud/apphub/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/asset/v1/Cargo.toml
+++ b/src/generated/cloud/asset/v1/Cargo.toml
@@ -33,7 +33,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 orgpolicy_v1 = { version = "0.2", path = "../../../../../src/generated/cloud/orgpolicy/v1", package = "google-cloud-orgpolicy-v1" }
 osconfig_v1 = { version = "0.2", path = "../../../../../src/generated/cloud/osconfig/v1", package = "google-cloud-osconfig-v1" }

--- a/src/generated/cloud/assuredworkloads/v1/Cargo.toml
+++ b/src/generated/cloud/assuredworkloads/v1/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/backupdr/v1/Cargo.toml
+++ b/src/generated/cloud/backupdr/v1/Cargo.toml
@@ -33,7 +33,7 @@ gtype      = { version = "0.2", path = "../../../../../src/generated/type", pack
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/baremetalsolution/v2/Cargo.toml
+++ b/src/generated/cloud/baremetalsolution/v2/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/beyondcorp/appconnections/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../../src/gax", package = "
 iam_v1     = { version = "0.2", path = "../../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../../src/gax", package = "
 iam_v1     = { version = "0.2", path = "../../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/beyondcorp/appgateways/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../../src/gax", package = "
 iam_v1     = { version = "0.2", path = "../../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../../src/gax", package = "
 iam_v1     = { version = "0.2", path = "../../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../../src/gax", package = "
 iam_v1     = { version = "0.2", path = "../../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/bigquery/analyticshub/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/analyticshub/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 iam_v1     = { version = "0.2", path = "../../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/certificatemanager/v1/Cargo.toml
+++ b/src/generated/cloud/certificatemanager/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/clouddms/v1/Cargo.toml
+++ b/src/generated/cloud/clouddms/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/commerce/consumer/procurement/v1/Cargo.toml
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/config/v1/Cargo.toml
+++ b/src/generated/cloud/config/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/connectors/v1/Cargo.toml
+++ b/src/generated/cloud/connectors/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/contactcenterinsights/v1/Cargo.toml
+++ b/src/generated/cloud/contactcenterinsights/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/datacatalog/lineage/v1/Cargo.toml
+++ b/src/generated/cloud/datacatalog/lineage/v1/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/datacatalog/v1/Cargo.toml
+++ b/src/generated/cloud/datacatalog/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/datafusion/v1/Cargo.toml
+++ b/src/generated/cloud/datafusion/v1/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/dataproc/v1/Cargo.toml
+++ b/src/generated/cloud/dataproc/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/datastream/v1/Cargo.toml
+++ b/src/generated/cloud/datastream/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/deploy/v1/Cargo.toml
+++ b/src/generated/cloud/deploy/v1/Cargo.toml
@@ -33,7 +33,7 @@ gtype      = { version = "0.2", path = "../../../../../src/generated/type", pack
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/developerconnect/v1/Cargo.toml
+++ b/src/generated/cloud/developerconnect/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/dialogflow/cx/v3/Cargo.toml
+++ b/src/generated/cloud/dialogflow/cx/v3/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../../src/gax", package = "
 gtype      = { version = "0.2", path = "../../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/dialogflow/v2/Cargo.toml
+++ b/src/generated/cloud/dialogflow/v2/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/discoveryengine/v1/Cargo.toml
+++ b/src/generated/cloud/discoveryengine/v1/Cargo.toml
@@ -32,7 +32,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/documentai/v1/Cargo.toml
+++ b/src/generated/cloud/documentai/v1/Cargo.toml
@@ -33,7 +33,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/domains/v1/Cargo.toml
+++ b/src/generated/cloud/domains/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/edgecontainer/v1/Cargo.toml
+++ b/src/generated/cloud/edgecontainer/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/edgenetwork/v1/Cargo.toml
+++ b/src/generated/cloud/edgenetwork/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/eventarc/v1/Cargo.toml
+++ b/src/generated/cloud/eventarc/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/filestore/v1/Cargo.toml
+++ b/src/generated/cloud/filestore/v1/Cargo.toml
@@ -32,7 +32,7 @@ cloud_common = { version = "0.2", path = "../../../../../src/generated/cloud/com
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/functions/v2/Cargo.toml
+++ b/src/generated/cloud/functions/v2/Cargo.toml
@@ -33,7 +33,7 @@ gtype      = { version = "0.2", path = "../../../../../src/generated/type", pack
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/gkebackup/v1/Cargo.toml
+++ b/src/generated/cloud/gkebackup/v1/Cargo.toml
@@ -33,7 +33,7 @@ gtype      = { version = "0.2", path = "../../../../../src/generated/type", pack
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/gkehub/v1/Cargo.toml
+++ b/src/generated/cloud/gkehub/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 gkehub_configmanagement_v1 = { version = "0.2.0", path = "../../../../../src/generated/cloud/gkehub/configmanagement/v1", package = "google-cloud-gkehub-configmanagement-v1" }
 gkehub_multiclusteringress_v1 = { version = "0.2.0", path = "../../../../../src/generated/cloud/gkehub/multiclusteringress/v1", package = "google-cloud-gkehub-multiclusteringress-v1" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/gkemulticloud/v1/Cargo.toml
+++ b/src/generated/cloud/gkemulticloud/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/ids/v1/Cargo.toml
+++ b/src/generated/cloud/ids/v1/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/kms/v1/Cargo.toml
+++ b/src/generated/cloud/kms/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/managedidentities/v1/Cargo.toml
+++ b/src/generated/cloud/managedidentities/v1/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/memcache/v1/Cargo.toml
+++ b/src/generated/cloud/memcache/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/memorystore/v1/Cargo.toml
+++ b/src/generated/cloud/memorystore/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/metastore/v1/Cargo.toml
+++ b/src/generated/cloud/metastore/v1/Cargo.toml
@@ -33,7 +33,7 @@ gtype      = { version = "0.2", path = "../../../../../src/generated/type", pack
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/migrationcenter/v1/Cargo.toml
+++ b/src/generated/cloud/migrationcenter/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/netapp/v1/Cargo.toml
+++ b/src/generated/cloud/netapp/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/networkconnectivity/v1/Cargo.toml
+++ b/src/generated/cloud/networkconnectivity/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/networkmanagement/v1/Cargo.toml
+++ b/src/generated/cloud/networkmanagement/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/networksecurity/v1/Cargo.toml
+++ b/src/generated/cloud/networksecurity/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/networkservices/v1/Cargo.toml
+++ b/src/generated/cloud/networkservices/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/notebooks/v2/Cargo.toml
+++ b/src/generated/cloud/notebooks/v2/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/optimization/v1/Cargo.toml
+++ b/src/generated/cloud/optimization/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/oracledatabase/v1/Cargo.toml
+++ b/src/generated/cloud/oracledatabase/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/orchestration/airflow/service/v1/Cargo.toml
+++ b/src/generated/cloud/orchestration/airflow/service/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 gtype      = { version = "0.2", path = "../../../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/osconfig/v1/Cargo.toml
+++ b/src/generated/cloud/osconfig/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/parallelstore/v1/Cargo.toml
+++ b/src/generated/cloud/parallelstore/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/policysimulator/v1/Cargo.toml
+++ b/src/generated/cloud/policysimulator/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/privilegedaccessmanager/v1/Cargo.toml
+++ b/src/generated/cloud/privilegedaccessmanager/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/rapidmigrationassessment/v1/Cargo.toml
+++ b/src/generated/cloud/rapidmigrationassessment/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/redis/cluster/v1/Cargo.toml
+++ b/src/generated/cloud/redis/cluster/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../../src/gax", package = "
 gtype      = { version = "0.2", path = "../../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/redis/v1/Cargo.toml
+++ b/src/generated/cloud/redis/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/resourcemanager/v3/Cargo.toml
+++ b/src/generated/cloud/resourcemanager/v3/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/retail/v2/Cargo.toml
+++ b/src/generated/cloud/retail/v2/Cargo.toml
@@ -32,7 +32,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/run/v2/Cargo.toml
+++ b/src/generated/cloud/run/v2/Cargo.toml
@@ -32,7 +32,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/securesourcemanager/v1/Cargo.toml
+++ b/src/generated/cloud/securesourcemanager/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/security/privateca/v1/Cargo.toml
+++ b/src/generated/cloud/security/privateca/v1/Cargo.toml
@@ -33,7 +33,7 @@ gtype      = { version = "0.2", path = "../../../../../../src/generated/type", p
 iam_v1     = { version = "0.2", path = "../../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/securitycenter/v2/Cargo.toml
+++ b/src/generated/cloud/securitycenter/v2/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/securityposture/v1/Cargo.toml
+++ b/src/generated/cloud/securityposture/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/shell/v1/Cargo.toml
+++ b/src/generated/cloud/shell/v1/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/speech/v2/Cargo.toml
+++ b/src/generated/cloud/speech/v2/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/storageinsights/v1/Cargo.toml
+++ b/src/generated/cloud/storageinsights/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/talent/v4/Cargo.toml
+++ b/src/generated/cloud/talent/v4/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/telcoautomation/v1/Cargo.toml
+++ b/src/generated/cloud/telcoautomation/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/texttospeech/v1/Cargo.toml
+++ b/src/generated/cloud/texttospeech/v1/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/tpu/v2/Cargo.toml
+++ b/src/generated/cloud/tpu/v2/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/translate/v3/Cargo.toml
+++ b/src/generated/cloud/translate/v3/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/video/livestream/v1/Cargo.toml
+++ b/src/generated/cloud/video/livestream/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../../src/gax", package = "
 gtype      = { version = "0.2", path = "../../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/video/stitcher/v1/Cargo.toml
+++ b/src/generated/cloud/video/stitcher/v1/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/videointelligence/v1/Cargo.toml
+++ b/src/generated/cloud/videointelligence/v1/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/vision/v1/Cargo.toml
+++ b/src/generated/cloud/vision/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/vmmigration/v1/Cargo.toml
+++ b/src/generated/cloud/vmmigration/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/cloud/vmwareengine/v1/Cargo.toml
+++ b/src/generated/cloud/vmwareengine/v1/Cargo.toml
@@ -32,7 +32,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/vpcaccess/v1/Cargo.toml
+++ b/src/generated/cloud/vpcaccess/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/webrisk/v1/Cargo.toml
+++ b/src/generated/cloud/webrisk/v1/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/workflows/v1/Cargo.toml
+++ b/src/generated/cloud/workflows/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/cloud/workstations/v1/Cargo.toml
+++ b/src/generated/cloud/workstations/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/datastore/admin/v1/Cargo.toml
+++ b/src/generated/datastore/admin/v1/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/devtools/artifactregistry/v1/Cargo.toml
+++ b/src/generated/devtools/artifactregistry/v1/Cargo.toml
@@ -33,7 +33,7 @@ gtype      = { version = "0.2", path = "../../../../../src/generated/type", pack
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
 location   = { version = "0.2", path = "../../../../../src/generated/cloud/location", package = "google-cloud-location" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/devtools/cloudbuild/v1/Cargo.toml
+++ b/src/generated/devtools/cloudbuild/v1/Cargo.toml
@@ -31,7 +31,7 @@ async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/devtools/cloudbuild/v2/Cargo.toml
+++ b/src/generated/devtools/cloudbuild/v2/Cargo.toml
@@ -32,7 +32,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/firestore/admin/v1/Cargo.toml
+++ b/src/generated/firestore/admin/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/iam/v2/Cargo.toml
+++ b/src/generated/iam/v2/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 gtype      = { version = "0.2", path = "../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/iam/v3/Cargo.toml
+++ b/src/generated/iam/v3/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 gtype      = { version = "0.2", path = "../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/identity/accesscontextmanager/v1/Cargo.toml
+++ b/src/generated/identity/accesscontextmanager/v1/Cargo.toml
@@ -33,7 +33,7 @@ gax        = { version = "0.20", path = "../../../../../src/gax", package = "goo
 gtype      = { version = "0.2", path = "../../../../../src/generated/type", package = "google-cloud-type" }
 iam_v1     = { version = "0.2", path = "../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/logging/v2/Cargo.toml
+++ b/src/generated/logging/v2/Cargo.toml
@@ -32,7 +32,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
 logging_type = { version = "0.2", path = "../../../../src/generated/logging/type", package = "google-cloud-logging-type" }
-longrunning = { version = "0.2", path = "../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/longrunning/.sidekick.toml
+++ b/src/generated/longrunning/.sidekick.toml
@@ -17,5 +17,6 @@ specification-source = 'google/longrunning'
 service-config = 'google/longrunning/longrunning.yaml'
 
 [codec]
+version = "0.22.0" # Match existing version
 copyright-year = '2024'
 'package:longrunning' = 'ignore=true'

--- a/src/generated/longrunning/Cargo.toml
+++ b/src/generated/longrunning/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                 = "google-cloud-longrunning"
-version              = "0.2.0"
+version              = "0.22.0"
 description          = "Google Cloud Client Libraries for Rust - Long Running Operations API"
 edition.workspace    = true
 authors.workspace    = true

--- a/src/generated/monitoring/metricsscope/v1/Cargo.toml
+++ b/src/generated/monitoring/metricsscope/v1/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = { version = "0.1" }
 bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/spanner/admin/database/v1/Cargo.toml
+++ b/src/generated/spanner/admin/database/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 iam_v1     = { version = "0.2", path = "../../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/generated/spanner/admin/instance/v1/Cargo.toml
+++ b/src/generated/spanner/admin/instance/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 iam_v1     = { version = "0.2", path = "../../../../../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 serde      = { version = "1", features = ["serde_derive"] }

--- a/src/generated/storagetransfer/v1/Cargo.toml
+++ b/src/generated/storagetransfer/v1/Cargo.toml
@@ -31,7 +31,7 @@ bytes      = { version = "1", features = ["serde"] }
 gax        = { version = "0.20", path = "../../../../src/gax", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 gtype      = { version = "0.2", path = "../../../../src/generated/type", package = "google-cloud-type" }
 lazy_static = { version = "1" }
-longrunning = { version = "0.2", path = "../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../../../../src/generated/longrunning", package = "google-cloud-longrunning" }
 lro        = { version = "0.1", path = "../../../../src/lro", package = "google-cloud-lro" }
 reqwest    = { version = "0.12", features = ["json"] }
 rpc        = { version = "0.2", path = "../../../../src/generated/rpc/types", package = "google-cloud-rpc" }

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -26,7 +26,7 @@ version              = "0.1.0"
 [dependencies]
 futures     = { version = "0.3.31", optional = true }
 gax         = { version = "0.20", path = "../gax", package = "google-cloud-gax" }
-longrunning = { version = "0.2", path = "../generated/longrunning", package = "google-cloud-longrunning" }
+longrunning = { version = "0.22", path = "../generated/longrunning", package = "google-cloud-longrunning" }
 pin-project = { version = "1.1.9", optional = true }
 rpc         = { version = "0.2", path = "../generated/rpc/types", package = "google-cloud-rpc" }
 serde       = "1.0.216"


### PR DESCRIPTION
The `google-cloud-longrunning` crate already exists. We have received
ownership, but we must match the existing version before a release.