### PR TITLE
feat(generator): support description overrides

### DIFF
--- a/generator/internal/sidekick/refresh.go
+++ b/generator/internal/sidekick/refresh.go
@@ -79,6 +79,9 @@ func refreshDir(rootConfig *config.Config, cmdLine *CommandLine, output string) 
 	if title, ok := config.Source["title-override"]; ok {
 		model.Title = title
 	}
+	if description, ok := config.Source["description-override"]; ok {
+		model.Description = description
+	}
 	if cmdLine.DryRun {
 		return nil
 	}

--- a/generator/internal/sidekick/sidekick_test.go
+++ b/generator/internal/sidekick/sidekick_test.go
@@ -251,7 +251,7 @@ func TestRustBootstrapWkt(t *testing.T) {
 	}
 }
 
-func TestRustOverrideTitle(t *testing.T) {
+func TestRustOverrideTitleAndDescription(t *testing.T) {
 	cmdLine := &CommandLine{
 		Command:             []string{},
 		ProjectRoot:         projectRoot,
@@ -259,8 +259,9 @@ func TestRustOverrideTitle(t *testing.T) {
 		SpecificationSource: "google/type",
 		Language:            "rust",
 		Source: map[string]string{
-			"googleapis-root": googleapisRoot,
-			"title-override":  "Replace or Provide Custom Title",
+			"googleapis-root":      googleapisRoot,
+			"title-override":       "Replace or Provide Custom Title",
+			"description-override": "Replace or Provide Custom Description\nIncluding multiple lines.",
 		},
 		Output: path.Join(testdataDir, "rust/protobuf/golden/override/type"),
 		Codec: map[string]string{

--- a/generator/testdata/rust/protobuf/golden/override/type/.sidekick.toml
+++ b/generator/testdata/rust/protobuf/golden/override/type/.sidekick.toml
@@ -18,6 +18,7 @@ specification-format = 'protobuf'
 specification-source = 'google/type'
 
 [source]
+description-override = "Replace or Provide Custom Description\nIncluding multiple lines."
 googleapis-root = 'testdata/googleapis'
 title-override = 'Replace or Provide Custom Title'
 

--- a/generator/testdata/rust/protobuf/golden/override/type/README.md
+++ b/generator/testdata/rust/protobuf/golden/override/type/README.md
@@ -7,6 +7,9 @@ changes in the upcoming releases. Testing is also incomplete, we do **not**
 recommend that you use this crate in production. We welcome feedback about the
 APIs, documentation, missing features, bugs, etc.
 
+Replace or Provide Custom Description
+Including multiple lines.
+
 ## More Information
 
 * Read the [crate's documentation](https://docs.rs/google-cloud-test-only/latest/google-cloud-test-only)


### PR DESCRIPTION
The immediate need is to override the `google-cloud-longrunning` description (nit: there is none, so maybe s/overridethe /provide a/).

We may use this for any other crate / library that lacks a description.
