### PR TITLE
feat(auth)!: clone-able `CredentialError`

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -256,14 +256,14 @@ pub async fn create_access_token_credential() -> Result<Credential> {
         serde_json::from_str(&contents).map_err(CredentialError::non_retryable)?;
     let cred_type = js
         .get("type")
-        .ok_or_else(|| CredentialError::non_retryable("Failed to parse Application Default Credentials (ADC). No `type` field found."))?
+        .ok_or_else(|| CredentialError::non_retryable_from_str("Failed to parse Application Default Credentials (ADC). No `type` field found."))?
         .as_str()
-        .ok_or_else(|| CredentialError::non_retryable("Failed to parse Application Default Credentials (ADC). `type` field is not a string.")
+        .ok_or_else(|| CredentialError::non_retryable_from_str("Failed to parse Application Default Credentials (ADC). `type` field is not a string.")
         )?;
     match cred_type {
         "authorized_user" => user_credential::creds_from(js),
         "service_account" => service_account_credential::creds_from(js),
-        _ => Err(CredentialError::non_retryable(format!(
+        _ => Err(CredentialError::non_retryable_from_str(format!(
             "Unimplemented credential type: {cred_type}"
         ))),
     }
@@ -282,7 +282,7 @@ enum AdcContents {
 }
 
 fn path_not_found(path: String) -> CredentialError {
-    CredentialError::non_retryable(
+    CredentialError::non_retryable_from_str(
         format!(
             "Failed to load Application Default Credentials (ADC) from {path}. Check that the `GOOGLE_APPLICATION_CREDENTIALS` environment variable points to a valid file."
         ))

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -339,7 +339,7 @@ fn adc_well_known_path() -> Option<String> {
 /// These credentials are a convenient way to avoid errors from loading
 /// Application Default Credentials in tests.
 ///
-/// This module is mainly relevant to other `google-cloudk-*` crates, but some
+/// This module is mainly relevant to other `google-cloud-*` crates, but some
 /// external developers (i.e. consumers, not developers of `google-cloud-rust`)
 /// may find it useful.
 pub mod testing {

--- a/src/auth/src/credentials/mds_credential.rs
+++ b/src/auth/src/credentials/mds_credential.rs
@@ -141,15 +141,15 @@ impl TokenProvider for MDSAccessTokenProvider {
             let body = response
                 .text()
                 .await
-                .map_err(|e| CredentialError::new(is_retryable(status), e.into()))?;
-            return Err(CredentialError::new(
+                .map_err(|e| CredentialError::new(is_retryable(status), e))?;
+            return Err(CredentialError::new_from_str(
                 is_retryable(status),
-                Box::from(format!("Failed to fetch token. {body}")),
+                format!("Failed to fetch token. {body}"),
             ));
         }
         let response = response.json::<MDSTokenResponse>().await.map_err(|e| {
             let retryable = !e.is_decode();
-            CredentialError::new(retryable, e.into())
+            CredentialError::new(retryable, e)
         })?;
         let token = Token {
             token: response.access_token,
@@ -202,7 +202,7 @@ mod test {
         let mut mock = MockTokenProvider::new();
         mock.expect_get_token()
             .times(1)
-            .return_once(|| Err(CredentialError::non_retryable("fail")));
+            .return_once(|| Err(CredentialError::non_retryable_from_str("fail")));
 
         let mdsc = MDSCredential {
             token_provider: mock,
@@ -259,7 +259,7 @@ mod test {
         let mut mock = MockTokenProvider::new();
         mock.expect_get_token()
             .times(1)
-            .return_once(|| Err(CredentialError::non_retryable("fail")));
+            .return_once(|| Err(CredentialError::non_retryable_from_str("fail")));
 
         let mdsc = MDSCredential {
             token_provider: mock,

--- a/src/auth/src/credentials/mds_credential.rs
+++ b/src/auth/src/credentials/mds_credential.rs
@@ -142,7 +142,7 @@ impl TokenProvider for MDSAccessTokenProvider {
                 .text()
                 .await
                 .map_err(|e| CredentialError::new(is_retryable(status), e))?;
-            return Err(CredentialError::new_from_str(
+            return Err(CredentialError::from_str(
                 is_retryable(status),
                 format!("Failed to fetch token. {body}"),
             ));

--- a/src/auth/src/credentials/service_account_credential/jws.rs
+++ b/src/auth/src/credentials/service_account_credential/jws.rs
@@ -47,14 +47,14 @@ pub struct JwsClaims {
 impl JwsClaims {
     pub fn encode(&self) -> Result<String> {
         if self.exp < self.iat {
-            return Err(CredentialError::non_retryable(format!(
+            return Err(CredentialError::non_retryable_from_str(format!(
                 "expiration time {:?}, must be later than issued time {:?}",
                 self.exp, self.iat
             )));
         }
 
         if self.aud.is_some() && self.scope.is_some() {
-            return Err(CredentialError::non_retryable(format!(
+            return Err(CredentialError::non_retryable_from_str(format!(
                 "Found {:?} for audience and {:?} for scope, however expecting only 1 of them to be set.",
                 self.aud, self.scope
             )));

--- a/src/auth/src/credentials/user_credential.rs
+++ b/src/auth/src/credentials/user_credential.rs
@@ -85,15 +85,15 @@ impl TokenProvider for UserTokenProvider {
             let body = resp
                 .text()
                 .await
-                .map_err(|e| CredentialError::new(is_retryable(status), e.into()))?;
-            return Err(CredentialError::new(
+                .map_err(|e| CredentialError::new(is_retryable(status), e))?;
+            return Err(CredentialError::new_from_str(
                 is_retryable(status),
-                Box::from(format!("Failed to fetch token. {body}")),
+                format!("Failed to fetch token. {body}"),
             ));
         }
         let response = resp.json::<Oauth2RefreshResponse>().await.map_err(|e| {
             let retryable = !e.is_decode();
-            CredentialError::new(retryable, e.into())
+            CredentialError::new(retryable, e)
         })?;
         let token = Token {
             token: response.access_token,
@@ -300,7 +300,7 @@ mod test {
         let mut mock = MockTokenProvider::new();
         mock.expect_get_token()
             .times(1)
-            .return_once(|| Err(CredentialError::non_retryable("fail")));
+            .return_once(|| Err(CredentialError::non_retryable_from_str("fail")));
 
         let uc = UserCredential {
             token_provider: mock,
@@ -360,7 +360,7 @@ mod test {
         let mut mock = MockTokenProvider::new();
         mock.expect_get_token()
             .times(1)
-            .return_once(|| Err(CredentialError::non_retryable("fail")));
+            .return_once(|| Err(CredentialError::non_retryable_from_str("fail")));
 
         let uc = UserCredential {
             token_provider: mock,

--- a/src/auth/src/credentials/user_credential.rs
+++ b/src/auth/src/credentials/user_credential.rs
@@ -86,7 +86,7 @@ impl TokenProvider for UserTokenProvider {
                 .text()
                 .await
                 .map_err(|e| CredentialError::new(is_retryable(status), e))?;
-            return Err(CredentialError::new_from_str(
+            return Err(CredentialError::from_str(
                 is_retryable(status),
                 format!("Failed to fetch token. {body}"),
             ));


### PR DESCRIPTION
Part of the work for #1210, second try at #1213

The point is that we are making `CredentialError` clone-able.

This is a breaking change because `CredentialError::new(...)` accepts different types.

Add new `*_from_str()` methods for constructing a `CredentialError`. While these could be helpful to customers mocking credentials, leave them crate-private for now.

Arguably I should have used `anyhow::Error` instead of writing `StringError`.