### PR TITLE
docs(longrunning): link previous crate version

### DIFF
--- a/src/generated/longrunning/.sidekick.toml
+++ b/src/generated/longrunning/.sidekick.toml
@@ -16,6 +16,23 @@
 specification-source = 'google/longrunning'
 service-config = 'google/longrunning/longrunning.yaml'
 
+[source]
+description-override = """Defines types and an abstract service to handle long-running operations.
+
+[Long-running operations] are a common pattern to handle methods that may take a
+significant amount of time to execute. Many Google APIs return an `Operation`
+message (defined in this crate) that are roughly analogous to a future. The
+operation will eventually complete, though it may still return an error on
+completion. The client libraries provide helpers to simplify polling of these
+operations.
+
+> This crate used to contain a different implementation, with a different
+> surface. [@yoshidan](https://github.com/yoshidan) generously donated the crate
+> name to Google. Their crate continues to live as [gcloud-longrunning].
+
+[Long-running operations]: https://google.aip.dev/151
+[gcloud-longrunning]: https://crates.io/crates/gcloud-longrunning"""
+
 [codec]
 version = "0.22.0" # Match existing version
 copyright-year = '2024'

--- a/src/generated/longrunning/README.md
+++ b/src/generated/longrunning/README.md
@@ -7,6 +7,22 @@ changes in the upcoming releases. Testing is also incomplete, we do **not**
 recommend that you use this crate in production. We welcome feedback about the
 APIs, documentation, missing features, bugs, etc.
 
+Defines types and an abstract service to handle long-running operations.
+
+[Long-running operations] are a common pattern to handle methods that may take a
+significant amount of time to execute. Many Google APIs return an `Operation`
+message (defined in this crate) that are roughly analogous to a future. The
+operation will eventually complete, though it may still return an error on
+completion. The client libraries provide helpers to simplify polling of these
+operations.
+
+> This crate used to contain a different implementation, with a different
+> surface. [@yoshidan](https://github.com/yoshidan) generously donated the crate
+> name to Google. Their crate continues to live as [gcloud-longrunning].
+
+[Long-running operations]: https://google.aip.dev/151
+[gcloud-longrunning]: https://crates.io/crates/gcloud-longrunning
+
 ## Quickstart
 
 The main types to work with this crate are the clients:


### PR DESCRIPTION
Link the previous version of the crate, it is polite and may avoid
confusion for some folks. Since I was customizing the description, might
as well add something about what the crate is about.