### PR TITLE
chore(generator): update `staticcheck`

### DIFF
--- a/generator/all_test.go
+++ b/generator/all_test.go
@@ -54,7 +54,7 @@ func TestHeaders(t *testing.T) {
 }
 
 func TestStaticCheck(t *testing.T) {
-	rungo(t, "run", "honnef.co/go/tools/cmd/staticcheck@v0.5.1", "./...")
+	rungo(t, "run", "honnef.co/go/tools/cmd/staticcheck@v0.6.0", "./...")
 }
 
 func TestUnparam(t *testing.T) {


### PR DESCRIPTION
`go test ./...` was broken for me without this update. :shrug:

Ah, maybe because I am using go 1.24 on my laptop and 0.6.0 adds support for that version.
