### PR TITLE
fix(generator): refresh with github roots

### DIFF
--- a/generator/internal/sidekick/refresh.go
+++ b/generator/internal/sidekick/refresh.go
@@ -41,7 +41,11 @@ Reruns the generator for a single client library, using the configuration parame
 // refresh reruns the generator in one directory, using the configuration
 // parameters saved in its `.sidekick.toml` file.
 func refresh(rootConfig *config.Config, cmdLine *CommandLine) error {
-	return refreshDir(rootConfig, cmdLine, cmdLine.Output)
+	override, err := overrideSources(rootConfig)
+	if err != nil {
+		return err
+	}
+	return refreshDir(override, cmdLine, cmdLine.Output)
 }
 
 func refreshDir(rootConfig *config.Config, cmdLine *CommandLine, output string) error {


### PR DESCRIPTION
Using `sidekick refresh` for a single directory required 
- Overriding the googleapis root option
- Having the googleapis root already extracted

Now you can say:

```shell
sidekick refresh -output src/generated/iam/v2
```

and it will use the right googleapis version. `refreshall` also works, but it is slower now that we have so many libraries.
