### PR TITLE
style: update the yamlfmt config to allow separator lines

### DIFF
--- a/.yamlfmt.yaml
+++ b/.yamlfmt.yaml
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: pkg_workspace
-publish_to: none
+# See https://github.com/google/yamlfmt/blob/main/docs/config-file.md for
+# configuration options.
 
-environment:
-  sdk: ^3.6.0
-
-workspace:
-  - packages/generated/rpc/types
+formatter:
+  type: basic
+  retain_line_breaks_single: true


### PR DESCRIPTION
- update the yamlfmt config to allow separator lines

I like being able to have some ws separators between yaml elements; I'm not sure if this fits in w/ the repo philosophy or not 🤷 
