### PR TITLE
fix(auth): feature gate aws_lc_rs from rustls

### DIFF
--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -25,8 +25,7 @@ keywords.workspace   = true
 categories.workspace = true
 
 [features]
-default = ["default-crypto-provider"]
-
+default                 = ["default-crypto-provider"]
 default-crypto-provider = ["rustls/aws_lc_rs"]
 
 [dependencies]

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -25,11 +25,9 @@ keywords.workspace   = true
 categories.workspace = true
 
 [features]
-default = ["aws_lc_rs"]
+default = ["default-crypto-provider"]
 
-aws-lc-rs = ["aws_lc_rs"]
-aws_lc_rs = ["rustls/aws_lc_rs"]
-ring      = []
+default-crypto-provider = ["rustls/aws_lc_rs"]
 
 [dependencies]
 async-trait    = "0.1"

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -24,6 +24,13 @@ repository.workspace = true
 keywords.workspace   = true
 categories.workspace = true
 
+[features]
+default = ["aws_lc_rs"]
+
+aws-lc-rs = ["aws_lc_rs"]
+aws_lc_rs = ["rustls/aws_lc_rs"]
+ring      = []
+
 [dependencies]
 async-trait    = "0.1"
 http           = "1"
@@ -32,12 +39,11 @@ serde          = { version = "1", features = ["derive"] }
 serde_json     = "1"
 thiserror      = "2"
 time           = { version = "0.3.37", features = ["serde"] }
-rustls         = "0.23"
+rustls         = { version = "0.23", default-features = false, features = ["logging", "std", "tls12"] }
 rustls-pemfile = "2.2"
 tokio          = { version = "1", features = ["fs"] }
 base64         = "0.22"
 derive_builder = "0.20"
-
 
 [dev-dependencies]
 axum        = "0.8"

--- a/src/auth/src/credentials/service_account_credential.rs
+++ b/src/auth/src/credentials/service_account_credential.rs
@@ -129,6 +129,12 @@ impl TokenProvider for ServiceAccountTokenProvider {
 impl ServiceAccountTokenProvider {
     // Creates a signer using the private key stored in the service account file.
     fn signer(&self, private_key: &String) -> Result<Box<dyn Signer>> {
+        #[cfg(not(feature = "aws_lc_rs"))]
+        let key_provider = CryptoProvider::get_default()
+                    .map(|p| p.key_provider)
+                    .ok_or_else(|| CredentialError::non_retryable_from_str("No default crypto provider found. Please enable one of the following features: `aws_lc_rs`"))?;
+
+        #[cfg(feature = "aws_lc_rs")]
         let key_provider = CryptoProvider::get_default().map_or_else(
             || rustls::crypto::aws_lc_rs::default_provider().key_provider,
             |p| p.key_provider,

--- a/src/auth/src/credentials/service_account_credential.rs
+++ b/src/auth/src/credentials/service_account_credential.rs
@@ -126,15 +126,19 @@ impl TokenProvider for ServiceAccountTokenProvider {
     }
 }
 
+#[cfg(not(feature = "default-crypto-provider"))]
+fn no_crypto_provider_error() -> CredentialError {
+    CredentialError::non_retryable_from_str("No default crypto provider found. Please (1) install a global CryptoProvider, or (2) enable the feature `default-crypto-provider` to have the library pick one for you.")
+}
+
 impl ServiceAccountTokenProvider {
     // Creates a signer using the private key stored in the service account file.
     fn signer(&self, private_key: &String) -> Result<Box<dyn Signer>> {
-        #[cfg(not(feature = "aws_lc_rs"))]
+        #[cfg(not(feature = "default-crypto-provider"))]
         let key_provider = CryptoProvider::get_default()
-                    .map(|p| p.key_provider)
-                    .ok_or_else(|| CredentialError::non_retryable_from_str("No default crypto provider found. Please enable one of the following features: `aws_lc_rs`"))?;
-
-        #[cfg(feature = "aws_lc_rs")]
+            .map(|p| p.key_provider)
+            .ok_or_else(no_crypto_provider_error)?;
+        #[cfg(feature = "default-crypto-provider")]
         let key_provider = CryptoProvider::get_default().map_or_else(
             || rustls::crypto::aws_lc_rs::default_provider().key_provider,
             |p| p.key_provider,
@@ -312,6 +316,7 @@ mod test {
             .to_string()
     }
 
+    #[cfg(feature = "default-crypto-provider")]
     #[tokio::test]
     async fn get_service_account_token_pkcs1_key_failure() -> TestResult {
         let mut service_account_info = get_mock_service_account();
@@ -347,6 +352,7 @@ mod test {
         serde_json::from_str(&decoded).unwrap()
     }
 
+    #[cfg(feature = "default-crypto-provider")]
     #[tokio::test]
     async fn get_service_account_token_pkcs8_key_success() -> TestResult {
         let mut service_account_info = get_mock_service_account();
@@ -378,6 +384,7 @@ mod test {
         Ok(())
     }
 
+    #[cfg(feature = "default-crypto-provider")]
     #[tokio::test]
     async fn get_service_account_token_invalid_key_failure() -> TestResult {
         let mut service_account_info = get_mock_service_account();
@@ -392,6 +399,7 @@ mod test {
         Ok(())
     }
 
+    #[cfg(feature = "default-crypto-provider")]
     #[test]
     fn signer_failure() -> TestResult {
         let tp = ServiceAccountTokenProvider {
@@ -414,5 +422,17 @@ mod test {
             ServiceAccountTokenProvider::unexpected_private_key_error(Item::Crl(Vec::new().into()));
         assert!(error.to_string().contains(&expected_message));
         Ok(())
+    }
+
+    #[cfg(not(feature = "default-crypto-provider"))]
+    #[tokio::test]
+    async fn no_crypto_provider_error() {
+        let token_provider = ServiceAccountTokenProvider {
+            service_account_info: get_mock_service_account(),
+        };
+        let token = token_provider.get_token().await;
+        assert!(token.is_err());
+        let e = format!("{}", token.err().unwrap());
+        assert!(e.to_string().contains("No default crypto provider"), "{e}");
     }
 }


### PR DESCRIPTION
Part of the work for #1077 

It avoids bringing in the entire aws_lc_rs crate when ring is used for the crypto provider.

Maybe aws_lc_rs needs to be disabled by default, but this why it won't be breaking change.