### PR TITLE
fix(generator/rust): enum default values

### DIFF
--- a/generator/internal/rust/rusttemplate.go
+++ b/generator/internal/rust/rusttemplate.go
@@ -172,9 +172,10 @@ type fieldAnnotations struct {
 }
 
 type enumAnnotation struct {
-	Name       string
-	ModuleName string
-	DocLines   []string
+	Name             string
+	ModuleName       string
+	DocLines         []string
+	DefaultValueName string
 }
 
 type enumValueAnnotation struct {
@@ -457,10 +458,18 @@ func annotateEnum(e *api.Enum, state *api.APIState, modulePath string, packageMa
 	for _, ev := range e.Values {
 		annotateEnumValue(ev, e, state, modulePath, packageMapping)
 	}
+	defaultValueName := ""
+	for _, ev := range e.Values {
+		if ev.Number == 0 {
+			defaultValueName = enumValueName(ev)
+			break
+		}
+	}
 	e.Codec = &enumAnnotation{
-		Name:       enumName(e),
-		ModuleName: toSnake(enumName(e)),
-		DocLines:   formatDocComments(e.Documentation, e.ID, state, modulePath, e.Scopes(), packageMapping),
+		Name:             enumName(e),
+		ModuleName:       toSnake(enumName(e)),
+		DocLines:         formatDocComments(e.Documentation, e.ID, state, modulePath, e.Scopes(), packageMapping),
+		DefaultValueName: defaultValueName,
 	}
 }
 

--- a/generator/internal/rust/rusttemplate_test.go
+++ b/generator/internal/rust/rusttemplate_test.go
@@ -173,16 +173,19 @@ func Test_RustEnumAnnotations(t *testing.T) {
 		Name:          "week5",
 		ID:            ".test.v1.TestEnum.week5",
 		Documentation: "week5 is also documented.",
+		Number:        2,
 	}
 	v1 := &api.EnumValue{
 		Name:          "MULTI_WORD_VALUE",
 		ID:            ".test.v1.TestEnum.MULTI_WORD_VALUES",
 		Documentation: "MULTI_WORD_VALUE is also documented.",
+		Number:        1,
 	}
 	v2 := &api.EnumValue{
 		Name:          "VALUE",
 		ID:            ".test.v1.TestEnum.VALUE",
 		Documentation: "VALUE is also documented.",
+		Number:        0,
 	}
 	enum := &api.Enum{
 		Name:          "TestEnum",
@@ -200,9 +203,10 @@ func Test_RustEnumAnnotations(t *testing.T) {
 	annotateModel(model, codec, "")
 
 	if diff := cmp.Diff(&enumAnnotation{
-		Name:       "TestEnum",
-		ModuleName: "test_enum",
-		DocLines:   []string{"/// The enum is documented."},
+		Name:             "TestEnum",
+		ModuleName:       "test_enum",
+		DocLines:         []string{"/// The enum is documented."},
+		DefaultValueName: "VALUE",
 	}, enum.Codec); diff != "" {
 		t.Errorf("mismatch in enum annotations (-want, +got)\n:%s", diff)
 	}

--- a/generator/internal/rust/templates/common/enum.mustache
+++ b/generator/internal/rust/templates/common/enum.mustache
@@ -17,7 +17,7 @@ limitations under the License.
 {{#Codec.DocLines}}
 {{{.}}}
 {{/Codec.DocLines}}
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct {{Codec.Name}}(std::borrow::Cow<'static, str>);
 
 impl {{Codec.Name}} {
@@ -49,4 +49,10 @@ impl std::convert::From<std::string::String> for {{Codec.Name}} {
   fn from(value: std::string::String) -> Self {
     Self(std::borrow::Cow::Owned(value))
   }
+}
+
+impl std::default::Default for {{Codec.Name}} {
+    fn default() -> Self {
+        {{Codec.ModuleName}}::{{Codec.DefaultValueName}}
+    }
 }

--- a/generator/testdata/rust/protobuf/golden/iam/v1/src/model.rs
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/src/model.rs
@@ -720,7 +720,7 @@ pub mod audit_log_config {
 
     /// The list of valid permission types for which logging can be configured.
     /// Admin writes are always logged, and are not configurable.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LogType(std::borrow::Cow<'static, str>);
 
     impl LogType {
@@ -757,6 +757,12 @@ pub mod audit_log_config {
       fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
       }
+    }
+
+    impl std::default::Default for LogType {
+        fn default() -> Self {
+            log_type::LOG_TYPE_UNSPECIFIED
+        }
     }
 }
 
@@ -882,7 +888,7 @@ pub mod binding_delta {
 
 
     /// The type of action performed on a Binding in a policy.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Action(std::borrow::Cow<'static, str>);
 
     impl Action {
@@ -916,6 +922,12 @@ pub mod binding_delta {
       fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
       }
+    }
+
+    impl std::default::Default for Action {
+        fn default() -> Self {
+            action::ACTION_UNSPECIFIED
+        }
     }
 }
 
@@ -994,7 +1006,7 @@ pub mod audit_config_delta {
 
 
     /// The type of action performed on an audit configuration in a policy.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Action(std::borrow::Cow<'static, str>);
 
     impl Action {
@@ -1028,5 +1040,11 @@ pub mod audit_config_delta {
       fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
       }
+    }
+
+    impl std::default::Default for Action {
+        fn default() -> Self {
+            action::ACTION_UNSPECIFIED
+        }
     }
 }

--- a/generator/testdata/rust/protobuf/golden/module/rpc/mod.rs
+++ b/generator/testdata/rust/protobuf/golden/module/rpc/mod.rs
@@ -847,7 +847,7 @@ impl wkt::message::Message for Status {
 /// the most specific error code that applies.  For example, prefer
 /// `OUT_OF_RANGE` over `FAILED_PRECONDITION` if both codes apply.
 /// Similarly prefer `NOT_FOUND` or `ALREADY_EXISTS` over `FAILED_PRECONDITION`.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Code(std::borrow::Cow<'static, str>);
 
 impl Code {
@@ -1026,4 +1026,10 @@ impl std::convert::From<std::string::String> for Code {
   fn from(value: std::string::String) -> Self {
     Self(std::borrow::Cow::Owned(value))
   }
+}
+
+impl std::default::Default for Code {
+    fn default() -> Self {
+        code::OK
+    }
 }

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/model.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/model.rs
@@ -530,7 +530,7 @@ pub mod secret_version {
     /// it can be accessed.
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -581,6 +581,12 @@ pub mod secret_version {
       fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
       }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
     }
 }
 

--- a/src/generated/api/servicecontrol/v1/src/model.rs
+++ b/src/generated/api/servicecontrol/v1/src/model.rs
@@ -112,7 +112,7 @@ pub mod check_error {
     use super::*;
 
     /// Error codes for Check responses.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Code(std::borrow::Cow<'static, str>);
 
     impl Code {
@@ -206,6 +206,12 @@ pub mod check_error {
     impl std::convert::From<std::string::String> for Code {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Code {
+        fn default() -> Self {
+            code::ERROR_CODE_UNSPECIFIED
         }
     }
 }
@@ -1704,7 +1710,7 @@ pub mod operation {
     use super::*;
 
     /// Defines the importance of the data contained in the operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Importance(std::borrow::Cow<'static, str>);
 
     impl Importance {
@@ -1736,6 +1742,12 @@ pub mod operation {
     impl std::convert::From<std::string::String> for Importance {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Importance {
+        fn default() -> Self {
+            importance::LOW
         }
     }
 }
@@ -1933,7 +1945,7 @@ pub mod quota_operation {
     use super::*;
 
     /// Supported quota modes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct QuotaMode(std::borrow::Cow<'static, str>);
 
     impl QuotaMode {
@@ -1996,6 +2008,12 @@ pub mod quota_operation {
     impl std::convert::From<std::string::String> for QuotaMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for QuotaMode {
+        fn default() -> Self {
+            quota_mode::UNSPECIFIED
         }
     }
 }
@@ -2162,7 +2180,7 @@ pub mod quota_error {
     /// have to call the Check method, without quota_properties field, to perform
     /// these validations before calling the quota controller methods. These
     /// methods check only for project deletion to be wipe out compliant.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Code(std::borrow::Cow<'static, str>);
 
     impl Code {
@@ -2205,6 +2223,12 @@ pub mod quota_error {
     impl std::convert::From<std::string::String> for Code {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Code {
+        fn default() -> Self {
+            code::UNSPECIFIED
         }
     }
 }
@@ -2502,7 +2526,7 @@ pub mod check_response {
 
         /// The type of the consumer as defined in
         /// [Google Resource Manager](https://cloud.google.com/resource-manager/).
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct ConsumerType(std::borrow::Cow<'static, str>);
 
         impl ConsumerType {
@@ -2543,6 +2567,12 @@ pub mod check_response {
         impl std::convert::From<std::string::String> for ConsumerType {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for ConsumerType {
+            fn default() -> Self {
+                consumer_type::CONSUMER_TYPE_UNSPECIFIED
             }
         }
     }

--- a/src/generated/api/servicemanagement/v1/src/model.rs
+++ b/src/generated/api/servicemanagement/v1/src/model.rs
@@ -197,7 +197,7 @@ pub mod operation_metadata {
     }
 
     /// Code describes the status of the operation (or one of its steps).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Status(std::borrow::Cow<'static, str>);
 
     impl Status {
@@ -239,6 +239,12 @@ pub mod operation_metadata {
     impl std::convert::From<std::string::String> for Status {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Status {
+        fn default() -> Self {
+            status::STATUS_UNSPECIFIED
         }
     }
 }
@@ -297,7 +303,7 @@ pub mod diagnostic {
     use super::*;
 
     /// The kind of diagnostic information possible.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Kind(std::borrow::Cow<'static, str>);
 
     impl Kind {
@@ -326,6 +332,12 @@ pub mod diagnostic {
     impl std::convert::From<std::string::String> for Kind {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Kind {
+        fn default() -> Self {
+            kind::WARNING
         }
     }
 }
@@ -435,7 +447,7 @@ pub mod config_file {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct FileType(std::borrow::Cow<'static, str>);
 
     impl FileType {
@@ -486,6 +498,12 @@ pub mod config_file {
     impl std::convert::From<std::string::String> for FileType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for FileType {
+        fn default() -> Self {
+            file_type::FILE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -824,7 +842,7 @@ pub mod rollout {
     }
 
     /// Status of a Rollout.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RolloutStatus(std::borrow::Cow<'static, str>);
 
     impl RolloutStatus {
@@ -871,6 +889,12 @@ pub mod rollout {
     impl std::convert::From<std::string::String> for RolloutStatus {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RolloutStatus {
+        fn default() -> Self {
+            rollout_status::ROLLOUT_STATUS_UNSPECIFIED
         }
     }
 
@@ -1233,7 +1257,7 @@ pub mod get_service_config_request {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ConfigView(std::borrow::Cow<'static, str>);
 
     impl ConfigView {
@@ -1265,6 +1289,12 @@ pub mod get_service_config_request {
     impl std::convert::From<std::string::String> for ConfigView {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ConfigView {
+        fn default() -> Self {
+            config_view::BASIC
         }
     }
 }

--- a/src/generated/api/serviceusage/v1/src/model.rs
+++ b/src/generated/api/serviceusage/v1/src/model.rs
@@ -443,7 +443,7 @@ pub mod disable_service_request {
 
     /// Enum to determine if service usage should be checked when disabling a
     /// service.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CheckIfServiceHasUsage(std::borrow::Cow<'static, str>);
 
     impl CheckIfServiceHasUsage {
@@ -478,6 +478,12 @@ pub mod disable_service_request {
     impl std::convert::From<std::string::String> for CheckIfServiceHasUsage {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CheckIfServiceHasUsage {
+        fn default() -> Self {
+            check_if_service_has_usage::CHECK_IF_SERVICE_HAS_USAGE_UNSPECIFIED
         }
     }
 }
@@ -919,7 +925,7 @@ impl wkt::message::Message for BatchGetServicesResponse {
 }
 
 /// Whether or not a service has been enabled for use by a consumer.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct State(std::borrow::Cow<'static, str>);
 
 impl State {
@@ -954,5 +960,11 @@ pub mod state {
 impl std::convert::From<std::string::String> for State {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for State {
+    fn default() -> Self {
+        state::STATE_UNSPECIFIED
     }
 }

--- a/src/generated/api/types/src/model.rs
+++ b/src/generated/api/types/src/model.rs
@@ -863,7 +863,7 @@ pub mod backend_rule {
     /// Path Translation is applicable only to HTTP-based backends. Backends which
     /// do not accept requests over HTTP/HTTPS should leave `path_translation`
     /// unspecified.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PathTranslation(std::borrow::Cow<'static, str>);
 
     impl PathTranslation {
@@ -944,6 +944,12 @@ pub mod backend_rule {
     impl std::convert::From<std::string::String> for PathTranslation {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PathTranslation {
+        fn default() -> Self {
+            path_translation::PATH_TRANSLATION_UNSPECIFIED
         }
     }
 
@@ -2495,7 +2501,7 @@ pub mod property {
     use super::*;
 
     /// Supported data type of the property values
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PropertyType(std::borrow::Cow<'static, str>);
 
     impl PropertyType {
@@ -2533,6 +2539,12 @@ pub mod property {
     impl std::convert::From<std::string::String> for PropertyType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PropertyType {
+        fn default() -> Self {
+            property_type::UNSPECIFIED
         }
     }
 }
@@ -3779,7 +3791,7 @@ pub mod field_info {
 
     /// The standard format of a field value. The supported formats are all backed
     /// by either an RFC defined by the IETF or a Google-defined AIP.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Format(std::borrow::Cow<'static, str>);
 
     impl Format {
@@ -3830,6 +3842,12 @@ pub mod field_info {
     impl std::convert::From<std::string::String> for Format {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Format {
+        fn default() -> Self {
+            format::FORMAT_UNSPECIFIED
         }
     }
 }
@@ -4670,7 +4688,7 @@ pub mod label_descriptor {
     use super::*;
 
     /// Value types that can be used as label values.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ValueType(std::borrow::Cow<'static, str>);
 
     impl ValueType {
@@ -4702,6 +4720,12 @@ pub mod label_descriptor {
     impl std::convert::From<std::string::String> for ValueType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ValueType {
+        fn default() -> Self {
+            value_type::STRING
         }
     }
 }
@@ -5330,7 +5354,7 @@ pub mod metric_descriptor {
         use super::*;
 
         /// The resource hierarchy level of the timeseries data of a metric.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct TimeSeriesResourceHierarchyLevel(std::borrow::Cow<'static, str>);
 
         impl TimeSeriesResourceHierarchyLevel {
@@ -5373,12 +5397,18 @@ pub mod metric_descriptor {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for TimeSeriesResourceHierarchyLevel {
+            fn default() -> Self {
+                time_series_resource_hierarchy_level::TIME_SERIES_RESOURCE_HIERARCHY_LEVEL_UNSPECIFIED
+            }
+        }
     }
 
     /// The kind of measurement. It describes how the data is reported.
     /// For information on setting the start time and end time based on
     /// the MetricKind, see [TimeInterval][google.monitoring.v3.TimeInterval].
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MetricKind(std::borrow::Cow<'static, str>);
 
     impl MetricKind {
@@ -5420,8 +5450,14 @@ pub mod metric_descriptor {
         }
     }
 
+    impl std::default::Default for MetricKind {
+        fn default() -> Self {
+            metric_kind::METRIC_KIND_UNSPECIFIED
+        }
+    }
+
     /// The value type of a metric.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ValueType(std::borrow::Cow<'static, str>);
 
     impl ValueType {
@@ -5469,6 +5505,12 @@ pub mod metric_descriptor {
     impl std::convert::From<std::string::String> for ValueType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ValueType {
+        fn default() -> Self {
+            value_type::VALUE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -6646,7 +6688,7 @@ pub mod resource_descriptor {
 
     /// A description of the historical or future-looking state of the
     /// resource pattern.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct History(std::borrow::Cow<'static, str>);
 
     impl History {
@@ -6684,8 +6726,14 @@ pub mod resource_descriptor {
         }
     }
 
+    impl std::default::Default for History {
+        fn default() -> Self {
+            history::HISTORY_UNSPECIFIED
+        }
+    }
+
     /// A flag representing a specific style that a resource claims to conform to.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Style(std::borrow::Cow<'static, str>);
 
     impl Style {
@@ -6721,6 +6769,12 @@ pub mod resource_descriptor {
     impl std::convert::From<std::string::String> for Style {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Style {
+        fn default() -> Self {
+            style::STYLE_UNSPECIFIED
         }
     }
 }
@@ -8295,7 +8349,7 @@ impl wkt::message::Message for VisibilityRule {
 
 /// The organization for which the client libraries are being published.
 /// Affects the url where generated docs are published, etc.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ClientLibraryOrganization(std::borrow::Cow<'static, str>);
 
 impl ClientLibraryOrganization {
@@ -8348,8 +8402,14 @@ impl std::convert::From<std::string::String> for ClientLibraryOrganization {
     }
 }
 
+impl std::default::Default for ClientLibraryOrganization {
+    fn default() -> Self {
+        client_library_organization::CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED
+    }
+}
+
 /// To where should client libraries be published?
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ClientLibraryDestination(std::borrow::Cow<'static, str>);
 
 impl ClientLibraryDestination {
@@ -8388,9 +8448,15 @@ impl std::convert::From<std::string::String> for ClientLibraryDestination {
     }
 }
 
+impl std::default::Default for ClientLibraryDestination {
+    fn default() -> Self {
+        client_library_destination::CLIENT_LIBRARY_DESTINATION_UNSPECIFIED
+    }
+}
+
 /// Classifies set of possible modifications to an object in the service
 /// configuration.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ChangeType(std::borrow::Cow<'static, str>);
 
 impl ChangeType {
@@ -8431,6 +8497,12 @@ impl std::convert::From<std::string::String> for ChangeType {
     }
 }
 
+impl std::default::Default for ChangeType {
+    fn default() -> Self {
+        change_type::CHANGE_TYPE_UNSPECIFIED
+    }
+}
+
 /// Defines the supported values for `google.rpc.ErrorInfo.reason` for the
 /// `googleapis.com` error domain. This error domain is reserved for [Service
 /// Infrastructure](https://cloud.google.com/service-infrastructure/docs/overview).
@@ -8441,7 +8513,7 @@ impl std::convert::From<std::string::String> for ChangeType {
 /// such as "projects/123". Other metadata keys are specific to each error
 /// reason. For more information, see the definition of the specific error
 /// reason.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ErrorReason(std::borrow::Cow<'static, str>);
 
 impl ErrorReason {
@@ -9124,13 +9196,19 @@ impl std::convert::From<std::string::String> for ErrorReason {
     }
 }
 
+impl std::default::Default for ErrorReason {
+    fn default() -> Self {
+        error_reason::ERROR_REASON_UNSPECIFIED
+    }
+}
+
 /// An indicator of the behavior of a given field (for example, that a field
 /// is required in requests, or given as output but ignored as input).
 /// This **does not** change the behavior in protocol buffers itself; it only
 /// denotes the behavior and may affect how API tooling handles the field.
 ///
 /// Note: This enum **may** receive new values in the future.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct FieldBehavior(std::borrow::Cow<'static, str>);
 
 impl FieldBehavior {
@@ -9212,9 +9290,15 @@ impl std::convert::From<std::string::String> for FieldBehavior {
     }
 }
 
+impl std::default::Default for FieldBehavior {
+    fn default() -> Self {
+        field_behavior::FIELD_BEHAVIOR_UNSPECIFIED
+    }
+}
+
 /// The launch stage as defined by [Google Cloud Platform
 /// Launch Stages](https://cloud.google.com/terms/launch-stages).
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct LaunchStage(std::borrow::Cow<'static, str>);
 
 impl LaunchStage {
@@ -9282,5 +9366,11 @@ pub mod launch_stage {
 impl std::convert::From<std::string::String> for LaunchStage {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for LaunchStage {
+    fn default() -> Self {
+        launch_stage::LAUNCH_STAGE_UNSPECIFIED
     }
 }

--- a/src/generated/appengine/v1/src/model.rs
+++ b/src/generated/appengine/v1/src/model.rs
@@ -166,7 +166,7 @@ pub mod error_handler {
     use super::*;
 
     /// Error codes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ErrorCode(std::borrow::Cow<'static, str>);
 
     impl ErrorCode {
@@ -206,6 +206,12 @@ pub mod error_handler {
     impl std::convert::From<std::string::String> for ErrorCode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ErrorCode {
+        fn default() -> Self {
+            error_code::ERROR_CODE_UNSPECIFIED
         }
     }
 }
@@ -401,7 +407,7 @@ pub mod url_map {
     use super::*;
 
     /// Redirect codes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RedirectHttpResponseCode(std::borrow::Cow<'static, str>);
 
     impl RedirectHttpResponseCode {
@@ -444,6 +450,12 @@ pub mod url_map {
     impl std::convert::From<std::string::String> for RedirectHttpResponseCode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RedirectHttpResponseCode {
+        fn default() -> Self {
+            redirect_http_response_code::REDIRECT_HTTP_RESPONSE_CODE_UNSPECIFIED
         }
     }
 
@@ -3259,7 +3271,7 @@ pub mod application {
         }
     }
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ServingStatus(std::borrow::Cow<'static, str>);
 
     impl ServingStatus {
@@ -3297,7 +3309,13 @@ pub mod application {
         }
     }
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    impl std::default::Default for ServingStatus {
+        fn default() -> Self {
+            serving_status::UNSPECIFIED
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DatabaseType(std::borrow::Cow<'static, str>);
 
     impl DatabaseType {
@@ -3334,6 +3352,12 @@ pub mod application {
     impl std::convert::From<std::string::String> for DatabaseType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DatabaseType {
+        fn default() -> Self {
+            database_type::DATABASE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -4315,7 +4339,7 @@ pub mod ssl_settings {
     use super::*;
 
     /// The SSL management type for this domain.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SslManagementType(std::borrow::Cow<'static, str>);
 
     impl SslManagementType {
@@ -4351,6 +4375,12 @@ pub mod ssl_settings {
     impl std::convert::From<std::string::String> for SslManagementType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SslManagementType {
+        fn default() -> Self {
+            ssl_management_type::SSL_MANAGEMENT_TYPE_UNSPECIFIED
         }
     }
 }
@@ -4415,7 +4445,7 @@ pub mod resource_record {
     use super::*;
 
     /// A resource record type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RecordType(std::borrow::Cow<'static, str>);
 
     impl RecordType {
@@ -4450,6 +4480,12 @@ pub mod resource_record {
     impl std::convert::From<std::string::String> for RecordType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RecordType {
+        fn default() -> Self {
+            record_type::RECORD_TYPE_UNSPECIFIED
         }
     }
 }
@@ -4531,7 +4567,7 @@ pub mod firewall_rule {
     use super::*;
 
     /// Available actions to take on matching requests.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Action(std::borrow::Cow<'static, str>);
 
     impl Action {
@@ -4562,6 +4598,12 @@ pub mod firewall_rule {
     impl std::convert::From<std::string::String> for Action {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Action {
+        fn default() -> Self {
+            action::UNSPECIFIED_ACTION
         }
     }
 }
@@ -4804,7 +4846,7 @@ pub mod instance {
         use super::*;
 
         /// Liveness health check status for Flex instances.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct LivenessState(std::borrow::Cow<'static, str>);
 
         impl LivenessState {
@@ -4856,10 +4898,16 @@ pub mod instance {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for LivenessState {
+            fn default() -> Self {
+                liveness_state::LIVENESS_STATE_UNSPECIFIED
+            }
+        }
     }
 
     /// Availability of the instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Availability(std::borrow::Cow<'static, str>);
 
     impl Availability {
@@ -4888,6 +4936,12 @@ pub mod instance {
     impl std::convert::From<std::string::String> for Availability {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Availability {
+        fn default() -> Self {
+            availability::UNSPECIFIED
         }
     }
 }
@@ -4983,7 +5037,7 @@ pub mod network_settings {
     use super::*;
 
     /// If unspecified, INGRESS_TRAFFIC_ALLOWED_ALL will be used.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct IngressTrafficAllowed(std::borrow::Cow<'static, str>);
 
     impl IngressTrafficAllowed {
@@ -5022,6 +5076,12 @@ pub mod network_settings {
     impl std::convert::From<std::string::String> for IngressTrafficAllowed {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for IngressTrafficAllowed {
+        fn default() -> Self {
+            ingress_traffic_allowed::INGRESS_TRAFFIC_ALLOWED_UNSPECIFIED
         }
     }
 }
@@ -5408,7 +5468,7 @@ pub mod traffic_split {
     use super::*;
 
     /// Available sharding mechanisms.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ShardBy(std::borrow::Cow<'static, str>);
 
     impl ShardBy {
@@ -5447,6 +5507,12 @@ pub mod traffic_split {
     impl std::convert::From<std::string::String> for ShardBy {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ShardBy {
+        fn default() -> Self {
+            shard_by::UNSPECIFIED
         }
     }
 }
@@ -6234,7 +6300,7 @@ pub mod endpoints_api_service {
     use super::*;
 
     /// Available rollout strategies.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RolloutStrategy(std::borrow::Cow<'static, str>);
 
     impl RolloutStrategy {
@@ -6268,6 +6334,12 @@ pub mod endpoints_api_service {
     impl std::convert::From<std::string::String> for RolloutStrategy {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RolloutStrategy {
+        fn default() -> Self {
+            rollout_strategy::UNSPECIFIED_ROLLOUT_STRATEGY
         }
     }
 }
@@ -7075,7 +7147,7 @@ pub mod vpc_access_connector {
     ///
     /// This controls what traffic is diverted through the VPC Access Connector
     /// resource. By default PRIVATE_IP_RANGES will be used.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EgressSetting(std::borrow::Cow<'static, str>);
 
     impl EgressSetting {
@@ -7107,6 +7179,12 @@ pub mod vpc_access_connector {
     impl std::convert::From<std::string::String> for EgressSetting {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EgressSetting {
+        fn default() -> Self {
+            egress_setting::EGRESS_SETTING_UNSPECIFIED
         }
     }
 }
@@ -7183,7 +7261,7 @@ pub mod entrypoint {
 }
 
 /// Actions to take when the user is not logged in.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct AuthFailAction(std::borrow::Cow<'static, str>);
 
 impl AuthFailAction {
@@ -7223,8 +7301,14 @@ impl std::convert::From<std::string::String> for AuthFailAction {
     }
 }
 
+impl std::default::Default for AuthFailAction {
+    fn default() -> Self {
+        auth_fail_action::AUTH_FAIL_ACTION_UNSPECIFIED
+    }
+}
+
 /// Methods to restrict access to a URL based on login status.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct LoginRequirement(std::borrow::Cow<'static, str>);
 
 impl LoginRequirement {
@@ -7267,8 +7351,14 @@ impl std::convert::From<std::string::String> for LoginRequirement {
     }
 }
 
+impl std::default::Default for LoginRequirement {
+    fn default() -> Self {
+        login_requirement::LOGIN_UNSPECIFIED
+    }
+}
+
 /// Methods to enforce security (HTTPS) on a URL.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SecurityLevel(std::borrow::Cow<'static, str>);
 
 impl SecurityLevel {
@@ -7316,11 +7406,17 @@ impl std::convert::From<std::string::String> for SecurityLevel {
     }
 }
 
+impl std::default::Default for SecurityLevel {
+    fn default() -> Self {
+        security_level::SECURE_UNSPECIFIED
+    }
+}
+
 /// Fields that should be returned when [Version][google.appengine.v1.Version] resources
 /// are retrieved.
 ///
 /// [google.appengine.v1.Version]: crate::model::Version
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct VersionView(std::borrow::Cow<'static, str>);
 
 impl VersionView {
@@ -7355,9 +7451,15 @@ impl std::convert::From<std::string::String> for VersionView {
     }
 }
 
+impl std::default::Default for VersionView {
+    fn default() -> Self {
+        version_view::BASIC
+    }
+}
+
 /// Fields that should be returned when an AuthorizedCertificate resource is
 /// retrieved.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct AuthorizedCertificateView(std::borrow::Cow<'static, str>);
 
 impl AuthorizedCertificateView {
@@ -7393,8 +7495,14 @@ impl std::convert::From<std::string::String> for AuthorizedCertificateView {
     }
 }
 
+impl std::default::Default for AuthorizedCertificateView {
+    fn default() -> Self {
+        authorized_certificate_view::BASIC_CERTIFICATE
+    }
+}
+
 /// Override strategy for mutating an existing mapping.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DomainOverrideStrategy(std::borrow::Cow<'static, str>);
 
 impl DomainOverrideStrategy {
@@ -7435,9 +7543,15 @@ impl std::convert::From<std::string::String> for DomainOverrideStrategy {
     }
 }
 
+impl std::default::Default for DomainOverrideStrategy {
+    fn default() -> Self {
+        domain_override_strategy::UNSPECIFIED_DOMAIN_OVERRIDE_STRATEGY
+    }
+}
+
 /// State of certificate management. Refers to the most recent certificate
 /// acquisition or renewal attempt.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ManagementStatus(std::borrow::Cow<'static, str>);
 
 impl ManagementStatus {
@@ -7500,8 +7614,14 @@ impl std::convert::From<std::string::String> for ManagementStatus {
     }
 }
 
+impl std::default::Default for ManagementStatus {
+    fn default() -> Self {
+        management_status::MANAGEMENT_STATUS_UNSPECIFIED
+    }
+}
+
 /// Available inbound services.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct InboundServiceType(std::borrow::Cow<'static, str>);
 
 impl InboundServiceType {
@@ -7564,8 +7684,14 @@ impl std::convert::From<std::string::String> for InboundServiceType {
     }
 }
 
+impl std::default::Default for InboundServiceType {
+    fn default() -> Self {
+        inbound_service_type::INBOUND_SERVICE_UNSPECIFIED
+    }
+}
+
 /// Run states of a version.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ServingStatus(std::borrow::Cow<'static, str>);
 
 impl ServingStatus {
@@ -7601,5 +7727,11 @@ pub mod serving_status {
 impl std::convert::From<std::string::String> for ServingStatus {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for ServingStatus {
+    fn default() -> Self {
+        serving_status::SERVING_STATUS_UNSPECIFIED
     }
 }

--- a/src/generated/apps/script/calendar/src/model.rs
+++ b/src/generated/apps/script/calendar/src/model.rs
@@ -142,7 +142,7 @@ pub mod calendar_add_on_manifest {
     use super::*;
 
     /// An enum defining the level of data access event triggers require.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EventAccess(std::borrow::Cow<'static, str>);
 
     impl EventAccess {
@@ -186,6 +186,12 @@ pub mod calendar_add_on_manifest {
     impl std::convert::From<std::string::String> for EventAccess {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EventAccess {
+        fn default() -> Self {
+            event_access::UNSPECIFIED
         }
     }
 }

--- a/src/generated/apps/script/gmail/src/model.rs
+++ b/src/generated/apps/script/gmail/src/model.rs
@@ -301,7 +301,7 @@ pub mod compose_trigger {
     use super::*;
 
     /// An enum defining the level of data access this compose trigger requires.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DraftAccess(std::borrow::Cow<'static, str>);
 
     impl DraftAccess {
@@ -336,6 +336,12 @@ pub mod compose_trigger {
     impl std::convert::From<std::string::String> for DraftAccess {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DraftAccess {
+        fn default() -> Self {
+            draft_access::UNSPECIFIED
         }
     }
 }

--- a/src/generated/apps/script/gtype/src/model.rs
+++ b/src/generated/apps/script/gtype/src/model.rs
@@ -63,7 +63,7 @@ pub mod add_on_widget_set {
     use super::*;
 
     /// The Widget type. DEFAULT is the basic widget set.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct WidgetType(std::borrow::Cow<'static, str>);
 
     impl WidgetType {
@@ -111,6 +111,12 @@ pub mod add_on_widget_set {
     impl std::convert::From<std::string::String> for WidgetType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for WidgetType {
+        fn default() -> Self {
+            widget_type::WIDGET_TYPE_UNSPECIFIED
         }
     }
 }
@@ -549,7 +555,7 @@ impl wkt::message::Message for HttpOptions {
 }
 
 /// Authorization header sent in add-on HTTP requests
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct HttpAuthorizationHeader(std::borrow::Cow<'static, str>);
 
 impl HttpAuthorizationHeader {
@@ -588,5 +594,11 @@ pub mod http_authorization_header {
 impl std::convert::From<std::string::String> for HttpAuthorizationHeader {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for HttpAuthorizationHeader {
+    fn default() -> Self {
+        http_authorization_header::HTTP_AUTHORIZATION_HEADER_UNSPECIFIED
     }
 }

--- a/src/generated/bigtable/admin/v2/src/model.rs
+++ b/src/generated/bigtable/admin/v2/src/model.rs
@@ -811,7 +811,7 @@ pub mod create_cluster_metadata {
         #[allow(unused_imports)]
         use super::*;
 
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct State(std::borrow::Cow<'static, str>);
 
         impl State {
@@ -850,6 +850,12 @@ pub mod create_cluster_metadata {
         impl std::convert::From<std::string::String> for State {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for State {
+            fn default() -> Self {
+                state::STATE_UNSPECIFIED
             }
         }
     }
@@ -4775,7 +4781,7 @@ pub mod instance {
     use super::*;
 
     /// Possible states of an instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -4812,8 +4818,14 @@ pub mod instance {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_NOT_KNOWN
+        }
+    }
+
     /// The type of the instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -4849,6 +4861,12 @@ pub mod instance {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -5223,7 +5241,7 @@ pub mod cluster {
     }
 
     /// Possible states of a cluster.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -5271,9 +5289,15 @@ pub mod cluster {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_NOT_KNOWN
+        }
+    }
+
     /// Possible node scaling factors of the clusters. Node scaling delivers better
     /// latency and more throughput by removing node boundaries.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct NodeScalingFactor(std::borrow::Cow<'static, str>);
 
     impl NodeScalingFactor {
@@ -5310,6 +5334,12 @@ pub mod cluster {
     impl std::convert::From<std::string::String> for NodeScalingFactor {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for NodeScalingFactor {
+        fn default() -> Self {
+            node_scaling_factor::NODE_SCALING_FACTOR_UNSPECIFIED
         }
     }
 
@@ -5865,7 +5895,7 @@ pub mod app_profile {
         /// Compute Billing Owner specifies how usage should be accounted when using
         /// Data Boost. Compute Billing Owner also configures which Cloud Project is
         /// charged for relevant quota.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct ComputeBillingOwner(std::borrow::Cow<'static, str>);
 
         impl ComputeBillingOwner {
@@ -5898,12 +5928,18 @@ pub mod app_profile {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for ComputeBillingOwner {
+            fn default() -> Self {
+                compute_billing_owner::COMPUTE_BILLING_OWNER_UNSPECIFIED
+            }
+        }
     }
 
     /// Possible priorities for an app profile. Note that higher priority writes
     /// can sometimes queue behind lower priority writes to the same tablet, as
     /// writes must be strictly sequenced in the durability log.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Priority(std::borrow::Cow<'static, str>);
 
     impl Priority {
@@ -5935,6 +5971,12 @@ pub mod app_profile {
     impl std::convert::From<std::string::String> for Priority {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Priority {
+        fn default() -> Self {
+            priority::PRIORITY_UNSPECIFIED
         }
     }
 
@@ -6444,7 +6486,7 @@ pub mod table {
         use super::*;
 
         /// Table replication states.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct ReplicationState(std::borrow::Cow<'static, str>);
 
         impl ReplicationState {
@@ -6498,6 +6540,12 @@ pub mod table {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for ReplicationState {
+            fn default() -> Self {
+                replication_state::STATE_NOT_KNOWN
+            }
+        }
     }
 
     /// Defines an automated backup policy for a table
@@ -6549,7 +6597,7 @@ pub mod table {
 
     /// Possible timestamp granularities to use when keeping multiple versions
     /// of data in a table.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TimestampGranularity(std::borrow::Cow<'static, str>);
 
     impl TimestampGranularity {
@@ -6583,8 +6631,14 @@ pub mod table {
         }
     }
 
+    impl std::default::Default for TimestampGranularity {
+        fn default() -> Self {
+            timestamp_granularity::TIMESTAMP_GRANULARITY_UNSPECIFIED
+        }
+    }
+
     /// Defines a view over a table's fields.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct View(std::borrow::Cow<'static, str>);
 
     impl View {
@@ -6626,6 +6680,12 @@ pub mod table {
     impl std::convert::From<std::string::String> for View {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for View {
+        fn default() -> Self {
+            view::VIEW_UNSPECIFIED
         }
     }
 
@@ -6859,7 +6919,7 @@ pub mod authorized_view {
     }
 
     /// Defines a subset of an AuthorizedView's fields.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ResponseView(std::borrow::Cow<'static, str>);
 
     impl ResponseView {
@@ -6896,6 +6956,12 @@ pub mod authorized_view {
     impl std::convert::From<std::string::String> for ResponseView {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ResponseView {
+        fn default() -> Self {
+            response_view::RESPONSE_VIEW_UNSPECIFIED
         }
     }
 
@@ -7257,7 +7323,7 @@ pub mod encryption_info {
     use super::*;
 
     /// Possible encryption types for a resource.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EncryptionType(std::borrow::Cow<'static, str>);
 
     impl EncryptionType {
@@ -7300,6 +7366,12 @@ pub mod encryption_info {
     impl std::convert::From<std::string::String> for EncryptionType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EncryptionType {
+        fn default() -> Self {
+            encryption_type::ENCRYPTION_TYPE_UNSPECIFIED
         }
     }
 }
@@ -7420,7 +7492,7 @@ pub mod snapshot {
     use super::*;
 
     /// Possible states of a snapshot.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -7454,6 +7526,12 @@ pub mod snapshot {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_NOT_KNOWN
         }
     }
 }
@@ -7647,7 +7725,7 @@ pub mod backup {
     use super::*;
 
     /// Indicates the current state of the backup.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -7683,8 +7761,14 @@ pub mod backup {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// The type of the backup.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct BackupType(std::borrow::Cow<'static, str>);
 
     impl BackupType {
@@ -7721,6 +7805,12 @@ pub mod backup {
     impl std::convert::From<std::string::String> for BackupType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for BackupType {
+        fn default() -> Self {
+            backup_type::BACKUP_TYPE_UNSPECIFIED
         }
     }
 }
@@ -9339,7 +9429,7 @@ pub mod r#type {
 }
 
 /// Storage media types for persisting Bigtable data.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct StorageType(std::borrow::Cow<'static, str>);
 
 impl StorageType {
@@ -9374,8 +9464,14 @@ impl std::convert::From<std::string::String> for StorageType {
     }
 }
 
+impl std::default::Default for StorageType {
+    fn default() -> Self {
+        storage_type::STORAGE_TYPE_UNSPECIFIED
+    }
+}
+
 /// Indicates the type of the restore source.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct RestoreSourceType(std::borrow::Cow<'static, str>);
 
 impl RestoreSourceType {
@@ -9405,5 +9501,11 @@ pub mod restore_source_type {
 impl std::convert::From<std::string::String> for RestoreSourceType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for RestoreSourceType {
+    fn default() -> Self {
+        restore_source_type::RESTORE_SOURCE_TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/accessapproval/v1/src/model.rs
+++ b/src/generated/cloud/accessapproval/v1/src/model.rs
@@ -147,7 +147,7 @@ pub mod access_reason {
     use super::*;
 
     /// Type of access justification.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -204,6 +204,12 @@ pub mod access_reason {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -1372,7 +1378,7 @@ impl wkt::message::Message for GetAccessApprovalServiceAccountMessage {
 }
 
 /// Represents the type of enrollment for a given service to Access Approval.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct EnrollmentLevel(std::borrow::Cow<'static, str>);
 
 impl EnrollmentLevel {
@@ -1402,5 +1408,11 @@ pub mod enrollment_level {
 impl std::convert::From<std::string::String> for EnrollmentLevel {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for EnrollmentLevel {
+    fn default() -> Self {
+        enrollment_level::ENROLLMENT_LEVEL_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/advisorynotifications/v1/src/model.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/model.rs
@@ -831,7 +831,7 @@ impl wkt::message::Message for UpdateSettingsRequest {
 }
 
 /// Notification view.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct NotificationView(std::borrow::Cow<'static, str>);
 
 impl NotificationView {
@@ -869,8 +869,14 @@ impl std::convert::From<std::string::String> for NotificationView {
     }
 }
 
+impl std::default::Default for NotificationView {
+    fn default() -> Self {
+        notification_view::NOTIFICATION_VIEW_UNSPECIFIED
+    }
+}
+
 /// Status of localized text.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct LocalizationState(std::borrow::Cow<'static, str>);
 
 impl LocalizationState {
@@ -918,8 +924,14 @@ impl std::convert::From<std::string::String> for LocalizationState {
     }
 }
 
+impl std::default::Default for LocalizationState {
+    fn default() -> Self {
+        localization_state::LOCALIZATION_STATE_UNSPECIFIED
+    }
+}
+
 /// Type of notification
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct NotificationType(std::borrow::Cow<'static, str>);
 
 impl NotificationType {
@@ -962,5 +974,11 @@ pub mod notification_type {
 impl std::convert::From<std::string::String> for NotificationType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for NotificationType {
+    fn default() -> Self {
+        notification_type::NOTIFICATION_TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/aiplatform/v1/src/model.rs
+++ b/src/generated/cloud/aiplatform/v1/src/model.rs
@@ -567,7 +567,7 @@ pub mod artifact {
     use super::*;
 
     /// Describes the state of the Artifact.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -601,6 +601,12 @@ pub mod artifact {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -3000,7 +3006,7 @@ pub mod generation_config {
             use super::*;
 
             /// The model routing preference.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct ModelRoutingPreference(std::borrow::Cow<'static, str>);
 
             impl ModelRoutingPreference {
@@ -3038,6 +3044,12 @@ pub mod generation_config {
             impl std::convert::From<std::string::String> for ModelRoutingPreference {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for ModelRoutingPreference {
+                fn default() -> Self {
+                    model_routing_preference::UNKNOWN
                 }
             }
         }
@@ -3155,7 +3167,7 @@ pub mod safety_setting {
     use super::*;
 
     /// Probability based thresholds levels for blocking.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct HarmBlockThreshold(std::borrow::Cow<'static, str>);
 
     impl HarmBlockThreshold {
@@ -3202,8 +3214,14 @@ pub mod safety_setting {
         }
     }
 
+    impl std::default::Default for HarmBlockThreshold {
+        fn default() -> Self {
+            harm_block_threshold::HARM_BLOCK_THRESHOLD_UNSPECIFIED
+        }
+    }
+
     /// Probability vs severity.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct HarmBlockMethod(std::borrow::Cow<'static, str>);
 
     impl HarmBlockMethod {
@@ -3236,6 +3254,12 @@ pub mod safety_setting {
     impl std::convert::From<std::string::String> for HarmBlockMethod {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for HarmBlockMethod {
+        fn default() -> Self {
+            harm_block_method::HARM_BLOCK_METHOD_UNSPECIFIED
         }
     }
 }
@@ -3326,7 +3350,7 @@ pub mod safety_rating {
     use super::*;
 
     /// Harm probability levels in the content.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct HarmProbability(std::borrow::Cow<'static, str>);
 
     impl HarmProbability {
@@ -3368,8 +3392,14 @@ pub mod safety_rating {
         }
     }
 
+    impl std::default::Default for HarmProbability {
+        fn default() -> Self {
+            harm_probability::HARM_PROBABILITY_UNSPECIFIED
+        }
+    }
+
     /// Harm severity levels.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct HarmSeverity(std::borrow::Cow<'static, str>);
 
     impl HarmSeverity {
@@ -3409,6 +3439,12 @@ pub mod safety_rating {
     impl std::convert::From<std::string::String> for HarmSeverity {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for HarmSeverity {
+        fn default() -> Self {
+            harm_severity::HARM_SEVERITY_UNSPECIFIED
         }
     }
 }
@@ -3682,7 +3718,7 @@ pub mod candidate {
 
     /// The reason why the model stopped generating tokens.
     /// If empty, the model has not stopped generating the tokens.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct FinishReason(std::borrow::Cow<'static, str>);
 
     impl FinishReason {
@@ -3745,6 +3781,12 @@ pub mod candidate {
     impl std::convert::From<std::string::String> for FinishReason {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for FinishReason {
+        fn default() -> Self {
+            finish_reason::FINISH_REASON_UNSPECIFIED
         }
     }
 }
@@ -5555,7 +5597,7 @@ pub mod scheduling {
     /// demand resources to schedule the job, the other is SPOT which would
     /// leverage spot resources alongwith regular resources to schedule
     /// the job.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Strategy(std::borrow::Cow<'static, str>);
 
     impl Strategy {
@@ -5596,6 +5638,12 @@ pub mod scheduling {
     impl std::convert::From<std::string::String> for Strategy {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Strategy {
+        fn default() -> Self {
+            strategy::STRATEGY_UNSPECIFIED
         }
     }
 }
@@ -6293,7 +6341,7 @@ pub mod sample_config {
 
     /// Sample strategy decides which subset of DataItems should be selected for
     /// human labeling in every batch.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SampleStrategy(std::borrow::Cow<'static, str>);
 
     impl SampleStrategy {
@@ -6323,6 +6371,12 @@ pub mod sample_config {
     impl std::convert::From<std::string::String> for SampleStrategy {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SampleStrategy {
+        fn default() -> Self {
+            sample_strategy::SAMPLE_STRATEGY_UNSPECIFIED
         }
     }
 
@@ -7035,7 +7089,7 @@ pub mod export_data_config {
     /// destination, format, annotations to be exported, whether to allow
     /// unannotated data to be exported and whether to clone files to temp Cloud
     /// Storage bucket.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ExportUse(std::borrow::Cow<'static, str>);
 
     impl ExportUse {
@@ -7064,6 +7118,12 @@ pub mod export_data_config {
     impl std::convert::From<std::string::String> for ExportUse {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ExportUse {
+        fn default() -> Self {
+            export_use::EXPORT_USE_UNSPECIFIED
         }
     }
 
@@ -12726,7 +12786,7 @@ pub mod evaluated_annotation {
     use super::*;
 
     /// Describes the type of the EvaluatedAnnotation. The type is determined
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EvaluatedAnnotationType(std::borrow::Cow<'static, str>);
 
     impl EvaluatedAnnotationType {
@@ -12768,6 +12828,12 @@ pub mod evaluated_annotation {
     impl std::convert::From<std::string::String> for EvaluatedAnnotationType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EvaluatedAnnotationType {
+        fn default() -> Self {
+            evaluated_annotation_type::EVALUATED_ANNOTATION_TYPE_UNSPECIFIED
         }
     }
 }
@@ -12941,7 +13007,7 @@ pub mod error_analysis_annotation {
     }
 
     /// The query type used for finding the attributed items.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct QueryType(std::borrow::Cow<'static, str>);
 
     impl QueryType {
@@ -12976,6 +13042,12 @@ pub mod error_analysis_annotation {
     impl std::convert::From<std::string::String> for QueryType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for QueryType {
+        fn default() -> Self {
+            query_type::QUERY_TYPE_UNSPECIFIED
         }
     }
 }
@@ -19338,7 +19410,7 @@ pub mod comet_spec {
     use super::*;
 
     /// Comet version options.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CometVersion(std::borrow::Cow<'static, str>);
 
     impl CometVersion {
@@ -19369,6 +19441,12 @@ pub mod comet_spec {
     impl std::convert::From<std::string::String> for CometVersion {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CometVersion {
+        fn default() -> Self {
+            comet_version::COMET_VERSION_UNSPECIFIED
         }
     }
 }
@@ -19572,7 +19650,7 @@ pub mod metricx_spec {
     use super::*;
 
     /// MetricX Version options.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MetricxVersion(std::borrow::Cow<'static, str>);
 
     impl MetricxVersion {
@@ -19609,6 +19687,12 @@ pub mod metricx_spec {
     impl std::convert::From<std::string::String> for MetricxVersion {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for MetricxVersion {
+        fn default() -> Self {
+            metricx_version::METRICX_VERSION_UNSPECIFIED
         }
     }
 }
@@ -19797,7 +19881,7 @@ pub mod event {
     use super::*;
 
     /// Describes whether an Event's Artifact is the Execution's input or output.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -19829,6 +19913,12 @@ pub mod event {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -20006,7 +20096,7 @@ pub mod execution {
     use super::*;
 
     /// Describes the state of the Execution.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -20050,6 +20140,12 @@ pub mod execution {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -21398,7 +21494,7 @@ pub mod examples {
         use super::*;
 
         /// The format of the input example instances.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct DataFormat(std::borrow::Cow<'static, str>);
 
         impl DataFormat {
@@ -21428,6 +21524,12 @@ pub mod examples {
         impl std::convert::From<std::string::String> for DataFormat {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for DataFormat {
+            fn default() -> Self {
+                data_format::DATA_FORMAT_UNSPECIFIED
             }
         }
     }
@@ -21511,7 +21613,7 @@ pub mod presets {
     use super::*;
 
     /// Preset option controlling parameters for query speed-precision trade-off
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Query(std::borrow::Cow<'static, str>);
 
     impl Query {
@@ -21543,8 +21645,14 @@ pub mod presets {
         }
     }
 
+    impl std::default::Default for Query {
+        fn default() -> Self {
+            query::PRECISE
+        }
+    }
+
     /// Preset option controlling parameters for different modalities
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Modality(std::borrow::Cow<'static, str>);
 
     impl Modality {
@@ -21579,6 +21687,12 @@ pub mod presets {
     impl std::convert::From<std::string::String> for Modality {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Modality {
+        fn default() -> Self {
+            modality::MODALITY_UNSPECIFIED
         }
     }
 }
@@ -21834,7 +21948,7 @@ pub mod examples_override {
     use super::*;
 
     /// Data format enum.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DataFormat(std::borrow::Cow<'static, str>);
 
     impl DataFormat {
@@ -21866,6 +21980,12 @@ pub mod examples_override {
     impl std::convert::From<std::string::String> for DataFormat {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DataFormat {
+        fn default() -> Self {
+            data_format::DATA_FORMAT_UNSPECIFIED
         }
     }
 }
@@ -22525,7 +22645,7 @@ pub mod explanation_metadata {
             /// attribution][google.cloud.aiplatform.v1.ExplanationParameters.integrated_gradients_attribution].
             ///
             /// [google.cloud.aiplatform.v1.ExplanationParameters.integrated_gradients_attribution]: crate::model::ExplanationParameters::method
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct Type(std::borrow::Cow<'static, str>);
 
             impl Type {
@@ -22561,9 +22681,15 @@ pub mod explanation_metadata {
                 }
             }
 
+            impl std::default::Default for Type {
+                fn default() -> Self {
+                    r#type::TYPE_UNSPECIFIED
+                }
+            }
+
             /// Whether to only highlight pixels with positive contributions, negative
             /// or both. Defaults to POSITIVE.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct Polarity(std::borrow::Cow<'static, str>);
 
             impl Polarity {
@@ -22603,8 +22729,14 @@ pub mod explanation_metadata {
                 }
             }
 
+            impl std::default::Default for Polarity {
+                fn default() -> Self {
+                    polarity::POLARITY_UNSPECIFIED
+                }
+            }
+
             /// The color scheme used for highlighting areas.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct ColorMap(std::borrow::Cow<'static, str>);
 
             impl ColorMap {
@@ -22653,8 +22785,14 @@ pub mod explanation_metadata {
                 }
             }
 
+            impl std::default::Default for ColorMap {
+                fn default() -> Self {
+                    color_map::COLOR_MAP_UNSPECIFIED
+                }
+            }
+
             /// How the original image is displayed in the visualization.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct OverlayType(std::borrow::Cow<'static, str>);
 
             impl OverlayType {
@@ -22697,10 +22835,16 @@ pub mod explanation_metadata {
                     Self(std::borrow::Cow::Owned(value))
                 }
             }
+
+            impl std::default::Default for OverlayType {
+                fn default() -> Self {
+                    overlay_type::OVERLAY_TYPE_UNSPECIFIED
+                }
+            }
         }
 
         /// Defines how a feature is encoded. Defaults to IDENTITY.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Encoding(std::borrow::Cow<'static, str>);
 
         impl Encoding {
@@ -22800,6 +22944,12 @@ pub mod explanation_metadata {
         impl std::convert::From<std::string::String> for Encoding {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Encoding {
+            fn default() -> Self {
+                encoding::ENCODING_UNSPECIFIED
             }
         }
     }
@@ -23243,7 +23393,7 @@ pub mod feature {
         /// Import Feature Analysis and Snapshot Analysis, this objective could be
         /// one of them. Otherwise, this objective should be the same as the
         /// objective in the request.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Objective(std::borrow::Cow<'static, str>);
 
         impl Objective {
@@ -23278,11 +23428,17 @@ pub mod feature {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for Objective {
+            fn default() -> Self {
+                objective::OBJECTIVE_UNSPECIFIED
+            }
+        }
     }
 
     /// Only applicable for Vertex AI Legacy Feature Store.
     /// An enum representing the value type of a feature.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ValueType(std::borrow::Cow<'static, str>);
 
     impl ValueType {
@@ -23338,6 +23494,12 @@ pub mod feature {
     impl std::convert::From<std::string::String> for ValueType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ValueType {
+        fn default() -> Self {
+            value_type::VALUE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -24210,7 +24372,7 @@ pub mod feature_online_store {
     }
 
     /// Possible states a featureOnlineStore can have.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -24247,6 +24409,12 @@ pub mod feature_online_store {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -26331,7 +26499,7 @@ pub mod nearest_neighbor_query {
 
         /// Datapoints for which Operator is true relative to the query's Value
         /// field will be allowlisted.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Operator(std::borrow::Cow<'static, str>);
 
         impl Operator {
@@ -26375,6 +26543,12 @@ pub mod nearest_neighbor_query {
         impl std::convert::From<std::string::String> for Operator {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Operator {
+            fn default() -> Self {
+                operator::OPERATOR_UNSPECIFIED
             }
         }
 
@@ -27884,7 +28058,7 @@ pub mod feature_view {
         }
 
         /// The distance measure used in nearest neighbor search.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct DistanceMeasureType(std::borrow::Cow<'static, str>);
 
         impl DistanceMeasureType {
@@ -27929,6 +28103,12 @@ pub mod feature_view {
         impl std::convert::From<std::string::String> for DistanceMeasureType {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for DistanceMeasureType {
+            fn default() -> Self {
+                distance_measure_type::DISTANCE_MEASURE_TYPE_UNSPECIFIED
             }
         }
 
@@ -28148,7 +28328,7 @@ pub mod feature_view {
     }
 
     /// Service agent type used during data sync.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ServiceAgentType(std::borrow::Cow<'static, str>);
 
     impl ServiceAgentType {
@@ -28187,6 +28367,12 @@ pub mod feature_view {
     impl std::convert::From<std::string::String> for ServiceAgentType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ServiceAgentType {
+        fn default() -> Self {
+            service_agent_type::SERVICE_AGENT_TYPE_UNSPECIFIED
         }
     }
 
@@ -28666,7 +28852,7 @@ pub mod featurestore {
     }
 
     /// Possible states a featurestore can have.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -28709,6 +28895,12 @@ pub mod featurestore {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -28951,7 +29143,7 @@ pub mod featurestore_monitoring_config {
         use super::*;
 
         /// The state defines whether to enable ImportFeature analysis.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct State(std::borrow::Cow<'static, str>);
 
         impl State {
@@ -28998,13 +29190,19 @@ pub mod featurestore_monitoring_config {
             }
         }
 
+        impl std::default::Default for State {
+            fn default() -> Self {
+                state::STATE_UNSPECIFIED
+            }
+        }
+
         /// Defines the baseline to do anomaly detection for feature values imported
         /// by each
         /// [ImportFeatureValues][google.cloud.aiplatform.v1.FeaturestoreService.ImportFeatureValues]
         /// operation.
         ///
         /// [google.cloud.aiplatform.v1.FeaturestoreService.ImportFeatureValues]: crate::client::FeaturestoreService::import_feature_values
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Baseline(std::borrow::Cow<'static, str>);
 
         impl Baseline {
@@ -29045,6 +29243,12 @@ pub mod featurestore_monitoring_config {
         impl std::convert::From<std::string::String> for Baseline {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Baseline {
+            fn default() -> Self {
+                baseline::BASELINE_UNSPECIFIED
             }
         }
     }
@@ -35132,7 +35336,7 @@ pub mod index {
     use super::*;
 
     /// The update method of an Index.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct IndexUpdateMethod(std::borrow::Cow<'static, str>);
 
     impl IndexUpdateMethod {
@@ -35168,6 +35372,12 @@ pub mod index {
     impl std::convert::From<std::string::String> for IndexUpdateMethod {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for IndexUpdateMethod {
+        fn default() -> Self {
+            index_update_method::INDEX_UPDATE_METHOD_UNSPECIFIED
         }
     }
 }
@@ -35548,7 +35758,7 @@ pub mod index_datapoint {
         ///
         /// Datapoints for which Operator is true relative to the query's Value
         /// field will be allowlisted.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Operator(std::borrow::Cow<'static, str>);
 
         impl Operator {
@@ -35592,6 +35802,12 @@ pub mod index_datapoint {
         impl std::convert::From<std::string::String> for Operator {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Operator {
+            fn default() -> Self {
+                operator::OPERATOR_UNSPECIFIED
             }
         }
 
@@ -37880,7 +38096,7 @@ pub mod nearest_neighbor_search_operation_metadata {
         #[allow(unused_imports)]
         use super::*;
 
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct RecordErrorType(std::borrow::Cow<'static, str>);
 
         impl RecordErrorType {
@@ -37972,6 +38188,12 @@ pub mod nearest_neighbor_search_operation_metadata {
         impl std::convert::From<std::string::String> for RecordErrorType {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for RecordErrorType {
+            fn default() -> Self {
+                record_error_type::ERROR_TYPE_UNSPECIFIED
             }
         }
     }
@@ -38470,7 +38692,7 @@ pub mod google_drive_source {
         use super::*;
 
         /// The type of the Google Drive resource.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct ResourceType(std::borrow::Cow<'static, str>);
 
         impl ResourceType {
@@ -38504,6 +38726,12 @@ pub mod google_drive_source {
         impl std::convert::From<std::string::String> for ResourceType {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for ResourceType {
+            fn default() -> Self {
+                resource_type::RESOURCE_TYPE_UNSPECIFIED
             }
         }
     }
@@ -43063,7 +43291,7 @@ pub mod metadata_schema {
     use super::*;
 
     /// Describes the type of the MetadataSchema.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MetadataSchemaType(std::borrow::Cow<'static, str>);
 
     impl MetadataSchemaType {
@@ -43099,6 +43327,12 @@ pub mod metadata_schema {
     impl std::convert::From<std::string::String> for MetadataSchemaType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for MetadataSchemaType {
+        fn default() -> Self {
+            metadata_schema_type::METADATA_SCHEMA_TYPE_UNSPECIFIED
         }
     }
 }
@@ -48247,7 +48481,7 @@ pub mod model {
         use super::*;
 
         /// The Model content that can be exported.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct ExportableContent(std::borrow::Cow<'static, str>);
 
         impl ExportableContent {
@@ -48291,6 +48525,12 @@ pub mod model {
         impl std::convert::From<std::string::String> for ExportableContent {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for ExportableContent {
+            fn default() -> Self {
+                exportable_content::EXPORTABLE_CONTENT_UNSPECIFIED
             }
         }
     }
@@ -48531,7 +48771,7 @@ pub mod model {
     }
 
     /// Identifies a type of Model's prediction resources.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DeploymentResourcesType(std::borrow::Cow<'static, str>);
 
     impl DeploymentResourcesType {
@@ -48582,6 +48822,12 @@ pub mod model {
     impl std::convert::From<std::string::String> for DeploymentResourcesType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DeploymentResourcesType {
+        fn default() -> Self {
+            deployment_resources_type::DEPLOYMENT_RESOURCES_TYPE_UNSPECIFIED
         }
     }
 }
@@ -49287,7 +49533,7 @@ pub mod model_source_info {
     /// indicates the source from which the model was accessed or obtained,
     /// whereas the `objective` indicates the overall aim or function of this
     /// model.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ModelSourceType(std::borrow::Cow<'static, str>);
 
     impl ModelSourceType {
@@ -49336,6 +49582,12 @@ pub mod model_source_info {
     impl std::convert::From<std::string::String> for ModelSourceType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ModelSourceType {
+        fn default() -> Self {
+            model_source_type::MODEL_SOURCE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -50267,7 +50519,7 @@ pub mod model_deployment_monitoring_job {
     }
 
     /// The state to Specify the monitoring pipeline.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MonitoringScheduleState(std::borrow::Cow<'static, str>);
 
     impl MonitoringScheduleState {
@@ -50303,6 +50555,12 @@ pub mod model_deployment_monitoring_job {
     impl std::convert::From<std::string::String> for MonitoringScheduleState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for MonitoringScheduleState {
+        fn default() -> Self {
+            monitoring_schedule_state::MONITORING_SCHEDULE_STATE_UNSPECIFIED
         }
     }
 }
@@ -50392,7 +50650,7 @@ pub mod model_deployment_monitoring_big_query_table {
     use super::*;
 
     /// Indicates where does the log come from.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LogSource(std::borrow::Cow<'static, str>);
 
     impl LogSource {
@@ -50427,8 +50685,14 @@ pub mod model_deployment_monitoring_big_query_table {
         }
     }
 
+    impl std::default::Default for LogSource {
+        fn default() -> Self {
+            log_source::LOG_SOURCE_UNSPECIFIED
+        }
+    }
+
     /// Indicates what type of traffic does the log belong to.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LogType(std::borrow::Cow<'static, str>);
 
     impl LogType {
@@ -50460,6 +50724,12 @@ pub mod model_deployment_monitoring_big_query_table {
     impl std::convert::From<std::string::String> for LogType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for LogType {
+        fn default() -> Self {
+            log_type::LOG_TYPE_UNSPECIFIED
         }
     }
 }
@@ -52302,7 +52572,7 @@ pub mod model_monitoring_objective_config {
             use super::*;
 
             /// The storage format of the predictions generated BatchPrediction job.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct PredictionFormat(std::borrow::Cow<'static, str>);
 
             impl PredictionFormat {
@@ -52335,6 +52605,12 @@ pub mod model_monitoring_objective_config {
             impl std::convert::From<std::string::String> for PredictionFormat {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for PredictionFormat {
+                fn default() -> Self {
+                    prediction_format::PREDICTION_FORMAT_UNSPECIFIED
                 }
             }
 
@@ -55358,7 +55634,7 @@ pub mod nas_job_spec {
             use super::*;
 
             /// The available types of optimization goals.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct GoalType(std::borrow::Cow<'static, str>);
 
             impl GoalType {
@@ -55390,6 +55666,12 @@ pub mod nas_job_spec {
             impl std::convert::From<std::string::String> for GoalType {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for GoalType {
+                fn default() -> Self {
+                    goal_type::GOAL_TYPE_UNSPECIFIED
                 }
             }
         }
@@ -55524,7 +55806,7 @@ pub mod nas_job_spec {
         }
 
         /// The available types of multi-trial algorithms.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct MultiTrialAlgorithm(std::borrow::Cow<'static, str>);
 
         impl MultiTrialAlgorithm {
@@ -55560,6 +55842,12 @@ pub mod nas_job_spec {
         impl std::convert::From<std::string::String> for MultiTrialAlgorithm {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for MultiTrialAlgorithm {
+            fn default() -> Self {
+                multi_trial_algorithm::MULTI_TRIAL_ALGORITHM_UNSPECIFIED
             }
         }
     }
@@ -55797,7 +56085,7 @@ pub mod nas_trial {
     use super::*;
 
     /// Describes a NasTrial state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -55841,6 +56129,12 @@ pub mod nas_trial {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -57510,7 +57804,7 @@ pub mod notebook_runtime {
     use super::*;
 
     /// The substate of the NotebookRuntime to display health information.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct HealthState(std::borrow::Cow<'static, str>);
 
     impl HealthState {
@@ -57546,9 +57840,15 @@ pub mod notebook_runtime {
         }
     }
 
+    impl std::default::Default for HealthState {
+        fn default() -> Self {
+            health_state::HEALTH_STATE_UNSPECIFIED
+        }
+    }
+
     /// The substate of the NotebookRuntime to display state of runtime.
     /// The resource of NotebookRuntime is in ACTIVE state for these sub state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RuntimeState(std::borrow::Cow<'static, str>);
 
     impl RuntimeState {
@@ -57597,6 +57897,12 @@ pub mod notebook_runtime {
     impl std::convert::From<std::string::String> for RuntimeState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RuntimeState {
+        fn default() -> Self {
+            runtime_state::RUNTIME_STATE_UNSPECIFIED
         }
     }
 }
@@ -59175,7 +59481,7 @@ pub mod post_startup_script_config {
     use super::*;
 
     /// Represents a notebook runtime post startup script behavior.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PostStartupScriptBehavior(std::borrow::Cow<'static, str>);
 
     impl PostStartupScriptBehavior {
@@ -59213,6 +59519,12 @@ pub mod post_startup_script_config {
     impl std::convert::From<std::string::String> for PostStartupScriptBehavior {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PostStartupScriptBehavior {
+        fn default() -> Self {
+            post_startup_script_behavior::POST_STARTUP_SCRIPT_BEHAVIOR_UNSPECIFIED
         }
     }
 }
@@ -59910,7 +60222,7 @@ pub mod persistent_resource {
     use super::*;
 
     /// Describes the PersistentResource state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -59958,6 +60270,12 @@ pub mod persistent_resource {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -61858,7 +62176,7 @@ pub mod pipeline_task_detail {
     }
 
     /// Specifies state of TaskExecution
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -61916,6 +62234,12 @@ pub mod pipeline_task_detail {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -64778,7 +65102,7 @@ pub mod generate_content_response {
         use super::*;
 
         /// Blocked reason enumeration.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct BlockedReason(std::borrow::Cow<'static, str>);
 
         impl BlockedReason {
@@ -64818,6 +65142,12 @@ pub mod generate_content_response {
         impl std::convert::From<std::string::String> for BlockedReason {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for BlockedReason {
+            fn default() -> Self {
+                blocked_reason::BLOCKED_REASON_UNSPECIFIED
             }
         }
     }
@@ -66141,7 +66471,7 @@ pub mod publisher_model {
     }
 
     /// An enum representing the open source category of a PublisherModel.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct OpenSourceCategory(std::borrow::Cow<'static, str>);
 
     impl OpenSourceCategory {
@@ -66193,8 +66523,14 @@ pub mod publisher_model {
         }
     }
 
+    impl std::default::Default for OpenSourceCategory {
+        fn default() -> Self {
+            open_source_category::OPEN_SOURCE_CATEGORY_UNSPECIFIED
+        }
+    }
+
     /// An enum representing the launch stage of a PublisherModel.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LaunchStage(std::borrow::Cow<'static, str>);
 
     impl LaunchStage {
@@ -66243,8 +66579,14 @@ pub mod publisher_model {
         }
     }
 
+    impl std::default::Default for LaunchStage {
+        fn default() -> Self {
+            launch_stage::LAUNCH_STAGE_UNSPECIFIED
+        }
+    }
+
     /// An enum representing the state of the PublicModelVersion.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct VersionState(std::borrow::Cow<'static, str>);
 
     impl VersionState {
@@ -66278,6 +66620,12 @@ pub mod publisher_model {
     impl std::convert::From<std::string::String> for VersionState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for VersionState {
+        fn default() -> Self {
+            version_state::VERSION_STATE_UNSPECIFIED
         }
     }
 }
@@ -67096,7 +67444,7 @@ pub mod reservation_affinity {
     use super::*;
 
     /// Identifies a type of reservation affinity.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -67132,6 +67480,12 @@ pub mod reservation_affinity {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -67684,7 +68038,7 @@ pub mod schedule {
     }
 
     /// Possible state of the schedule.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -67723,6 +68077,12 @@ pub mod schedule {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -68950,7 +69310,7 @@ pub mod study {
     use super::*;
 
     /// Describes the Study state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -68986,6 +69346,12 @@ pub mod study {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -69248,7 +69614,7 @@ pub mod trial {
     }
 
     /// Describes a Trial state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -69292,6 +69658,12 @@ pub mod trial {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -69798,7 +70170,7 @@ pub mod study_spec {
         }
 
         /// The available types of optimization goals.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct GoalType(std::borrow::Cow<'static, str>);
 
         impl GoalType {
@@ -69830,6 +70202,12 @@ pub mod study_spec {
         impl std::convert::From<std::string::String> for GoalType {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for GoalType {
+            fn default() -> Self {
+                goal_type::GOAL_TYPE_UNSPECIFIED
             }
         }
     }
@@ -70556,7 +70934,7 @@ pub mod study_spec {
         }
 
         /// The type of scaling that should be applied to this parameter.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct ScaleType(std::borrow::Cow<'static, str>);
 
         impl ScaleType {
@@ -70595,6 +70973,12 @@ pub mod study_spec {
         impl std::convert::From<std::string::String> for ScaleType {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for ScaleType {
+            fn default() -> Self {
+                scale_type::SCALE_TYPE_UNSPECIFIED
             }
         }
 
@@ -70969,7 +71353,7 @@ pub mod study_spec {
     }
 
     /// The available search algorithms for the Study.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Algorithm(std::borrow::Cow<'static, str>);
 
     impl Algorithm {
@@ -71007,11 +71391,17 @@ pub mod study_spec {
         }
     }
 
+    impl std::default::Default for Algorithm {
+        fn default() -> Self {
+            algorithm::ALGORITHM_UNSPECIFIED
+        }
+    }
+
     /// Describes the noise level of the repeated observations.
     ///
     /// "Noisy" means that the repeated observations with the same Trial parameters
     /// may lead to different metric evaluations.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ObservationNoise(std::borrow::Cow<'static, str>);
 
     impl ObservationNoise {
@@ -71050,6 +71440,12 @@ pub mod study_spec {
         }
     }
 
+    impl std::default::Default for ObservationNoise {
+        fn default() -> Self {
+            observation_noise::OBSERVATION_NOISE_UNSPECIFIED
+        }
+    }
+
     /// This indicates which measurement to use if/when the service automatically
     /// selects the final measurement from previously reported intermediate
     /// measurements. Choose this based on two considerations:
@@ -71063,7 +71459,7 @@ pub mod study_spec {
     /// may be better to choose LAST_MEASUREMENT.
     /// If both or neither of (A) and (B) apply, it doesn't matter which
     /// selection type is chosen.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MeasurementSelectionType(std::borrow::Cow<'static, str>);
 
     impl MeasurementSelectionType {
@@ -71098,6 +71494,12 @@ pub mod study_spec {
     impl std::convert::From<std::string::String> for MeasurementSelectionType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for MeasurementSelectionType {
+        fn default() -> Self {
+            measurement_selection_type::MEASUREMENT_SELECTION_TYPE_UNSPECIFIED
         }
     }
 
@@ -74682,7 +75084,7 @@ pub mod tensorboard_time_series {
     }
 
     /// An enum representing the value type of a TensorboardTimeSeries.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ValueType(std::borrow::Cow<'static, str>);
 
     impl ValueType {
@@ -74720,6 +75122,12 @@ pub mod tensorboard_time_series {
     impl std::convert::From<std::string::String> for ValueType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ValueType {
+        fn default() -> Self {
+            value_type::VALUE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -75084,7 +75492,7 @@ pub mod executable_code {
     use super::*;
 
     /// Supported programming languages for the generated code.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Language(std::borrow::Cow<'static, str>);
 
     impl Language {
@@ -75113,6 +75521,12 @@ pub mod executable_code {
     impl std::convert::From<std::string::String> for Language {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Language {
+        fn default() -> Self {
+            language::LANGUAGE_UNSPECIFIED
         }
     }
 }
@@ -75167,7 +75581,7 @@ pub mod code_execution_result {
     use super::*;
 
     /// Enumeration of possible outcomes of the code execution.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Outcome(std::borrow::Cow<'static, str>);
 
     impl Outcome {
@@ -75204,6 +75618,12 @@ pub mod code_execution_result {
     impl std::convert::From<std::string::String> for Outcome {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Outcome {
+        fn default() -> Self {
+            outcome::OUTCOME_UNSPECIFIED
         }
     }
 }
@@ -75576,7 +75996,7 @@ pub mod dynamic_retrieval_config {
     use super::*;
 
     /// The mode of the predictor to be used in dynamic retrieval.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Mode(std::borrow::Cow<'static, str>);
 
     impl Mode {
@@ -75605,6 +76025,12 @@ pub mod dynamic_retrieval_config {
     impl std::convert::From<std::string::String> for Mode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Mode {
+        fn default() -> Self {
+            mode::MODE_UNSPECIFIED
         }
     }
 }
@@ -75712,7 +76138,7 @@ pub mod function_calling_config {
     use super::*;
 
     /// Function calling mode.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Mode(std::borrow::Cow<'static, str>);
 
     impl Mode {
@@ -75752,6 +76178,12 @@ pub mod function_calling_config {
     impl std::convert::From<std::string::String> for Mode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Mode {
+        fn default() -> Self {
+            mode::MODE_UNSPECIFIED
         }
     }
 }
@@ -77971,7 +78403,7 @@ pub mod supervised_hyper_parameters {
     use super::*;
 
     /// Supported adapter sizes for tuning.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AdapterSize(std::borrow::Cow<'static, str>);
 
     impl AdapterSize {
@@ -78010,6 +78442,12 @@ pub mod supervised_hyper_parameters {
     impl std::convert::From<std::string::String> for AdapterSize {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AdapterSize {
+        fn default() -> Self {
+            adapter_size::ADAPTER_SIZE_UNSPECIFIED
         }
     }
 }
@@ -78607,7 +79045,7 @@ pub mod tensor {
     use super::*;
 
     /// Data type of the tensor.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DataType(std::borrow::Cow<'static, str>);
 
     impl DataType {
@@ -78660,6 +79098,12 @@ pub mod tensor {
     impl std::convert::From<std::string::String> for DataType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DataType {
+        fn default() -> Self {
+            data_type::DATA_TYPE_UNSPECIFIED
         }
     }
 }
@@ -79434,7 +79878,7 @@ pub mod file_status {
     use super::*;
 
     /// RagFile state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -79467,6 +79911,12 @@ pub mod file_status {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -79518,7 +79968,7 @@ pub mod corpus_status {
     use super::*;
 
     /// RagCorpus life state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -79554,6 +80004,12 @@ pub mod corpus_status {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::UNKNOWN
         }
     }
 }
@@ -83658,7 +84114,7 @@ impl wkt::message::Message for ListOptimalTrialsResponse {
 }
 
 /// Represents a hardware accelerator type.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct AcceleratorType(std::borrow::Cow<'static, str>);
 
 impl AcceleratorType {
@@ -83732,8 +84188,14 @@ impl std::convert::From<std::string::String> for AcceleratorType {
     }
 }
 
+impl std::default::Default for AcceleratorType {
+    fn default() -> Self {
+        accelerator_type::ACCELERATOR_TYPE_UNSPECIFIED
+    }
+}
+
 /// Harm categories that will block the content.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct HarmCategory(std::borrow::Cow<'static, str>);
 
 impl HarmCategory {
@@ -83783,8 +84245,14 @@ impl std::convert::From<std::string::String> for HarmCategory {
     }
 }
 
+impl std::default::Default for HarmCategory {
+    fn default() -> Self {
+        harm_category::HARM_CATEGORY_UNSPECIFIED
+    }
+}
+
 /// Content Part modality
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Modality(std::borrow::Cow<'static, str>);
 
 impl Modality {
@@ -83828,8 +84296,14 @@ impl std::convert::From<std::string::String> for Modality {
     }
 }
 
+impl std::default::Default for Modality {
+    fn default() -> Self {
+        modality::MODALITY_UNSPECIFIED
+    }
+}
+
 /// Pairwise prediction autorater preference.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct PairwiseChoice(std::borrow::Cow<'static, str>);
 
 impl PairwiseChoice {
@@ -83868,8 +84342,14 @@ impl std::convert::From<std::string::String> for PairwiseChoice {
     }
 }
 
+impl std::default::Default for PairwiseChoice {
+    fn default() -> Self {
+        pairwise_choice::PAIRWISE_CHOICE_UNSPECIFIED
+    }
+}
+
 /// Format of the data in the Feature View.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct FeatureViewDataFormat(std::borrow::Cow<'static, str>);
 
 impl FeatureViewDataFormat {
@@ -83905,8 +84385,14 @@ impl std::convert::From<std::string::String> for FeatureViewDataFormat {
     }
 }
 
+impl std::default::Default for FeatureViewDataFormat {
+    fn default() -> Self {
+        feature_view_data_format::FEATURE_VIEW_DATA_FORMAT_UNSPECIFIED
+    }
+}
+
 /// Describes the state of a job.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct JobState(std::borrow::Cow<'static, str>);
 
 impl JobState {
@@ -83971,8 +84457,14 @@ impl std::convert::From<std::string::String> for JobState {
     }
 }
 
+impl std::default::Default for JobState {
+    fn default() -> Self {
+        job_state::JOB_STATE_UNSPECIFIED
+    }
+}
+
 /// The Model Monitoring Objective types.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ModelDeploymentMonitoringObjectiveType(std::borrow::Cow<'static, str>);
 
 impl ModelDeploymentMonitoringObjectiveType {
@@ -84024,8 +84516,14 @@ impl std::convert::From<std::string::String> for ModelDeploymentMonitoringObject
     }
 }
 
+impl std::default::Default for ModelDeploymentMonitoringObjectiveType {
+    fn default() -> Self {
+        model_deployment_monitoring_objective_type::MODEL_DEPLOYMENT_MONITORING_OBJECTIVE_TYPE_UNSPECIFIED
+    }
+}
+
 /// View enumeration of PublisherModel.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct PublisherModelView(std::borrow::Cow<'static, str>);
 
 impl PublisherModelView {
@@ -84068,8 +84566,14 @@ impl std::convert::From<std::string::String> for PublisherModelView {
     }
 }
 
+impl std::default::Default for PublisherModelView {
+    fn default() -> Self {
+        publisher_model_view::PUBLISHER_MODEL_VIEW_UNSPECIFIED
+    }
+}
+
 /// Represents a notebook runtime type.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct NotebookRuntimeType(std::borrow::Cow<'static, str>);
 
 impl NotebookRuntimeType {
@@ -84106,8 +84610,14 @@ impl std::convert::From<std::string::String> for NotebookRuntimeType {
     }
 }
 
+impl std::default::Default for NotebookRuntimeType {
+    fn default() -> Self {
+        notebook_runtime_type::NOTEBOOK_RUNTIME_TYPE_UNSPECIFIED
+    }
+}
+
 /// Views for Get/List NotebookExecutionJob
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct NotebookExecutionJobView(std::borrow::Cow<'static, str>);
 
 impl NotebookExecutionJobView {
@@ -84145,9 +84655,15 @@ impl std::convert::From<std::string::String> for NotebookExecutionJobView {
     }
 }
 
+impl std::default::Default for NotebookExecutionJobView {
+    fn default() -> Self {
+        notebook_execution_job_view::NOTEBOOK_EXECUTION_JOB_VIEW_UNSPECIFIED
+    }
+}
+
 /// Type contains the list of OpenAPI data types as defined by
 /// <https://swagger.io/docs/specification/data-models/data-types/>
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Type(std::borrow::Cow<'static, str>);
 
 impl Type {
@@ -84194,13 +84710,19 @@ impl std::convert::From<std::string::String> for Type {
     }
 }
 
+impl std::default::Default for Type {
+    fn default() -> Self {
+        r#type::TYPE_UNSPECIFIED
+    }
+}
+
 /// Represents the failure policy of a pipeline. Currently, the default of a
 /// pipeline is that the pipeline will continue to run until no more tasks can be
 /// executed, also known as PIPELINE_FAILURE_POLICY_FAIL_SLOW. However, if a
 /// pipeline is set to PIPELINE_FAILURE_POLICY_FAIL_FAST, it will stop scheduling
 /// any new tasks when a task has failed. Any scheduled tasks will continue to
 /// completion.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct PipelineFailurePolicy(std::borrow::Cow<'static, str>);
 
 impl PipelineFailurePolicy {
@@ -84240,8 +84762,14 @@ impl std::convert::From<std::string::String> for PipelineFailurePolicy {
     }
 }
 
+impl std::default::Default for PipelineFailurePolicy {
+    fn default() -> Self {
+        pipeline_failure_policy::PIPELINE_FAILURE_POLICY_UNSPECIFIED
+    }
+}
+
 /// Describes the state of a pipeline.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct PipelineState(std::borrow::Cow<'static, str>);
 
 impl PipelineState {
@@ -84298,5 +84826,11 @@ pub mod pipeline_state {
 impl std::convert::From<std::string::String> for PipelineState {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for PipelineState {
+    fn default() -> Self {
+        pipeline_state::PIPELINE_STATE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/alloydb/connectors/v1/src/model.rs
+++ b/src/generated/cloud/alloydb/connectors/v1/src/model.rs
@@ -88,7 +88,7 @@ pub mod metadata_exchange_request {
     use super::*;
 
     /// AuthType contains all supported authentication types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AuthType(std::borrow::Cow<'static, str>);
 
     impl AuthType {
@@ -120,6 +120,12 @@ pub mod metadata_exchange_request {
     impl std::convert::From<std::string::String> for AuthType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AuthType {
+        fn default() -> Self {
+            auth_type::AUTH_TYPE_UNSPECIFIED
         }
     }
 }
@@ -175,7 +181,7 @@ pub mod metadata_exchange_response {
     use super::*;
 
     /// Response code.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ResponseCode(std::borrow::Cow<'static, str>);
 
     impl ResponseCode {
@@ -208,6 +214,12 @@ pub mod metadata_exchange_response {
     impl std::convert::From<std::string::String> for ResponseCode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ResponseCode {
+        fn default() -> Self {
+            response_code::RESPONSE_CODE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/alloydb/v1/src/model.rs
+++ b/src/generated/cloud/alloydb/v1/src/model.rs
@@ -308,7 +308,7 @@ pub mod migration_source {
     use super::*;
 
     /// Denote the type of migration source that created this cluster.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MigrationSourceType(std::borrow::Cow<'static, str>);
 
     impl MigrationSourceType {
@@ -338,6 +338,12 @@ pub mod migration_source {
     impl std::convert::From<std::string::String> for MigrationSourceType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for MigrationSourceType {
+        fn default() -> Self {
+            migration_source_type::MIGRATION_SOURCE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -427,7 +433,7 @@ pub mod encryption_info {
     use super::*;
 
     /// Possible encryption types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -461,6 +467,12 @@ pub mod encryption_info {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -515,7 +527,7 @@ pub mod ssl_config {
     use super::*;
 
     /// SSL mode options.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SslMode(std::borrow::Cow<'static, str>);
 
     impl SslMode {
@@ -564,8 +576,14 @@ pub mod ssl_config {
         }
     }
 
+    impl std::default::Default for SslMode {
+        fn default() -> Self {
+            ssl_mode::SSL_MODE_UNSPECIFIED
+        }
+    }
+
     /// Certificate Authority (CA) source for SSL/TLS certificates.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CaSource(std::borrow::Cow<'static, str>);
 
     impl CaSource {
@@ -595,6 +613,12 @@ pub mod ssl_config {
     impl std::convert::From<std::string::String> for CaSource {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CaSource {
+        fn default() -> Self {
+            ca_source::CA_SOURCE_UNSPECIFIED
         }
     }
 }
@@ -2135,7 +2159,7 @@ pub mod cluster {
     }
 
     /// Cluster State
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2199,8 +2223,14 @@ pub mod cluster {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Type of Cluster
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ClusterType(std::borrow::Cow<'static, str>);
 
     impl ClusterType {
@@ -2234,6 +2264,12 @@ pub mod cluster {
     impl std::convert::From<std::string::String> for ClusterType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ClusterType {
+        fn default() -> Self {
+            cluster_type::CLUSTER_TYPE_UNSPECIFIED
         }
     }
 
@@ -3071,7 +3107,7 @@ pub mod instance {
     }
 
     /// Instance State
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3130,8 +3166,14 @@ pub mod instance {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Type of an Instance
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct InstanceType(std::borrow::Cow<'static, str>);
 
     impl InstanceType {
@@ -3176,13 +3218,19 @@ pub mod instance {
         }
     }
 
+    impl std::default::Default for InstanceType {
+        fn default() -> Self {
+            instance_type::INSTANCE_TYPE_UNSPECIFIED
+        }
+    }
+
     /// The Availability type of an instance. Potential values:
     ///
     /// - ZONAL: The instance serves data from only one zone. Outages in that
     ///   zone affect instance availability.
     /// - REGIONAL: The instance can serve data from more than one zone in a
     ///   region (it is highly available).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AvailabilityType(std::borrow::Cow<'static, str>);
 
     impl AvailabilityType {
@@ -3215,6 +3263,12 @@ pub mod instance {
     impl std::convert::From<std::string::String> for AvailabilityType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AvailabilityType {
+        fn default() -> Self {
+            availability_type::AVAILABILITY_TYPE_UNSPECIFIED
         }
     }
 }
@@ -3670,7 +3724,7 @@ pub mod backup {
     }
 
     /// Backup State
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3711,8 +3765,14 @@ pub mod backup {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Backup Type
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -3750,6 +3810,12 @@ pub mod backup {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -4030,7 +4096,7 @@ pub mod supported_database_flag {
     /// ValueType describes the semantic type of the value that the flag accepts.
     /// Regardless of the ValueType, the Instance.database_flags field accepts the
     /// stringified version of the value, i.e. "20" or "3.14".
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ValueType(std::borrow::Cow<'static, str>);
 
     impl ValueType {
@@ -4068,6 +4134,12 @@ pub mod supported_database_flag {
     impl std::convert::From<std::string::String> for ValueType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ValueType {
+        fn default() -> Self {
+            value_type::VALUE_TYPE_UNSPECIFIED
         }
     }
 
@@ -4171,7 +4243,7 @@ pub mod user {
     use super::*;
 
     /// Enum that details the user type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct UserType(std::borrow::Cow<'static, str>);
 
     impl UserType {
@@ -4204,6 +4276,12 @@ pub mod user {
     impl std::convert::From<std::string::String> for UserType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for UserType {
+        fn default() -> Self {
+            user_type::USER_TYPE_UNSPECIFIED
         }
     }
 }
@@ -5768,7 +5846,7 @@ pub mod batch_create_instance_status {
     /// State contains all valid instance states for the BatchCreateInstances
     /// operation. This is mainly used for status reporting through the LRO
     /// metadata.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -5815,6 +5893,12 @@ pub mod batch_create_instance_status {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -6131,7 +6215,7 @@ pub mod inject_fault_request {
 
     /// FaultType contains all valid types of faults that can be injected to an
     /// instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct FaultType(std::borrow::Cow<'static, str>);
 
     impl FaultType {
@@ -6160,6 +6244,12 @@ pub mod inject_fault_request {
     impl std::convert::From<std::string::String> for FaultType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for FaultType {
+        fn default() -> Self {
+            fault_type::FAULT_TYPE_UNSPECIFIED
         }
     }
 }
@@ -6489,7 +6579,7 @@ pub mod execute_sql_metadata {
     use super::*;
 
     /// Status contains all valid Status a SQL execution can end up in.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Status(std::borrow::Cow<'static, str>);
 
     impl Status {
@@ -6532,6 +6622,12 @@ pub mod execute_sql_metadata {
     impl std::convert::From<std::string::String> for Status {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Status {
+        fn default() -> Self {
+            status::STATUS_UNSPECIFIED
         }
     }
 }
@@ -7952,7 +8048,7 @@ impl gax::paginator::PageableResponse for ListDatabasesResponse {
 
 /// View on Instance. Pass this enum to rpcs that returns an Instance message to
 /// control which subsets of fields to get.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct InstanceView(std::borrow::Cow<'static, str>);
 
 impl InstanceView {
@@ -7991,9 +8087,15 @@ impl std::convert::From<std::string::String> for InstanceView {
     }
 }
 
+impl std::default::Default for InstanceView {
+    fn default() -> Self {
+        instance_view::INSTANCE_VIEW_UNSPECIFIED
+    }
+}
+
 /// View on Cluster. Pass this enum to rpcs that returns a cluster message to
 /// control which subsets of fields to get.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ClusterView(std::borrow::Cow<'static, str>);
 
 impl ClusterView {
@@ -8033,8 +8135,14 @@ impl std::convert::From<std::string::String> for ClusterView {
     }
 }
 
+impl std::default::Default for ClusterView {
+    fn default() -> Self {
+        cluster_view::CLUSTER_VIEW_UNSPECIFIED
+    }
+}
+
 /// The supported database engine versions.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DatabaseVersion(std::borrow::Cow<'static, str>);
 
 impl DatabaseVersion {
@@ -8076,10 +8184,16 @@ impl std::convert::From<std::string::String> for DatabaseVersion {
     }
 }
 
+impl std::default::Default for DatabaseVersion {
+    fn default() -> Self {
+        database_version::DATABASE_VERSION_UNSPECIFIED
+    }
+}
+
 /// Subscription_type added to distinguish between Standard and Trial
 /// subscriptions. By default, a subscription type is considered STANDARD unless
 /// explicitly specified.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SubscriptionType(std::borrow::Cow<'static, str>);
 
 impl SubscriptionType {
@@ -8113,5 +8227,11 @@ pub mod subscription_type {
 impl std::convert::From<std::string::String> for SubscriptionType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for SubscriptionType {
+    fn default() -> Self {
+        subscription_type::SUBSCRIPTION_TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/apigateway/v1/src/model.rs
+++ b/src/generated/cloud/apigateway/v1/src/model.rs
@@ -143,7 +143,7 @@ pub mod api {
     use super::*;
 
     /// All the possible API states.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -184,6 +184,12 @@ pub mod api {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -516,7 +522,7 @@ pub mod api_config {
     }
 
     /// All the possible API Config states.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -561,6 +567,12 @@ pub mod api_config {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -691,7 +703,7 @@ pub mod gateway {
     use super::*;
 
     /// All the possible Gateway states.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -732,6 +744,12 @@ pub mod gateway {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1534,7 +1552,7 @@ pub mod get_api_config_request {
     use super::*;
 
     /// Enum to control which fields should be included in the response.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ConfigView(std::borrow::Cow<'static, str>);
 
     impl ConfigView {
@@ -1565,6 +1583,12 @@ pub mod get_api_config_request {
     impl std::convert::From<std::string::String> for ConfigView {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ConfigView {
+        fn default() -> Self {
+            config_view::CONFIG_VIEW_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/apigeeconnect/v1/src/model.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/model.rs
@@ -838,7 +838,7 @@ impl wkt::message::Message for HttpResponse {
 }
 
 /// The action taken by agent.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Action(std::borrow::Cow<'static, str>);
 
 impl Action {
@@ -870,8 +870,14 @@ impl std::convert::From<std::string::String> for Action {
     }
 }
 
+impl std::default::Default for Action {
+    fn default() -> Self {
+        action::ACTION_UNSPECIFIED
+    }
+}
+
 /// Endpoint indicates where the messages will be delivered.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TetherEndpoint(std::borrow::Cow<'static, str>);
 
 impl TetherEndpoint {
@@ -910,8 +916,14 @@ impl std::convert::From<std::string::String> for TetherEndpoint {
     }
 }
 
+impl std::default::Default for TetherEndpoint {
+    fn default() -> Self {
+        tether_endpoint::TETHER_ENDPOINT_UNSPECIFIED
+    }
+}
+
 /// HTTP Scheme.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Scheme(std::borrow::Cow<'static, str>);
 
 impl Scheme {
@@ -940,5 +952,11 @@ pub mod scheme {
 impl std::convert::From<std::string::String> for Scheme {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for Scheme {
+    fn default() -> Self {
+        scheme::SCHEME_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/apihub/v1/src/model.rs
+++ b/src/generated/cloud/apihub/v1/src/model.rs
@@ -3999,7 +3999,7 @@ pub mod spec {
     /// - `STRICT`: Parsing errors in the specification content result in failure
     ///   of the API call.
     ///   If not specified, defaults to `RELAXED`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ParsingMode(std::borrow::Cow<'static, str>);
 
     impl ParsingMode {
@@ -4034,6 +4034,12 @@ pub mod spec {
     impl std::convert::From<std::string::String> for ParsingMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ParsingMode {
+        fn default() -> Self {
+            parsing_mode::PARSING_MODE_UNSPECIFIED
         }
     }
 }
@@ -4520,7 +4526,7 @@ pub mod definition {
     use super::*;
 
     /// Enumeration of definition types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -4549,6 +4555,12 @@ pub mod definition {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 
@@ -4799,7 +4811,7 @@ pub mod attribute {
     }
 
     /// Enumeration of attribute definition types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DefinitionType(std::borrow::Cow<'static, str>);
 
     impl DefinitionType {
@@ -4836,9 +4848,15 @@ pub mod attribute {
         }
     }
 
+    impl std::default::Default for DefinitionType {
+        fn default() -> Self {
+            definition_type::DEFINITION_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Enumeration for the scope of the attribute representing the resource in the
     /// API Hub to which the attribute can be linked.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Scope(std::borrow::Cow<'static, str>);
 
     impl Scope {
@@ -4894,8 +4912,14 @@ pub mod attribute {
         }
     }
 
+    impl std::default::Default for Scope {
+        fn default() -> Self {
+            scope::SCOPE_UNSPECIFIED
+        }
+    }
+
     /// Enumeration of attribute's data type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DataType(std::borrow::Cow<'static, str>);
 
     impl DataType {
@@ -4930,6 +4954,12 @@ pub mod attribute {
     impl std::convert::From<std::string::String> for DataType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DataType {
+        fn default() -> Self {
+            data_type::DATA_TYPE_UNSPECIFIED
         }
     }
 }
@@ -5137,7 +5167,7 @@ pub mod open_api_spec_details {
     use super::*;
 
     /// Enumeration of spec formats.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Format(std::borrow::Cow<'static, str>);
 
     impl Format {
@@ -5172,6 +5202,12 @@ pub mod open_api_spec_details {
     impl std::convert::From<std::string::String> for Format {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Format {
+        fn default() -> Self {
+            format::FORMAT_UNSPECIFIED
         }
     }
 }
@@ -5343,7 +5379,7 @@ pub mod http_operation {
     use super::*;
 
     /// Enumeration of Method types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Method(std::borrow::Cow<'static, str>);
 
     impl Method {
@@ -5393,6 +5429,12 @@ pub mod http_operation {
     impl std::convert::From<std::string::String> for Method {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Method {
+        fn default() -> Self {
+            method::METHOD_UNSPECIFIED
         }
     }
 }
@@ -5945,7 +5987,7 @@ pub mod dependency {
     use super::*;
 
     /// Possible states for a dependency.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -5982,8 +6024,14 @@ pub mod dependency {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Possible modes of discovering the dependency.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DiscoveryMode(std::borrow::Cow<'static, str>);
 
     impl DiscoveryMode {
@@ -6013,6 +6061,12 @@ pub mod dependency {
     impl std::convert::From<std::string::String> for DiscoveryMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DiscoveryMode {
+        fn default() -> Self {
+            discovery_mode::DISCOVERY_MODE_UNSPECIFIED
         }
     }
 }
@@ -6194,7 +6248,7 @@ pub mod dependency_error_detail {
     use super::*;
 
     /// Possible values representing an error in the dependency.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Error(std::borrow::Cow<'static, str>);
 
     impl Error {
@@ -6226,6 +6280,12 @@ pub mod dependency_error_detail {
     impl std::convert::From<std::string::String> for Error {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Error {
+        fn default() -> Self {
+            error::ERROR_UNSPECIFIED
         }
     }
 }
@@ -6786,7 +6846,7 @@ pub mod api_hub_instance {
     }
 
     /// State of the ApiHub Instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -6830,6 +6890,12 @@ pub mod api_hub_instance {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -7622,7 +7688,7 @@ pub mod plugin {
     /// Possible states a plugin can have. Note that this enum may receive new
     /// values in the future. Consumers are advised to always code against the
     /// enum values expecting new states can be added later on.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -7654,6 +7720,12 @@ pub mod plugin {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -8360,7 +8432,7 @@ impl wkt::message::Message for RuntimeProjectAttachment {
 }
 
 /// Lint state represents success or failure for linting.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct LintState(std::borrow::Cow<'static, str>);
 
 impl LintState {
@@ -8395,8 +8467,14 @@ impl std::convert::From<std::string::String> for LintState {
     }
 }
 
+impl std::default::Default for LintState {
+    fn default() -> Self {
+        lint_state::LINT_STATE_UNSPECIFIED
+    }
+}
+
 /// Enumeration of linter types.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Linter(std::borrow::Cow<'static, str>);
 
 impl Linter {
@@ -8431,8 +8509,14 @@ impl std::convert::From<std::string::String> for Linter {
     }
 }
 
+impl std::default::Default for Linter {
+    fn default() -> Self {
+        linter::LINTER_UNSPECIFIED
+    }
+}
+
 /// Severity of the issue.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Severity(std::borrow::Cow<'static, str>);
 
 impl Severity {
@@ -8470,5 +8554,11 @@ pub mod severity {
 impl std::convert::From<std::string::String> for Severity {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for Severity {
+    fn default() -> Self {
+        severity::SEVERITY_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/apphub/v1/src/model.rs
+++ b/src/generated/cloud/apphub/v1/src/model.rs
@@ -2338,7 +2338,7 @@ pub mod application {
     use super::*;
 
     /// Application state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2373,6 +2373,12 @@ pub mod application {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -2412,7 +2418,7 @@ pub mod scope {
     use super::*;
 
     /// Scope Type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -2441,6 +2447,12 @@ pub mod scope {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -2578,7 +2590,7 @@ pub mod criticality {
     use super::*;
 
     /// Criticality Type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -2616,6 +2628,12 @@ pub mod criticality {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -2658,7 +2676,7 @@ pub mod environment {
     use super::*;
 
     /// Environment Type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -2696,6 +2714,12 @@ pub mod environment {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -2904,7 +2928,7 @@ pub mod service {
     use super::*;
 
     /// Service state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2942,6 +2966,12 @@ pub mod service {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -3180,7 +3210,7 @@ pub mod service_project_attachment {
     use super::*;
 
     /// ServiceProjectAttachment state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3217,6 +3247,12 @@ pub mod service_project_attachment {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -3386,7 +3422,7 @@ pub mod workload {
     use super::*;
 
     /// Workload state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3424,6 +3460,12 @@ pub mod workload {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/asset/v1/src/model.rs
+++ b/src/generated/cloud/asset/v1/src/model.rs
@@ -1395,7 +1395,7 @@ pub mod partition_spec {
     /// a timestamp column, the actual partition is based on its date value
     /// (expressed in UTC. see details in
     /// <https://cloud.google.com/bigquery/docs/partitioned-tables#date_timestamp_partitioned_tables>).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PartitionKey(std::borrow::Cow<'static, str>);
 
     impl PartitionKey {
@@ -1435,6 +1435,12 @@ pub mod partition_spec {
     impl std::convert::From<std::string::String> for PartitionKey {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PartitionKey {
+        fn default() -> Self {
+            partition_key::PARTITION_KEY_UNSPECIFIED
         }
     }
 }
@@ -3273,7 +3279,7 @@ pub mod iam_policy_analysis_output_config {
         /// Partitioning can improve query performance and reduce query cost by
         /// filtering partitions. Refer to
         /// <https://cloud.google.com/bigquery/docs/partitioned-tables> for details.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct PartitionKey(std::borrow::Cow<'static, str>);
 
         impl PartitionKey {
@@ -3306,6 +3312,12 @@ pub mod iam_policy_analysis_output_config {
         impl std::convert::From<std::string::String> for PartitionKey {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for PartitionKey {
+            fn default() -> Self {
+                partition_key::PARTITION_KEY_UNSPECIFIED
             }
         }
     }
@@ -4034,7 +4046,7 @@ pub mod analyze_move_request {
     use super::*;
 
     /// View enum for supporting partial analysis responses.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AnalysisView(std::borrow::Cow<'static, str>);
 
     impl AnalysisView {
@@ -4070,6 +4082,12 @@ pub mod analyze_move_request {
     impl std::convert::From<std::string::String> for AnalysisView {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AnalysisView {
+        fn default() -> Self {
+            analysis_view::ANALYSIS_VIEW_UNSPECIFIED
         }
     }
 }
@@ -6048,7 +6066,7 @@ pub mod analyzer_org_policy_constraint {
 
         /// Specifies the default behavior in the absence of any `Policy` for the
         /// `Constraint`. This must not be `CONSTRAINT_DEFAULT_UNSPECIFIED`.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct ConstraintDefault(std::borrow::Cow<'static, str>);
 
         impl ConstraintDefault {
@@ -6084,6 +6102,12 @@ pub mod analyzer_org_policy_constraint {
         impl std::convert::From<std::string::String> for ConstraintDefault {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for ConstraintDefault {
+            fn default() -> Self {
+                constraint_default::CONSTRAINT_DEFAULT_UNSPECIFIED
             }
         }
 
@@ -6242,7 +6266,7 @@ pub mod analyzer_org_policy_constraint {
         /// If the constraint applies only when create VMs, the method_types will be
         /// "CREATE" only. If the constraint applied when create or delete VMs, the
         /// method_types will be "CREATE" and "DELETE".
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct MethodType(std::borrow::Cow<'static, str>);
 
         impl MethodType {
@@ -6281,8 +6305,14 @@ pub mod analyzer_org_policy_constraint {
             }
         }
 
+        impl std::default::Default for MethodType {
+            fn default() -> Self {
+                method_type::METHOD_TYPE_UNSPECIFIED
+            }
+        }
+
         /// Allow or deny type.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct ActionType(std::borrow::Cow<'static, str>);
 
         impl ActionType {
@@ -6315,6 +6345,12 @@ pub mod analyzer_org_policy_constraint {
         impl std::convert::From<std::string::String> for ActionType {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for ActionType {
+            fn default() -> Self {
+                action_type::ACTION_TYPE_UNSPECIFIED
             }
         }
     }
@@ -7679,7 +7715,7 @@ pub mod temporal_asset {
     use super::*;
 
     /// State of prior asset.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PriorAssetState(std::borrow::Cow<'static, str>);
 
     impl PriorAssetState {
@@ -7718,6 +7754,12 @@ pub mod temporal_asset {
     impl std::convert::From<std::string::String> for PriorAssetState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PriorAssetState {
+        fn default() -> Self {
+            prior_asset_state::PRIOR_ASSET_STATE_UNSPECIFIED
         }
     }
 }
@@ -9729,7 +9771,7 @@ pub mod condition_evaluation {
     use super::*;
 
     /// Value of this expression.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EvaluationValue(std::borrow::Cow<'static, str>);
 
     impl EvaluationValue {
@@ -9767,6 +9809,12 @@ pub mod condition_evaluation {
     impl std::convert::From<std::string::String> for EvaluationValue {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EvaluationValue {
+        fn default() -> Self {
+            evaluation_value::EVALUATION_VALUE_UNSPECIFIED
         }
     }
 }
@@ -10322,7 +10370,7 @@ pub mod iam_policy_analysis_result {
 }
 
 /// Asset content type.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ContentType(std::borrow::Cow<'static, str>);
 
 impl ContentType {
@@ -10366,5 +10414,11 @@ pub mod content_type {
 impl std::convert::From<std::string::String> for ContentType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for ContentType {
+    fn default() -> Self {
+        content_type::CONTENT_TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/assuredworkloads/v1/src/model.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/model.rs
@@ -647,7 +647,7 @@ pub mod workload {
         use super::*;
 
         /// The type of resource.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct ResourceType(std::borrow::Cow<'static, str>);
 
         impl ResourceType {
@@ -691,6 +691,12 @@ pub mod workload {
         impl std::convert::From<std::string::String> for ResourceType {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for ResourceType {
+            fn default() -> Self {
+                resource_type::RESOURCE_TYPE_UNSPECIFIED
             }
         }
     }
@@ -871,7 +877,7 @@ pub mod workload {
         use super::*;
 
         /// Setup state of SAA enrollment.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct SetupState(std::borrow::Cow<'static, str>);
 
         impl SetupState {
@@ -907,8 +913,14 @@ pub mod workload {
             }
         }
 
+        impl std::default::Default for SetupState {
+            fn default() -> Self {
+                setup_state::SETUP_STATE_UNSPECIFIED
+            }
+        }
+
         /// Setup error of SAA enrollment.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct SetupError(std::borrow::Cow<'static, str>);
 
         impl SetupError {
@@ -956,10 +968,16 @@ pub mod workload {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for SetupError {
+            fn default() -> Self {
+                setup_error::SETUP_ERROR_UNSPECIFIED
+            }
+        }
     }
 
     /// Supported Compliance Regimes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ComplianceRegime(std::borrow::Cow<'static, str>);
 
     impl ComplianceRegime {
@@ -1032,8 +1050,14 @@ pub mod workload {
         }
     }
 
+    impl std::default::Default for ComplianceRegime {
+        fn default() -> Self {
+            compliance_regime::COMPLIANCE_REGIME_UNSPECIFIED
+        }
+    }
+
     /// Key Access Justifications(KAJ) Enrollment State.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct KajEnrollmentState(std::borrow::Cow<'static, str>);
 
     impl KajEnrollmentState {
@@ -1071,8 +1095,14 @@ pub mod workload {
         }
     }
 
+    impl std::default::Default for KajEnrollmentState {
+        fn default() -> Self {
+            kaj_enrollment_state::KAJ_ENROLLMENT_STATE_UNSPECIFIED
+        }
+    }
+
     /// Supported Assured Workloads Partners.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Partner(std::borrow::Cow<'static, str>);
 
     impl Partner {
@@ -1101,6 +1131,12 @@ pub mod workload {
     impl std::convert::From<std::string::String> for Partner {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Partner {
+        fn default() -> Self {
+            partner::PARTNER_UNSPECIFIED
         }
     }
 }
@@ -1225,7 +1261,7 @@ pub mod restrict_allowed_resources_request {
     use super::*;
 
     /// The type of restriction.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RestrictionType(std::borrow::Cow<'static, str>);
 
     impl RestrictionType {
@@ -1264,6 +1300,12 @@ pub mod restrict_allowed_resources_request {
     impl std::convert::From<std::string::String> for RestrictionType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RestrictionType {
+        fn default() -> Self {
+            restriction_type::RESTRICTION_TYPE_UNSPECIFIED
         }
     }
 }
@@ -2049,7 +2091,7 @@ pub mod violation {
         /// violation. For example, violations caused due to changes in boolean org
         /// policy requires different remediation instructions compared to violation
         /// caused due to changes in allowed values of list org policy.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct RemediationType(std::borrow::Cow<'static, str>);
 
         impl RemediationType {
@@ -2098,10 +2140,16 @@ pub mod violation {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for RemediationType {
+            fn default() -> Self {
+                remediation_type::REMEDIATION_TYPE_UNSPECIFIED
+            }
+        }
     }
 
     /// Violation State Values
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2136,6 +2184,12 @@ pub mod violation {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/backupdr/v1/src/model.rs
+++ b/src/generated/cloud/backupdr/v1/src/model.rs
@@ -84,7 +84,7 @@ pub mod network_config {
     use super::*;
 
     /// VPC peering modes supported by Cloud BackupDR.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PeeringMode(std::borrow::Cow<'static, str>);
 
     impl PeeringMode {
@@ -116,6 +116,12 @@ pub mod network_config {
     impl std::convert::From<std::string::String> for PeeringMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PeeringMode {
+        fn default() -> Self {
+            peering_mode::PEERING_MODE_UNSPECIFIED
         }
     }
 }
@@ -498,7 +504,7 @@ pub mod management_server {
     use super::*;
 
     /// Type of backup service resource.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct InstanceType(std::borrow::Cow<'static, str>);
 
     impl InstanceType {
@@ -531,8 +537,14 @@ pub mod management_server {
         }
     }
 
+    impl std::default::Default for InstanceType {
+        fn default() -> Self {
+            instance_type::INSTANCE_TYPE_UNSPECIFIED
+        }
+    }
+
     /// State of Management server instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct InstanceState(std::borrow::Cow<'static, str>);
 
     impl InstanceState {
@@ -583,6 +595,12 @@ pub mod management_server {
     impl std::convert::From<std::string::String> for InstanceState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for InstanceState {
+        fn default() -> Self {
+            instance_state::INSTANCE_STATE_UNSPECIFIED
         }
     }
 }
@@ -1322,7 +1340,7 @@ pub mod backup_plan {
     use super::*;
 
     /// `State` enumerates the possible states for a `BackupPlan`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1360,6 +1378,12 @@ pub mod backup_plan {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1651,7 +1675,7 @@ pub mod standard_schedule {
     use super::*;
 
     /// `RecurrenceTypes` enumerates the applicable periodicity for the schedule.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RecurrenceType(std::borrow::Cow<'static, str>);
 
     impl RecurrenceType {
@@ -1693,6 +1717,12 @@ pub mod standard_schedule {
     impl std::convert::From<std::string::String> for RecurrenceType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RecurrenceType {
+        fn default() -> Self {
+            recurrence_type::RECURRENCE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -1793,7 +1823,7 @@ pub mod week_day_of_month {
 
     /// `WeekOfMonth` enumerates possible weeks in the month, e.g. the first,
     /// third, or last week of the month.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct WeekOfMonth(std::borrow::Cow<'static, str>);
 
     impl WeekOfMonth {
@@ -1835,6 +1865,12 @@ pub mod week_day_of_month {
     impl std::convert::From<std::string::String> for WeekOfMonth {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for WeekOfMonth {
+        fn default() -> Self {
+            week_of_month::WEEK_OF_MONTH_UNSPECIFIED
         }
     }
 }
@@ -2311,7 +2347,7 @@ pub mod backup_plan_association {
     use super::*;
 
     /// Enum for State of BackupPlan Association
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2349,6 +2385,12 @@ pub mod backup_plan_association {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -2431,7 +2473,7 @@ pub mod rule_config_info {
     use super::*;
 
     /// Enum for LastBackupState
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LastBackupState(std::borrow::Cow<'static, str>);
 
     impl LastBackupState {
@@ -2472,6 +2514,12 @@ pub mod rule_config_info {
     impl std::convert::From<std::string::String> for LastBackupState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for LastBackupState {
+        fn default() -> Self {
+            last_backup_state::LAST_BACKUP_STATE_UNSPECIFIED
         }
     }
 }
@@ -3084,7 +3132,7 @@ pub mod backup_vault {
     use super::*;
 
     /// Holds the state of the backup vault resource.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3125,8 +3173,14 @@ pub mod backup_vault {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Holds the access restriction for the backup vault.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AccessRestriction(std::borrow::Cow<'static, str>);
 
     impl AccessRestriction {
@@ -3170,6 +3224,12 @@ pub mod backup_vault {
     impl std::convert::From<std::string::String> for AccessRestriction {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AccessRestriction {
+        fn default() -> Self {
+            access_restriction::ACCESS_RESTRICTION_UNSPECIFIED
         }
     }
 }
@@ -3422,7 +3482,7 @@ pub mod data_source {
     use super::*;
 
     /// Holds the state of the data source resource.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3460,6 +3520,12 @@ pub mod data_source {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -3630,7 +3696,7 @@ pub mod backup_config_info {
 
     /// LastBackupstate tracks whether the last backup was not yet started,
     /// successful, failed, or could not be run because of the lack of permissions.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LastBackupState(std::borrow::Cow<'static, str>);
 
     impl LastBackupState {
@@ -3671,6 +3737,12 @@ pub mod backup_config_info {
     impl std::convert::From<std::string::String> for LastBackupState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for LastBackupState {
+        fn default() -> Self {
+            last_backup_state::LAST_BACKUP_STATE_UNSPECIFIED
         }
     }
 
@@ -4789,7 +4861,7 @@ pub mod backup {
     }
 
     /// Holds the state of the backup resource.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -4830,8 +4902,14 @@ pub mod backup {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Type of the backup, scheduled or ondemand.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct BackupType(std::borrow::Cow<'static, str>);
 
     impl BackupType {
@@ -4863,6 +4941,12 @@ pub mod backup {
     impl std::convert::From<std::string::String> for BackupType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for BackupType {
+        fn default() -> Self {
+            backup_type::BACKUP_TYPE_UNSPECIFIED
         }
     }
 
@@ -7194,7 +7278,7 @@ pub mod compute_instance_restore_properties {
     use super::*;
 
     /// The private IPv6 google access type for the VMs.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct InstancePrivateIpv6GoogleAccess(std::borrow::Cow<'static, str>);
 
     impl InstancePrivateIpv6GoogleAccess {
@@ -7240,6 +7324,12 @@ pub mod compute_instance_restore_properties {
     impl std::convert::From<std::string::String> for InstancePrivateIpv6GoogleAccess {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for InstancePrivateIpv6GoogleAccess {
+        fn default() -> Self {
+            instance_private_ipv_6_google_access::INSTANCE_PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED
         }
     }
 }
@@ -8020,7 +8110,7 @@ pub mod network_interface {
     use super::*;
 
     /// Stack type for this network interface.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct StackType(std::borrow::Cow<'static, str>);
 
     impl StackType {
@@ -8055,8 +8145,14 @@ pub mod network_interface {
         }
     }
 
+    impl std::default::Default for StackType {
+        fn default() -> Self {
+            stack_type::STACK_TYPE_UNSPECIFIED
+        }
+    }
+
     /// IPv6 access type for this network interface.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Ipv6AccessType(std::borrow::Cow<'static, str>);
 
     impl Ipv6AccessType {
@@ -8093,8 +8189,14 @@ pub mod network_interface {
         }
     }
 
+    impl std::default::Default for Ipv6AccessType {
+        fn default() -> Self {
+            ipv_6_access_type::UNSPECIFIED_IPV6_ACCESS_TYPE
+        }
+    }
+
     /// Nic type for this network interface.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct NicType(std::borrow::Cow<'static, str>);
 
     impl NicType {
@@ -8126,6 +8228,12 @@ pub mod network_interface {
     impl std::convert::From<std::string::String> for NicType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for NicType {
+        fn default() -> Self {
+            nic_type::NIC_TYPE_UNSPECIFIED
         }
     }
 }
@@ -8171,7 +8279,7 @@ pub mod network_performance_config {
     use super::*;
 
     /// Network performance tier.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Tier(std::borrow::Cow<'static, str>);
 
     impl Tier {
@@ -8203,6 +8311,12 @@ pub mod network_performance_config {
     impl std::convert::From<std::string::String> for Tier {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Tier {
+        fn default() -> Self {
+            tier::TIER_UNSPECIFIED
         }
     }
 }
@@ -8349,7 +8463,7 @@ pub mod access_config {
     use super::*;
 
     /// The type of configuration.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AccessType(std::borrow::Cow<'static, str>);
 
     impl AccessType {
@@ -8384,8 +8498,14 @@ pub mod access_config {
         }
     }
 
+    impl std::default::Default for AccessType {
+        fn default() -> Self {
+            access_type::ACCESS_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Network tier property used by addresses, instances and forwarding rules.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct NetworkTier(std::borrow::Cow<'static, str>);
 
     impl NetworkTier {
@@ -8420,6 +8540,12 @@ pub mod access_config {
     impl std::convert::From<std::string::String> for NetworkTier {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for NetworkTier {
+        fn default() -> Self {
+            network_tier::NETWORK_TIER_UNSPECIFIED
         }
     }
 }
@@ -8577,7 +8703,7 @@ pub mod allocation_affinity {
     use super::*;
 
     /// Indicates whether to consume from a reservation or not.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -8613,6 +8739,12 @@ pub mod allocation_affinity {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -8835,7 +8967,7 @@ pub mod scheduling {
         use super::*;
 
         /// Defines the type of node selections.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Operator(std::borrow::Cow<'static, str>);
 
         impl Operator {
@@ -8869,10 +9001,16 @@ pub mod scheduling {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for Operator {
+            fn default() -> Self {
+                operator::OPERATOR_UNSPECIFIED
+            }
+        }
     }
 
     /// Defines the maintenance behavior for this instance=
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct OnHostMaintenance(std::borrow::Cow<'static, str>);
 
     impl OnHostMaintenance {
@@ -8910,8 +9048,14 @@ pub mod scheduling {
         }
     }
 
+    impl std::default::Default for OnHostMaintenance {
+        fn default() -> Self {
+            on_host_maintenance::ON_HOST_MAINTENANCE_UNSPECIFIED
+        }
+    }
+
     /// Defines the provisioning model for an instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ProvisioningModel(std::borrow::Cow<'static, str>);
 
     impl ProvisioningModel {
@@ -8947,8 +9091,14 @@ pub mod scheduling {
         }
     }
 
+    impl std::default::Default for ProvisioningModel {
+        fn default() -> Self {
+            provisioning_model::PROVISIONING_MODEL_UNSPECIFIED
+        }
+    }
+
     /// Defines the supported termination actions for an instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct InstanceTerminationAction(std::borrow::Cow<'static, str>);
 
     impl InstanceTerminationAction {
@@ -8981,6 +9131,12 @@ pub mod scheduling {
     impl std::convert::From<std::string::String> for InstanceTerminationAction {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for InstanceTerminationAction {
+        fn default() -> Self {
+            instance_termination_action::INSTANCE_TERMINATION_ACTION_UNSPECIFIED
         }
     }
 }
@@ -9430,7 +9586,7 @@ pub mod attached_disk {
     }
 
     /// List of the Disk Types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DiskType(std::borrow::Cow<'static, str>);
 
     impl DiskType {
@@ -9465,8 +9621,14 @@ pub mod attached_disk {
         }
     }
 
+    impl std::default::Default for DiskType {
+        fn default() -> Self {
+            disk_type::DISK_TYPE_UNSPECIFIED
+        }
+    }
+
     /// List of the Disk Modes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DiskMode(std::borrow::Cow<'static, str>);
 
     impl DiskMode {
@@ -9509,8 +9671,14 @@ pub mod attached_disk {
         }
     }
 
+    impl std::default::Default for DiskMode {
+        fn default() -> Self {
+            disk_mode::DISK_MODE_UNSPECIFIED
+        }
+    }
+
     /// List of the Disk Interfaces.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DiskInterface(std::borrow::Cow<'static, str>);
 
     impl DiskInterface {
@@ -9552,8 +9720,14 @@ pub mod attached_disk {
         }
     }
 
+    impl std::default::Default for DiskInterface {
+        fn default() -> Self {
+            disk_interface::DISK_INTERFACE_UNSPECIFIED
+        }
+    }
+
     /// List of the states of the Disk.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DiskSavedState(std::borrow::Cow<'static, str>);
 
     impl DiskSavedState {
@@ -9583,6 +9757,12 @@ pub mod attached_disk {
     impl std::convert::From<std::string::String> for DiskSavedState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DiskSavedState {
+        fn default() -> Self {
+            disk_saved_state::DISK_SAVED_STATE_UNSPECIFIED
         }
     }
 }
@@ -9628,7 +9808,7 @@ pub mod guest_os_feature {
     use super::*;
 
     /// List of the Feature Types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct FeatureType(std::borrow::Cow<'static, str>);
 
     impl FeatureType {
@@ -9701,10 +9881,16 @@ pub mod guest_os_feature {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for FeatureType {
+        fn default() -> Self {
+            feature_type::FEATURE_TYPE_UNSPECIFIED
+        }
+    }
 }
 
 /// Backup configuration state. Is the resource configured for backup?
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct BackupConfigState(std::borrow::Cow<'static, str>);
 
 impl BackupConfigState {
@@ -9742,8 +9928,14 @@ impl std::convert::From<std::string::String> for BackupConfigState {
     }
 }
 
+impl std::default::Default for BackupConfigState {
+    fn default() -> Self {
+        backup_config_state::BACKUP_CONFIG_STATE_UNSPECIFIED
+    }
+}
+
 /// BackupView contains enum options for Partial and Full view.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct BackupView(std::borrow::Cow<'static, str>);
 
 impl BackupView {
@@ -9779,8 +9971,14 @@ impl std::convert::From<std::string::String> for BackupView {
     }
 }
 
+impl std::default::Default for BackupView {
+    fn default() -> Self {
+        backup_view::BACKUP_VIEW_UNSPECIFIED
+    }
+}
+
 /// BackupVaultView contains enum options for Partial and Full view.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct BackupVaultView(std::borrow::Cow<'static, str>);
 
 impl BackupVaultView {
@@ -9819,10 +10017,16 @@ impl std::convert::From<std::string::String> for BackupVaultView {
     }
 }
 
+impl std::default::Default for BackupVaultView {
+    fn default() -> Self {
+        backup_vault_view::BACKUP_VAULT_VIEW_UNSPECIFIED
+    }
+}
+
 /// Specifies whether the virtual machine instance will be shut down on key
 /// revocation. It is currently used in instance, instance properties and GMI
 /// protos
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct KeyRevocationActionType(std::borrow::Cow<'static, str>);
 
 impl KeyRevocationActionType {
@@ -9855,5 +10059,11 @@ pub mod key_revocation_action_type {
 impl std::convert::From<std::string::String> for KeyRevocationActionType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for KeyRevocationActionType {
+    fn default() -> Self {
+        key_revocation_action_type::KEY_REVOCATION_ACTION_TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/baremetalsolution/v2/src/model.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/model.rs
@@ -426,7 +426,7 @@ pub mod instance {
     use super::*;
 
     /// The possible states for this server.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -473,6 +473,12 @@ pub mod instance {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1131,7 +1137,7 @@ pub mod server_network_template {
         use super::*;
 
         /// Interface type.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct InterfaceType(std::borrow::Cow<'static, str>);
 
         impl InterfaceType {
@@ -1164,6 +1170,12 @@ pub mod server_network_template {
         impl std::convert::From<std::string::String> for InterfaceType {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for InterfaceType {
+            fn default() -> Self {
+                interface_type::INTERFACE_TYPE_UNSPECIFIED
             }
         }
     }
@@ -1325,7 +1337,7 @@ pub mod lun {
     use super::*;
 
     /// The possible states for the LUN.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1369,8 +1381,14 @@ pub mod lun {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Display the operating systems present for the LUN multiprotocol type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MultiprotocolType(std::borrow::Cow<'static, str>);
 
     impl MultiprotocolType {
@@ -1403,8 +1421,14 @@ pub mod lun {
         }
     }
 
+    impl std::default::Default for MultiprotocolType {
+        fn default() -> Self {
+            multiprotocol_type::MULTIPROTOCOL_TYPE_UNSPECIFIED
+        }
+    }
+
     /// The storage types for a LUN.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct StorageType(std::borrow::Cow<'static, str>);
 
     impl StorageType {
@@ -1437,6 +1461,12 @@ pub mod lun {
     impl std::convert::From<std::string::String> for StorageType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for StorageType {
+        fn default() -> Self {
+            storage_type::STORAGE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -1833,7 +1863,7 @@ pub mod network {
     use super::*;
 
     /// Network type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -1868,8 +1898,14 @@ pub mod network {
         }
     }
 
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
+        }
+    }
+
     /// The possible states for this Network.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1907,6 +1943,12 @@ pub mod network {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -2168,7 +2210,7 @@ pub mod vrf {
     }
 
     /// The possible states for this VRF.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2200,6 +2242,12 @@ pub mod vrf {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -3002,7 +3050,7 @@ pub mod nfs_share {
     }
 
     /// The possible states for this NFS share.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3043,8 +3091,14 @@ pub mod nfs_share {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// The possible mount permissions.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MountPermissions(std::borrow::Cow<'static, str>);
 
     impl MountPermissions {
@@ -3080,8 +3134,14 @@ pub mod nfs_share {
         }
     }
 
+    impl std::default::Default for MountPermissions {
+        fn default() -> Self {
+            mount_permissions::MOUNT_PERMISSIONS_UNSPECIFIED
+        }
+    }
+
     /// The storage type for a volume.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct StorageType(std::borrow::Cow<'static, str>);
 
     impl StorageType {
@@ -3114,6 +3174,12 @@ pub mod nfs_share {
     impl std::convert::From<std::string::String> for StorageType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for StorageType {
+        fn default() -> Self {
+            storage_type::STORAGE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -3824,7 +3890,7 @@ pub mod provisioning_config {
     use super::*;
 
     /// The possible states for this ProvisioningConfig.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3874,6 +3940,12 @@ pub mod provisioning_config {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -4181,7 +4253,7 @@ pub mod provisioning_quota {
     use super::*;
 
     /// The available asset types for intake.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AssetType(std::borrow::Cow<'static, str>);
 
     impl AssetType {
@@ -4216,6 +4288,12 @@ pub mod provisioning_quota {
     impl std::convert::From<std::string::String> for AssetType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AssetType {
+        fn default() -> Self {
+            asset_type::ASSET_TYPE_UNSPECIFIED
         }
     }
 
@@ -4593,7 +4671,7 @@ pub mod instance_config {
     }
 
     /// The network configuration of the instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct NetworkConfig(std::borrow::Cow<'static, str>);
 
     impl NetworkConfig {
@@ -4627,6 +4705,12 @@ pub mod instance_config {
     impl std::convert::From<std::string::String> for NetworkConfig {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for NetworkConfig {
+        fn default() -> Self {
+            network_config::NETWORKCONFIG_UNSPECIFIED
         }
     }
 }
@@ -4982,7 +5066,7 @@ pub mod volume_config {
         use super::*;
 
         /// Permissions that can granted for an export.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Permissions(std::borrow::Cow<'static, str>);
 
         impl Permissions {
@@ -5018,6 +5102,12 @@ pub mod volume_config {
             }
         }
 
+        impl std::default::Default for Permissions {
+            fn default() -> Self {
+                permissions::PERMISSIONS_UNSPECIFIED
+            }
+        }
+
         /// A client object.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         #[serde(rename_all = "camelCase")]
@@ -5032,7 +5122,7 @@ pub mod volume_config {
     }
 
     /// The types of Volumes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -5067,8 +5157,14 @@ pub mod volume_config {
         }
     }
 
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
+        }
+    }
+
     /// The protocol used to access the volume.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Protocol(std::borrow::Cow<'static, str>);
 
     impl Protocol {
@@ -5100,6 +5196,12 @@ pub mod volume_config {
     impl std::convert::From<std::string::String> for Protocol {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Protocol {
+        fn default() -> Self {
+            protocol::PROTOCOL_UNSPECIFIED
         }
     }
 }
@@ -5292,7 +5394,7 @@ pub mod network_config {
     }
 
     /// Network type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -5327,8 +5429,14 @@ pub mod network_config {
         }
     }
 
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
+        }
+    }
+
     /// Interconnect bandwidth.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Bandwidth(std::borrow::Cow<'static, str>);
 
     impl Bandwidth {
@@ -5369,8 +5477,14 @@ pub mod network_config {
         }
     }
 
+    impl std::default::Default for Bandwidth {
+        fn default() -> Self {
+            bandwidth::BANDWIDTH_UNSPECIFIED
+        }
+    }
+
     /// Service network block.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ServiceCidr(std::borrow::Cow<'static, str>);
 
     impl ServiceCidr {
@@ -5409,6 +5523,12 @@ pub mod network_config {
     impl std::convert::From<std::string::String> for ServiceCidr {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ServiceCidr {
+        fn default() -> Self {
+            service_cidr::SERVICE_CIDR_UNSPECIFIED
         }
     }
 }
@@ -6236,7 +6356,7 @@ pub mod volume {
     }
 
     /// The storage type for a volume.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct StorageType(std::borrow::Cow<'static, str>);
 
     impl StorageType {
@@ -6272,8 +6392,14 @@ pub mod volume {
         }
     }
 
+    impl std::default::Default for StorageType {
+        fn default() -> Self {
+            storage_type::STORAGE_TYPE_UNSPECIFIED
+        }
+    }
+
     /// The possible states for a storage volume.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -6318,9 +6444,15 @@ pub mod volume {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// The kinds of auto delete behavior to use when snapshot reserved space is
     /// full.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SnapshotAutoDeleteBehavior(std::borrow::Cow<'static, str>);
 
     impl SnapshotAutoDeleteBehavior {
@@ -6363,8 +6495,14 @@ pub mod volume {
         }
     }
 
+    impl std::default::Default for SnapshotAutoDeleteBehavior {
+        fn default() -> Self {
+            snapshot_auto_delete_behavior::SNAPSHOT_AUTO_DELETE_BEHAVIOR_UNSPECIFIED
+        }
+    }
+
     /// Storage protocol.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Protocol(std::borrow::Cow<'static, str>);
 
     impl Protocol {
@@ -6400,8 +6538,14 @@ pub mod volume {
         }
     }
 
+    impl std::default::Default for Protocol {
+        fn default() -> Self {
+            protocol::PROTOCOL_UNSPECIFIED
+        }
+    }
+
     /// The possible values for a workload profile.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct WorkloadProfile(std::borrow::Cow<'static, str>);
 
     impl WorkloadProfile {
@@ -6434,6 +6578,12 @@ pub mod volume {
     impl std::convert::From<std::string::String> for WorkloadProfile {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for WorkloadProfile {
+        fn default() -> Self {
+            workload_profile::WORKLOAD_PROFILE_UNSPECIFIED
         }
     }
 }
@@ -6848,7 +6998,7 @@ pub mod volume_snapshot {
     use super::*;
 
     /// Represents the type of a snapshot.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SnapshotType(std::borrow::Cow<'static, str>);
 
     impl SnapshotType {
@@ -6881,6 +7031,12 @@ pub mod volume_snapshot {
     impl std::convert::From<std::string::String> for SnapshotType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SnapshotType {
+        fn default() -> Self {
+            snapshot_type::SNAPSHOT_TYPE_UNSPECIFIED
         }
     }
 }
@@ -7139,7 +7295,7 @@ impl wkt::message::Message for RestoreVolumeSnapshotRequest {
 }
 
 /// Performance tier of the Volume.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct VolumePerformanceTier(std::borrow::Cow<'static, str>);
 
 impl VolumePerformanceTier {
@@ -7181,8 +7337,14 @@ impl std::convert::From<std::string::String> for VolumePerformanceTier {
     }
 }
 
+impl std::default::Default for VolumePerformanceTier {
+    fn default() -> Self {
+        volume_performance_tier::VOLUME_PERFORMANCE_TIER_UNSPECIFIED
+    }
+}
+
 /// The possible values for a workload profile.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct WorkloadProfile(std::borrow::Cow<'static, str>);
 
 impl WorkloadProfile {
@@ -7217,5 +7379,11 @@ pub mod workload_profile {
 impl std::convert::From<std::string::String> for WorkloadProfile {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for WorkloadProfile {
+    fn default() -> Self {
+        workload_profile::WORKLOAD_PROFILE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/model.rs
@@ -949,7 +949,7 @@ pub mod app_connection {
         use super::*;
 
         /// Enum listing possible gateway hosting options.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Type(std::borrow::Cow<'static, str>);
 
         impl Type {
@@ -980,11 +980,17 @@ pub mod app_connection {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for Type {
+            fn default() -> Self {
+                r#type::TYPE_UNSPECIFIED
+            }
+        }
     }
 
     /// Enum containing list of all possible network connectivity options
     /// supported by BeyondCorp AppConnection.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -1017,8 +1023,14 @@ pub mod app_connection {
         }
     }
 
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
+        }
+    }
+
     /// Represents the different states of a AppConnection.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1060,6 +1072,12 @@ pub mod app_connection {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/model.rs
@@ -1028,7 +1028,7 @@ pub mod app_connector {
     }
 
     /// Represents the different states of a AppConnector.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1070,6 +1070,12 @@ pub mod app_connector {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1266,7 +1272,7 @@ impl wkt::message::Message for ResourceInfo {
 }
 
 /// HealthStatus represents the health status.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct HealthStatus(std::borrow::Cow<'static, str>);
 
 impl HealthStatus {
@@ -1305,5 +1311,11 @@ pub mod health_status {
 impl std::convert::From<std::string::String> for HealthStatus {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for HealthStatus {
+    fn default() -> Self {
+        health_status::HEALTH_STATUS_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/model.rs
@@ -569,7 +569,7 @@ pub mod app_gateway {
 
     /// Enum containing list of all possible network connectivity options
     /// supported by BeyondCorp AppGateway.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -601,8 +601,14 @@ pub mod app_gateway {
         }
     }
 
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
+        }
+    }
+
     /// Represents the different states of an AppGateway.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -647,9 +653,15 @@ pub mod app_gateway {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Enum containing list of all possible host types supported by BeyondCorp
     /// Connection.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct HostType(std::borrow::Cow<'static, str>);
 
     impl HostType {
@@ -678,6 +690,12 @@ pub mod app_gateway {
     impl std::convert::From<std::string::String> for HostType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for HostType {
+        fn default() -> Self {
+            host_type::HOST_TYPE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/model.rs
@@ -339,7 +339,7 @@ pub mod client_connector_service {
             }
 
             /// The protocol used to connect to the server.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct TransportProtocol(std::borrow::Cow<'static, str>);
 
             impl TransportProtocol {
@@ -369,6 +369,12 @@ pub mod client_connector_service {
             impl std::convert::From<std::string::String> for TransportProtocol {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for TransportProtocol {
+                fn default() -> Self {
+                    transport_protocol::TRANSPORT_PROTOCOL_UNSPECIFIED
                 }
             }
         }
@@ -505,7 +511,7 @@ pub mod client_connector_service {
     }
 
     /// Represents the different states of a ClientConnectorService.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -551,6 +557,12 @@ pub mod client_connector_service {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/model.rs
@@ -131,7 +131,7 @@ pub mod client_gateway {
     use super::*;
 
     /// Represents the different states of a gateway.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -176,6 +176,12 @@ pub mod client_gateway {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/model.rs
@@ -1100,7 +1100,7 @@ pub mod listing {
     }
 
     /// State of the listing.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1133,8 +1133,14 @@ pub mod listing {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Listing categories.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Category(std::borrow::Cow<'static, str>);
 
     impl Category {
@@ -1203,6 +1209,12 @@ pub mod listing {
     impl std::convert::From<std::string::String> for Category {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Category {
+        fn default() -> Self {
+            category::CATEGORY_UNSPECIFIED
         }
     }
 
@@ -1490,7 +1502,7 @@ pub mod subscription {
     }
 
     /// State of the subscription.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1527,6 +1539,12 @@ pub mod subscription {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -2955,7 +2973,7 @@ impl wkt::message::Message for OperationMetadata {
 /// Specifies the type of discovery on the discovery page. Note that
 /// this does not control the visibility of the exchange/listing which is
 /// defined by IAM permission.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DiscoveryType(std::borrow::Cow<'static, str>);
 
 impl DiscoveryType {
@@ -2990,5 +3008,11 @@ pub mod discovery_type {
 impl std::convert::From<std::string::String> for DiscoveryType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for DiscoveryType {
+    fn default() -> Self {
+        discovery_type::DISCOVERY_TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/bigquery/connection/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/model.rs
@@ -734,7 +734,7 @@ pub mod cloud_sql_properties {
     use super::*;
 
     /// Supported Cloud SQL database types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DatabaseType(std::borrow::Cow<'static, str>);
 
     impl DatabaseType {
@@ -767,6 +767,12 @@ pub mod cloud_sql_properties {
     impl std::convert::From<std::string::String> for DatabaseType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DatabaseType {
+        fn default() -> Self {
+            database_type::DATABASE_TYPE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/model.rs
@@ -502,7 +502,7 @@ pub mod data_policy {
     use super::*;
 
     /// A list of supported data policy types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DataPolicyType(std::borrow::Cow<'static, str>);
 
     impl DataPolicyType {
@@ -537,6 +537,12 @@ pub mod data_policy {
     impl std::convert::From<std::string::String> for DataPolicyType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DataPolicyType {
+        fn default() -> Self {
+            data_policy_type::DATA_POLICY_TYPE_UNSPECIFIED
         }
     }
 
@@ -661,7 +667,7 @@ pub mod data_masking_policy {
 
     /// The available masking rules. Learn more here:
     /// <https://cloud.google.com/bigquery/docs/column-data-masking-intro#masking_options>.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PredefinedExpression(std::borrow::Cow<'static, str>);
 
     impl PredefinedExpression {
@@ -761,6 +767,12 @@ pub mod data_masking_policy {
     impl std::convert::From<std::string::String> for PredefinedExpression {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PredefinedExpression {
+        fn default() -> Self {
+            predefined_expression::PREDEFINED_EXPRESSION_UNSPECIFIED
         }
     }
 

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/model.rs
@@ -241,7 +241,7 @@ pub mod data_source_parameter {
     use super::*;
 
     /// Parameter type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -289,6 +289,12 @@ pub mod data_source_parameter {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -538,7 +544,7 @@ pub mod data_source {
     use super::*;
 
     /// The type of authorization needed for this data source.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AuthorizationType(std::borrow::Cow<'static, str>);
 
     impl AuthorizationType {
@@ -582,8 +588,14 @@ pub mod data_source {
         }
     }
 
+    impl std::default::Default for AuthorizationType {
+        fn default() -> Self {
+            authorization_type::AUTHORIZATION_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Represents how the data source supports data auto refresh.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DataRefreshType(std::borrow::Cow<'static, str>);
 
     impl DataRefreshType {
@@ -621,6 +633,12 @@ pub mod data_source {
     impl std::convert::From<std::string::String> for DataRefreshType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DataRefreshType {
+        fn default() -> Self {
+            data_refresh_type::DATA_REFRESH_TYPE_UNSPECIFIED
         }
     }
 }
@@ -1369,7 +1387,7 @@ pub mod list_transfer_runs_request {
     use super::*;
 
     /// Represents which runs should be pulled.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RunAttempt(std::borrow::Cow<'static, str>);
 
     impl RunAttempt {
@@ -1398,6 +1416,12 @@ pub mod list_transfer_runs_request {
     impl std::convert::From<std::string::String> for RunAttempt {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RunAttempt {
+        fn default() -> Self {
+            run_attempt::RUN_ATTEMPT_UNSPECIFIED
         }
     }
 }
@@ -3183,7 +3207,7 @@ pub mod transfer_message {
     use super::*;
 
     /// Represents data transfer user facing message severity.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MessageSeverity(std::borrow::Cow<'static, str>);
 
     impl MessageSeverity {
@@ -3221,10 +3245,16 @@ pub mod transfer_message {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for MessageSeverity {
+        fn default() -> Self {
+            message_severity::MESSAGE_SEVERITY_UNSPECIFIED
+        }
+    }
 }
 
 /// DEPRECATED. Represents data transfer type.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TransferType(std::borrow::Cow<'static, str>);
 
 impl TransferType {
@@ -3261,8 +3291,14 @@ impl std::convert::From<std::string::String> for TransferType {
     }
 }
 
+impl std::default::Default for TransferType {
+    fn default() -> Self {
+        transfer_type::TRANSFER_TYPE_UNSPECIFIED
+    }
+}
+
 /// Represents data transfer run state.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TransferState(std::borrow::Cow<'static, str>);
 
 impl TransferState {
@@ -3305,5 +3341,11 @@ pub mod transfer_state {
 impl std::convert::From<std::string::String> for TransferState {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for TransferState {
+    fn default() -> Self {
+        transfer_state::TRANSFER_STATE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/bigquery/migration/v2/src/model.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/model.rs
@@ -137,7 +137,7 @@ pub mod migration_workflow {
     use super::*;
 
     /// Possible migration workflow states.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -179,6 +179,12 @@ pub mod migration_workflow {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -447,7 +453,7 @@ pub mod migration_task {
     use super::*;
 
     /// Possible states of a migration task.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -492,6 +498,12 @@ pub mod migration_task {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -669,7 +681,7 @@ pub mod migration_subtask {
     use super::*;
 
     /// Possible states of a migration subtask.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -715,6 +727,12 @@ pub mod migration_subtask {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -2751,7 +2769,7 @@ pub mod teradata_dialect {
     use super::*;
 
     /// The sub-dialect options for Teradata.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Mode(std::borrow::Cow<'static, str>);
 
     impl Mode {
@@ -2783,6 +2801,12 @@ pub mod teradata_dialect {
     impl std::convert::From<std::string::String> for Mode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Mode {
+        fn default() -> Self {
+            mode::MODE_UNSPECIFIED
         }
     }
 }
@@ -3199,7 +3223,7 @@ pub mod name_mapping_key {
     use super::*;
 
     /// The type of the object that is being mapped.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -3246,6 +3270,12 @@ pub mod name_mapping_key {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -3910,7 +3940,7 @@ pub mod translation_report_record {
     use super::*;
 
     /// The severity type of the record.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Severity(std::borrow::Cow<'static, str>);
 
     impl Severity {
@@ -3946,6 +3976,12 @@ pub mod translation_report_record {
     impl std::convert::From<std::string::String> for Severity {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Severity {
+        fn default() -> Self {
+            severity::SEVERITY_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/bigquery/reservation/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/model.rs
@@ -465,7 +465,7 @@ pub mod capacity_commitment {
 
     /// Commitment plan defines the current committed period. Capacity commitment
     /// cannot be deleted during it's committed period.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CommitmentPlan(std::borrow::Cow<'static, str>);
 
     impl CommitmentPlan {
@@ -542,9 +542,15 @@ pub mod capacity_commitment {
         }
     }
 
+    impl std::default::Default for CommitmentPlan {
+        fn default() -> Self {
+            commitment_plan::COMMITMENT_PLAN_UNSPECIFIED
+        }
+    }
+
     /// Capacity commitment can either become ACTIVE right away or transition
     /// from PENDING to ACTIVE or FAILED.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -581,6 +587,12 @@ pub mod capacity_commitment {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1443,7 +1455,7 @@ pub mod assignment {
     use super::*;
 
     /// Types of job, which could be specified when using the reservation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct JobType(std::borrow::Cow<'static, str>);
 
     impl JobType {
@@ -1486,10 +1498,16 @@ pub mod assignment {
         }
     }
 
+    impl std::default::Default for JobType {
+        fn default() -> Self {
+            job_type::JOB_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Assignment will remain in PENDING state if no active capacity commitment is
     /// present. It will become ACTIVE when some capacity commitment becomes
     /// active.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1522,6 +1540,12 @@ pub mod assignment {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -2317,7 +2341,7 @@ impl wkt::message::Message for UpdateBiReservationRequest {
 /// The type of editions.
 /// Different features and behaviors are provided to different editions
 /// Capacity commitments and reservations are linked to editions.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Edition(std::borrow::Cow<'static, str>);
 
 impl Edition {
@@ -2352,5 +2376,11 @@ pub mod edition {
 impl std::convert::From<std::string::String> for Edition {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for Edition {
+    fn default() -> Self {
+        edition::EDITION_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/billing/v1/src/model.rs
+++ b/src/generated/cloud/billing/v1/src/model.rs
@@ -1307,7 +1307,7 @@ pub mod aggregation_info {
     /// The level at which usage is aggregated to compute cost.
     /// Example: "ACCOUNT" aggregation level indicates that usage for tiered
     /// pricing is aggregated across all projects in a single account.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AggregationLevel(std::borrow::Cow<'static, str>);
 
     impl AggregationLevel {
@@ -1340,10 +1340,16 @@ pub mod aggregation_info {
         }
     }
 
+    impl std::default::Default for AggregationLevel {
+        fn default() -> Self {
+            aggregation_level::AGGREGATION_LEVEL_UNSPECIFIED
+        }
+    }
+
     /// The interval at which usage is aggregated to compute cost.
     /// Example: "MONTHLY" aggregation interval indicates that usage for tiered
     /// pricing is aggregated every month.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AggregationInterval(std::borrow::Cow<'static, str>);
 
     impl AggregationInterval {
@@ -1373,6 +1379,12 @@ pub mod aggregation_info {
     impl std::convert::From<std::string::String> for AggregationInterval {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AggregationInterval {
+        fn default() -> Self {
+            aggregation_interval::AGGREGATION_INTERVAL_UNSPECIFIED
         }
     }
 }
@@ -1431,7 +1443,7 @@ pub mod geo_taxonomy {
     use super::*;
 
     /// The type of Geo Taxonomy: GLOBAL, REGIONAL, or MULTI_REGIONAL.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -1468,6 +1480,12 @@ pub mod geo_taxonomy {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/binaryauthorization/v1/src/model.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/model.rs
@@ -223,7 +223,7 @@ pub mod policy {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct GlobalPolicyEvaluationMode(std::borrow::Cow<'static, str>);
 
     impl GlobalPolicyEvaluationMode {
@@ -256,6 +256,12 @@ pub mod policy {
     impl std::convert::From<std::string::String> for GlobalPolicyEvaluationMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for GlobalPolicyEvaluationMode {
+        fn default() -> Self {
+            global_policy_evaluation_mode::GLOBAL_POLICY_EVALUATION_MODE_UNSPECIFIED
         }
     }
 }
@@ -380,7 +386,7 @@ pub mod admission_rule {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EvaluationMode(std::borrow::Cow<'static, str>);
 
     impl EvaluationMode {
@@ -421,9 +427,15 @@ pub mod admission_rule {
         }
     }
 
+    impl std::default::Default for EvaluationMode {
+        fn default() -> Self {
+            evaluation_mode::EVALUATION_MODE_UNSPECIFIED
+        }
+    }
+
     /// Defines the possible actions when a pod creation is denied by an admission
     /// rule.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EnforcementMode(std::borrow::Cow<'static, str>);
 
     impl EnforcementMode {
@@ -459,6 +471,12 @@ pub mod admission_rule {
     impl std::convert::From<std::string::String> for EnforcementMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EnforcementMode {
+        fn default() -> Self {
+            enforcement_mode::ENFORCEMENT_MODE_UNSPECIFIED
         }
     }
 }
@@ -726,7 +744,7 @@ pub mod pkix_public_key {
     /// PemKeyType, which is in turn based on KMS's supported signing algorithms.
     /// See <https://cloud.google.com/kms/docs/algorithms>. In the future, BinAuthz
     /// might support additional public key types independently of Tink and/or KMS.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SignatureAlgorithm(std::borrow::Cow<'static, str>);
 
     impl SignatureAlgorithm {
@@ -809,6 +827,12 @@ pub mod pkix_public_key {
     impl std::convert::From<std::string::String> for SignatureAlgorithm {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SignatureAlgorithm {
+        fn default() -> Self {
+            signature_algorithm::SIGNATURE_ALGORITHM_UNSPECIFIED
         }
     }
 }
@@ -1476,7 +1500,7 @@ pub mod validate_attestation_occurrence_response {
     use super::*;
 
     /// The enum returned in the "result" field.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Result(std::borrow::Cow<'static, str>);
 
     impl Result {
@@ -1508,6 +1532,12 @@ pub mod validate_attestation_occurrence_response {
     impl std::convert::From<std::string::String> for Result {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Result {
+        fn default() -> Self {
+            result::RESULT_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/certificatemanager/v1/src/model.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/model.rs
@@ -556,7 +556,7 @@ pub mod certificate_issuance_config {
     }
 
     /// The type of keypair to generate.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct KeyAlgorithm(std::borrow::Cow<'static, str>);
 
     impl KeyAlgorithm {
@@ -589,6 +589,12 @@ pub mod certificate_issuance_config {
     impl std::convert::From<std::string::String> for KeyAlgorithm {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for KeyAlgorithm {
+        fn default() -> Self {
+            key_algorithm::KEY_ALGORITHM_UNSPECIFIED
         }
     }
 }
@@ -2396,7 +2402,7 @@ pub mod certificate {
             use super::*;
 
             /// Reason for provisioning failures.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct Reason(std::borrow::Cow<'static, str>);
 
             impl Reason {
@@ -2432,6 +2438,12 @@ pub mod certificate {
             impl std::convert::From<std::string::String> for Reason {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for Reason {
+                fn default() -> Self {
+                    reason::REASON_UNSPECIFIED
                 }
             }
         }
@@ -2504,7 +2516,7 @@ pub mod certificate {
             use super::*;
 
             /// State of the domain for managed certificate issuance.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct State(std::borrow::Cow<'static, str>);
 
             impl State {
@@ -2545,8 +2557,14 @@ pub mod certificate {
                 }
             }
 
+            impl std::default::Default for State {
+                fn default() -> Self {
+                    state::STATE_UNSPECIFIED
+                }
+            }
+
             /// Reason for failure of the authorization attempt for the domain.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct FailureReason(std::borrow::Cow<'static, str>);
 
             impl FailureReason {
@@ -2587,10 +2605,16 @@ pub mod certificate {
                     Self(std::borrow::Cow::Owned(value))
                 }
             }
+
+            impl std::default::Default for FailureReason {
+                fn default() -> Self {
+                    failure_reason::FAILURE_REASON_UNSPECIFIED
+                }
+            }
         }
 
         /// State of the managed certificate resource.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct State(std::borrow::Cow<'static, str>);
 
         impl State {
@@ -2633,10 +2657,16 @@ pub mod certificate {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for State {
+            fn default() -> Self {
+                state::STATE_UNSPECIFIED
+            }
+        }
     }
 
     /// Certificate scope.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Scope(std::borrow::Cow<'static, str>);
 
     impl Scope {
@@ -2672,6 +2702,12 @@ pub mod certificate {
     impl std::convert::From<std::string::String> for Scope {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Scope {
+        fn default() -> Self {
+            scope::DEFAULT
         }
     }
 
@@ -3150,7 +3186,7 @@ pub mod certificate_map_entry {
 
     /// Defines predefined cases other than SNI-hostname match when this
     /// configuration should be applied.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Matcher(std::borrow::Cow<'static, str>);
 
     impl Matcher {
@@ -3180,6 +3216,12 @@ pub mod certificate_map_entry {
     impl std::convert::From<std::string::String> for Matcher {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Matcher {
+        fn default() -> Self {
+            matcher::MATCHER_UNSPECIFIED
         }
     }
 
@@ -3386,7 +3428,7 @@ pub mod dns_authorization {
     }
 
     /// DnsAuthorization type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -3420,6 +3462,12 @@ pub mod dns_authorization {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -4081,7 +4129,7 @@ pub mod trust_config {
 }
 
 /// Defines set of serving states associated with a resource.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ServingState(std::borrow::Cow<'static, str>);
 
 impl ServingState {
@@ -4114,5 +4162,11 @@ pub mod serving_state {
 impl std::convert::From<std::string::String> for ServingState {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for ServingState {
+    fn default() -> Self {
+        serving_state::SERVING_STATE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/model.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/model.rs
@@ -299,7 +299,7 @@ pub mod access_reason {
     use super::*;
 
     /// Type of access justification.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -362,6 +362,12 @@ pub mod access_reason {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -594,7 +600,7 @@ pub mod workload {
     use super::*;
 
     /// Supported Assured Workloads Partners.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Partner(std::borrow::Cow<'static, str>);
 
     impl Partner {
@@ -645,6 +651,12 @@ pub mod workload {
     impl std::convert::From<std::string::String> for Partner {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Partner {
+        fn default() -> Self {
+            partner::PARTNER_UNSPECIFIED
         }
     }
 }
@@ -933,7 +945,7 @@ pub mod workload_onboarding_step {
     use super::*;
 
     /// Enum for possible onboarding steps.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Step(std::borrow::Cow<'static, str>);
 
     impl Step {
@@ -966,6 +978,12 @@ pub mod workload_onboarding_step {
     impl std::convert::From<std::string::String> for Step {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Step {
+        fn default() -> Self {
+            step::STEP_UNSPECIFIED
         }
     }
 }
@@ -1317,7 +1335,7 @@ pub mod customer_onboarding_step {
     use super::*;
 
     /// Enum for possible onboarding steps
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Step(std::borrow::Cow<'static, str>);
 
     impl Step {
@@ -1349,6 +1367,12 @@ pub mod customer_onboarding_step {
     impl std::convert::From<std::string::String> for Step {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Step {
+        fn default() -> Self {
+            step::STEP_UNSPECIFIED
         }
     }
 }
@@ -1539,7 +1563,7 @@ pub mod ekm_connection {
     }
 
     /// The EKM connection state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ConnectionState(std::borrow::Cow<'static, str>);
 
     impl ConnectionState {
@@ -1578,6 +1602,12 @@ pub mod ekm_connection {
     impl std::convert::From<std::string::String> for ConnectionState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ConnectionState {
+        fn default() -> Self {
+            connection_state::CONNECTION_STATE_UNSPECIFIED
         }
     }
 }
@@ -1632,7 +1662,7 @@ pub mod partner_permissions {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Permission(std::borrow::Cow<'static, str>);
 
     impl Permission {
@@ -1678,6 +1708,12 @@ pub mod partner_permissions {
     impl std::convert::From<std::string::String> for Permission {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Permission {
+        fn default() -> Self {
+            permission::PERMISSION_UNSPECIFIED
         }
     }
 }
@@ -1956,7 +1992,7 @@ pub mod ekm_metadata {
     /// Represents Google Cloud supported external key management partners
     /// [Google Cloud EKM partners
     /// docs](https://cloud.google.com/kms/docs/ekm#supported_partners).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EkmSolution(std::borrow::Cow<'static, str>);
 
     impl EkmSolution {
@@ -1995,6 +2031,12 @@ pub mod ekm_metadata {
     impl std::convert::From<std::string::String> for EkmSolution {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EkmSolution {
+        fn default() -> Self {
+            ekm_solution::EKM_SOLUTION_UNSPECIFIED
         }
     }
 }
@@ -2419,7 +2461,7 @@ pub mod violation {
         /// violation. For example, violations caused due to changes in boolean org
         /// policy requires different remediation instructions compared to violation
         /// caused due to changes in allowed values of list org policy.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct RemediationType(std::borrow::Cow<'static, str>);
 
         impl RemediationType {
@@ -2472,10 +2514,16 @@ pub mod violation {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for RemediationType {
+            fn default() -> Self {
+                remediation_type::REMEDIATION_TYPE_UNSPECIFIED
+            }
+        }
     }
 
     /// Violation State Values
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2510,6 +2558,12 @@ pub mod violation {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -2706,7 +2760,7 @@ impl wkt::message::Message for GetViolationRequest {
 }
 
 /// Enum for possible completion states.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct CompletionState(std::borrow::Cow<'static, str>);
 
 impl CompletionState {
@@ -2745,5 +2799,11 @@ pub mod completion_state {
 impl std::convert::From<std::string::String> for CompletionState {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for CompletionState {
+    fn default() -> Self {
+        completion_state::COMPLETION_STATE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/clouddms/v1/src/model.rs
+++ b/src/generated/cloud/clouddms/v1/src/model.rs
@@ -2982,7 +2982,7 @@ pub mod describe_database_entities_request {
     use super::*;
 
     /// The type of a tree to return
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DBTreeType(std::borrow::Cow<'static, str>);
 
     impl DBTreeType {
@@ -3018,6 +3018,12 @@ pub mod describe_database_entities_request {
     impl std::convert::From<std::string::String> for DBTreeType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DBTreeType {
+        fn default() -> Self {
+            db_tree_type::DB_TREE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -3553,7 +3559,7 @@ pub mod ssl_config {
     use super::*;
 
     /// Specifies The kind of ssl configuration used.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SslType(std::borrow::Cow<'static, str>);
 
     impl SslType {
@@ -3586,6 +3592,12 @@ pub mod ssl_config {
     impl std::convert::From<std::string::String> for SslType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SslType {
+        fn default() -> Self {
+            ssl_type::SSL_TYPE_UNSPECIFIED
         }
     }
 }
@@ -4774,7 +4786,7 @@ pub mod cloud_sql_settings {
     use super::*;
 
     /// Specifies when the instance should be activated.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SqlActivationPolicy(std::borrow::Cow<'static, str>);
 
     impl SqlActivationPolicy {
@@ -4810,8 +4822,14 @@ pub mod cloud_sql_settings {
         }
     }
 
+    impl std::default::Default for SqlActivationPolicy {
+        fn default() -> Self {
+            sql_activation_policy::SQL_ACTIVATION_POLICY_UNSPECIFIED
+        }
+    }
+
     /// The storage options for Cloud SQL databases.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SqlDataDiskType(std::borrow::Cow<'static, str>);
 
     impl SqlDataDiskType {
@@ -4847,8 +4865,14 @@ pub mod cloud_sql_settings {
         }
     }
 
+    impl std::default::Default for SqlDataDiskType {
+        fn default() -> Self {
+            sql_data_disk_type::SQL_DATA_DISK_TYPE_UNSPECIFIED
+        }
+    }
+
     /// The database engine type and version.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SqlDatabaseVersion(std::borrow::Cow<'static, str>);
 
     impl SqlDatabaseVersion {
@@ -4908,8 +4932,14 @@ pub mod cloud_sql_settings {
         }
     }
 
+    impl std::default::Default for SqlDatabaseVersion {
+        fn default() -> Self {
+            sql_database_version::SQL_DATABASE_VERSION_UNSPECIFIED
+        }
+    }
+
     /// The availability type of the given Cloud SQL instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SqlAvailabilityType(std::borrow::Cow<'static, str>);
 
     impl SqlAvailabilityType {
@@ -4945,9 +4975,15 @@ pub mod cloud_sql_settings {
         }
     }
 
+    impl std::default::Default for SqlAvailabilityType {
+        fn default() -> Self {
+            sql_availability_type::SQL_AVAILABILITY_TYPE_UNSPECIFIED
+        }
+    }
+
     /// The edition of the given Cloud SQL instance.
     /// Can be ENTERPRISE or ENTERPRISE_PLUS.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Edition(std::borrow::Cow<'static, str>);
 
     impl Edition {
@@ -4979,6 +5015,12 @@ pub mod cloud_sql_settings {
     impl std::convert::From<std::string::String> for Edition {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Edition {
+        fn default() -> Self {
+            edition::EDITION_UNSPECIFIED
         }
     }
 }
@@ -6228,7 +6270,7 @@ pub mod migration_job {
         use super::*;
 
         /// Describes the parallelism level during initial dump.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct DumpParallelLevel(std::borrow::Cow<'static, str>);
 
         impl DumpParallelLevel {
@@ -6266,10 +6308,16 @@ pub mod migration_job {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for DumpParallelLevel {
+            fn default() -> Self {
+                dump_parallel_level::DUMP_PARALLEL_LEVEL_UNSPECIFIED
+            }
+        }
     }
 
     /// The current migration job states.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -6343,8 +6391,14 @@ pub mod migration_job {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// The current migration job phase.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Phase(std::borrow::Cow<'static, str>);
 
     impl Phase {
@@ -6389,8 +6443,14 @@ pub mod migration_job {
         }
     }
 
+    impl std::default::Default for Phase {
+        fn default() -> Self {
+            phase::PHASE_UNSPECIFIED
+        }
+    }
+
     /// The type of migration job (one-time or continuous).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -6422,6 +6482,12 @@ pub mod migration_job {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 
@@ -6790,7 +6856,7 @@ pub mod connection_profile {
     use super::*;
 
     /// The current connection profile state (e.g. DRAFT, READY, or FAILED).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -6837,6 +6903,12 @@ pub mod connection_profile {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -6921,7 +6993,7 @@ pub mod migration_job_verification_error {
     use super::*;
 
     /// A general error code describing the type of error that occurred.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ErrorCode(std::borrow::Cow<'static, str>);
 
     impl ErrorCode {
@@ -7051,6 +7123,12 @@ pub mod migration_job_verification_error {
     impl std::convert::From<std::string::String> for ErrorCode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ErrorCode {
+        fn default() -> Self {
+            error_code::ERROR_CODE_UNSPECIFIED
         }
     }
 }
@@ -7218,7 +7296,7 @@ pub mod private_connection {
     use super::*;
 
     /// Private Connection state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -7261,6 +7339,12 @@ pub mod private_connection {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -7920,7 +8004,7 @@ pub mod background_job_log_entry {
     }
 
     /// Final state after a job completes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct JobCompletionState(std::borrow::Cow<'static, str>);
 
     impl JobCompletionState {
@@ -7954,6 +8038,12 @@ pub mod background_job_log_entry {
     impl std::convert::From<std::string::String> for JobCompletionState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for JobCompletionState {
+        fn default() -> Self {
+            job_completion_state::JOB_COMPLETION_STATE_UNSPECIFIED
         }
     }
 
@@ -8553,7 +8643,7 @@ pub mod mapping_rule {
     use super::*;
 
     /// The current mapping rule state such as enabled, disabled or deleted.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -8588,6 +8678,12 @@ pub mod mapping_rule {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -10746,7 +10842,7 @@ pub mod database_entity {
     use super::*;
 
     /// The type of database entities tree.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TreeType(std::borrow::Cow<'static, str>);
 
     impl TreeType {
@@ -10781,6 +10877,12 @@ pub mod database_entity {
     impl std::convert::From<std::string::String> for TreeType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for TreeType {
+        fn default() -> Self {
+            tree_type::TREE_TYPE_UNSPECIFIED
         }
     }
 
@@ -12288,7 +12390,7 @@ pub mod entity_issue {
     }
 
     /// Type of issue.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct IssueType(std::borrow::Cow<'static, str>);
 
     impl IssueType {
@@ -12326,8 +12428,14 @@ pub mod entity_issue {
         }
     }
 
+    impl std::default::Default for IssueType {
+        fn default() -> Self {
+            issue_type::ISSUE_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Severity of issue.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct IssueSeverity(std::borrow::Cow<'static, str>);
 
     impl IssueSeverity {
@@ -12366,10 +12474,16 @@ pub mod entity_issue {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for IssueSeverity {
+        fn default() -> Self {
+            issue_severity::ISSUE_SEVERITY_UNSPECIFIED
+        }
+    }
 }
 
 /// AIP-157 Partial Response view for Database Entity.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DatabaseEntityView(std::borrow::Cow<'static, str>);
 
 impl DatabaseEntityView {
@@ -12415,7 +12529,13 @@ impl std::convert::From<std::string::String> for DatabaseEntityView {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+impl std::default::Default for DatabaseEntityView {
+    fn default() -> Self {
+        database_entity_view::DATABASE_ENTITY_VIEW_UNSPECIFIED
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct NetworkArchitecture(std::borrow::Cow<'static, str>);
 
 impl NetworkArchitecture {
@@ -12452,8 +12572,14 @@ impl std::convert::From<std::string::String> for NetworkArchitecture {
     }
 }
 
+impl std::default::Default for NetworkArchitecture {
+    fn default() -> Self {
+        network_architecture::NETWORK_ARCHITECTURE_UNSPECIFIED
+    }
+}
+
 /// The database engine types.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DatabaseEngine(std::borrow::Cow<'static, str>);
 
 impl DatabaseEngine {
@@ -12492,8 +12618,14 @@ impl std::convert::From<std::string::String> for DatabaseEngine {
     }
 }
 
+impl std::default::Default for DatabaseEngine {
+    fn default() -> Self {
+        database_engine::DATABASE_ENGINE_UNSPECIFIED
+    }
+}
+
 /// The database providers.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DatabaseProvider(std::borrow::Cow<'static, str>);
 
 impl DatabaseProvider {
@@ -12535,9 +12667,15 @@ impl std::convert::From<std::string::String> for DatabaseProvider {
     }
 }
 
+impl std::default::Default for DatabaseProvider {
+    fn default() -> Self {
+        database_provider::DATABASE_PROVIDER_UNSPECIFIED
+    }
+}
+
 /// Enum used by ValueListFilter to indicate whether the source value is in the
 /// supplied list
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ValuePresentInList(std::borrow::Cow<'static, str>);
 
 impl ValuePresentInList {
@@ -12575,8 +12713,14 @@ impl std::convert::From<std::string::String> for ValuePresentInList {
     }
 }
 
+impl std::default::Default for ValuePresentInList {
+    fn default() -> Self {
+        value_present_in_list::VALUE_PRESENT_IN_LIST_UNSPECIFIED
+    }
+}
+
 /// The type of database entities supported,
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DatabaseEntityType(std::borrow::Cow<'static, str>);
 
 impl DatabaseEntityType {
@@ -12666,8 +12810,14 @@ impl std::convert::From<std::string::String> for DatabaseEntityType {
     }
 }
 
+impl std::default::Default for DatabaseEntityType {
+    fn default() -> Self {
+        database_entity_type::DATABASE_ENTITY_TYPE_UNSPECIFIED
+    }
+}
+
 /// Entity Name Transformation Types
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct EntityNameTransformation(std::borrow::Cow<'static, str>);
 
 impl EntityNameTransformation {
@@ -12713,8 +12863,14 @@ impl std::convert::From<std::string::String> for EntityNameTransformation {
     }
 }
 
+impl std::default::Default for EntityNameTransformation {
+    fn default() -> Self {
+        entity_name_transformation::ENTITY_NAME_TRANSFORMATION_UNSPECIFIED
+    }
+}
+
 /// The types of jobs that can be executed in the background.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct BackgroundJobType(std::borrow::Cow<'static, str>);
 
 impl BackgroundJobType {
@@ -12762,8 +12918,14 @@ impl std::convert::From<std::string::String> for BackgroundJobType {
     }
 }
 
+impl std::default::Default for BackgroundJobType {
+    fn default() -> Self {
+        background_job_type::BACKGROUND_JOB_TYPE_UNSPECIFIED
+    }
+}
+
 /// The format for the import rules file.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ImportRulesFileFormat(std::borrow::Cow<'static, str>);
 
 impl ImportRulesFileFormat {
@@ -12801,9 +12963,15 @@ impl std::convert::From<std::string::String> for ImportRulesFileFormat {
     }
 }
 
+impl std::default::Default for ImportRulesFileFormat {
+    fn default() -> Self {
+        import_rules_file_format::IMPORT_RULES_FILE_FORMAT_UNSPECIFIED
+    }
+}
+
 /// Enum used by IntComparisonFilter and DoubleComparisonFilter to indicate the
 /// relation between source value and compare value.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ValueComparison(std::borrow::Cow<'static, str>);
 
 impl ValueComparison {
@@ -12849,8 +13017,14 @@ impl std::convert::From<std::string::String> for ValueComparison {
     }
 }
 
+impl std::default::Default for ValueComparison {
+    fn default() -> Self {
+        value_comparison::VALUE_COMPARISON_UNSPECIFIED
+    }
+}
+
 /// Specifies the columns on which numeric filter needs to be applied.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct NumericFilterOption(std::borrow::Cow<'static, str>);
 
 impl NumericFilterOption {
@@ -12891,5 +13065,11 @@ pub mod numeric_filter_option {
 impl std::convert::From<std::string::String> for NumericFilterOption {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for NumericFilterOption {
+    fn default() -> Self {
+        numeric_filter_option::NUMERIC_FILTER_OPTION_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/model.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/model.rs
@@ -1821,7 +1821,7 @@ pub mod cancel_order_request {
     use super::*;
 
     /// Indicates the cancellation policy the customer uses to cancel the order.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CancellationPolicy(std::borrow::Cow<'static, str>);
 
     impl CancellationPolicy {
@@ -1864,6 +1864,12 @@ pub mod cancel_order_request {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for CancellationPolicy {
+        fn default() -> Self {
+            cancellation_policy::CANCELLATION_POLICY_UNSPECIFIED
+        }
+    }
 }
 
 /// Message stored in the metadata field of the Operation returned by
@@ -1889,7 +1895,7 @@ impl wkt::message::Message for CancelOrderMetadata {
 }
 
 /// Type of a line item change.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct LineItemChangeType(std::borrow::Cow<'static, str>);
 
 impl LineItemChangeType {
@@ -1935,8 +1941,14 @@ impl std::convert::From<std::string::String> for LineItemChangeType {
     }
 }
 
+impl std::default::Default for LineItemChangeType {
+    fn default() -> Self {
+        line_item_change_type::LINE_ITEM_CHANGE_TYPE_UNSPECIFIED
+    }
+}
+
 /// State of a change.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct LineItemChangeState(std::borrow::Cow<'static, str>);
 
 impl LineItemChangeState {
@@ -2000,8 +2012,14 @@ impl std::convert::From<std::string::String> for LineItemChangeState {
     }
 }
 
+impl std::default::Default for LineItemChangeState {
+    fn default() -> Self {
+        line_item_change_state::LINE_ITEM_CHANGE_STATE_UNSPECIFIED
+    }
+}
+
 /// Predefined types for line item change state reason.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct LineItemChangeStateReasonType(std::borrow::Cow<'static, str>);
 
 impl LineItemChangeStateReasonType {
@@ -2044,8 +2062,14 @@ impl std::convert::From<std::string::String> for LineItemChangeStateReasonType {
     }
 }
 
+impl std::default::Default for LineItemChangeStateReasonType {
+    fn default() -> Self {
+        line_item_change_state_reason_type::LINE_ITEM_CHANGE_STATE_REASON_TYPE_UNSPECIFIED
+    }
+}
+
 /// Indicates the auto renewal behavior customer specifies on subscription.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct AutoRenewalBehavior(std::borrow::Cow<'static, str>);
 
 impl AutoRenewalBehavior {
@@ -2080,5 +2104,11 @@ pub mod auto_renewal_behavior {
 impl std::convert::From<std::string::String> for AutoRenewalBehavior {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for AutoRenewalBehavior {
+    fn default() -> Self {
+        auto_renewal_behavior::AUTO_RENEWAL_BEHAVIOR_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/confidentialcomputing/v1/src/model.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/model.rs
@@ -1096,7 +1096,7 @@ impl wkt::message::Message for ContainerImageSignature {
 }
 
 /// SigningAlgorithm enumerates all the supported signing algorithms.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SigningAlgorithm(std::borrow::Cow<'static, str>);
 
 impl SigningAlgorithm {
@@ -1136,9 +1136,15 @@ impl std::convert::From<std::string::String> for SigningAlgorithm {
     }
 }
 
+impl std::default::Default for SigningAlgorithm {
+    fn default() -> Self {
+        signing_algorithm::SIGNING_ALGORITHM_UNSPECIFIED
+    }
+}
+
 /// Token type enum contains the different types of token responses Confidential
 /// Space supports
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TokenType(std::borrow::Cow<'static, str>);
 
 impl TokenType {
@@ -1177,5 +1183,11 @@ pub mod token_type {
 impl std::convert::From<std::string::String> for TokenType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for TokenType {
+    fn default() -> Self {
+        token_type::TOKEN_TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/config/v1/src/model.rs
+++ b/src/generated/cloud/config/v1/src/model.rs
@@ -418,7 +418,7 @@ pub mod deployment {
     use super::*;
 
     /// Possible states of a deployment.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -469,8 +469,14 @@ pub mod deployment {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Possible errors that can occur with deployments.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ErrorCode(std::borrow::Cow<'static, str>);
 
     impl ErrorCode {
@@ -522,8 +528,14 @@ pub mod deployment {
         }
     }
 
+    impl std::default::Default for ErrorCode {
+        fn default() -> Self {
+            error_code::ERROR_CODE_UNSPECIFIED
+        }
+    }
+
     /// Possible lock states of a deployment.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LockState(std::borrow::Cow<'static, str>);
 
     impl LockState {
@@ -567,6 +579,12 @@ pub mod deployment {
     impl std::convert::From<std::string::String> for LockState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for LockState {
+        fn default() -> Self {
+            lock_state::LOCK_STATE_UNSPECIFIED
         }
     }
 
@@ -1472,7 +1490,7 @@ pub mod delete_deployment_request {
     use super::*;
 
     /// Policy on how resources actuated by the deployment should be deleted.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DeletePolicy(std::borrow::Cow<'static, str>);
 
     impl DeletePolicy {
@@ -1505,6 +1523,12 @@ pub mod delete_deployment_request {
     impl std::convert::From<std::string::String> for DeletePolicy {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DeletePolicy {
+        fn default() -> Self {
+            delete_policy::DELETE_POLICY_UNSPECIFIED
         }
     }
 }
@@ -2022,7 +2046,7 @@ pub mod revision {
     use super::*;
 
     /// Actions that generate a revision.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Action(std::borrow::Cow<'static, str>);
 
     impl Action {
@@ -2060,8 +2084,14 @@ pub mod revision {
         }
     }
 
+    impl std::default::Default for Action {
+        fn default() -> Self {
+            action::ACTION_UNSPECIFIED
+        }
+    }
+
     /// Possible states of a revision.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2099,8 +2129,14 @@ pub mod revision {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Possible errors if Revision could not be created or updated successfully.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ErrorCode(std::borrow::Cow<'static, str>);
 
     impl ErrorCode {
@@ -2142,6 +2178,12 @@ pub mod revision {
     impl std::convert::From<std::string::String> for ErrorCode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ErrorCode {
+        fn default() -> Self {
+            error_code::ERROR_CODE_UNSPECIFIED
         }
     }
 
@@ -2362,7 +2404,7 @@ pub mod deployment_operation_metadata {
     use super::*;
 
     /// The possible steps a deployment may be running.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DeploymentStep(std::borrow::Cow<'static, str>);
 
     impl DeploymentStep {
@@ -2431,6 +2473,12 @@ pub mod deployment_operation_metadata {
     impl std::convert::From<std::string::String> for DeploymentStep {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DeploymentStep {
+        fn default() -> Self {
+            deployment_step::DEPLOYMENT_STEP_UNSPECIFIED
         }
     }
 }
@@ -2528,7 +2576,7 @@ pub mod resource {
     use super::*;
 
     /// Possible intent of the resource.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Intent(std::borrow::Cow<'static, str>);
 
     impl Intent {
@@ -2572,8 +2620,14 @@ pub mod resource {
         }
     }
 
+    impl std::default::Default for Intent {
+        fn default() -> Self {
+            intent::INTENT_UNSPECIFIED
+        }
+    }
+
     /// Possible states of a resource.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2611,6 +2665,12 @@ pub mod resource {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -3606,7 +3666,7 @@ pub mod preview {
     use super::*;
 
     /// Possible states of a preview.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3657,8 +3717,14 @@ pub mod preview {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Preview mode provides options for customizing preview operations.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PreviewMode(std::borrow::Cow<'static, str>);
 
     impl PreviewMode {
@@ -3695,8 +3761,14 @@ pub mod preview {
         }
     }
 
+    impl std::default::Default for PreviewMode {
+        fn default() -> Self {
+            preview_mode::PREVIEW_MODE_UNSPECIFIED
+        }
+    }
+
     /// Possible errors that can occur with previews.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ErrorCode(std::borrow::Cow<'static, str>);
 
     impl ErrorCode {
@@ -3743,6 +3815,12 @@ pub mod preview {
     impl std::convert::From<std::string::String> for ErrorCode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ErrorCode {
+        fn default() -> Self {
+            error_code::ERROR_CODE_UNSPECIFIED
         }
     }
 
@@ -3830,7 +3908,7 @@ pub mod preview_operation_metadata {
     use super::*;
 
     /// The possible steps a preview may be running.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PreviewStep(std::borrow::Cow<'static, str>);
 
     impl PreviewStep {
@@ -3889,6 +3967,12 @@ pub mod preview_operation_metadata {
     impl std::convert::From<std::string::String> for PreviewStep {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PreviewStep {
+        fn default() -> Self {
+            preview_step::PREVIEW_STEP_UNSPECIFIED
         }
     }
 }
@@ -4642,7 +4726,7 @@ pub mod terraform_version {
     use super::*;
 
     /// Possible states of a TerraformVersion.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -4679,11 +4763,17 @@ pub mod terraform_version {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
 }
 
 /// Enum values to control quota checks for resources in terraform
 /// configuration files.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct QuotaValidation(std::borrow::Cow<'static, str>);
 
 impl QuotaValidation {
@@ -4720,5 +4810,11 @@ pub mod quota_validation {
 impl std::convert::From<std::string::String> for QuotaValidation {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for QuotaValidation {
+    fn default() -> Self {
+        quota_validation::QUOTA_VALIDATION_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/connectors/v1/src/model.rs
+++ b/src/generated/cloud/connectors/v1/src/model.rs
@@ -824,7 +824,7 @@ pub mod config_variable_template {
     use super::*;
 
     /// ValueType indicates the data type of the value.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ValueType(std::borrow::Cow<'static, str>);
 
     impl ValueType {
@@ -871,8 +871,14 @@ pub mod config_variable_template {
         }
     }
 
+    impl std::default::Default for ValueType {
+        fn default() -> Self {
+            value_type::VALUE_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Indicates the state of the config variable.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -904,6 +910,12 @@ pub mod config_variable_template {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1270,7 +1282,7 @@ pub mod role_grant {
         use super::*;
 
         /// Resource Type definition.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Type(std::borrow::Cow<'static, str>);
 
         impl Type {
@@ -1311,10 +1323,16 @@ pub mod role_grant {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for Type {
+            fn default() -> Self {
+                r#type::TYPE_UNSPECIFIED
+            }
+        }
     }
 
     /// Supported Principal values.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Principal(std::borrow::Cow<'static, str>);
 
     impl Principal {
@@ -1345,6 +1363,12 @@ pub mod role_grant {
     impl std::convert::From<std::string::String> for Principal {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Principal {
+        fn default() -> Self {
+            principal::PRINCIPAL_UNSPECIFIED
         }
     }
 }
@@ -1822,7 +1846,7 @@ pub mod connection_schema_metadata {
     use super::*;
 
     /// State of connection runtime schema.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1854,6 +1878,12 @@ pub mod connection_schema_metadata {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -2952,7 +2982,7 @@ pub mod connection_status {
     use super::*;
 
     /// All the possible Connection State.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3000,6 +3030,12 @@ pub mod connection_status {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -3985,7 +4021,7 @@ pub mod extraction_rule {
     }
 
     /// Supported Source types for extraction.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SourceType(std::borrow::Cow<'static, str>);
 
     impl SourceType {
@@ -4014,6 +4050,12 @@ pub mod extraction_rule {
     impl std::convert::From<std::string::String> for SourceType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SourceType {
+        fn default() -> Self {
+            source_type::SOURCE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -4651,7 +4693,7 @@ pub mod runtime_config {
     use super::*;
 
     /// State of the location.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -4695,6 +4737,12 @@ pub mod runtime_config {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -5014,7 +5062,7 @@ pub mod ssl_config {
     use super::*;
 
     /// Enum for Ttust Model
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TrustModel(std::borrow::Cow<'static, str>);
 
     impl TrustModel {
@@ -5048,10 +5096,16 @@ pub mod ssl_config {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for TrustModel {
+        fn default() -> Self {
+            trust_model::PUBLIC
+        }
+    }
 }
 
 /// AuthType defines different authentication types.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct AuthType(std::borrow::Cow<'static, str>);
 
 impl AuthType {
@@ -5096,9 +5150,15 @@ impl std::convert::From<std::string::String> for AuthType {
     }
 }
 
+impl std::default::Default for AuthType {
+    fn default() -> Self {
+        auth_type::AUTH_TYPE_UNSPECIFIED
+    }
+}
+
 /// LaunchStage is a enum to indicate launch stage:
 /// PREVIEW, GA, DEPRECATED, PRIVATE_PREVIEW.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct LaunchStage(std::borrow::Cow<'static, str>);
 
 impl LaunchStage {
@@ -5139,8 +5199,14 @@ impl std::convert::From<std::string::String> for LaunchStage {
     }
 }
 
+impl std::default::Default for LaunchStage {
+    fn default() -> Self {
+        launch_stage::LAUNCH_STAGE_UNSPECIFIED
+    }
+}
+
 /// All possible data types of a entity or action field.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DataType(std::borrow::Cow<'static, str>);
 
 impl DataType {
@@ -5303,8 +5369,14 @@ impl std::convert::From<std::string::String> for DataType {
     }
 }
 
+impl std::default::Default for DataType {
+    fn default() -> Self {
+        data_type::DATA_TYPE_UNSPECIFIED
+    }
+}
+
 /// Enum to control which fields should be included in the response.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ConnectionView(std::borrow::Cow<'static, str>);
 
 impl ConnectionView {
@@ -5340,8 +5412,14 @@ impl std::convert::From<std::string::String> for ConnectionView {
     }
 }
 
+impl std::default::Default for ConnectionView {
+    fn default() -> Self {
+        connection_view::CONNECTION_VIEW_UNSPECIFIED
+    }
+}
+
 /// Enum to control which fields should be included in the response.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ConnectorVersionView(std::borrow::Cow<'static, str>);
 
 impl ConnectorVersionView {
@@ -5379,8 +5457,14 @@ impl std::convert::From<std::string::String> for ConnectorVersionView {
     }
 }
 
+impl std::default::Default for ConnectorVersionView {
+    fn default() -> Self {
+        connector_version_view::CONNECTOR_VERSION_VIEW_UNSPECIFIED
+    }
+}
+
 /// Enum for controlling the SSL Type (TLS/MTLS)
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SslType(std::borrow::Cow<'static, str>);
 
 impl SslType {
@@ -5415,8 +5499,14 @@ impl std::convert::From<std::string::String> for SslType {
     }
 }
 
+impl std::default::Default for SslType {
+    fn default() -> Self {
+        ssl_type::SSL_TYPE_UNSPECIFIED
+    }
+}
+
 /// Enum for Cert Types
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct CertType(std::borrow::Cow<'static, str>);
 
 impl CertType {
@@ -5445,5 +5535,11 @@ pub mod cert_type {
 impl std::convert::From<std::string::String> for CertType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for CertType {
+    fn default() -> Self {
+        cert_type::CERT_TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/contactcenterinsights/v1/src/model.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/model.rs
@@ -1216,7 +1216,7 @@ pub mod ingest_conversations_request {
         #[allow(unused_imports)]
         use super::*;
 
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct BucketObjectType(std::borrow::Cow<'static, str>);
 
         impl BucketObjectType {
@@ -1249,6 +1249,12 @@ pub mod ingest_conversations_request {
         impl std::convert::From<std::string::String> for BucketObjectType {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for BucketObjectType {
+            fn default() -> Self {
+                bucket_object_type::BUCKET_OBJECT_TYPE_UNSPECIFIED
             }
         }
     }
@@ -2304,7 +2310,7 @@ pub mod export_insights_data_request {
     }
 
     /// Specifies the action that occurs if the destination table already exists.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct WriteDisposition(std::borrow::Cow<'static, str>);
 
     impl WriteDisposition {
@@ -2338,6 +2344,12 @@ pub mod export_insights_data_request {
     impl std::convert::From<std::string::String> for WriteDisposition {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for WriteDisposition {
+        fn default() -> Self {
+            write_disposition::WRITE_DISPOSITION_UNSPECIFIED
         }
     }
 
@@ -5094,7 +5106,7 @@ pub mod dimension {
     }
 
     /// The key of the dimension.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DimensionKey(std::borrow::Cow<'static, str>);
 
     impl DimensionKey {
@@ -5148,6 +5160,12 @@ pub mod dimension {
     impl std::convert::From<std::string::String> for DimensionKey {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DimensionKey {
+        fn default() -> Self {
+            dimension_key::DIMENSION_KEY_UNSPECIFIED
         }
     }
 
@@ -5275,7 +5293,7 @@ pub mod query_metrics_request {
     /// A time granularity divides the time line into discrete time periods.
     /// This is useful for defining buckets over which filtering and aggregation
     /// should be performed.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TimeGranularity(std::borrow::Cow<'static, str>);
 
     impl TimeGranularity {
@@ -5326,6 +5344,12 @@ pub mod query_metrics_request {
     impl std::convert::From<std::string::String> for TimeGranularity {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for TimeGranularity {
+        fn default() -> Self {
+            time_granularity::TIME_GRANULARITY_UNSPECIFIED
         }
     }
 }
@@ -7668,7 +7692,7 @@ pub mod bulk_upload_feedback_labels_request {
         use super::*;
 
         /// All permissible file formats.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Format(std::borrow::Cow<'static, str>);
 
         impl Format {
@@ -7700,6 +7724,12 @@ pub mod bulk_upload_feedback_labels_request {
         impl std::convert::From<std::string::String> for Format {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Format {
+            fn default() -> Self {
+                format::FORMAT_UNSPECIFIED
             }
         }
     }
@@ -8140,7 +8170,7 @@ pub mod bulk_download_feedback_labels_request {
         /// All permissible file formats.
         /// See `records_per_file_count` to override the default number of records
         /// per file.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Format(std::borrow::Cow<'static, str>);
 
         impl Format {
@@ -8176,10 +8206,16 @@ pub mod bulk_download_feedback_labels_request {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for Format {
+            fn default() -> Self {
+                format::FORMAT_UNSPECIFIED
+            }
+        }
     }
 
     /// Possible feedback label types that will be downloaded.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct FeedbackLabelType(std::borrow::Cow<'static, str>);
 
     impl FeedbackLabelType {
@@ -8213,6 +8249,12 @@ pub mod bulk_download_feedback_labels_request {
     impl std::convert::From<std::string::String> for FeedbackLabelType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for FeedbackLabelType {
+        fn default() -> Self {
+            feedback_label_type::FEEDBACK_LABEL_TYPE_UNSPECIFIED
         }
     }
 
@@ -9291,7 +9333,7 @@ pub mod conversation {
     }
 
     /// Possible media for the conversation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Medium(std::borrow::Cow<'static, str>);
 
     impl Medium {
@@ -9323,6 +9365,12 @@ pub mod conversation {
     impl std::convert::From<std::string::String> for Medium {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Medium {
+        fn default() -> Self {
+            medium::MEDIUM_UNSPECIFIED
         }
     }
 
@@ -10736,7 +10784,7 @@ pub mod entity {
     /// Wikipedia URL (`wikipedia_url`) and Knowledge Graph MID (`mid`). The table
     /// below lists the associated fields for entities that have different
     /// metadata.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -10832,6 +10880,12 @@ pub mod entity {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -11071,7 +11125,7 @@ pub mod entity_mention_data {
     use super::*;
 
     /// The supported types of mentions.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MentionType(std::borrow::Cow<'static, str>);
 
     impl MentionType {
@@ -11104,6 +11158,12 @@ pub mod entity_mention_data {
     impl std::convert::From<std::string::String> for MentionType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for MentionType {
+        fn default() -> Self {
+            mention_type::MENTION_TYPE_UNSPECIFIED
         }
     }
 }
@@ -11421,7 +11481,7 @@ pub mod issue_model {
     }
 
     /// State of the model.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -11466,8 +11526,14 @@ pub mod issue_model {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Type of the model.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ModelType(std::borrow::Cow<'static, str>);
 
     impl ModelType {
@@ -11499,6 +11565,12 @@ pub mod issue_model {
     impl std::convert::From<std::string::String> for ModelType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ModelType {
+        fn default() -> Self {
+            model_type::MODEL_TYPE_UNSPECIFIED
         }
     }
 }
@@ -11887,7 +11959,7 @@ pub mod phrase_matcher {
 
     /// Specifies how to combine each phrase match rule group to determine whether
     /// there is a match.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PhraseMatcherType(std::borrow::Cow<'static, str>);
 
     impl PhraseMatcherType {
@@ -11920,6 +11992,12 @@ pub mod phrase_matcher {
     impl std::convert::From<std::string::String> for PhraseMatcherType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PhraseMatcherType {
+        fn default() -> Self {
+            phrase_matcher_type::PHRASE_MATCHER_TYPE_UNSPECIFIED
         }
     }
 }
@@ -11980,7 +12058,7 @@ pub mod phrase_match_rule_group {
 
     /// Specifies how to combine each phrase match rule for whether there is a
     /// match.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PhraseMatchRuleGroupType(std::borrow::Cow<'static, str>);
 
     impl PhraseMatchRuleGroupType {
@@ -12013,6 +12091,12 @@ pub mod phrase_match_rule_group {
     impl std::convert::From<std::string::String> for PhraseMatchRuleGroupType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PhraseMatchRuleGroupType {
+        fn default() -> Self {
+            phrase_match_rule_group_type::PHRASE_MATCH_RULE_GROUP_TYPE_UNSPECIFIED
         }
     }
 }
@@ -13063,7 +13147,7 @@ pub mod runtime_annotation {
         use super::*;
 
         /// The source of the query.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct QuerySource(std::borrow::Cow<'static, str>);
 
         impl QuerySource {
@@ -13097,6 +13181,12 @@ pub mod runtime_annotation {
         impl std::convert::From<std::string::String> for QuerySource {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for QuerySource {
+            fn default() -> Self {
+                query_source::QUERY_SOURCE_UNSPECIFIED
             }
         }
     }
@@ -13182,7 +13272,7 @@ pub mod answer_feedback {
     use super::*;
 
     /// The correctness level of an answer.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CorrectnessLevel(std::borrow::Cow<'static, str>);
 
     impl CorrectnessLevel {
@@ -13218,6 +13308,12 @@ pub mod answer_feedback {
     impl std::convert::From<std::string::String> for CorrectnessLevel {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CorrectnessLevel {
+        fn default() -> Self {
+            correctness_level::CORRECTNESS_LEVEL_UNSPECIFIED
         }
     }
 }
@@ -13821,7 +13917,7 @@ pub mod conversation_participant {
     use super::*;
 
     /// The role of the participant.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Role(std::borrow::Cow<'static, str>);
 
     impl Role {
@@ -13859,6 +13955,12 @@ pub mod conversation_participant {
     impl std::convert::From<std::string::String> for Role {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Role {
+        fn default() -> Self {
+            role::ROLE_UNSPECIFIED
         }
     }
 
@@ -14239,7 +14341,7 @@ pub mod annotator_selector {
         use super::*;
 
         /// Summarization model to use, if `conversation_profile` is not used.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct SummarizationModel(std::borrow::Cow<'static, str>);
 
         impl SummarizationModel {
@@ -14274,6 +14376,12 @@ pub mod annotator_selector {
         impl std::convert::From<std::string::String> for SummarizationModel {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for SummarizationModel {
+            fn default() -> Self {
+                summarization_model::SUMMARIZATION_MODEL_UNSPECIFIED
             }
         }
 
@@ -15039,7 +15147,7 @@ pub mod qa_scorecard_revision {
     use super::*;
 
     /// Enum representing the set of states a scorecard revision may be in.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -15083,6 +15191,12 @@ pub mod qa_scorecard_revision {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -15453,7 +15567,7 @@ pub mod qa_answer {
         use super::*;
 
         /// What created the answer.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct SourceType(std::borrow::Cow<'static, str>);
 
         impl SourceType {
@@ -15486,6 +15600,12 @@ pub mod qa_answer {
         impl std::convert::From<std::string::String> for SourceType {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for SourceType {
+            fn default() -> Self {
+                source_type::SOURCE_TYPE_UNSPECIFIED
             }
         }
     }
@@ -15816,7 +15936,7 @@ pub mod qa_scorecard_result {
         use super::*;
 
         /// What created the score.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct SourceType(std::borrow::Cow<'static, str>);
 
         impl SourceType {
@@ -15852,11 +15972,17 @@ pub mod qa_scorecard_result {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for SourceType {
+            fn default() -> Self {
+                source_type::SOURCE_TYPE_UNSPECIFIED
+            }
+        }
     }
 }
 
 /// Represents the options for viewing a conversation.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ConversationView(std::borrow::Cow<'static, str>);
 
 impl ConversationView {
@@ -15895,10 +16021,16 @@ impl std::convert::From<std::string::String> for ConversationView {
     }
 }
 
+impl std::default::Default for ConversationView {
+    fn default() -> Self {
+        conversation_view::CONVERSATION_VIEW_UNSPECIFIED
+    }
+}
+
 /// Enum for the different types of issues a tuning dataset can have.
 /// These warnings are currentlyraised when trying to validate a dataset for
 /// tuning a scorecard.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DatasetValidationWarning(std::borrow::Cow<'static, str>);
 
 impl DatasetValidationWarning {
@@ -15943,5 +16075,11 @@ pub mod dataset_validation_warning {
 impl std::convert::From<std::string::String> for DatasetValidationWarning {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for DatasetValidationWarning {
+    fn default() -> Self {
+        dataset_validation_warning::DATASET_VALIDATION_WARNING_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/datacatalog/lineage/v1/src/model.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/model.rs
@@ -215,7 +215,7 @@ pub mod run {
     use super::*;
 
     /// The current state of the run.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -254,6 +254,12 @@ pub mod run {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::UNKNOWN
         }
     }
 }
@@ -515,7 +521,7 @@ pub mod operation_metadata {
     use super::*;
 
     /// An enum with the state of the operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -556,8 +562,14 @@ pub mod operation_metadata {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Type of the long running operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -589,6 +601,12 @@ pub mod operation_metadata {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -2157,7 +2175,7 @@ pub mod origin {
     use super::*;
 
     /// Type of the source of a process.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SourceType(std::borrow::Cow<'static, str>);
 
     impl SourceType {
@@ -2201,6 +2219,12 @@ pub mod origin {
     impl std::convert::From<std::string::String> for SourceType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SourceType {
+        fn default() -> Self {
+            source_type::SOURCE_TYPE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/datacatalog/v1/src/model.rs
+++ b/src/generated/cloud/datacatalog/v1/src/model.rs
@@ -131,7 +131,7 @@ pub mod big_query_connection_spec {
     use super::*;
 
     /// The type of the BigQuery connection.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ConnectionType(std::borrow::Cow<'static, str>);
 
     impl ConnectionType {
@@ -161,6 +161,12 @@ pub mod big_query_connection_spec {
     impl std::convert::From<std::string::String> for ConnectionType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ConnectionType {
+        fn default() -> Self {
+            connection_type::CONNECTION_TYPE_UNSPECIFIED
         }
     }
 
@@ -233,7 +239,7 @@ pub mod cloud_sql_big_query_connection_spec {
     use super::*;
 
     /// Supported Cloud SQL database types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DatabaseType(std::borrow::Cow<'static, str>);
 
     impl DatabaseType {
@@ -266,6 +272,12 @@ pub mod cloud_sql_big_query_connection_spec {
     impl std::convert::From<std::string::String> for DatabaseType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DatabaseType {
+        fn default() -> Self {
+            database_type::DATABASE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -450,7 +462,7 @@ pub mod data_source {
     use super::*;
 
     /// Name of a service that stores the data.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Service(std::borrow::Cow<'static, str>);
 
     impl Service {
@@ -482,6 +494,12 @@ pub mod data_source {
     impl std::convert::From<std::string::String> for Service {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Service {
+        fn default() -> Self {
+            service::SERVICE_UNSPECIFIED
         }
     }
 
@@ -2728,7 +2746,7 @@ pub mod database_table_spec {
         use super::*;
 
         /// Concrete type of the view.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct ViewType(std::borrow::Cow<'static, str>);
 
         impl ViewType {
@@ -2763,6 +2781,12 @@ pub mod database_table_spec {
             }
         }
 
+        impl std::default::Default for ViewType {
+            fn default() -> Self {
+                view_type::VIEW_TYPE_UNSPECIFIED
+            }
+        }
+
         /// Definition of the view.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         #[serde(rename_all = "camelCase")]
@@ -2776,7 +2800,7 @@ pub mod database_table_spec {
     }
 
     /// Type of the table.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TableType(std::borrow::Cow<'static, str>);
 
     impl TableType {
@@ -2808,6 +2832,12 @@ pub mod database_table_spec {
     impl std::convert::From<std::string::String> for TableType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for TableType {
+        fn default() -> Self {
+            table_type::TABLE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -3079,7 +3109,7 @@ pub mod routine_spec {
         use super::*;
 
         /// The input or output mode of the argument.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Mode(std::borrow::Cow<'static, str>);
 
         impl Mode {
@@ -3116,10 +3146,16 @@ pub mod routine_spec {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for Mode {
+            fn default() -> Self {
+                mode::MODE_UNSPECIFIED
+            }
+        }
     }
 
     /// The fine-grained type of the routine.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RoutineType(std::borrow::Cow<'static, str>);
 
     impl RoutineType {
@@ -3152,6 +3188,12 @@ pub mod routine_spec {
     impl std::convert::From<std::string::String> for RoutineType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RoutineType {
+        fn default() -> Self {
+            routine_type::ROUTINE_TYPE_UNSPECIFIED
         }
     }
 
@@ -3689,7 +3731,7 @@ pub mod vertex_model_source_info {
     use super::*;
 
     /// Source of the model.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ModelSourceType(std::borrow::Cow<'static, str>);
 
     impl ModelSourceType {
@@ -3738,6 +3780,12 @@ pub mod vertex_model_source_info {
     impl std::convert::From<std::string::String> for ModelSourceType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ModelSourceType {
+        fn default() -> Self {
+            model_source_type::MODEL_SOURCE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -3877,7 +3925,7 @@ pub mod vertex_dataset_spec {
     use super::*;
 
     /// Type of data stored in the dataset.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DataType(std::borrow::Cow<'static, str>);
 
     impl DataType {
@@ -3944,6 +3992,12 @@ pub mod vertex_dataset_spec {
     impl std::convert::From<std::string::String> for DataType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DataType {
+        fn default() -> Self {
+            data_type::DATA_TYPE_UNSPECIFIED
         }
     }
 }
@@ -4070,7 +4124,7 @@ pub mod feature_online_store_spec {
     use super::*;
 
     /// Type of underlaying storage type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct StorageType(std::borrow::Cow<'static, str>);
 
     impl StorageType {
@@ -4103,6 +4157,12 @@ pub mod feature_online_store_spec {
     impl std::convert::From<std::string::String> for StorageType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for StorageType {
+        fn default() -> Self {
+            storage_type::STORAGE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -5278,7 +5338,7 @@ pub mod reconcile_tags_metadata {
     use super::*;
 
     /// Enum holding possible states of the reconciliation operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ReconciliationState(std::borrow::Cow<'static, str>);
 
     impl ReconciliationState {
@@ -5317,6 +5377,12 @@ pub mod reconcile_tags_metadata {
     impl std::convert::From<std::string::String> for ReconciliationState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ReconciliationState {
+        fn default() -> Self {
+            reconciliation_state::RECONCILIATION_STATE_UNSPECIFIED
         }
     }
 }
@@ -5776,7 +5842,7 @@ pub mod import_entries_metadata {
     use super::*;
 
     /// Enum holding possible states of the import operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ImportState(std::borrow::Cow<'static, str>);
 
     impl ImportState {
@@ -5815,6 +5881,12 @@ pub mod import_entries_metadata {
     impl std::convert::From<std::string::String> for ImportState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ImportState {
+        fn default() -> Self {
+            import_state::IMPORT_STATE_UNSPECIFIED
         }
     }
 }
@@ -7308,7 +7380,7 @@ pub mod taxonomy {
     }
 
     /// Defines policy types where the policy tags can be used for.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PolicyType(std::borrow::Cow<'static, str>);
 
     impl PolicyType {
@@ -7339,6 +7411,12 @@ pub mod taxonomy {
     impl std::convert::From<std::string::String> for PolicyType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PolicyType {
+        fn default() -> Self {
+            policy_type::POLICY_TYPE_UNSPECIFIED
         }
     }
 }
@@ -8863,7 +8941,7 @@ pub mod column_schema {
         use super::*;
 
         /// Column type in Looker.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct LookerColumnType(std::borrow::Cow<'static, str>);
 
         impl LookerColumnType {
@@ -8907,6 +8985,12 @@ pub mod column_schema {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for LookerColumnType {
+            fn default() -> Self {
+                looker_column_type::LOOKER_COLUMN_TYPE_UNSPECIFIED
+            }
+        }
     }
 
     /// Represents the type of a field element.
@@ -8943,7 +9027,7 @@ pub mod column_schema {
     }
 
     /// Specifies inclusion of the column in an index
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct IndexingType(std::borrow::Cow<'static, str>);
 
     impl IndexingType {
@@ -8984,6 +9068,12 @@ pub mod column_schema {
     impl std::convert::From<std::string::String> for IndexingType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for IndexingType {
+        fn default() -> Self {
+            indexing_type::INDEXING_TYPE_UNSPECIFIED
         }
     }
 
@@ -10042,7 +10132,7 @@ pub mod tag_template {
     use super::*;
 
     /// This enum describes TagTemplate transfer status to Dataplex service.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DataplexTransferStatus(std::borrow::Cow<'static, str>);
 
     impl DataplexTransferStatus {
@@ -10080,6 +10170,12 @@ pub mod tag_template {
     impl std::convert::From<std::string::String> for DataplexTransferStatus {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DataplexTransferStatus {
+        fn default() -> Self {
+            dataplex_transfer_status::DATAPLEX_TRANSFER_STATUS_UNSPECIFIED
         }
     }
 }
@@ -10361,7 +10457,7 @@ pub mod field_type {
         }
     }
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PrimitiveType(std::borrow::Cow<'static, str>);
 
     impl PrimitiveType {
@@ -10403,6 +10499,12 @@ pub mod field_type {
     impl std::convert::From<std::string::String> for PrimitiveType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PrimitiveType {
+        fn default() -> Self {
+            primitive_type::PRIMITIVE_TYPE_UNSPECIFIED
         }
     }
 
@@ -10673,7 +10775,7 @@ impl wkt::message::Message for UsageSignal {
 }
 
 /// This enum lists all the systems that Data Catalog integrates with.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct IntegratedSystem(std::borrow::Cow<'static, str>);
 
 impl IntegratedSystem {
@@ -10730,9 +10832,15 @@ impl std::convert::From<std::string::String> for IntegratedSystem {
     }
 }
 
+impl std::default::Default for IntegratedSystem {
+    fn default() -> Self {
+        integrated_system::INTEGRATED_SYSTEM_UNSPECIFIED
+    }
+}
+
 /// This enum describes all the systems that manage
 /// Taxonomy and PolicyTag resources in DataCatalog.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ManagingSystem(std::borrow::Cow<'static, str>);
 
 impl ManagingSystem {
@@ -10769,6 +10877,12 @@ impl std::convert::From<std::string::String> for ManagingSystem {
     }
 }
 
+impl std::default::Default for ManagingSystem {
+    fn default() -> Self {
+        managing_system::MANAGING_SYSTEM_UNSPECIFIED
+    }
+}
+
 /// Metadata automatically ingested from Google Cloud resources like BigQuery
 /// tables or Pub/Sub topics always uses enum values from `EntryType` as the type
 /// of entry.
@@ -10781,7 +10895,7 @@ impl std::convert::From<std::string::String> for ManagingSystem {
 /// [Surface files from Cloud Storage with fileset
 /// entries](/data-catalog/docs/how-to/filesets) or [Create custom entries for
 /// your data sources](/data-catalog/docs/how-to/custom-entries).
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct EntryType(std::borrow::Cow<'static, str>);
 
 impl EntryType {
@@ -10876,9 +10990,15 @@ impl std::convert::From<std::string::String> for EntryType {
     }
 }
 
+impl std::default::Default for EntryType {
+    fn default() -> Self {
+        entry_type::ENTRY_TYPE_UNSPECIFIED
+    }
+}
+
 /// Configuration related to the opt-in status for the migration of TagTemplates
 /// to Dataplex.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TagTemplateMigration(std::borrow::Cow<'static, str>);
 
 impl TagTemplateMigration {
@@ -10917,8 +11037,14 @@ impl std::convert::From<std::string::String> for TagTemplateMigration {
     }
 }
 
+impl std::default::Default for TagTemplateMigration {
+    fn default() -> Self {
+        tag_template_migration::TAG_TEMPLATE_MIGRATION_UNSPECIFIED
+    }
+}
+
 /// Configuration related to the opt-in status for the UI switch to Dataplex.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct CatalogUIExperience(std::borrow::Cow<'static, str>);
 
 impl CatalogUIExperience {
@@ -10956,8 +11082,14 @@ impl std::convert::From<std::string::String> for CatalogUIExperience {
     }
 }
 
+impl std::default::Default for CatalogUIExperience {
+    fn default() -> Self {
+        catalog_ui_experience::CATALOG_UI_EXPERIENCE_UNSPECIFIED
+    }
+}
+
 /// The resource types that can be returned in search results.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SearchResultType(std::borrow::Cow<'static, str>);
 
 impl SearchResultType {
@@ -11002,8 +11134,14 @@ impl std::convert::From<std::string::String> for SearchResultType {
     }
 }
 
+impl std::default::Default for SearchResultType {
+    fn default() -> Self {
+        search_result_type::SEARCH_RESULT_TYPE_UNSPECIFIED
+    }
+}
+
 /// Table source type.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TableSourceType(std::borrow::Cow<'static, str>);
 
 impl TableSourceType {
@@ -11040,5 +11178,11 @@ pub mod table_source_type {
 impl std::convert::From<std::string::String> for TableSourceType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for TableSourceType {
+    fn default() -> Self {
+        table_source_type::TABLE_SOURCE_TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/datafusion/v1/src/model.rs
+++ b/src/generated/cloud/datafusion/v1/src/model.rs
@@ -150,7 +150,7 @@ pub mod version {
     use super::*;
 
     /// Each type represents the release availability of a CDF version
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -182,6 +182,12 @@ pub mod version {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -238,7 +244,7 @@ pub mod accelerator {
 
     /// Each type represents an Accelerator (Add-On) supported by Cloud Data Fusion
     /// service.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AcceleratorType(std::borrow::Cow<'static, str>);
 
     impl AcceleratorType {
@@ -280,8 +286,14 @@ pub mod accelerator {
         }
     }
 
+    impl std::default::Default for AcceleratorType {
+        fn default() -> Self {
+            accelerator_type::ACCELERATOR_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Different values possible for the state of an accelerator
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -317,6 +329,12 @@ pub mod accelerator {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -724,7 +742,7 @@ pub mod instance {
 
     /// Represents the type of Data Fusion instance. Each type is configured with
     /// the default settings for processing and memory.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -770,8 +788,14 @@ pub mod instance {
         }
     }
 
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
+        }
+    }
+
     /// Represents the state of a Data Fusion instance
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -831,8 +855,14 @@ pub mod instance {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// The reason for disabling the instance if the state is DISABLED.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DisabledReason(std::borrow::Cow<'static, str>);
 
     impl DisabledReason {
@@ -862,6 +892,12 @@ pub mod instance {
     impl std::convert::From<std::string::String> for DisabledReason {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DisabledReason {
+        fn default() -> Self {
+            disabled_reason::DISABLED_REASON_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/dataproc/v1/src/model.rs
+++ b/src/generated/cloud/dataproc/v1/src/model.rs
@@ -1434,7 +1434,7 @@ pub mod batch {
     }
 
     /// The batch state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1478,6 +1478,12 @@ pub mod batch {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -2984,7 +2990,7 @@ pub mod gce_cluster_config {
     /// These values are directly mapped to corresponding values in the
     /// [Compute Engine Instance
     /// fields](https://cloud.google.com/compute/docs/reference/rest/v1/instances).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PrivateIpv6GoogleAccess(std::borrow::Cow<'static, str>);
 
     impl PrivateIpv6GoogleAccess {
@@ -3030,6 +3036,12 @@ pub mod gce_cluster_config {
     impl std::convert::From<std::string::String> for PrivateIpv6GoogleAccess {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PrivateIpv6GoogleAccess {
+        fn default() -> Self {
+            private_ipv_6_google_access::PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED
         }
     }
 }
@@ -3433,7 +3445,7 @@ pub mod instance_group_config {
     use super::*;
 
     /// Controls the use of preemptible instances within the group.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Preemptibility(std::borrow::Cow<'static, str>);
 
     impl Preemptibility {
@@ -3485,6 +3497,12 @@ pub mod instance_group_config {
     impl std::convert::From<std::string::String> for Preemptibility {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Preemptibility {
+        fn default() -> Self {
+            preemptibility::PREEMPTIBILITY_UNSPECIFIED
         }
     }
 }
@@ -4186,7 +4204,7 @@ pub mod node_group {
     use super::*;
 
     /// Node pool roles.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Role(std::borrow::Cow<'static, str>);
 
     impl Role {
@@ -4215,6 +4233,12 @@ pub mod node_group {
     impl std::convert::From<std::string::String> for Role {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Role {
+        fn default() -> Self {
+            role::ROLE_UNSPECIFIED
         }
     }
 }
@@ -4342,7 +4366,7 @@ pub mod cluster_status {
     use super::*;
 
     /// The cluster state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -4406,8 +4430,14 @@ pub mod cluster_status {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::UNKNOWN
+        }
+    }
+
     /// The cluster substate.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Substate(std::borrow::Cow<'static, str>);
 
     impl Substate {
@@ -4446,6 +4476,12 @@ pub mod cluster_status {
     impl std::convert::From<std::string::String> for Substate {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Substate {
+        fn default() -> Self {
+            substate::UNSPECIFIED
         }
     }
 }
@@ -5189,7 +5225,7 @@ pub mod dataproc_metric_config {
     /// A source for the collection of Dataproc custom metrics (see [Custom
     /// metrics]
     /// (<https://cloud.google.com//dataproc/docs/guides/dataproc-metrics#custom_metrics>)).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MetricSource(std::borrow::Cow<'static, str>);
 
     impl MetricSource {
@@ -5244,6 +5280,12 @@ pub mod dataproc_metric_config {
     impl std::convert::From<std::string::String> for MetricSource {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for MetricSource {
+        fn default() -> Self {
+            metric_source::METRIC_SOURCE_UNSPECIFIED
         }
     }
 }
@@ -6070,7 +6112,7 @@ pub mod diagnose_cluster_request {
     use super::*;
 
     /// Defines who has access to the diagnostic tarball
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TarballAccess(std::borrow::Cow<'static, str>);
 
     impl TarballAccess {
@@ -6106,6 +6148,12 @@ pub mod diagnose_cluster_request {
     impl std::convert::From<std::string::String> for TarballAccess {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for TarballAccess {
+        fn default() -> Self {
+            tarball_access::TARBALL_ACCESS_UNSPECIFIED
         }
     }
 }
@@ -6205,7 +6253,7 @@ pub mod reservation_affinity {
     use super::*;
 
     /// Indicates whether to consume capacity from an reservation or not.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -6240,6 +6288,12 @@ pub mod reservation_affinity {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -6294,7 +6348,7 @@ pub mod logging_config {
     /// The Log4j level for job execution. When running an
     /// [Apache Hive](https://hive.apache.org/) job, Cloud
     /// Dataproc configures the Hive client to an equivalent verbosity level.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Level(std::borrow::Cow<'static, str>);
 
     impl Level {
@@ -6344,6 +6398,12 @@ pub mod logging_config {
     impl std::convert::From<std::string::String> for Level {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Level {
+        fn default() -> Self {
+            level::LEVEL_UNSPECIFIED
         }
     }
 }
@@ -8282,7 +8342,7 @@ pub mod job_status {
     use super::*;
 
     /// The job state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -8343,8 +8403,14 @@ pub mod job_status {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// The job substate.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Substate(std::borrow::Cow<'static, str>);
 
     impl Substate {
@@ -8389,6 +8455,12 @@ pub mod job_status {
     impl std::convert::From<std::string::String> for Substate {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Substate {
+        fn default() -> Self {
+            substate::UNSPECIFIED
         }
     }
 }
@@ -8512,7 +8584,7 @@ pub mod yarn_application {
 
     /// The application state, corresponding to
     /// \<code\>YarnProtos.YarnApplicationStateProto\</code\>.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -8562,6 +8634,12 @@ pub mod yarn_application {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -9463,7 +9541,7 @@ pub mod list_jobs_request {
     use super::*;
 
     /// A matcher that specifies categories of job states.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct JobStateMatcher(std::borrow::Cow<'static, str>);
 
     impl JobStateMatcher {
@@ -9496,6 +9574,12 @@ pub mod list_jobs_request {
     impl std::convert::From<std::string::String> for JobStateMatcher {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for JobStateMatcher {
+        fn default() -> Self {
+            job_state_matcher::ALL
         }
     }
 }
@@ -10088,7 +10172,7 @@ pub mod batch_operation_metadata {
     use super::*;
 
     /// Operation type for Batch resources
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct BatchOperationType(std::borrow::Cow<'static, str>);
 
     impl BatchOperationType {
@@ -10118,6 +10202,12 @@ pub mod batch_operation_metadata {
     impl std::convert::From<std::string::String> for BatchOperationType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for BatchOperationType {
+        fn default() -> Self {
+            batch_operation_type::BATCH_OPERATION_TYPE_UNSPECIFIED
         }
     }
 }
@@ -10248,7 +10338,7 @@ pub mod session_operation_metadata {
     use super::*;
 
     /// Operation type for Session resources
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SessionOperationType(std::borrow::Cow<'static, str>);
 
     impl SessionOperationType {
@@ -10284,6 +10374,12 @@ pub mod session_operation_metadata {
     impl std::convert::From<std::string::String> for SessionOperationType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SessionOperationType {
+        fn default() -> Self {
+            session_operation_type::SESSION_OPERATION_TYPE_UNSPECIFIED
         }
     }
 }
@@ -10358,7 +10454,7 @@ pub mod cluster_operation_status {
     use super::*;
 
     /// The operation state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -10393,6 +10489,12 @@ pub mod cluster_operation_status {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::UNKNOWN
         }
     }
 }
@@ -10662,7 +10764,7 @@ pub mod node_group_operation_metadata {
     use super::*;
 
     /// Operation type for node group resources.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct NodeGroupOperationType(std::borrow::Cow<'static, str>);
 
     impl NodeGroupOperationType {
@@ -10701,6 +10803,12 @@ pub mod node_group_operation_metadata {
     impl std::convert::From<std::string::String> for NodeGroupOperationType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for NodeGroupOperationType {
+        fn default() -> Self {
+            node_group_operation_type::NODE_GROUP_OPERATION_TYPE_UNSPECIFIED
         }
     }
 }
@@ -11885,7 +11993,7 @@ pub mod session {
     }
 
     /// The session state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -11926,6 +12034,12 @@ pub mod session {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -11988,7 +12102,7 @@ pub mod jupyter_config {
     use super::*;
 
     /// Jupyter kernel types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Kernel(std::borrow::Cow<'static, str>);
 
     impl Kernel {
@@ -12020,6 +12134,12 @@ pub mod jupyter_config {
     impl std::convert::From<std::string::String> for Kernel {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Kernel {
+        fn default() -> Self {
+            kernel::KERNEL_UNSPECIFIED
         }
     }
 }
@@ -13064,7 +13184,7 @@ pub mod gke_node_pool_target {
     /// workloads that are not associated with a node pool.
     ///
     /// [google.cloud.dataproc.v1.GkeNodePoolTarget]: crate::model::GkeNodePoolTarget
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Role(std::borrow::Cow<'static, str>);
 
     impl Role {
@@ -13107,6 +13227,12 @@ pub mod gke_node_pool_target {
     impl std::convert::From<std::string::String> for Role {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Role {
+        fn default() -> Self {
+            role::ROLE_UNSPECIFIED
         }
     }
 }
@@ -13472,7 +13598,7 @@ pub mod autotuning_config {
 
     /// Scenario represents a specific goal that autotuning will attempt to achieve
     /// by modifying workloads.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Scenario(std::borrow::Cow<'static, str>);
 
     impl Scenario {
@@ -13507,6 +13633,12 @@ pub mod autotuning_config {
     impl std::convert::From<std::string::String> for Scenario {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Scenario {
+        fn default() -> Self {
+            scenario::SCENARIO_UNSPECIFIED
         }
     }
 }
@@ -15019,7 +15151,7 @@ pub mod workflow_metadata {
     use super::*;
 
     /// The operation state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -15054,6 +15186,12 @@ pub mod workflow_metadata {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::UNKNOWN
         }
     }
 }
@@ -15222,7 +15360,7 @@ pub mod workflow_node {
     use super::*;
 
     /// The workflow node state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct NodeState(std::borrow::Cow<'static, str>);
 
     impl NodeState {
@@ -15264,6 +15402,12 @@ pub mod workflow_node {
     impl std::convert::From<std::string::String> for NodeState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for NodeState {
+        fn default() -> Self {
+            node_state::NODE_STATE_UNSPECIFIED
         }
     }
 }
@@ -15757,7 +15901,7 @@ impl wkt::message::Message for DeleteWorkflowTemplateRequest {
 }
 
 /// Cluster components that can be activated.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Component(std::borrow::Cow<'static, str>);
 
 impl Component {
@@ -15832,8 +15976,14 @@ impl std::convert::From<std::string::String> for Component {
     }
 }
 
+impl std::default::Default for Component {
+    fn default() -> Self {
+        component::COMPONENT_UNSPECIFIED
+    }
+}
+
 /// Actions in response to failure of a resource associated with a cluster.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct FailureAction(std::borrow::Cow<'static, str>);
 
 impl FailureAction {
@@ -15867,5 +16017,11 @@ pub mod failure_action {
 impl std::convert::From<std::string::String> for FailureAction {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for FailureAction {
+    fn default() -> Self {
+        failure_action::FAILURE_ACTION_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/datastream/v1/src/model.rs
+++ b/src/generated/cloud/datastream/v1/src/model.rs
@@ -3467,7 +3467,7 @@ pub mod private_connection {
     use super::*;
 
     /// Private Connection state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3508,6 +3508,12 @@ pub mod private_connection {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -6621,7 +6627,7 @@ pub mod json_file_format {
     use super::*;
 
     /// Schema file format.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SchemaFileFormat(std::borrow::Cow<'static, str>);
 
     impl SchemaFileFormat {
@@ -6657,8 +6663,14 @@ pub mod json_file_format {
         }
     }
 
+    impl std::default::Default for SchemaFileFormat {
+        fn default() -> Self {
+            schema_file_format::SCHEMA_FILE_FORMAT_UNSPECIFIED
+        }
+    }
+
     /// Json file compression.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct JsonCompression(std::borrow::Cow<'static, str>);
 
     impl JsonCompression {
@@ -6691,6 +6703,12 @@ pub mod json_file_format {
     impl std::convert::From<std::string::String> for JsonCompression {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for JsonCompression {
+        fn default() -> Self {
+            json_compression::JSON_COMPRESSION_UNSPECIFIED
         }
     }
 }
@@ -7853,7 +7871,7 @@ pub mod stream {
     }
 
     /// Stream state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -7907,6 +7925,12 @@ pub mod stream {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -8491,7 +8515,7 @@ pub mod backfill_job {
     use super::*;
 
     /// State of the stream object's backfill job.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -8544,8 +8568,14 @@ pub mod backfill_job {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Triggering reason for a backfill job.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Trigger(std::borrow::Cow<'static, str>);
 
     impl Trigger {
@@ -8578,6 +8608,12 @@ pub mod backfill_job {
     impl std::convert::From<std::string::String> for Trigger {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Trigger {
+        fn default() -> Self {
+            trigger::TRIGGER_UNSPECIFIED
         }
     }
 }
@@ -8768,7 +8804,7 @@ pub mod validation {
     use super::*;
 
     /// Validation execution state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -8806,6 +8842,12 @@ pub mod validation {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -8883,7 +8925,7 @@ pub mod validation_message {
     use super::*;
 
     /// Validation message level.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Level(std::borrow::Cow<'static, str>);
 
     impl Level {
@@ -8915,6 +8957,12 @@ pub mod validation_message {
     impl std::convert::From<std::string::String> for Level {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Level {
+        fn default() -> Self {
+            level::LEVEL_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/deploy/v1/src/model.rs
+++ b/src/generated/cloud/deploy/v1/src/model.rs
@@ -3157,7 +3157,7 @@ pub mod execution_config {
     use super::*;
 
     /// Possible usages of this configuration.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ExecutionEnvironmentUsage(std::borrow::Cow<'static, str>);
 
     impl ExecutionEnvironmentUsage {
@@ -3201,6 +3201,12 @@ pub mod execution_config {
     impl std::convert::From<std::string::String> for ExecutionEnvironmentUsage {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ExecutionEnvironmentUsage {
+        fn default() -> Self {
+            execution_environment_usage::EXECUTION_ENVIRONMENT_USAGE_UNSPECIFIED
         }
     }
 
@@ -5243,7 +5249,7 @@ pub mod deploy_policy {
 
     /// What invoked the action. Filters enforcing the policy depending on what
     /// invoked the action.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Invoker(std::borrow::Cow<'static, str>);
 
     impl Invoker {
@@ -5276,6 +5282,12 @@ pub mod deploy_policy {
     impl std::convert::From<std::string::String> for Invoker {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Invoker {
+        fn default() -> Self {
+            invoker::INVOKER_UNSPECIFIED
         }
     }
 }
@@ -5588,7 +5600,7 @@ pub mod rollout_restriction {
     use super::*;
 
     /// Rollout actions to be restricted as part of the policy.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RolloutActions(std::borrow::Cow<'static, str>);
 
     impl RolloutActions {
@@ -5639,6 +5651,12 @@ pub mod rollout_restriction {
     impl std::convert::From<std::string::String> for RolloutActions {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RolloutActions {
+        fn default() -> Self {
+            rollout_actions::ROLLOUT_ACTIONS_UNSPECIFIED
         }
     }
 }
@@ -6378,7 +6396,7 @@ pub mod release {
         use super::*;
 
         /// Valid states of the render operation.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct TargetRenderState(std::borrow::Cow<'static, str>);
 
         impl TargetRenderState {
@@ -6417,8 +6435,14 @@ pub mod release {
             }
         }
 
+        impl std::default::Default for TargetRenderState {
+            fn default() -> Self {
+                target_render_state::TARGET_RENDER_STATE_UNSPECIFIED
+            }
+        }
+
         /// Well-known rendering failures.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct FailureCause(std::borrow::Cow<'static, str>);
 
         impl FailureCause {
@@ -6481,6 +6505,12 @@ pub mod release {
         impl std::convert::From<std::string::String> for FailureCause {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for FailureCause {
+            fn default() -> Self {
+                failure_cause::FAILURE_CAUSE_UNSPECIFIED
             }
         }
     }
@@ -6648,7 +6678,7 @@ pub mod release {
     }
 
     /// Valid states of the render operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RenderState(std::borrow::Cow<'static, str>);
 
     impl RenderState {
@@ -6684,6 +6714,12 @@ pub mod release {
     impl std::convert::From<std::string::String> for RenderState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RenderState {
+        fn default() -> Self {
+            render_state::RENDER_STATE_UNSPECIFIED
         }
     }
 }
@@ -8090,7 +8126,7 @@ pub mod rollout {
     use super::*;
 
     /// Valid approval states of a `Rollout`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ApprovalState(std::borrow::Cow<'static, str>);
 
     impl ApprovalState {
@@ -8133,8 +8169,14 @@ pub mod rollout {
         }
     }
 
+    impl std::default::Default for ApprovalState {
+        fn default() -> Self {
+            approval_state::APPROVAL_STATE_UNSPECIFIED
+        }
+    }
+
     /// Valid states of a `Rollout`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -8194,8 +8236,14 @@ pub mod rollout {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Well-known rollout failures.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct FailureCause(std::borrow::Cow<'static, str>);
 
     impl FailureCause {
@@ -8254,6 +8302,12 @@ pub mod rollout {
     impl std::convert::From<std::string::String> for FailureCause {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for FailureCause {
+        fn default() -> Self {
+            failure_cause::FAILURE_CAUSE_UNSPECIFIED
         }
     }
 }
@@ -8713,7 +8767,7 @@ pub mod phase {
     use super::*;
 
     /// Valid states of a Phase.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -8757,6 +8811,12 @@ pub mod phase {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -9133,7 +9193,7 @@ pub mod job {
     use super::*;
 
     /// Valid states of a Job.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -9183,6 +9243,12 @@ pub mod job {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -10504,7 +10570,7 @@ pub mod job_run {
     use super::*;
 
     /// Valid states of a `JobRun`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -10545,6 +10611,12 @@ pub mod job_run {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -10658,7 +10730,7 @@ pub mod deploy_job_run {
     use super::*;
 
     /// Well-known deploy failures.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct FailureCause(std::borrow::Cow<'static, str>);
 
     impl FailureCause {
@@ -10712,6 +10784,12 @@ pub mod deploy_job_run {
     impl std::convert::From<std::string::String> for FailureCause {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for FailureCause {
+        fn default() -> Self {
+            failure_cause::FAILURE_CAUSE_UNSPECIFIED
         }
     }
 }
@@ -10798,7 +10876,7 @@ pub mod verify_job_run {
     use super::*;
 
     /// Well-known verify failures.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct FailureCause(std::borrow::Cow<'static, str>);
 
     impl FailureCause {
@@ -10847,6 +10925,12 @@ pub mod verify_job_run {
     impl std::convert::From<std::string::String> for FailureCause {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for FailureCause {
+        fn default() -> Self {
+            failure_cause::FAILURE_CAUSE_UNSPECIFIED
         }
     }
 }
@@ -10914,7 +10998,7 @@ pub mod predeploy_job_run {
     use super::*;
 
     /// Well-known predeploy failures.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct FailureCause(std::borrow::Cow<'static, str>);
 
     impl FailureCause {
@@ -10959,6 +11043,12 @@ pub mod predeploy_job_run {
     impl std::convert::From<std::string::String> for FailureCause {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for FailureCause {
+        fn default() -> Self {
+            failure_cause::FAILURE_CAUSE_UNSPECIFIED
         }
     }
 }
@@ -11026,7 +11116,7 @@ pub mod postdeploy_job_run {
     use super::*;
 
     /// Well-known postdeploy failures.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct FailureCause(std::borrow::Cow<'static, str>);
 
     impl FailureCause {
@@ -11071,6 +11161,12 @@ pub mod postdeploy_job_run {
     impl std::convert::From<std::string::String> for FailureCause {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for FailureCause {
+        fn default() -> Self {
+            failure_cause::FAILURE_CAUSE_UNSPECIFIED
         }
     }
 }
@@ -13573,7 +13669,7 @@ pub mod automation_run {
     use super::*;
 
     /// Valid state of an `AutomationRun`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -13617,6 +13713,12 @@ pub mod automation_run {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -14730,7 +14832,7 @@ pub mod deploy_policy_evaluation_event {
     use super::*;
 
     /// The policy verdict of the request.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PolicyVerdict(std::borrow::Cow<'static, str>);
 
     impl PolicyVerdict {
@@ -14768,9 +14870,15 @@ pub mod deploy_policy_evaluation_event {
         }
     }
 
+    impl std::default::Default for PolicyVerdict {
+        fn default() -> Self {
+            policy_verdict::POLICY_VERDICT_UNSPECIFIED
+        }
+    }
+
     /// Things that could have overridden the policy verdict. When overrides are
     /// used, the request will be allowed even if it is DENIED_BY_POLICY.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PolicyVerdictOverride(std::borrow::Cow<'static, str>);
 
     impl PolicyVerdictOverride {
@@ -14805,6 +14913,12 @@ pub mod deploy_policy_evaluation_event {
     impl std::convert::From<std::string::String> for PolicyVerdictOverride {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PolicyVerdictOverride {
+        fn default() -> Self {
+            policy_verdict_override::POLICY_VERDICT_OVERRIDE_UNSPECIFIED
         }
     }
 }
@@ -15344,7 +15458,7 @@ pub mod rollout_update_event {
     use super::*;
 
     /// RolloutUpdateType indicates the type of the rollout update.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RolloutUpdateType(std::borrow::Cow<'static, str>);
 
     impl RolloutUpdateType {
@@ -15413,6 +15527,12 @@ pub mod rollout_update_event {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for RolloutUpdateType {
+        fn default() -> Self {
+            rollout_update_type::ROLLOUT_UPDATE_TYPE_UNSPECIFIED
+        }
+    }
 }
 
 /// Payload proto for "clouddeploy.googleapis.com/target_notification"
@@ -15467,7 +15587,7 @@ impl wkt::message::Message for TargetNotificationEvent {
 }
 
 /// The support state of a specific Skaffold version.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SkaffoldSupportState(std::borrow::Cow<'static, str>);
 
 impl SkaffoldSupportState {
@@ -15509,8 +15629,14 @@ impl std::convert::From<std::string::String> for SkaffoldSupportState {
     }
 }
 
+impl std::default::Default for SkaffoldSupportState {
+    fn default() -> Self {
+        skaffold_support_state::SKAFFOLD_SUPPORT_STATE_UNSPECIFIED
+    }
+}
+
 /// The pattern of how wait time is increased.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct BackoffMode(std::borrow::Cow<'static, str>);
 
 impl BackoffMode {
@@ -15545,8 +15671,14 @@ impl std::convert::From<std::string::String> for BackoffMode {
     }
 }
 
+impl std::default::Default for BackoffMode {
+    fn default() -> Self {
+        backoff_mode::BACKOFF_MODE_UNSPECIFIED
+    }
+}
+
 /// Valid state of a repair attempt.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct RepairState(std::borrow::Cow<'static, str>);
 
 impl RepairState {
@@ -15593,8 +15725,14 @@ impl std::convert::From<std::string::String> for RepairState {
     }
 }
 
+impl std::default::Default for RepairState {
+    fn default() -> Self {
+        repair_state::REPAIR_STATE_UNSPECIFIED
+    }
+}
+
 /// Type indicates the type of the log entry and can be used as a filter.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Type(std::borrow::Cow<'static, str>);
 
 impl Type {
@@ -15645,5 +15783,11 @@ pub mod r#type {
 impl std::convert::From<std::string::String> for Type {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for Type {
+    fn default() -> Self {
+        r#type::TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/developerconnect/v1/src/model.rs
+++ b/src/generated/cloud/developerconnect/v1/src/model.rs
@@ -461,7 +461,7 @@ pub mod installation_state {
     use super::*;
 
     /// Stage of the installation process.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Stage(std::borrow::Cow<'static, str>);
 
     impl Stage {
@@ -500,6 +500,12 @@ pub mod installation_state {
     impl std::convert::From<std::string::String> for Stage {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Stage {
+        fn default() -> Self {
+            stage::STAGE_UNSPECIFIED
         }
     }
 }
@@ -584,7 +590,7 @@ pub mod git_hub_config {
 
     /// Represents the various GitHub Applications that can be installed to a
     /// GitHub user or organization and used with Developer Connect.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct GitHubApp(std::borrow::Cow<'static, str>);
 
     impl GitHubApp {
@@ -616,6 +622,12 @@ pub mod git_hub_config {
     impl std::convert::From<std::string::String> for GitHubApp {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for GitHubApp {
+        fn default() -> Self {
+            git_hub_app::GIT_HUB_APP_UNSPECIFIED
         }
     }
 }
@@ -2589,7 +2601,7 @@ pub mod fetch_git_refs_request {
     use super::*;
 
     /// Type of refs.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RefType(std::borrow::Cow<'static, str>);
 
     impl RefType {
@@ -2621,6 +2633,12 @@ pub mod fetch_git_refs_request {
     impl std::convert::From<std::string::String> for RefType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RefType {
+        fn default() -> Self {
+            ref_type::REF_TYPE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/dialogflow/cx/v3/src/model.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/model.rs
@@ -1512,7 +1512,7 @@ pub mod export_agent_request {
     }
 
     /// Data format of the exported agent.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DataFormat(std::borrow::Cow<'static, str>);
 
     impl DataFormat {
@@ -1544,6 +1544,12 @@ pub mod export_agent_request {
     impl std::convert::From<std::string::String> for DataFormat {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DataFormat {
+        fn default() -> Self {
+            data_format::DATA_FORMAT_UNSPECIFIED
         }
     }
 }
@@ -1869,7 +1875,7 @@ pub mod restore_agent_request {
     }
 
     /// Restore option.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RestoreOption(std::borrow::Cow<'static, str>);
 
     impl RestoreOption {
@@ -1905,6 +1911,12 @@ pub mod restore_agent_request {
     impl std::convert::From<std::string::String> for RestoreOption {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RestoreOption {
+        fn default() -> Self {
+            restore_option::RESTORE_OPTION_UNSPECIFIED
         }
     }
 
@@ -3538,7 +3550,7 @@ pub mod data_store_connection_signals {
         use super::*;
 
         /// Represents the decision of the grounding check.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct GroundingDecision(std::borrow::Cow<'static, str>);
 
         impl GroundingDecision {
@@ -3576,8 +3588,14 @@ pub mod data_store_connection_signals {
             }
         }
 
+        impl std::default::Default for GroundingDecision {
+            fn default() -> Self {
+                grounding_decision::GROUNDING_DECISION_UNSPECIFIED
+            }
+        }
+
         /// Grounding score buckets.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct GroundingScoreBucket(std::borrow::Cow<'static, str>);
 
         impl GroundingScoreBucket {
@@ -3619,6 +3637,12 @@ pub mod data_store_connection_signals {
         impl std::convert::From<std::string::String> for GroundingScoreBucket {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for GroundingScoreBucket {
+            fn default() -> Self {
+                grounding_score_bucket::GROUNDING_SCORE_BUCKET_UNSPECIFIED
             }
         }
     }
@@ -3696,7 +3720,7 @@ pub mod data_store_connection_signals {
         /// Safety decision.
         /// All kinds of check are incorporated into this final decision, including
         /// banned phrases check.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct SafetyDecision(std::borrow::Cow<'static, str>);
 
         impl SafetyDecision {
@@ -3734,8 +3758,14 @@ pub mod data_store_connection_signals {
             }
         }
 
+        impl std::default::Default for SafetyDecision {
+            fn default() -> Self {
+                safety_decision::SAFETY_DECISION_UNSPECIFIED
+            }
+        }
+
         /// Specifies banned phrase match subject.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct BannedPhraseMatch(std::borrow::Cow<'static, str>);
 
         impl BannedPhraseMatch {
@@ -3774,6 +3804,12 @@ pub mod data_store_connection_signals {
         impl std::convert::From<std::string::String> for BannedPhraseMatch {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for BannedPhraseMatch {
+            fn default() -> Self {
+                banned_phrase_match::BANNED_PHRASE_MATCH_UNSPECIFIED
             }
         }
     }
@@ -3932,7 +3968,7 @@ pub mod deployment {
     }
 
     /// The state of the deployment.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3967,6 +4003,12 @@ pub mod deployment {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -4380,7 +4422,7 @@ pub mod entity_type {
     }
 
     /// Represents kinds of entities.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Kind(std::borrow::Cow<'static, str>);
 
     impl Kind {
@@ -4422,10 +4464,16 @@ pub mod entity_type {
         }
     }
 
+    impl std::default::Default for Kind {
+        fn default() -> Self {
+            kind::KIND_UNSPECIFIED
+        }
+    }
+
     /// Represents different entity type expansion modes. Automated expansion
     /// allows an agent to recognize values that have not been explicitly listed in
     /// the entity (for example, new kinds of shopping list items).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AutoExpansionMode(std::borrow::Cow<'static, str>);
 
     impl AutoExpansionMode {
@@ -4457,6 +4505,12 @@ pub mod entity_type {
     impl std::convert::From<std::string::String> for AutoExpansionMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AutoExpansionMode {
+        fn default() -> Self {
+            auto_expansion_mode::AUTO_EXPANSION_MODE_UNSPECIFIED
         }
     }
 }
@@ -4625,7 +4679,7 @@ pub mod export_entity_types_request {
     use super::*;
 
     /// Data format of the exported entity types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DataFormat(std::borrow::Cow<'static, str>);
 
     impl DataFormat {
@@ -4657,6 +4711,12 @@ pub mod export_entity_types_request {
     impl std::convert::From<std::string::String> for DataFormat {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DataFormat {
+        fn default() -> Self {
+            data_format::DATA_FORMAT_UNSPECIFIED
         }
     }
 
@@ -4986,7 +5046,7 @@ pub mod import_entity_types_request {
     use super::*;
 
     /// Merge option when display name conflicts exist during import.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MergeOption(std::borrow::Cow<'static, str>);
 
     impl MergeOption {
@@ -5033,6 +5093,12 @@ pub mod import_entity_types_request {
     impl std::convert::From<std::string::String> for MergeOption {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for MergeOption {
+        fn default() -> Self {
+            merge_option::MERGE_OPTION_UNSPECIFIED
         }
     }
 
@@ -6334,7 +6400,7 @@ pub mod continuous_test_result {
     use super::*;
 
     /// The overall result for a continuous test run in an agent environment.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AggregatedTestResult(std::borrow::Cow<'static, str>);
 
     impl AggregatedTestResult {
@@ -6367,6 +6433,12 @@ pub mod continuous_test_result {
     impl std::convert::From<std::string::String> for AggregatedTestResult {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AggregatedTestResult {
+        fn default() -> Self {
+            aggregated_test_result::AGGREGATED_TEST_RESULT_UNSPECIFIED
         }
     }
 }
@@ -7376,7 +7448,7 @@ pub mod experiment {
         }
 
         /// Types of ratio-based metric for Dialogflow experiment.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct MetricType(std::borrow::Cow<'static, str>);
 
         impl MetricType {
@@ -7424,8 +7496,14 @@ pub mod experiment {
             }
         }
 
+        impl std::default::Default for MetricType {
+            fn default() -> Self {
+                metric_type::METRIC_UNSPECIFIED
+            }
+        }
+
         /// Types of count-based metric for Dialogflow experiment.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct CountType(std::borrow::Cow<'static, str>);
 
         impl CountType {
@@ -7462,10 +7540,16 @@ pub mod experiment {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for CountType {
+            fn default() -> Self {
+                count_type::COUNT_TYPE_UNSPECIFIED
+            }
+        }
     }
 
     /// The state of the experiment.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -7503,6 +7587,12 @@ pub mod experiment {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -8299,7 +8389,7 @@ pub mod nlu_settings {
     use super::*;
 
     /// NLU model type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ModelType(std::borrow::Cow<'static, str>);
 
     impl ModelType {
@@ -8334,8 +8424,14 @@ pub mod nlu_settings {
         }
     }
 
+    impl std::default::Default for ModelType {
+        fn default() -> Self {
+            model_type::MODEL_TYPE_UNSPECIFIED
+        }
+    }
+
     /// NLU model training mode.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ModelTrainingMode(std::borrow::Cow<'static, str>);
 
     impl ModelTrainingMode {
@@ -8372,6 +8468,12 @@ pub mod nlu_settings {
     impl std::convert::From<std::string::String> for ModelTrainingMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ModelTrainingMode {
+        fn default() -> Self {
+            model_training_mode::MODEL_TRAINING_MODE_UNSPECIFIED
         }
     }
 }
@@ -9367,7 +9469,7 @@ pub mod import_flow_request {
     use super::*;
 
     /// Import option.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ImportOption(std::borrow::Cow<'static, str>);
 
     impl ImportOption {
@@ -9404,6 +9506,12 @@ pub mod import_flow_request {
     impl std::convert::From<std::string::String> for ImportOption {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ImportOption {
+        fn default() -> Self {
+            import_option::IMPORT_OPTION_UNSPECIFIED
         }
     }
 
@@ -11937,7 +12045,7 @@ pub mod import_intents_request {
     use super::*;
 
     /// Merge option when display name conflicts exist during import.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MergeOption(std::borrow::Cow<'static, str>);
 
     impl MergeOption {
@@ -11990,6 +12098,12 @@ pub mod import_intents_request {
     impl std::convert::From<std::string::String> for MergeOption {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for MergeOption {
+        fn default() -> Self {
+            merge_option::MERGE_OPTION_UNSPECIFIED
         }
     }
 
@@ -12288,7 +12402,7 @@ pub mod export_intents_request {
     use super::*;
 
     /// Data format of the exported intents.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DataFormat(std::borrow::Cow<'static, str>);
 
     impl DataFormat {
@@ -12323,6 +12437,12 @@ pub mod export_intents_request {
     impl std::convert::From<std::string::String> for DataFormat {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DataFormat {
+        fn default() -> Self {
+            data_format::DATA_FORMAT_UNSPECIFIED
         }
     }
 
@@ -14950,7 +15070,7 @@ pub mod response_message {
     }
 
     /// Represents different response types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ResponseType(std::borrow::Cow<'static, str>);
 
     impl ResponseType {
@@ -14999,6 +15119,12 @@ pub mod response_message {
     impl std::convert::From<std::string::String> for ResponseType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ResponseType {
+        fn default() -> Self {
+            response_type::RESPONSE_TYPE_UNSPECIFIED
         }
     }
 
@@ -15795,7 +15921,7 @@ pub mod security_settings {
 
         /// File format for exported audio file. Currently only in telephony
         /// recordings.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct AudioFormat(std::borrow::Cow<'static, str>);
 
         impl AudioFormat {
@@ -15833,6 +15959,12 @@ pub mod security_settings {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for AudioFormat {
+            fn default() -> Self {
+                audio_format::AUDIO_FORMAT_UNSPECIFIED
+            }
+        }
     }
 
     /// Settings for exporting conversations to
@@ -15866,7 +15998,7 @@ pub mod security_settings {
     }
 
     /// Defines how we redact data.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RedactionStrategy(std::borrow::Cow<'static, str>);
 
     impl RedactionStrategy {
@@ -15900,8 +16032,14 @@ pub mod security_settings {
         }
     }
 
+    impl std::default::Default for RedactionStrategy {
+        fn default() -> Self {
+            redaction_strategy::REDACTION_STRATEGY_UNSPECIFIED
+        }
+    }
+
     /// Defines what types of data to redact.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RedactionScope(std::borrow::Cow<'static, str>);
 
     impl RedactionScope {
@@ -15936,8 +16074,14 @@ pub mod security_settings {
         }
     }
 
+    impl std::default::Default for RedactionScope {
+        fn default() -> Self {
+            redaction_scope::REDACTION_SCOPE_UNSPECIFIED
+        }
+    }
+
     /// Defines how long we retain persisted data that contains sensitive info.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RetentionStrategy(std::borrow::Cow<'static, str>);
 
     impl RetentionStrategy {
@@ -15973,8 +16117,14 @@ pub mod security_settings {
         }
     }
 
+    impl std::default::Default for RetentionStrategy {
+        fn default() -> Self {
+            retention_strategy::RETENTION_STRATEGY_UNSPECIFIED
+        }
+    }
+
     /// Type of data we purge after retention settings triggers purge.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PurgeDataType(std::borrow::Cow<'static, str>);
 
     impl PurgeDataType {
@@ -16005,6 +16155,12 @@ pub mod security_settings {
     impl std::convert::From<std::string::String> for PurgeDataType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PurgeDataType {
+        fn default() -> Self {
+            purge_data_type::PURGE_DATA_TYPE_UNSPECIFIED
         }
     }
 
@@ -16144,7 +16300,7 @@ pub mod answer_feedback {
     }
 
     /// Represents thumbs up/down rating provided by user about a response.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Rating(std::borrow::Cow<'static, str>);
 
     impl Rating {
@@ -16176,6 +16332,12 @@ pub mod answer_feedback {
     impl std::convert::From<std::string::String> for Rating {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Rating {
+        fn default() -> Self {
+            rating::RATING_UNSPECIFIED
         }
     }
 }
@@ -16451,7 +16613,7 @@ pub mod detect_intent_response {
     use super::*;
 
     /// Represents different DetectIntentResponse types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ResponseType(std::borrow::Cow<'static, str>);
 
     impl ResponseType {
@@ -16486,6 +16648,12 @@ pub mod detect_intent_response {
     impl std::convert::From<std::string::String> for ResponseType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ResponseType {
+        fn default() -> Self {
+            response_type::RESPONSE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -17233,7 +17401,7 @@ pub mod streaming_recognition_result {
     use super::*;
 
     /// Type of the response message.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MessageType(std::borrow::Cow<'static, str>);
 
     impl MessageType {
@@ -17276,6 +17444,12 @@ pub mod streaming_recognition_result {
     impl std::convert::From<std::string::String> for MessageType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for MessageType {
+        fn default() -> Self {
+            message_type::MESSAGE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -17907,7 +18081,7 @@ pub mod boost_spec {
 
             /// The attribute(or function) for which the custom ranking is to be
             /// applied.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct AttributeType(std::borrow::Cow<'static, str>);
 
             impl AttributeType {
@@ -17951,9 +18125,15 @@ pub mod boost_spec {
                 }
             }
 
+            impl std::default::Default for AttributeType {
+                fn default() -> Self {
+                    attribute_type::ATTRIBUTE_TYPE_UNSPECIFIED
+                }
+            }
+
             /// The interpolation type to be applied. Default will be linear
             /// (Piecewise Linear).
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct InterpolationType(std::borrow::Cow<'static, str>);
 
             impl InterpolationType {
@@ -17984,6 +18164,12 @@ pub mod boost_spec {
             impl std::convert::From<std::string::String> for InterpolationType {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for InterpolationType {
+                fn default() -> Self {
+                    interpolation_type::INTERPOLATION_TYPE_UNSPECIFIED
                 }
             }
         }
@@ -19127,7 +19313,7 @@ pub mod r#match {
     use super::*;
 
     /// Type of a Match.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MatchType(std::borrow::Cow<'static, str>);
 
     impl MatchType {
@@ -19177,6 +19363,12 @@ pub mod r#match {
     impl std::convert::From<std::string::String> for MatchType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for MatchType {
+        fn default() -> Self {
+            match_type::MATCH_TYPE_UNSPECIFIED
         }
     }
 }
@@ -19732,7 +19924,7 @@ pub mod session_entity_type {
     use super::*;
 
     /// The types of modifications for the session entity type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EntityOverrideMode(std::borrow::Cow<'static, str>);
 
     impl EntityOverrideMode {
@@ -19779,6 +19971,12 @@ pub mod session_entity_type {
     impl std::convert::From<std::string::String> for EntityOverrideMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EntityOverrideMode {
+        fn default() -> Self {
+            entity_override_mode::ENTITY_OVERRIDE_MODE_UNSPECIFIED
         }
     }
 }
@@ -20680,7 +20878,7 @@ pub mod test_run_difference {
     use super::*;
 
     /// What part of the message replay differs from the test case.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DiffType(std::borrow::Cow<'static, str>);
 
     impl DiffType {
@@ -20721,6 +20919,12 @@ pub mod test_run_difference {
     impl std::convert::From<std::string::String> for DiffType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DiffType {
+        fn default() -> Self {
+            diff_type::DIFF_TYPE_UNSPECIFIED
         }
     }
 }
@@ -21368,7 +21572,7 @@ pub mod calculate_coverage_request {
     use super::*;
 
     /// The type of coverage score requested.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CoverageType(std::borrow::Cow<'static, str>);
 
     impl CoverageType {
@@ -21405,6 +21609,12 @@ pub mod calculate_coverage_request {
     impl std::convert::From<std::string::String> for CoverageType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CoverageType {
+        fn default() -> Self {
+            coverage_type::COVERAGE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -21646,7 +21856,7 @@ pub mod list_test_cases_request {
     use super::*;
 
     /// Specifies how much test case information to include in the response.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TestCaseView(std::borrow::Cow<'static, str>);
 
     impl TestCaseView {
@@ -21681,6 +21891,12 @@ pub mod list_test_cases_request {
     impl std::convert::From<std::string::String> for TestCaseView {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for TestCaseView {
+        fn default() -> Self {
+            test_case_view::TEST_CASE_VIEW_UNSPECIFIED
         }
     }
 }
@@ -22588,7 +22804,7 @@ pub mod export_test_cases_request {
     use super::*;
 
     /// Data format of the exported test cases.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DataFormat(std::borrow::Cow<'static, str>);
 
     impl DataFormat {
@@ -22620,6 +22836,12 @@ pub mod export_test_cases_request {
     impl std::convert::From<std::string::String> for DataFormat {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DataFormat {
+        fn default() -> Self {
+            data_format::DATA_FORMAT_UNSPECIFIED
         }
     }
 
@@ -23518,7 +23740,7 @@ pub mod validation_message {
     use super::*;
 
     /// Resource types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ResourceType(std::borrow::Cow<'static, str>);
 
     impl ResourceType {
@@ -23594,8 +23816,14 @@ pub mod validation_message {
         }
     }
 
+    impl std::default::Default for ResourceType {
+        fn default() -> Self {
+            resource_type::RESOURCE_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Severity level.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Severity(std::borrow::Cow<'static, str>);
 
     impl Severity {
@@ -23630,6 +23858,12 @@ pub mod validation_message {
     impl std::convert::From<std::string::String> for Severity {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Severity {
+        fn default() -> Self {
+            severity::SEVERITY_UNSPECIFIED
         }
     }
 }
@@ -23804,7 +24038,7 @@ pub mod version {
     use super::*;
 
     /// The state of the version.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -23839,6 +24073,12 @@ pub mod version {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -24737,7 +24977,7 @@ pub mod webhook {
 
         /// Indicate the auth token type generated from the [Diglogflow service
         /// agent](https://cloud.google.com/iam/docs/service-agents#dialogflow-service-agent).
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct ServiceAgentAuth(std::borrow::Cow<'static, str>);
 
         impl ServiceAgentAuth {
@@ -24784,8 +25024,14 @@ pub mod webhook {
             }
         }
 
+        impl std::default::Default for ServiceAgentAuth {
+            fn default() -> Self {
+                service_agent_auth::SERVICE_AGENT_AUTH_UNSPECIFIED
+            }
+        }
+
         /// Represents the type of webhook configuration.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct WebhookType(std::borrow::Cow<'static, str>);
 
         impl WebhookType {
@@ -24821,8 +25067,14 @@ pub mod webhook {
             }
         }
 
+        impl std::default::Default for WebhookType {
+            fn default() -> Self {
+                webhook_type::WEBHOOK_TYPE_UNSPECIFIED
+            }
+        }
+
         /// HTTP method to use when calling webhooks.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct HttpMethod(std::borrow::Cow<'static, str>);
 
         impl HttpMethod {
@@ -24870,6 +25122,12 @@ pub mod webhook {
         impl std::convert::From<std::string::String> for HttpMethod {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for HttpMethod {
+            fn default() -> Self {
+                http_method::HTTP_METHOD_UNSPECIFIED
             }
         }
     }
@@ -26007,7 +26265,7 @@ pub mod webhook_response {
         use super::*;
 
         /// Defines merge behavior for `messages`.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct MergeBehavior(std::borrow::Cow<'static, str>);
 
         impl MergeBehavior {
@@ -26042,6 +26300,12 @@ pub mod webhook_response {
         impl std::convert::From<std::string::String> for MergeBehavior {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for MergeBehavior {
+            fn default() -> Self {
+                merge_behavior::MERGE_BEHAVIOR_UNSPECIFIED
             }
         }
     }
@@ -26314,7 +26578,7 @@ pub mod page_info {
             use super::*;
 
             /// Represents the state of a parameter.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct ParameterState(std::borrow::Cow<'static, str>);
 
             impl ParameterState {
@@ -26352,6 +26616,12 @@ pub mod page_info {
             impl std::convert::From<std::string::String> for ParameterState {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for ParameterState {
+                fn default() -> Self {
+                    parameter_state::PARAMETER_STATE_UNSPECIFIED
                 }
             }
         }
@@ -26490,7 +26760,7 @@ impl wkt::message::Message for LanguageInfo {
 /// [Cloud Speech API
 /// documentation](https://cloud.google.com/speech-to-text/docs/basics) for more
 /// details.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct AudioEncoding(std::borrow::Cow<'static, str>);
 
 impl AudioEncoding {
@@ -26565,6 +26835,12 @@ impl std::convert::From<std::string::String> for AudioEncoding {
     }
 }
 
+impl std::default::Default for AudioEncoding {
+    fn default() -> Self {
+        audio_encoding::AUDIO_ENCODING_UNSPECIFIED
+    }
+}
+
 /// Variant of the specified [Speech
 /// model][google.cloud.dialogflow.cx.v3.InputAudioConfig.model] to use.
 ///
@@ -26575,7 +26851,7 @@ impl std::convert::From<std::string::String> for AudioEncoding {
 /// you will generally receive higher quality results than for a standard model.
 ///
 /// [google.cloud.dialogflow.cx.v3.InputAudioConfig.model]: crate::model::InputAudioConfig::model
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SpeechModelVariant(std::borrow::Cow<'static, str>);
 
 impl SpeechModelVariant {
@@ -26633,9 +26909,15 @@ impl std::convert::From<std::string::String> for SpeechModelVariant {
     }
 }
 
+impl std::default::Default for SpeechModelVariant {
+    fn default() -> Self {
+        speech_model_variant::SPEECH_MODEL_VARIANT_UNSPECIFIED
+    }
+}
+
 /// Gender of the voice as described in
 /// [SSML voice element](https://www.w3.org/TR/speech-synthesis11/#edef_voice).
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SsmlVoiceGender(std::borrow::Cow<'static, str>);
 
 impl SsmlVoiceGender {
@@ -26678,8 +26960,14 @@ impl std::convert::From<std::string::String> for SsmlVoiceGender {
     }
 }
 
+impl std::default::Default for SsmlVoiceGender {
+    fn default() -> Self {
+        ssml_voice_gender::SSML_VOICE_GENDER_UNSPECIFIED
+    }
+}
+
 /// Audio encoding of the output audio format in Text-To-Speech.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct OutputAudioEncoding(std::borrow::Cow<'static, str>);
 
 impl OutputAudioEncoding {
@@ -26737,9 +27025,15 @@ impl std::convert::From<std::string::String> for OutputAudioEncoding {
     }
 }
 
+impl std::default::Default for OutputAudioEncoding {
+    fn default() -> Self {
+        output_audio_encoding::OUTPUT_AUDIO_ENCODING_UNSPECIFIED
+    }
+}
+
 /// Type of a data store.
 /// Determines how search is performed in the data store.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DataStoreType(std::borrow::Cow<'static, str>);
 
 impl DataStoreType {
@@ -26779,10 +27073,16 @@ impl std::convert::From<std::string::String> for DataStoreType {
     }
 }
 
+impl std::default::Default for DataStoreType {
+    fn default() -> Self {
+        data_store_type::DATA_STORE_TYPE_UNSPECIFIED
+    }
+}
+
 /// Import strategies for the conflict resolution of resources (i.e. intents,
 /// entities, and webhooks) with identical display names during import
 /// operations.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ImportStrategy(std::borrow::Cow<'static, str>);
 
 impl ImportStrategy {
@@ -26833,10 +27133,16 @@ impl std::convert::From<std::string::String> for ImportStrategy {
     }
 }
 
+impl std::default::Default for ImportStrategy {
+    fn default() -> Self {
+        import_strategy::IMPORT_STRATEGY_UNSPECIFIED
+    }
+}
+
 /// Represents the options for views of an intent.
 /// An intent can be a sizable object. Therefore, we provide a resource view that
 /// does not return training phrases in the response.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct IntentView(std::borrow::Cow<'static, str>);
 
 impl IntentView {
@@ -26871,8 +27177,14 @@ impl std::convert::From<std::string::String> for IntentView {
     }
 }
 
+impl std::default::Default for IntentView {
+    fn default() -> Self {
+        intent_view::INTENT_VIEW_UNSPECIFIED
+    }
+}
+
 /// The test result for a test case and an agent environment.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TestResult(std::borrow::Cow<'static, str>);
 
 impl TestResult {
@@ -26904,5 +27216,11 @@ pub mod test_result {
 impl std::convert::From<std::string::String> for TestResult {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for TestResult {
+    fn default() -> Self {
+        test_result::TEST_RESULT_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/dialogflow/v2/src/model.rs
+++ b/src/generated/cloud/dialogflow/v2/src/model.rs
@@ -218,7 +218,7 @@ pub mod agent {
     use super::*;
 
     /// Match mode determines how intents are detected from user queries.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MatchMode(std::borrow::Cow<'static, str>);
 
     impl MatchMode {
@@ -255,8 +255,14 @@ pub mod agent {
         }
     }
 
+    impl std::default::Default for MatchMode {
+        fn default() -> Self {
+            match_mode::MATCH_MODE_UNSPECIFIED
+        }
+    }
+
     /// API version for the agent.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ApiVersion(std::borrow::Cow<'static, str>);
 
     impl ApiVersion {
@@ -294,8 +300,14 @@ pub mod agent {
         }
     }
 
+    impl std::default::Default for ApiVersion {
+        fn default() -> Self {
+            api_version::API_VERSION_UNSPECIFIED
+        }
+    }
+
     /// Represents the agent tier.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Tier(std::borrow::Cow<'static, str>);
 
     impl Tier {
@@ -331,6 +343,12 @@ pub mod agent {
     impl std::convert::From<std::string::String> for Tier {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Tier {
+        fn default() -> Self {
+            tier::TIER_UNSPECIFIED
         }
     }
 }
@@ -1509,7 +1527,7 @@ pub mod answer_feedback {
     use super::*;
 
     /// The correctness level of an answer.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CorrectnessLevel(std::borrow::Cow<'static, str>);
 
     impl CorrectnessLevel {
@@ -1545,6 +1563,12 @@ pub mod answer_feedback {
     impl std::convert::From<std::string::String> for CorrectnessLevel {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CorrectnessLevel {
+        fn default() -> Self {
+            correctness_level::CORRECTNESS_LEVEL_UNSPECIFIED
         }
     }
 
@@ -1887,7 +1911,7 @@ pub mod agent_assistant_feedback {
     }
 
     /// Relevance of an answer.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AnswerRelevance(std::borrow::Cow<'static, str>);
 
     impl AnswerRelevance {
@@ -1923,8 +1947,14 @@ pub mod agent_assistant_feedback {
         }
     }
 
+    impl std::default::Default for AnswerRelevance {
+        fn default() -> Self {
+            answer_relevance::ANSWER_RELEVANCE_UNSPECIFIED
+        }
+    }
+
     /// Correctness of document.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DocumentCorrectness(std::borrow::Cow<'static, str>);
 
     impl DocumentCorrectness {
@@ -1960,8 +1990,14 @@ pub mod agent_assistant_feedback {
         }
     }
 
+    impl std::default::Default for DocumentCorrectness {
+        fn default() -> Self {
+            document_correctness::DOCUMENT_CORRECTNESS_UNSPECIFIED
+        }
+    }
+
     /// Efficiency of document.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DocumentEfficiency(std::borrow::Cow<'static, str>);
 
     impl DocumentEfficiency {
@@ -1994,6 +2030,12 @@ pub mod agent_assistant_feedback {
     impl std::convert::From<std::string::String> for DocumentEfficiency {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DocumentEfficiency {
+        fn default() -> Self {
+            document_efficiency::DOCUMENT_EFFICIENCY_UNSPECIFIED
         }
     }
 }
@@ -3463,7 +3505,7 @@ pub mod conversation {
     use super::*;
 
     /// Enumeration of the completion status of the conversation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LifecycleState(std::borrow::Cow<'static, str>);
 
     impl LifecycleState {
@@ -3499,10 +3541,16 @@ pub mod conversation {
         }
     }
 
+    impl std::default::Default for LifecycleState {
+        fn default() -> Self {
+            lifecycle_state::LIFECYCLE_STATE_UNSPECIFIED
+        }
+    }
+
     /// Enumeration of the different conversation stages a conversation can be in.
     /// Reference:
     /// <https://cloud.google.com/dialogflow/priv/docs/contact-center/basics#stages>
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ConversationStage(std::borrow::Cow<'static, str>);
 
     impl ConversationStage {
@@ -3540,6 +3588,12 @@ pub mod conversation {
     impl std::convert::From<std::string::String> for ConversationStage {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ConversationStage {
+        fn default() -> Self {
+            conversation_stage::CONVERSATION_STAGE_UNSPECIFIED
         }
     }
 }
@@ -5211,9 +5265,7 @@ pub mod search_knowledge_request {
 
                         /// The attribute(or function) for which the custom ranking is to be
                         /// applied.
-                        #[derive(
-                            Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize,
-                        )]
+                        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
                         pub struct AttributeType(std::borrow::Cow<'static, str>);
 
                         impl AttributeType {
@@ -5257,11 +5309,15 @@ pub mod search_knowledge_request {
                             }
                         }
 
+                        impl std::default::Default for AttributeType {
+                            fn default() -> Self {
+                                attribute_type::ATTRIBUTE_TYPE_UNSPECIFIED
+                            }
+                        }
+
                         /// The interpolation type to be applied. Default will be linear
                         /// (Piecewise Linear).
-                        #[derive(
-                            Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize,
-                        )]
+                        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
                         pub struct InterpolationType(std::borrow::Cow<'static, str>);
 
                         impl InterpolationType {
@@ -5292,6 +5348,12 @@ pub mod search_knowledge_request {
                         impl std::convert::From<std::string::String> for InterpolationType {
                             fn from(value: std::string::String) -> Self {
                                 Self(std::borrow::Cow::Owned(value))
+                            }
+                        }
+
+                        impl std::default::Default for InterpolationType {
+                            fn default() -> Self {
+                                interpolation_type::INTERPOLATION_TYPE_UNSPECIFIED
                             }
                         }
                     }
@@ -5356,7 +5418,7 @@ pub mod search_knowledge_request {
     /// of a SuggestKnowledgeAssist call.
     ///
     /// [google.cloud.dialogflow.v2.Participants.SuggestKnowledgeAssist]: crate::client::Participants::suggest_knowledge_assist
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct QuerySource(std::borrow::Cow<'static, str>);
 
     impl QuerySource {
@@ -5392,6 +5454,12 @@ pub mod search_knowledge_request {
     impl std::convert::From<std::string::String> for QuerySource {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for QuerySource {
+        fn default() -> Self {
+            query_source::QUERY_SOURCE_UNSPECIFIED
         }
     }
 }
@@ -5583,7 +5651,7 @@ pub mod search_knowledge_answer {
     }
 
     /// The type of the answer.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AnswerType(std::borrow::Cow<'static, str>);
 
     impl AnswerType {
@@ -5618,6 +5686,12 @@ pub mod search_knowledge_answer {
     impl std::convert::From<std::string::String> for AnswerType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AnswerType {
+        fn default() -> Self {
+            answer_type::ANSWER_TYPE_UNSPECIFIED
         }
     }
 }
@@ -6459,7 +6533,7 @@ pub mod conversation_event {
     use super::*;
 
     /// Enumeration of the types of events available.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -6522,6 +6596,12 @@ pub mod conversation_event {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 
@@ -6749,7 +6829,7 @@ pub mod conversation_model {
     use super::*;
 
     /// State of the model.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -6804,8 +6884,14 @@ pub mod conversation_model {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Model type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ModelType(std::borrow::Cow<'static, str>);
 
     impl ModelType {
@@ -6838,6 +6924,12 @@ pub mod conversation_model {
     impl std::convert::From<std::string::String> for ModelType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ModelType {
+        fn default() -> Self {
+            model_type::MODEL_TYPE_UNSPECIFIED
         }
     }
 
@@ -8010,7 +8102,7 @@ pub mod create_conversation_model_operation_metadata {
     use super::*;
 
     /// State of CreateConversationModel operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -8056,6 +8148,12 @@ pub mod create_conversation_model_operation_metadata {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -8302,7 +8400,7 @@ pub mod create_conversation_model_evaluation_operation_metadata {
     use super::*;
 
     /// State of CreateConversationModel operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -8343,6 +8441,12 @@ pub mod create_conversation_model_evaluation_operation_metadata {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -9826,7 +9930,7 @@ pub mod human_agent_assistant_config {
 
             /// Selectable sections to return when requesting a summary of a
             /// conversation.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct SectionType(std::borrow::Cow<'static, str>);
 
             impl SectionType {
@@ -9883,6 +9987,12 @@ pub mod human_agent_assistant_config {
             impl std::convert::From<std::string::String> for SectionType {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for SectionType {
+                fn default() -> Self {
+                    section_type::SECTION_TYPE_UNSPECIFIED
                 }
             }
         }
@@ -10362,7 +10472,7 @@ pub mod notification_config {
     use super::*;
 
     /// Format of cloud pub/sub message.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MessageFormat(std::borrow::Cow<'static, str>);
 
     impl MessageFormat {
@@ -10395,6 +10505,12 @@ pub mod notification_config {
     impl std::convert::From<std::string::String> for MessageFormat {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for MessageFormat {
+        fn default() -> Self {
+            message_format::MESSAGE_FORMAT_UNSPECIFIED
         }
     }
 }
@@ -10473,7 +10589,7 @@ pub mod suggestion_feature {
     use super::*;
 
     /// Defines the type of Human Agent Assistant feature.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -10514,6 +10630,12 @@ pub mod suggestion_feature {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -11066,7 +11188,7 @@ pub mod document {
     }
 
     /// The knowledge type of document content.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct KnowledgeType(std::borrow::Cow<'static, str>);
 
     impl KnowledgeType {
@@ -11117,8 +11239,14 @@ pub mod document {
         }
     }
 
+    impl std::default::Default for KnowledgeType {
+        fn default() -> Self {
+            knowledge_type::KNOWLEDGE_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Possible states of the document
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -11159,6 +11287,12 @@ pub mod document {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -12105,7 +12239,7 @@ pub mod knowledge_operation_metadata {
     use super::*;
 
     /// States of the operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -12140,6 +12274,12 @@ pub mod knowledge_operation_metadata {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -12495,7 +12635,7 @@ pub mod entity_type {
     }
 
     /// Represents kinds of entities.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Kind(std::borrow::Cow<'static, str>);
 
     impl Kind {
@@ -12537,10 +12677,16 @@ pub mod entity_type {
         }
     }
 
+    impl std::default::Default for Kind {
+        fn default() -> Self {
+            kind::KIND_UNSPECIFIED
+        }
+    }
+
     /// Represents different entity type expansion modes. Automated expansion
     /// allows an agent to recognize values that have not been explicitly listed in
     /// the entity (for example, new kinds of shopping list items).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AutoExpansionMode(std::borrow::Cow<'static, str>);
 
     impl AutoExpansionMode {
@@ -12572,6 +12718,12 @@ pub mod entity_type {
     impl std::convert::From<std::string::String> for AutoExpansionMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AutoExpansionMode {
+        fn default() -> Self {
+            auto_expansion_mode::AUTO_EXPANSION_MODE_UNSPECIFIED
         }
     }
 }
@@ -13542,7 +13694,7 @@ pub mod environment {
     /// During that time, the environment keeps on serving the previous version of
     /// the agent. After the new agent version is done loading, the environment is
     /// set back to the `RUNNING` state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -13577,6 +13729,12 @@ pub mod environment {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -14434,7 +14592,7 @@ pub mod fulfillment {
         use super::*;
 
         /// The type of the feature.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Type(std::borrow::Cow<'static, str>);
 
         impl Type {
@@ -14463,6 +14621,12 @@ pub mod fulfillment {
         impl std::convert::From<std::string::String> for Type {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Type {
+            fn default() -> Self {
+                r#type::TYPE_UNSPECIFIED
             }
         }
     }
@@ -14979,7 +15143,7 @@ pub mod message_entry {
     use super::*;
 
     /// Enumeration of the roles a participant can play in a conversation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Role(std::borrow::Cow<'static, str>);
 
     impl Role {
@@ -15015,6 +15179,12 @@ pub mod message_entry {
     impl std::convert::From<std::string::String> for Role {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Role {
+        fn default() -> Self {
+            role::ROLE_UNSPECIFIED
         }
     }
 }
@@ -15358,7 +15528,7 @@ pub mod summarization_section {
     use super::*;
 
     /// Type enum of the summarization sections.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -15415,6 +15585,12 @@ pub mod summarization_section {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -16361,7 +16537,7 @@ pub mod intent {
         }
 
         /// Represents different types of training phrases.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Type(std::borrow::Cow<'static, str>);
 
         impl Type {
@@ -16399,6 +16575,12 @@ pub mod intent {
         impl std::convert::From<std::string::String> for Type {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Type {
+            fn default() -> Self {
+                r#type::TYPE_UNSPECIFIED
             }
         }
     }
@@ -18174,7 +18356,7 @@ pub mod intent {
             }
 
             /// Format of response media type.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct ResponseMediaType(std::borrow::Cow<'static, str>);
 
             impl ResponseMediaType {
@@ -18204,6 +18386,12 @@ pub mod intent {
             impl std::convert::From<std::string::String> for ResponseMediaType {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for ResponseMediaType {
+                fn default() -> Self {
+                    response_media_type::RESPONSE_MEDIA_TYPE_UNSPECIFIED
                 }
             }
         }
@@ -18415,9 +18603,7 @@ pub mod intent {
                     use super::*;
 
                     /// Type of the URI.
-                    #[derive(
-                        Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize,
-                    )]
+                    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
                     pub struct UrlTypeHint(std::borrow::Cow<'static, str>);
 
                     impl UrlTypeHint {
@@ -18453,13 +18639,19 @@ pub mod intent {
                             Self(std::borrow::Cow::Owned(value))
                         }
                     }
+
+                    impl std::default::Default for UrlTypeHint {
+                        fn default() -> Self {
+                            url_type_hint::URL_TYPE_HINT_UNSPECIFIED
+                        }
+                    }
                 }
             }
 
             /// Image display options for Actions on Google. This should be used for
             /// when the image's aspect ratio does not match the image container's
             /// aspect ratio.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct ImageDisplayOptions(std::borrow::Cow<'static, str>);
 
             impl ImageDisplayOptions {
@@ -18508,6 +18700,12 @@ pub mod intent {
             impl std::convert::From<std::string::String> for ImageDisplayOptions {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for ImageDisplayOptions {
+                fn default() -> Self {
+                    image_display_options::IMAGE_DISPLAY_OPTIONS_UNSPECIFIED
                 }
             }
         }
@@ -18669,7 +18867,7 @@ pub mod intent {
             use super::*;
 
             /// Text alignments within a cell.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct HorizontalAlignment(std::borrow::Cow<'static, str>);
 
             impl HorizontalAlignment {
@@ -18705,6 +18903,12 @@ pub mod intent {
             impl std::convert::From<std::string::String> for HorizontalAlignment {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for HorizontalAlignment {
+                fn default() -> Self {
+                    horizontal_alignment::HORIZONTAL_ALIGNMENT_UNSPECIFIED
                 }
             }
         }
@@ -18788,7 +18992,7 @@ pub mod intent {
 
         /// The rich response message integration platform. See
         /// [Integrations](https://cloud.google.com/dialogflow/docs/integrations).
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Platform(std::borrow::Cow<'static, str>);
 
         impl Platform {
@@ -18843,6 +19047,12 @@ pub mod intent {
         impl std::convert::From<std::string::String> for Platform {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Platform {
+            fn default() -> Self {
+                platform::PLATFORM_UNSPECIFIED
             }
         }
 
@@ -18930,7 +19140,7 @@ pub mod intent {
     }
 
     /// Represents the different states that webhooks can be in.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct WebhookState(std::borrow::Cow<'static, str>);
 
     impl WebhookState {
@@ -18965,6 +19175,12 @@ pub mod intent {
     impl std::convert::From<std::string::String> for WebhookState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for WebhookState {
+        fn default() -> Self {
+            webhook_state::WEBHOOK_STATE_UNSPECIFIED
         }
     }
 }
@@ -20187,7 +20403,7 @@ pub mod participant {
     use super::*;
 
     /// Enumeration of the roles a participant can play in a conversation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Role(std::borrow::Cow<'static, str>);
 
     impl Role {
@@ -20223,6 +20439,12 @@ pub mod participant {
     impl std::convert::From<std::string::String> for Role {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Role {
+        fn default() -> Self {
+            role::ROLE_UNSPECIFIED
         }
     }
 }
@@ -22215,7 +22437,7 @@ pub mod automated_agent_reply {
     use super::*;
 
     /// Represents different automated agent reply types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AutomatedAgentReplyType(std::borrow::Cow<'static, str>);
 
     impl AutomatedAgentReplyType {
@@ -22250,6 +22472,12 @@ pub mod automated_agent_reply {
     impl std::convert::From<std::string::String> for AutomatedAgentReplyType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AutomatedAgentReplyType {
+        fn default() -> Self {
+            automated_agent_reply_type::AUTOMATED_AGENT_REPLY_TYPE_UNSPECIFIED
         }
     }
 }
@@ -25269,7 +25497,7 @@ pub mod streaming_recognition_result {
     use super::*;
 
     /// Type of the response message.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MessageType(std::borrow::Cow<'static, str>);
 
     impl MessageType {
@@ -25310,6 +25538,12 @@ pub mod streaming_recognition_result {
     impl std::convert::From<std::string::String> for MessageType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for MessageType {
+        fn default() -> Self {
+            message_type::MESSAGE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -25643,7 +25877,7 @@ pub mod session_entity_type {
     use super::*;
 
     /// The types of modifications for a session entity type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EntityOverrideMode(std::borrow::Cow<'static, str>);
 
     impl EntityOverrideMode {
@@ -25690,6 +25924,12 @@ pub mod session_entity_type {
     impl std::convert::From<std::string::String> for EntityOverrideMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EntityOverrideMode {
+        fn default() -> Self {
+            entity_override_mode::ENTITY_OVERRIDE_MODE_UNSPECIFIED
         }
     }
 }
@@ -26066,7 +26306,7 @@ pub mod validation_error {
     use super::*;
 
     /// Represents a level of severity.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Severity(std::borrow::Cow<'static, str>);
 
     impl Severity {
@@ -26104,6 +26344,12 @@ pub mod validation_error {
     impl std::convert::From<std::string::String> for Severity {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Severity {
+        fn default() -> Self {
+            severity::SEVERITY_UNSPECIFIED
         }
     }
 }
@@ -26246,7 +26492,7 @@ pub mod version {
     use super::*;
 
     /// The status of a version.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct VersionStatus(std::borrow::Cow<'static, str>);
 
     impl VersionStatus {
@@ -26282,6 +26528,12 @@ pub mod version {
     impl std::convert::From<std::string::String> for VersionStatus {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for VersionStatus {
+        fn default() -> Self {
+            version_status::VERSION_STATUS_UNSPECIFIED
         }
     }
 }
@@ -26898,7 +27150,7 @@ impl wkt::message::Message for OriginalDetectIntentRequest {
 
 /// [DTMF](https://en.wikipedia.org/wiki/Dual-tone_multi-frequency_signaling)
 /// digit in Telephony Gateway.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TelephonyDtmf(std::borrow::Cow<'static, str>);
 
 impl TelephonyDtmf {
@@ -26976,12 +27228,18 @@ impl std::convert::From<std::string::String> for TelephonyDtmf {
     }
 }
 
+impl std::default::Default for TelephonyDtmf {
+    fn default() -> Self {
+        telephony_dtmf::TELEPHONY_DTMF_UNSPECIFIED
+    }
+}
+
 /// Audio encoding of the audio content sent in the conversational query request.
 /// Refer to the
 /// [Cloud Speech API
 /// documentation](https://cloud.google.com/speech-to-text/docs/basics) for more
 /// details.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct AudioEncoding(std::borrow::Cow<'static, str>);
 
 impl AudioEncoding {
@@ -27056,6 +27314,12 @@ impl std::convert::From<std::string::String> for AudioEncoding {
     }
 }
 
+impl std::default::Default for AudioEncoding {
+    fn default() -> Self {
+        audio_encoding::AUDIO_ENCODING_UNSPECIFIED
+    }
+}
+
 /// Variant of the specified [Speech
 /// model][google.cloud.dialogflow.v2.InputAudioConfig.model] to use.
 ///
@@ -27066,7 +27330,7 @@ impl std::convert::From<std::string::String> for AudioEncoding {
 /// you will generally receive higher quality results than for a standard model.
 ///
 /// [google.cloud.dialogflow.v2.InputAudioConfig.model]: crate::model::InputAudioConfig::model
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SpeechModelVariant(std::borrow::Cow<'static, str>);
 
 impl SpeechModelVariant {
@@ -27131,9 +27395,15 @@ impl std::convert::From<std::string::String> for SpeechModelVariant {
     }
 }
 
+impl std::default::Default for SpeechModelVariant {
+    fn default() -> Self {
+        speech_model_variant::SPEECH_MODEL_VARIANT_UNSPECIFIED
+    }
+}
+
 /// Gender of the voice as described in
 /// [SSML voice element](https://www.w3.org/TR/speech-synthesis11/#edef_voice).
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SsmlVoiceGender(std::borrow::Cow<'static, str>);
 
 impl SsmlVoiceGender {
@@ -27176,8 +27446,14 @@ impl std::convert::From<std::string::String> for SsmlVoiceGender {
     }
 }
 
+impl std::default::Default for SsmlVoiceGender {
+    fn default() -> Self {
+        ssml_voice_gender::SSML_VOICE_GENDER_UNSPECIFIED
+    }
+}
+
 /// Audio encoding of the output audio format in Text-To-Speech.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct OutputAudioEncoding(std::borrow::Cow<'static, str>);
 
 impl OutputAudioEncoding {
@@ -27235,8 +27511,14 @@ impl std::convert::From<std::string::String> for OutputAudioEncoding {
     }
 }
 
+impl std::default::Default for OutputAudioEncoding {
+    fn default() -> Self {
+        output_audio_encoding::OUTPUT_AUDIO_ENCODING_UNSPECIFIED
+    }
+}
+
 /// The event that triggers the generator and LLM execution.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TriggerEvent(std::borrow::Cow<'static, str>);
 
 impl TriggerEvent {
@@ -27274,10 +27556,16 @@ impl std::convert::From<std::string::String> for TriggerEvent {
     }
 }
 
+impl std::default::Default for TriggerEvent {
+    fn default() -> Self {
+        trigger_event::TRIGGER_EVENT_UNSPECIFIED
+    }
+}
+
 /// Represents the options for views of an intent.
 /// An intent can be a sizable object. Therefore, we provide a resource view that
 /// does not return training phrases in the response by default.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct IntentView(std::borrow::Cow<'static, str>);
 
 impl IntentView {
@@ -27306,5 +27594,11 @@ pub mod intent_view {
 impl std::convert::From<std::string::String> for IntentView {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for IntentView {
+    fn default() -> Self {
+        intent_view::INTENT_VIEW_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/discoveryengine/v1/src/model.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/model.rs
@@ -1298,7 +1298,7 @@ pub mod answer {
         }
 
         /// Enumeration of the state of the step.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct State(std::borrow::Cow<'static, str>);
 
         impl State {
@@ -1333,6 +1333,12 @@ pub mod answer {
         impl std::convert::From<std::string::String> for State {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for State {
+            fn default() -> Self {
+                state::STATE_UNSPECIFIED
             }
         }
     }
@@ -1431,7 +1437,7 @@ pub mod answer {
             use super::*;
 
             /// Query classification types.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct Type(std::borrow::Cow<'static, str>);
 
             impl Type {
@@ -1472,11 +1478,17 @@ pub mod answer {
                     Self(std::borrow::Cow::Owned(value))
                 }
             }
+
+            impl std::default::Default for Type {
+                fn default() -> Self {
+                    r#type::TYPE_UNSPECIFIED
+                }
+            }
         }
     }
 
     /// Enumeration of the state of the answer generation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1514,8 +1526,14 @@ pub mod answer {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// An enum for answer skipped reasons.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AnswerSkippedReason(std::borrow::Cow<'static, str>);
 
     impl AnswerSkippedReason {
@@ -1600,6 +1618,12 @@ pub mod answer {
     impl std::convert::From<std::string::String> for AnswerSkippedReason {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AnswerSkippedReason {
+        fn default() -> Self {
+            answer_skipped_reason::ANSWER_SKIPPED_REASON_UNSPECIFIED
         }
     }
 }
@@ -2268,7 +2292,7 @@ pub mod suggestion_deny_list_entry {
     use super::*;
 
     /// Operator for matching with the generated suggestions.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MatchOperator(std::borrow::Cow<'static, str>);
 
     impl MatchOperator {
@@ -2301,6 +2325,12 @@ pub mod suggestion_deny_list_entry {
     impl std::convert::From<std::string::String> for MatchOperator {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for MatchOperator {
+        fn default() -> Self {
+            match_operator::MATCH_OPERATOR_UNSPECIFIED
         }
     }
 }
@@ -3711,7 +3741,7 @@ pub mod conversation {
     use super::*;
 
     /// Enumeration of the state of the conversation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3743,6 +3773,12 @@ pub mod conversation {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -5916,7 +5952,7 @@ pub mod answer_query_request {
             use super::*;
 
             /// Query classification types.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct Type(std::borrow::Cow<'static, str>);
 
             impl Type {
@@ -5955,6 +5991,12 @@ pub mod answer_query_request {
             impl std::convert::From<std::string::String> for Type {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for Type {
+                fn default() -> Self {
+                    r#type::TYPE_UNSPECIFIED
                 }
             }
         }
@@ -6532,7 +6574,7 @@ pub mod custom_tuning_model {
     use super::*;
 
     /// The state of the model.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ModelState(std::borrow::Cow<'static, str>);
 
     impl ModelState {
@@ -6579,6 +6621,12 @@ pub mod custom_tuning_model {
     impl std::convert::From<std::string::String> for ModelState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ModelState {
+        fn default() -> Self {
+            model_state::MODEL_STATE_UNSPECIFIED
         }
     }
 }
@@ -6894,7 +6942,7 @@ pub mod data_store {
     }
 
     /// Content config of the data store.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ContentConfig(std::borrow::Cow<'static, str>);
 
     impl ContentConfig {
@@ -6943,6 +6991,12 @@ pub mod data_store {
     impl std::convert::From<std::string::String> for ContentConfig {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ContentConfig {
+        fn default() -> Self {
+            content_config::CONTENT_CONFIG_UNSPECIFIED
         }
     }
 }
@@ -7028,7 +7082,7 @@ pub mod workspace_config {
     use super::*;
 
     /// Specifies the type of Workspace App supported by this DataStore
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -7075,6 +7129,12 @@ pub mod workspace_config {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -9444,7 +9504,7 @@ pub mod batch_get_documents_metadata_response {
     /// The state of the [Document][google.cloud.discoveryengine.v1.Document].
     ///
     /// [google.cloud.discoveryengine.v1.Document]: crate::model::Document
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -9488,6 +9548,12 @@ pub mod batch_get_documents_metadata_response {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -11043,7 +11109,7 @@ pub mod generate_grounded_content_request {
             use super::*;
 
             /// The version of the predictor to be used in dynamic retrieval.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct Version(std::borrow::Cow<'static, str>);
 
             impl Version {
@@ -11072,6 +11138,12 @@ pub mod generate_grounded_content_request {
             impl std::convert::From<std::string::String> for Version {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for Version {
+                fn default() -> Self {
+                    version::VERSION_UNSPECIFIED
                 }
             }
         }
@@ -11698,9 +11770,7 @@ pub mod generate_grounded_content_response {
                 use super::*;
 
                 /// Describes the source to which the metadata is associated to.
-                #[derive(
-                    Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize,
-                )]
+                #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
                 pub struct Source(std::borrow::Cow<'static, str>);
 
                 impl Source {
@@ -11738,6 +11808,12 @@ pub mod generate_grounded_content_response {
                 impl std::convert::From<std::string::String> for Source {
                     fn from(value: std::string::String) -> Self {
                         Self(std::borrow::Cow::Owned(value))
+                    }
+                }
+
+                impl std::default::Default for Source {
+                    fn default() -> Self {
+                        source::SOURCE_UNSPECIFIED
                     }
                 }
             }
@@ -11824,9 +11900,7 @@ pub mod generate_grounded_content_response {
                 use super::*;
 
                 /// The version of the predictor which was used in dynamic retrieval.
-                #[derive(
-                    Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize,
-                )]
+                #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
                 pub struct Version(std::borrow::Cow<'static, str>);
 
                 impl Version {
@@ -11855,6 +11929,12 @@ pub mod generate_grounded_content_response {
                 impl std::convert::From<std::string::String> for Version {
                     fn from(value: std::string::String) -> Self {
                         Self(std::borrow::Cow::Owned(value))
+                    }
+                }
+
+                impl std::default::Default for Version {
+                    fn default() -> Self {
+                        version::VERSION_UNSPECIFIED
                     }
                 }
             }
@@ -12943,7 +13023,7 @@ pub mod bigtable_options {
     /// [HBase
     /// Bytes.toBytes](https://hbase.apache.org/apidocs/org/apache/hadoop/hbase/util/Bytes.html)
     /// function when the encoding value is set to `BINARY`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -12993,8 +13073,14 @@ pub mod bigtable_options {
         }
     }
 
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
+        }
+    }
+
     /// The encoding mode of a Bigtable column or column family.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Encoding(std::borrow::Cow<'static, str>);
 
     impl Encoding {
@@ -13026,6 +13112,12 @@ pub mod bigtable_options {
     impl std::convert::From<std::string::String> for Encoding {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Encoding {
+        fn default() -> Self {
+            encoding::ENCODING_UNSPECIFIED
         }
     }
 }
@@ -14429,7 +14521,7 @@ pub mod import_documents_request {
 
     /// Indicates how imported documents are reconciled with the existing documents
     /// created or imported before.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ReconciliationMode(std::borrow::Cow<'static, str>);
 
     impl ReconciliationMode {
@@ -14463,6 +14555,12 @@ pub mod import_documents_request {
     impl std::convert::From<std::string::String> for ReconciliationMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ReconciliationMode {
+        fn default() -> Self {
+            reconciliation_mode::RECONCILIATION_MODE_UNSPECIFIED
         }
     }
 
@@ -15369,7 +15467,7 @@ pub mod project {
         use super::*;
 
         /// The agreement states this terms of service.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct State(std::borrow::Cow<'static, str>);
 
         impl State {
@@ -15404,6 +15502,12 @@ pub mod project {
         impl std::convert::From<std::string::String> for State {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for State {
+            fn default() -> Self {
+                state::STATE_UNSPECIFIED
             }
         }
     }
@@ -18751,9 +18855,7 @@ pub mod search_request {
 
                 /// The attribute(or function) for which the custom ranking is to be
                 /// applied.
-                #[derive(
-                    Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize,
-                )]
+                #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
                 pub struct AttributeType(std::borrow::Cow<'static, str>);
 
                 impl AttributeType {
@@ -18797,11 +18899,15 @@ pub mod search_request {
                     }
                 }
 
+                impl std::default::Default for AttributeType {
+                    fn default() -> Self {
+                        attribute_type::ATTRIBUTE_TYPE_UNSPECIFIED
+                    }
+                }
+
                 /// The interpolation type to be applied. Default will be linear
                 /// (Piecewise Linear).
-                #[derive(
-                    Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize,
-                )]
+                #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
                 pub struct InterpolationType(std::borrow::Cow<'static, str>);
 
                 impl InterpolationType {
@@ -18832,6 +18938,12 @@ pub mod search_request {
                 impl std::convert::From<std::string::String> for InterpolationType {
                     fn from(value: std::string::String) -> Self {
                         Self(std::borrow::Cow::Owned(value))
+                    }
+                }
+
+                impl std::default::Default for InterpolationType {
+                    fn default() -> Self {
+                        interpolation_type::INTERPOLATION_TYPE_UNSPECIFIED
                     }
                 }
             }
@@ -18892,7 +19004,7 @@ pub mod search_request {
         use super::*;
 
         /// Enum describing under which condition query expansion should occur.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Condition(std::borrow::Cow<'static, str>);
 
         impl Condition {
@@ -18932,6 +19044,12 @@ pub mod search_request {
         impl std::convert::From<std::string::String> for Condition {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Condition {
+            fn default() -> Self {
+                condition::CONDITION_UNSPECIFIED
             }
         }
     }
@@ -18979,7 +19097,7 @@ pub mod search_request {
         use super::*;
 
         /// Enum describing under which mode spell correction should occur.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Mode(std::borrow::Cow<'static, str>);
 
         impl Mode {
@@ -19021,6 +19139,12 @@ pub mod search_request {
         impl std::convert::From<std::string::String> for Mode {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Mode {
+            fn default() -> Self {
+                mode::MODE_UNSPECIFIED
             }
         }
     }
@@ -19659,7 +19783,7 @@ pub mod search_request {
 
         /// Specifies the search result mode. If unspecified, the
         /// search result mode defaults to `DOCUMENTS`.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct SearchResultMode(std::borrow::Cow<'static, str>);
 
         impl SearchResultMode {
@@ -19693,6 +19817,12 @@ pub mod search_request {
         impl std::convert::From<std::string::String> for SearchResultMode {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for SearchResultMode {
+            fn default() -> Self {
+                search_result_mode::SEARCH_RESULT_MODE_UNSPECIFIED
             }
         }
     }
@@ -19740,7 +19870,7 @@ pub mod search_request {
         use super::*;
 
         /// Enum describing under which condition search as you type should occur.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Condition(std::borrow::Cow<'static, str>);
 
         impl Condition {
@@ -19775,6 +19905,12 @@ pub mod search_request {
         impl std::convert::From<std::string::String> for Condition {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Condition {
+            fn default() -> Self {
+                condition::CONDITION_UNSPECIFIED
             }
         }
     }
@@ -20773,7 +20909,7 @@ pub mod search_response {
         }
 
         /// An Enum for summary-skipped reasons.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct SummarySkippedReason(std::borrow::Cow<'static, str>);
 
         impl SummarySkippedReason {
@@ -20874,6 +21010,12 @@ pub mod search_response {
         impl std::convert::From<std::string::String> for SummarySkippedReason {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for SummarySkippedReason {
+            fn default() -> Self {
+                summary_skipped_reason::SUMMARY_SKIPPED_REASON_UNSPECIFIED
             }
         }
     }
@@ -21568,7 +21710,7 @@ pub mod session {
     }
 
     /// Enumeration of the state of the session.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -21597,6 +21739,12 @@ pub mod session {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -21984,7 +22132,7 @@ pub mod target_site {
     }
 
     /// Possible target site types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -22022,8 +22170,14 @@ pub mod target_site {
         }
     }
 
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
+        }
+    }
+
     /// Target site indexing status enumeration.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct IndexingStatus(std::borrow::Cow<'static, str>);
 
     impl IndexingStatus {
@@ -22067,6 +22221,12 @@ pub mod target_site {
     impl std::convert::From<std::string::String> for IndexingStatus {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for IndexingStatus {
+        fn default() -> Self {
+            indexing_status::INDEXING_STATUS_UNSPECIFIED
         }
     }
 }
@@ -22123,7 +22283,7 @@ pub mod site_verification_info {
     use super::*;
 
     /// Site verification state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SiteVerificationState(std::borrow::Cow<'static, str>);
 
     impl SiteVerificationState {
@@ -22159,6 +22319,12 @@ pub mod site_verification_info {
     impl std::convert::From<std::string::String> for SiteVerificationState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SiteVerificationState {
+        fn default() -> Self {
+            site_verification_state::SITE_VERIFICATION_STATE_UNSPECIFIED
         }
     }
 }
@@ -23291,7 +23457,7 @@ pub mod recrawl_uris_response {
             use super::*;
 
             /// CorpusType for the failed crawling operation.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct CorpusType(std::borrow::Cow<'static, str>);
 
             impl CorpusType {
@@ -23324,6 +23490,12 @@ pub mod recrawl_uris_response {
             impl std::convert::From<std::string::String> for CorpusType {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for CorpusType {
+                fn default() -> Self {
+                    corpus_type::CORPUS_TYPE_UNSPECIFIED
                 }
             }
         }
@@ -24969,7 +25141,7 @@ impl wkt::message::Message for CollectUserEventRequest {
 /// [DataStore][google.cloud.discoveryengine.v1.DataStore].
 ///
 /// [google.cloud.discoveryengine.v1.DataStore]: crate::model::DataStore
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct IndustryVertical(std::borrow::Cow<'static, str>);
 
 impl IndustryVertical {
@@ -25009,8 +25181,14 @@ impl std::convert::From<std::string::String> for IndustryVertical {
     }
 }
 
+impl std::default::Default for IndustryVertical {
+    fn default() -> Self {
+        industry_vertical::INDUSTRY_VERTICAL_UNSPECIFIED
+    }
+}
+
 /// The type of solution.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SolutionType(std::borrow::Cow<'static, str>);
 
 impl SolutionType {
@@ -25056,12 +25234,18 @@ impl std::convert::From<std::string::String> for SolutionType {
     }
 }
 
+impl std::default::Default for SolutionType {
+    fn default() -> Self {
+        solution_type::SOLUTION_TYPE_UNSPECIFIED
+    }
+}
+
 /// Defines a further subdivision of `SolutionType`.
 /// Specifically applies to
 /// [SOLUTION_TYPE_SEARCH][google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH].
 ///
 /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::solution_type::SOLUTION_TYPE_SEARCH
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SearchUseCase(std::borrow::Cow<'static, str>);
 
 impl SearchUseCase {
@@ -25103,9 +25287,15 @@ impl std::convert::From<std::string::String> for SearchUseCase {
     }
 }
 
+impl std::default::Default for SearchUseCase {
+    fn default() -> Self {
+        search_use_case::SEARCH_USE_CASE_UNSPECIFIED
+    }
+}
+
 /// Tiers of search features. Different tiers might have different
 /// pricing. To learn more, check the pricing documentation.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SearchTier(std::borrow::Cow<'static, str>);
 
 impl SearchTier {
@@ -25140,8 +25330,14 @@ impl std::convert::From<std::string::String> for SearchTier {
     }
 }
 
+impl std::default::Default for SearchTier {
+    fn default() -> Self {
+        search_tier::SEARCH_TIER_UNSPECIFIED
+    }
+}
+
 /// Add-on that provides additional functionality for search.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SearchAddOn(std::borrow::Cow<'static, str>);
 
 impl SearchAddOn {
@@ -25171,5 +25367,11 @@ pub mod search_add_on {
 impl std::convert::From<std::string::String> for SearchAddOn {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for SearchAddOn {
+    fn default() -> Self {
+        search_add_on::SEARCH_ADD_ON_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/documentai/v1/src/model.rs
+++ b/src/generated/cloud/documentai/v1/src/model.rs
@@ -1178,7 +1178,7 @@ pub mod document {
             use super::*;
 
             /// Detected human reading orientation.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct Orientation(std::borrow::Cow<'static, str>);
 
             impl Orientation {
@@ -1220,6 +1220,12 @@ pub mod document {
             impl std::convert::From<std::string::String> for Orientation {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for Orientation {
+                fn default() -> Self {
+                    orientation::ORIENTATION_UNSPECIFIED
                 }
             }
         }
@@ -1584,9 +1590,7 @@ pub mod document {
                 use super::*;
 
                 /// Enum to denote the type of break found.
-                #[derive(
-                    Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize,
-                )]
+                #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
                 pub struct Type(std::borrow::Cow<'static, str>);
 
                 impl Type {
@@ -1621,6 +1625,12 @@ pub mod document {
                 impl std::convert::From<std::string::String> for Type {
                     fn from(value: std::string::String) -> Self {
                         Self(std::borrow::Cow::Owned(value))
+                    }
+                }
+
+                impl std::default::Default for Type {
+                    fn default() -> Self {
+                        r#type::TYPE_UNSPECIFIED
                     }
                 }
             }
@@ -3279,7 +3289,7 @@ pub mod document {
             use super::*;
 
             /// The type of layout that is being referenced.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct LayoutType(std::borrow::Cow<'static, str>);
 
             impl LayoutType {
@@ -3354,6 +3364,12 @@ pub mod document {
             impl std::convert::From<std::string::String> for LayoutType {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for LayoutType {
+                fn default() -> Self {
+                    layout_type::LAYOUT_TYPE_UNSPECIFIED
                 }
             }
         }
@@ -3482,7 +3498,7 @@ pub mod document {
         }
 
         /// If a processor or agent does an explicit operation on existing elements.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct OperationType(std::borrow::Cow<'static, str>);
 
         impl OperationType {
@@ -3536,6 +3552,12 @@ pub mod document {
         impl std::convert::From<std::string::String> for OperationType {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for OperationType {
+            fn default() -> Self {
+                operation_type::OPERATION_TYPE_UNSPECIFIED
             }
         }
     }
@@ -6017,7 +6039,7 @@ pub mod human_review_status {
     use super::*;
 
     /// The final state of human review on a processed document.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -6061,6 +6083,12 @@ pub mod human_review_status {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -6437,7 +6465,7 @@ pub mod batch_process_metadata {
     }
 
     /// Possible states of the batch processing operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -6481,6 +6509,12 @@ pub mod batch_process_metadata {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -7985,7 +8019,7 @@ pub mod train_processor_version_request {
 
         /// Training Method for CDE. `TRAINING_METHOD_UNSPECIFIED` will fall back to
         /// `MODEL_BASED`.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct TrainingMethod(std::borrow::Cow<'static, str>);
 
         impl TrainingMethod {
@@ -8015,6 +8049,12 @@ pub mod train_processor_version_request {
         impl std::convert::From<std::string::String> for TrainingMethod {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for TrainingMethod {
+            fn default() -> Self {
+                training_method::TRAINING_METHOD_UNSPECIFIED
             }
         }
     }
@@ -8386,7 +8426,7 @@ pub mod review_document_request {
     use super::*;
 
     /// The priority level of the human review task.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Priority(std::borrow::Cow<'static, str>);
 
     impl Priority {
@@ -8416,6 +8456,12 @@ pub mod review_document_request {
     impl std::convert::From<std::string::String> for Priority {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Priority {
+        fn default() -> Self {
+            priority::DEFAULT
         }
     }
 
@@ -8494,7 +8540,7 @@ pub mod review_document_response {
     use super::*;
 
     /// Possible states of the review operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -8526,6 +8572,12 @@ pub mod review_document_response {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -9198,7 +9250,7 @@ pub mod document_schema {
             /// expect a bank statement to contain the status of multiple different
             /// accounts for the customers, the occurrence type is set to
             /// `REQUIRED_MULTIPLE`.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct OccurrenceType(std::borrow::Cow<'static, str>);
 
             impl OccurrenceType {
@@ -9241,6 +9293,12 @@ pub mod document_schema {
             impl std::convert::From<std::string::String> for OccurrenceType {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for OccurrenceType {
+                fn default() -> Self {
+                    occurrence_type::OCCURRENCE_TYPE_UNSPECIFIED
                 }
             }
         }
@@ -9850,7 +9908,7 @@ pub mod evaluation {
         use super::*;
 
         /// A type that determines how metrics should be interpreted.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct MetricsType(std::borrow::Cow<'static, str>);
 
         impl MetricsType {
@@ -9886,6 +9944,12 @@ pub mod evaluation {
         impl std::convert::From<std::string::String> for MetricsType {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for MetricsType {
+            fn default() -> Self {
+                metrics_type::METRICS_TYPE_UNSPECIFIED
             }
         }
     }
@@ -10100,7 +10164,7 @@ pub mod common_operation_metadata {
     use super::*;
 
     /// State of the longrunning operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -10141,6 +10205,12 @@ pub mod common_operation_metadata {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -10601,7 +10671,7 @@ pub mod processor_version {
             use super::*;
 
             /// The type of custom model created by the user.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct CustomModelType(std::borrow::Cow<'static, str>);
 
             impl CustomModelType {
@@ -10637,6 +10707,12 @@ pub mod processor_version {
                     Self(std::borrow::Cow::Owned(value))
                 }
             }
+
+            impl std::default::Default for CustomModelType {
+                fn default() -> Self {
+                    custom_model_type::CUSTOM_MODEL_TYPE_UNSPECIFIED
+                }
+            }
         }
 
         /// The processor version is either a pretrained Google-managed foundation
@@ -10661,7 +10737,7 @@ pub mod processor_version {
     }
 
     /// The possible states of the processor version.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -10714,8 +10790,14 @@ pub mod processor_version {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// The possible model types of the processor version.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ModelType(std::borrow::Cow<'static, str>);
 
     impl ModelType {
@@ -10747,6 +10829,12 @@ pub mod processor_version {
     impl std::convert::From<std::string::String> for ModelType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ModelType {
+        fn default() -> Self {
+            model_type::MODEL_TYPE_UNSPECIFIED
         }
     }
 }
@@ -10951,7 +11039,7 @@ pub mod processor {
     use super::*;
 
     /// The possible states of the processor.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -11006,6 +11094,12 @@ pub mod processor {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/domains/v1/src/model.rs
+++ b/src/generated/cloud/domains/v1/src/model.rs
@@ -251,7 +251,7 @@ pub mod registration {
     use super::*;
 
     /// Possible states of a `Registration`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -310,8 +310,14 @@ pub mod registration {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Possible issues with a `Registration` that require attention.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Issue(std::borrow::Cow<'static, str>);
 
     impl Issue {
@@ -350,6 +356,12 @@ pub mod registration {
     impl std::convert::From<std::string::String> for Issue {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Issue {
+        fn default() -> Self {
+            issue::ISSUE_UNSPECIFIED
         }
     }
 }
@@ -405,7 +417,7 @@ pub mod management_settings {
     use super::*;
 
     /// Defines how the `Registration` is renewed.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RenewalMethod(std::borrow::Cow<'static, str>);
 
     impl RenewalMethod {
@@ -446,6 +458,12 @@ pub mod management_settings {
     impl std::convert::From<std::string::String> for RenewalMethod {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RenewalMethod {
+        fn default() -> Self {
+            renewal_method::RENEWAL_METHOD_UNSPECIFIED
         }
     }
 }
@@ -764,7 +782,7 @@ pub mod dns_settings {
 
         /// List of algorithms used to create a DNSKEY. Certain
         /// algorithms are not supported for particular domains.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Algorithm(std::borrow::Cow<'static, str>);
 
         impl Algorithm {
@@ -844,9 +862,15 @@ pub mod dns_settings {
             }
         }
 
+        impl std::default::Default for Algorithm {
+            fn default() -> Self {
+                algorithm::ALGORITHM_UNSPECIFIED
+            }
+        }
+
         /// List of hash functions that may have been used to generate a digest of a
         /// DNSKEY.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct DigestType(std::borrow::Cow<'static, str>);
 
         impl DigestType {
@@ -885,6 +909,12 @@ pub mod dns_settings {
         impl std::convert::From<std::string::String> for DigestType {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for DigestType {
+            fn default() -> Self {
+                digest_type::DIGEST_TYPE_UNSPECIFIED
             }
         }
     }
@@ -958,7 +988,7 @@ pub mod dns_settings {
     }
 
     /// The publication state of DS records for a `Registration`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DsState(std::borrow::Cow<'static, str>);
 
     impl DsState {
@@ -994,6 +1024,12 @@ pub mod dns_settings {
     impl std::convert::From<std::string::String> for DsState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DsState {
+        fn default() -> Self {
+            ds_state::DS_STATE_UNSPECIFIED
         }
     }
 
@@ -2249,7 +2285,7 @@ pub mod register_parameters {
     use super::*;
 
     /// Possible availability states of a domain name.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Availability(std::borrow::Cow<'static, str>);
 
     impl Availability {
@@ -2291,6 +2327,12 @@ pub mod register_parameters {
     impl std::convert::From<std::string::String> for Availability {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Availability {
+        fn default() -> Self {
+            availability::AVAILABILITY_UNSPECIFIED
         }
     }
 }
@@ -2515,7 +2557,7 @@ impl wkt::message::Message for OperationMetadata {
 /// accessible mapping from domain name to contact information, and requires that
 /// each domain name have an entry. Choose from these options to control how much
 /// information in your `ContactSettings` is published.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ContactPrivacy(std::borrow::Cow<'static, str>);
 
 impl ContactPrivacy {
@@ -2563,8 +2605,14 @@ impl std::convert::From<std::string::String> for ContactPrivacy {
     }
 }
 
+impl std::default::Default for ContactPrivacy {
+    fn default() -> Self {
+        contact_privacy::CONTACT_PRIVACY_UNSPECIFIED
+    }
+}
+
 /// Notices about special properties of certain domains.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DomainNotice(std::borrow::Cow<'static, str>);
 
 impl DomainNotice {
@@ -2601,8 +2649,14 @@ impl std::convert::From<std::string::String> for DomainNotice {
     }
 }
 
+impl std::default::Default for DomainNotice {
+    fn default() -> Self {
+        domain_notice::DOMAIN_NOTICE_UNSPECIFIED
+    }
+}
+
 /// Notices related to contact information.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ContactNotice(std::borrow::Cow<'static, str>);
 
 impl ContactNotice {
@@ -2637,8 +2691,14 @@ impl std::convert::From<std::string::String> for ContactNotice {
     }
 }
 
+impl std::default::Default for ContactNotice {
+    fn default() -> Self {
+        contact_notice::CONTACT_NOTICE_UNSPECIFIED
+    }
+}
+
 /// Possible states of a `Registration`'s transfer lock.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TransferLockState(std::borrow::Cow<'static, str>);
 
 impl TransferLockState {
@@ -2671,5 +2731,11 @@ pub mod transfer_lock_state {
 impl std::convert::From<std::string::String> for TransferLockState {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for TransferLockState {
+    fn default() -> Self {
+        transfer_lock_state::TRANSFER_LOCK_STATE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/edgecontainer/v1/src/model.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/model.rs
@@ -618,7 +618,7 @@ pub mod cluster {
 
         /// Represents the policy configuration about how user applications are
         /// deployed.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct SharedDeploymentPolicy(std::borrow::Cow<'static, str>);
 
         impl SharedDeploymentPolicy {
@@ -654,6 +654,12 @@ pub mod cluster {
         impl std::convert::From<std::string::String> for SharedDeploymentPolicy {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for SharedDeploymentPolicy {
+            fn default() -> Self {
+                shared_deployment_policy::SHARED_DEPLOYMENT_POLICY_UNSPECIFIED
             }
         }
 
@@ -1051,7 +1057,7 @@ pub mod cluster {
         use super::*;
 
         /// Indicates the maintenance event type.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Type(std::borrow::Cow<'static, str>);
 
         impl Type {
@@ -1086,8 +1092,14 @@ pub mod cluster {
             }
         }
 
+        impl std::default::Default for Type {
+            fn default() -> Self {
+                r#type::TYPE_UNSPECIFIED
+            }
+        }
+
         /// Indicates when the maintenance event should be performed.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Schedule(std::borrow::Cow<'static, str>);
 
         impl Schedule {
@@ -1119,8 +1131,14 @@ pub mod cluster {
             }
         }
 
+        impl std::default::Default for Schedule {
+            fn default() -> Self {
+                schedule::SCHEDULE_UNSPECIFIED
+            }
+        }
+
         /// Indicates the maintenance event state.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct State(std::borrow::Cow<'static, str>);
 
         impl State {
@@ -1155,6 +1173,12 @@ pub mod cluster {
         impl std::convert::From<std::string::String> for State {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for State {
+            fn default() -> Self {
+                state::STATE_UNSPECIFIED
             }
         }
     }
@@ -1245,7 +1269,7 @@ pub mod cluster {
         use super::*;
 
         /// The connection state.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct State(std::borrow::Cow<'static, str>);
 
         impl State {
@@ -1283,10 +1307,16 @@ pub mod cluster {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for State {
+            fn default() -> Self {
+                state::STATE_UNSPECIFIED
+            }
+        }
     }
 
     /// Indicates the status of the cluster.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Status(std::borrow::Cow<'static, str>);
 
     impl Status {
@@ -1331,8 +1361,14 @@ pub mod cluster {
         }
     }
 
+    impl std::default::Default for Status {
+        fn default() -> Self {
+            status::STATUS_UNSPECIFIED
+        }
+    }
+
     /// The release channel a cluster is subscribed to.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ReleaseChannel(std::borrow::Cow<'static, str>);
 
     impl ReleaseChannel {
@@ -1365,6 +1401,12 @@ pub mod cluster {
     impl std::convert::From<std::string::String> for ReleaseChannel {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ReleaseChannel {
+        fn default() -> Self {
+            release_channel::RELEASE_CHANNEL_UNSPECIFIED
         }
     }
 }
@@ -2303,7 +2345,7 @@ pub mod vpn_connection {
         }
 
         /// The current connection state.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct State(std::borrow::Cow<'static, str>);
 
         impl State {
@@ -2340,10 +2382,16 @@ pub mod vpn_connection {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for State {
+            fn default() -> Self {
+                state::STATE_UNSPECIFIED
+            }
+        }
     }
 
     /// Routing mode.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct BgpRoutingMode(std::borrow::Cow<'static, str>);
 
     impl BgpRoutingMode {
@@ -2376,6 +2424,12 @@ pub mod vpn_connection {
     impl std::convert::From<std::string::String> for BgpRoutingMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for BgpRoutingMode {
+        fn default() -> Self {
+            bgp_routing_mode::BGP_ROUTING_MODE_UNSPECIFIED
         }
     }
 }
@@ -2489,7 +2543,7 @@ pub mod zone_metadata {
     use super::*;
 
     /// Type of the rack.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RackType(std::borrow::Cow<'static, str>);
 
     impl RackType {
@@ -2523,6 +2577,12 @@ pub mod zone_metadata {
     impl std::convert::From<std::string::String> for RackType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RackType {
+        fn default() -> Self {
+            rack_type::RACK_TYPE_UNSPECIFIED
         }
     }
 }
@@ -3094,7 +3154,7 @@ pub mod operation_metadata {
     use super::*;
 
     /// Indicates the reason for the status of the operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct StatusReason(std::borrow::Cow<'static, str>);
 
     impl StatusReason {
@@ -3124,6 +3184,12 @@ pub mod operation_metadata {
     impl std::convert::From<std::string::String> for StatusReason {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for StatusReason {
+        fn default() -> Self {
+            status_reason::STATUS_REASON_UNSPECIFIED
         }
     }
 }
@@ -3492,7 +3558,7 @@ pub mod upgrade_cluster_request {
     use super::*;
 
     /// Represents the schedule about when the cluster is going to be upgraded.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Schedule(std::borrow::Cow<'static, str>);
 
     impl Schedule {
@@ -3523,6 +3589,12 @@ pub mod upgrade_cluster_request {
     impl std::convert::From<std::string::String> for Schedule {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Schedule {
+        fn default() -> Self {
+            schedule::SCHEDULE_UNSPECIFIED
         }
     }
 }
@@ -4549,7 +4621,7 @@ impl wkt::message::Message for GetServerConfigRequest {
 
 /// Represents the accessibility state of a customer-managed KMS key used for
 /// CMEK integration.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct KmsKeyState(std::borrow::Cow<'static, str>);
 
 impl KmsKeyState {
@@ -4588,8 +4660,14 @@ impl std::convert::From<std::string::String> for KmsKeyState {
     }
 }
 
+impl std::default::Default for KmsKeyState {
+    fn default() -> Self {
+        kms_key_state::KMS_KEY_STATE_UNSPECIFIED
+    }
+}
+
 /// Represents if the resource is in lock down state or pending.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ResourceState(std::borrow::Cow<'static, str>);
 
 impl ResourceState {
@@ -4624,5 +4702,11 @@ pub mod resource_state {
 impl std::convert::From<std::string::String> for ResourceState {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for ResourceState {
+    fn default() -> Self {
+        resource_state::RESOURCE_STATE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/edgenetwork/v1/src/model.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/model.rs
@@ -371,7 +371,7 @@ pub mod subnet {
     use super::*;
 
     /// Bonding type in the subnet.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct BondingType(std::borrow::Cow<'static, str>);
 
     impl BondingType {
@@ -408,6 +408,12 @@ pub mod subnet {
     impl std::convert::From<std::string::String> for BondingType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for BondingType {
+        fn default() -> Self {
+            bonding_type::BONDING_TYPE_UNSPECIFIED
         }
     }
 }
@@ -554,7 +560,7 @@ pub mod interconnect {
     use super::*;
 
     /// Type of interconnect.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct InterconnectType(std::borrow::Cow<'static, str>);
 
     impl InterconnectType {
@@ -584,6 +590,12 @@ pub mod interconnect {
     impl std::convert::From<std::string::String> for InterconnectType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for InterconnectType {
+        fn default() -> Self {
+            interconnect_type::INTERCONNECT_TYPE_UNSPECIFIED
         }
     }
 }
@@ -1555,7 +1567,7 @@ pub mod interconnect_diagnostics {
         use super::*;
 
         /// State enum for LACP link.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct State(std::borrow::Cow<'static, str>);
 
         impl State {
@@ -1588,6 +1600,12 @@ pub mod interconnect_diagnostics {
         impl std::convert::From<std::string::String> for State {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for State {
+            fn default() -> Self {
+                state::UNKNOWN
             }
         }
     }
@@ -1862,7 +1880,7 @@ pub mod router_status {
         use super::*;
 
         /// Status of the BGP peer: {UP, DOWN}
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct BgpStatus(std::borrow::Cow<'static, str>);
 
         impl BgpStatus {
@@ -1894,6 +1912,12 @@ pub mod router_status {
         impl std::convert::From<std::string::String> for BgpStatus {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for BgpStatus {
+            fn default() -> Self {
+                bgp_status::UNKNOWN
             }
         }
     }
@@ -3897,7 +3921,7 @@ pub mod diagnose_network_response {
         use super::*;
 
         /// Denotes the status of MACsec sessions for the links of a zone.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct MacsecStatus(std::borrow::Cow<'static, str>);
 
         impl MacsecStatus {
@@ -3930,6 +3954,12 @@ pub mod diagnose_network_response {
         impl std::convert::From<std::string::String> for MacsecStatus {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for MacsecStatus {
+            fn default() -> Self {
+                macsec_status::MACSEC_STATUS_UNSPECIFIED
             }
         }
     }
@@ -4140,7 +4170,7 @@ impl wkt::message::Message for InitializeZoneResponse {
 /// PROVISIONING -> RUNNING. A normal lifecycle of an existing resource being
 /// deleted would be: RUNNING -> DELETING. Any failures during processing will
 /// result the resource to be in a SUSPENDED state.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ResourceState(std::borrow::Cow<'static, str>);
 
 impl ResourceState {
@@ -4181,5 +4211,11 @@ pub mod resource_state {
 impl std::convert::From<std::string::String> for ResourceState {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for ResourceState {
+    fn default() -> Self {
+        resource_state::STATE_UNKNOWN
     }
 }

--- a/src/generated/cloud/essentialcontacts/v1/src/model.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/model.rs
@@ -603,7 +603,7 @@ impl wkt::message::Message for SendTestMessageRequest {
 /// Each notification will be categorized by the sender into one of the following
 /// categories. All contacts that are subscribed to that category will receive
 /// the notification.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct NotificationCategory(std::borrow::Cow<'static, str>);
 
 impl NotificationCategory {
@@ -665,9 +665,15 @@ impl std::convert::From<std::string::String> for NotificationCategory {
     }
 }
 
+impl std::default::Default for NotificationCategory {
+    fn default() -> Self {
+        notification_category::NOTIFICATION_CATEGORY_UNSPECIFIED
+    }
+}
+
 /// A contact's validation state indicates whether or not it is the correct
 /// contact to be receiving notifications for a particular resource.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ValidationState(std::borrow::Cow<'static, str>);
 
 impl ValidationState {
@@ -702,5 +708,11 @@ pub mod validation_state {
 impl std::convert::From<std::string::String> for ValidationState {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for ValidationState {
+    fn default() -> Self {
+        validation_state::VALIDATION_STATE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/eventarc/v1/src/model.rs
+++ b/src/generated/cloud/eventarc/v1/src/model.rs
@@ -208,7 +208,7 @@ pub mod channel {
     use super::*;
 
     /// State lists all the possible states of a Channel
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -256,6 +256,12 @@ pub mod channel {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -3883,7 +3889,7 @@ pub mod logging_config {
     /// resources.
     /// This enum is an exhaustive list of log severities and is FROZEN. Do not
     /// expect new values to be added.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LogSeverity(std::borrow::Cow<'static, str>);
 
     impl LogSeverity {
@@ -3941,6 +3947,12 @@ pub mod logging_config {
     impl std::convert::From<std::string::String> for LogSeverity {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for LogSeverity {
+        fn default() -> Self {
+            log_severity::LOG_SEVERITY_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/filestore/v1/src/model.rs
+++ b/src/generated/cloud/filestore/v1/src/model.rs
@@ -147,7 +147,7 @@ pub mod network_config {
     use super::*;
 
     /// Internet protocol versions supported by Filestore.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AddressMode(std::borrow::Cow<'static, str>);
 
     impl AddressMode {
@@ -180,8 +180,14 @@ pub mod network_config {
         }
     }
 
+    impl std::default::Default for AddressMode {
+        fn default() -> Self {
+            address_mode::ADDRESS_MODE_UNSPECIFIED
+        }
+    }
+
     /// Available connection modes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ConnectMode(std::borrow::Cow<'static, str>);
 
     impl ConnectMode {
@@ -216,6 +222,12 @@ pub mod network_config {
     impl std::convert::From<std::string::String> for ConnectMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ConnectMode {
+        fn default() -> Self {
+            connect_mode::CONNECT_MODE_UNSPECIFIED
         }
     }
 }
@@ -439,7 +451,7 @@ pub mod nfs_export_options {
     use super::*;
 
     /// The access mode.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AccessMode(std::borrow::Cow<'static, str>);
 
     impl AccessMode {
@@ -474,8 +486,14 @@ pub mod nfs_export_options {
         }
     }
 
+    impl std::default::Default for AccessMode {
+        fn default() -> Self {
+            access_mode::ACCESS_MODE_UNSPECIFIED
+        }
+    }
+
     /// The squash mode.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SquashMode(std::borrow::Cow<'static, str>);
 
     impl SquashMode {
@@ -507,6 +525,12 @@ pub mod nfs_export_options {
     impl std::convert::From<std::string::String> for SquashMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SquashMode {
+        fn default() -> Self {
+            squash_mode::SQUASH_MODE_UNSPECIFIED
         }
     }
 }
@@ -705,7 +729,7 @@ pub mod instance {
     use super::*;
 
     /// The instance state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -769,8 +793,14 @@ pub mod instance {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Available service tiers.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Tier(std::borrow::Cow<'static, str>);
 
     impl Tier {
@@ -831,8 +861,14 @@ pub mod instance {
         }
     }
 
+    impl std::default::Default for Tier {
+        fn default() -> Self {
+            tier::TIER_UNSPECIFIED
+        }
+    }
+
     /// SuspensionReason contains the possible reasons for a suspension.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SuspensionReason(std::borrow::Cow<'static, str>);
 
     impl SuspensionReason {
@@ -862,6 +898,12 @@ pub mod instance {
     impl std::convert::From<std::string::String> for SuspensionReason {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SuspensionReason {
+        fn default() -> Self {
+            suspension_reason::SUSPENSION_REASON_UNSPECIFIED
         }
     }
 }
@@ -1435,7 +1477,7 @@ pub mod snapshot {
     use super::*;
 
     /// The snapshot state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1470,6 +1512,12 @@ pub mod snapshot {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1955,7 +2003,7 @@ pub mod backup {
     use super::*;
 
     /// The backup state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1998,6 +2046,12 @@ pub mod backup {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/functions/v2/src/model.rs
+++ b/src/generated/cloud/functions/v2/src/model.rs
@@ -241,7 +241,7 @@ pub mod function {
     use super::*;
 
     /// Describes the current state of the function.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -283,6 +283,12 @@ pub mod function {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -345,7 +351,7 @@ pub mod state_message {
     use super::*;
 
     /// Severity of the state message.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Severity(std::borrow::Cow<'static, str>);
 
     impl Severity {
@@ -380,6 +386,12 @@ pub mod state_message {
     impl std::convert::From<std::string::String> for Severity {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Severity {
+        fn default() -> Self {
+            severity::SEVERITY_UNSPECIFIED
         }
     }
 }
@@ -1086,7 +1098,7 @@ pub mod build_config {
     use super::*;
 
     /// Docker Registry to use for storing function Docker images.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DockerRegistry(std::borrow::Cow<'static, str>);
 
     impl DockerRegistry {
@@ -1124,6 +1136,12 @@ pub mod build_config {
     impl std::convert::From<std::string::String> for DockerRegistry {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DockerRegistry {
+        fn default() -> Self {
+            docker_registry::DOCKER_REGISTRY_UNSPECIFIED
         }
     }
 
@@ -1436,7 +1454,7 @@ pub mod service_config {
     ///
     /// This controls what traffic is diverted through the VPC Access Connector
     /// resource. By default PRIVATE_RANGES_ONLY will be used.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct VpcConnectorEgressSettings(std::borrow::Cow<'static, str>);
 
     impl VpcConnectorEgressSettings {
@@ -1475,12 +1493,18 @@ pub mod service_config {
         }
     }
 
+    impl std::default::Default for VpcConnectorEgressSettings {
+        fn default() -> Self {
+            vpc_connector_egress_settings::VPC_CONNECTOR_EGRESS_SETTINGS_UNSPECIFIED
+        }
+    }
+
     /// Available ingress settings.
     ///
     /// This controls what traffic can reach the function.
     ///
     /// If unspecified, ALLOW_ALL will be used.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct IngressSettings(std::borrow::Cow<'static, str>);
 
     impl IngressSettings {
@@ -1521,13 +1545,19 @@ pub mod service_config {
         }
     }
 
+    impl std::default::Default for IngressSettings {
+        fn default() -> Self {
+            ingress_settings::INGRESS_SETTINGS_UNSPECIFIED
+        }
+    }
+
     /// Available security level settings.
     ///
     /// This enforces security protocol on function URL.
     ///
     /// Security level is only configurable for 1st Gen functions, If unspecified,
     /// SECURE_OPTIONAL will be used. 2nd Gen functions are SECURE_ALWAYS ONLY.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SecurityLevel(std::borrow::Cow<'static, str>);
 
     impl SecurityLevel {
@@ -1564,6 +1594,12 @@ pub mod service_config {
     impl std::convert::From<std::string::String> for SecurityLevel {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SecurityLevel {
+        fn default() -> Self {
+            security_level::SECURITY_LEVEL_UNSPECIFIED
         }
     }
 }
@@ -1911,7 +1947,7 @@ pub mod event_trigger {
 
     /// Describes the retry policy in case of function's execution failure.
     /// Retried execution is charged as any other execution.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RetryPolicy(std::borrow::Cow<'static, str>);
 
     impl RetryPolicy {
@@ -1946,6 +1982,12 @@ pub mod event_trigger {
     impl std::convert::From<std::string::String> for RetryPolicy {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RetryPolicy {
+        fn default() -> Self {
+            retry_policy::RETRY_POLICY_UNSPECIFIED
         }
     }
 }
@@ -2711,7 +2753,7 @@ pub mod list_runtimes_response {
     }
 
     /// The various stages that a runtime can be in.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RuntimeStage(std::borrow::Cow<'static, str>);
 
     impl RuntimeStage {
@@ -2756,6 +2798,12 @@ pub mod list_runtimes_response {
     impl std::convert::From<std::string::String> for RuntimeStage {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RuntimeStage {
+        fn default() -> Self {
+            runtime_stage::RUNTIME_STAGE_UNSPECIFIED
         }
     }
 }
@@ -3095,7 +3143,7 @@ pub mod stage {
     use super::*;
 
     /// Possible names for a Stage
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Name(std::borrow::Cow<'static, str>);
 
     impl Name {
@@ -3142,8 +3190,14 @@ pub mod stage {
         }
     }
 
+    impl std::default::Default for Name {
+        fn default() -> Self {
+            name::NAME_UNSPECIFIED
+        }
+    }
+
     /// Possible states for a Stage
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3180,10 +3234,16 @@ pub mod stage {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
 }
 
 /// The type of the long running operation.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct OperationType(std::borrow::Cow<'static, str>);
 
 impl OperationType {
@@ -3222,8 +3282,14 @@ impl std::convert::From<std::string::String> for OperationType {
     }
 }
 
+impl std::default::Default for OperationType {
+    fn default() -> Self {
+        operation_type::OPERATIONTYPE_UNSPECIFIED
+    }
+}
+
 /// The environment the function is hosted on.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Environment(std::borrow::Cow<'static, str>);
 
 impl Environment {
@@ -3255,5 +3321,11 @@ pub mod environment {
 impl std::convert::From<std::string::String> for Environment {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for Environment {
+    fn default() -> Self {
+        environment::ENVIRONMENT_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/gkebackup/v1/src/model.rs
+++ b/src/generated/cloud/gkebackup/v1/src/model.rs
@@ -669,7 +669,7 @@ pub mod backup {
     }
 
     /// State
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -713,6 +713,12 @@ pub mod backup {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -1377,7 +1383,7 @@ pub mod backup_plan {
     }
 
     /// State
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1421,6 +1427,12 @@ pub mod backup_plan {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1862,7 +1874,7 @@ pub mod volume_type_enum {
     use super::*;
 
     /// Supported volume types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct VolumeType(std::borrow::Cow<'static, str>);
 
     impl VolumeType {
@@ -1891,6 +1903,12 @@ pub mod volume_type_enum {
     impl std::convert::From<std::string::String> for VolumeType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for VolumeType {
+        fn default() -> Self {
+            volume_type::VOLUME_TYPE_UNSPECIFIED
         }
     }
 }
@@ -4160,7 +4178,7 @@ pub mod restore {
     }
 
     /// Possible values for state of the Restore.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -4204,6 +4222,12 @@ pub mod restore {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -4887,7 +4911,7 @@ pub mod restore_config {
         use super::*;
 
         /// Possible values for operations of a transformation rule action.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Op(std::borrow::Cow<'static, str>);
 
         impl Op {
@@ -4944,6 +4968,12 @@ pub mod restore_config {
         impl std::convert::From<std::string::String> for Op {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Op {
+            fn default() -> Self {
+                op::OP_UNSPECIFIED
             }
         }
     }
@@ -5286,7 +5316,7 @@ pub mod restore_config {
     }
 
     /// Defines how volume data should be restored.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct VolumeDataRestorePolicy(std::borrow::Cow<'static, str>);
 
     impl VolumeDataRestorePolicy {
@@ -5334,9 +5364,15 @@ pub mod restore_config {
         }
     }
 
+    impl std::default::Default for VolumeDataRestorePolicy {
+        fn default() -> Self {
+            volume_data_restore_policy::VOLUME_DATA_RESTORE_POLICY_UNSPECIFIED
+        }
+    }
+
     /// Defines the behavior for handling the situation where cluster-scoped
     /// resources being restored already exist in the target cluster.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ClusterResourceConflictPolicy(std::borrow::Cow<'static, str>);
 
     impl ClusterResourceConflictPolicy {
@@ -5378,9 +5414,15 @@ pub mod restore_config {
         }
     }
 
+    impl std::default::Default for ClusterResourceConflictPolicy {
+        fn default() -> Self {
+            cluster_resource_conflict_policy::CLUSTER_RESOURCE_CONFLICT_POLICY_UNSPECIFIED
+        }
+    }
+
     /// Defines the behavior for handling the situation where sets of namespaced
     /// resources being restored already exist in the target cluster.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct NamespacedResourceRestoreMode(std::borrow::Cow<'static, str>);
 
     impl NamespacedResourceRestoreMode {
@@ -5462,6 +5504,12 @@ pub mod restore_config {
     impl std::convert::From<std::string::String> for NamespacedResourceRestoreMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for NamespacedResourceRestoreMode {
+        fn default() -> Self {
+            namespaced_resource_restore_mode::NAMESPACED_RESOURCE_RESTORE_MODE_UNSPECIFIED
         }
     }
 
@@ -5871,7 +5919,7 @@ pub mod restore_plan {
     use super::*;
 
     /// State
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -5909,6 +5957,12 @@ pub mod restore_plan {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -6108,7 +6162,7 @@ pub mod volume_backup {
     use super::*;
 
     /// Identifies the format used for the volume backup.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct VolumeBackupFormat(std::borrow::Cow<'static, str>);
 
     impl VolumeBackupFormat {
@@ -6142,8 +6196,14 @@ pub mod volume_backup {
         }
     }
 
+    impl std::default::Default for VolumeBackupFormat {
+        fn default() -> Self {
+            volume_backup_format::VOLUME_BACKUP_FORMAT_UNSPECIFIED
+        }
+    }
+
     /// The current state of a VolumeBackup
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -6193,6 +6253,12 @@ pub mod volume_backup {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -6373,7 +6439,7 @@ pub mod volume_restore {
     use super::*;
 
     /// Supported volume types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct VolumeType(std::borrow::Cow<'static, str>);
 
     impl VolumeType {
@@ -6405,8 +6471,14 @@ pub mod volume_restore {
         }
     }
 
+    impl std::default::Default for VolumeType {
+        fn default() -> Self {
+            volume_type::VOLUME_TYPE_UNSPECIFIED
+        }
+    }
+
     /// The current state of a VolumeRestore
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -6448,6 +6520,12 @@ pub mod volume_restore {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/model.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/model.rs
@@ -121,7 +121,7 @@ pub mod generate_credentials_request {
     use super::*;
 
     /// Operating systems requiring specialized kubeconfigs.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct OperatingSystem(std::borrow::Cow<'static, str>);
 
     impl OperatingSystem {
@@ -154,6 +154,12 @@ pub mod generate_credentials_request {
     impl std::convert::From<std::string::String> for OperatingSystem {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for OperatingSystem {
+        fn default() -> Self {
+            operating_system::OPERATING_SYSTEM_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/gkehub/configmanagement/v1/src/model.rs
+++ b/src/generated/cloud/gkehub/configmanagement/v1/src/model.rs
@@ -237,7 +237,7 @@ pub mod membership_spec {
     use super::*;
 
     /// Whether to automatically manage the Feature.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Management(std::borrow::Cow<'static, str>);
 
     impl Management {
@@ -269,6 +269,12 @@ pub mod membership_spec {
     impl std::convert::From<std::string::String> for Management {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Management {
+        fn default() -> Self {
+            management::MANAGEMENT_UNSPECIFIED
         }
     }
 }
@@ -1031,7 +1037,7 @@ pub mod config_sync_state {
     use super::*;
 
     /// CRDState representing the state of a CRD
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CRDState(std::borrow::Cow<'static, str>);
 
     impl CRDState {
@@ -1072,7 +1078,13 @@ pub mod config_sync_state {
         }
     }
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    impl std::default::Default for CRDState {
+        fn default() -> Self {
+            crd_state::CRD_STATE_UNSPECIFIED
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1110,6 +1122,12 @@ pub mod config_sync_state {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1450,7 +1468,7 @@ pub mod sync_state {
     use super::*;
 
     /// An enum representing Config Sync's status of syncing configs to a cluster.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SyncCode(std::borrow::Cow<'static, str>);
 
     impl SyncCode {
@@ -1497,6 +1515,12 @@ pub mod sync_state {
     impl std::convert::From<std::string::String> for SyncCode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SyncCode {
+        fn default() -> Self {
+            sync_code::SYNC_CODE_UNSPECIFIED
         }
     }
 }
@@ -1796,7 +1820,7 @@ impl wkt::message::Message for GatekeeperDeploymentState {
 }
 
 /// Enum representing the state of an ACM's deployment on a cluster
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DeploymentState(std::borrow::Cow<'static, str>);
 
 impl DeploymentState {
@@ -1835,5 +1859,11 @@ pub mod deployment_state {
 impl std::convert::From<std::string::String> for DeploymentState {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for DeploymentState {
+    fn default() -> Self {
+        deployment_state::DEPLOYMENT_STATE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/gkehub/v1/src/model.rs
+++ b/src/generated/cloud/gkehub/v1/src/model.rs
@@ -264,7 +264,7 @@ pub mod feature_resource_state {
     use super::*;
 
     /// State describes the lifecycle status of a Feature.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -308,6 +308,12 @@ pub mod feature_resource_state {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -374,7 +380,7 @@ pub mod feature_state {
     use super::*;
 
     /// Code represents a machine-readable, high-level status of the Feature.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Code(std::borrow::Cow<'static, str>);
 
     impl Code {
@@ -415,6 +421,12 @@ pub mod feature_state {
     impl std::convert::From<std::string::String> for Code {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Code {
+        fn default() -> Self {
+            code::CODE_UNSPECIFIED
         }
     }
 }
@@ -1495,7 +1507,7 @@ pub mod membership_state {
     use super::*;
 
     /// Code describes the state of a Membership resource.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Code(std::borrow::Cow<'static, str>);
 
     impl Code {
@@ -1536,6 +1548,12 @@ pub mod membership_state {
     impl std::convert::From<std::string::String> for Code {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Code {
+        fn default() -> Self {
+            code::CODE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/gkemulticloud/v1/src/model.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/model.rs
@@ -412,7 +412,7 @@ pub mod attached_cluster {
     use super::*;
 
     /// The lifecycle state of the cluster.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -460,6 +460,12 @@ pub mod attached_cluster {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -2010,7 +2016,7 @@ pub mod aws_cluster {
     use super::*;
 
     /// The lifecycle state of the cluster.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2058,6 +2064,12 @@ pub mod aws_cluster {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -2596,7 +2608,7 @@ pub mod aws_volume_template {
     /// volumes.
     /// See <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html>
     /// for more information.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct VolumeType(std::borrow::Cow<'static, str>);
 
     impl VolumeType {
@@ -2628,6 +2640,12 @@ pub mod aws_volume_template {
     impl std::convert::From<std::string::String> for VolumeType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for VolumeType {
+        fn default() -> Self {
+            volume_type::VOLUME_TYPE_UNSPECIFIED
         }
     }
 }
@@ -2985,7 +3003,7 @@ pub mod aws_node_pool {
     use super::*;
 
     /// The lifecycle state of the node pool.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3032,6 +3050,12 @@ pub mod aws_node_pool {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -3886,7 +3910,7 @@ pub mod aws_instance_placement {
     use super::*;
 
     /// Tenancy defines how EC2 instances are distributed across physical hardware.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Tenancy(std::borrow::Cow<'static, str>);
 
     impl Tenancy {
@@ -3921,6 +3945,12 @@ pub mod aws_instance_placement {
     impl std::convert::From<std::string::String> for Tenancy {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Tenancy {
+        fn default() -> Self {
+            tenancy::TENANCY_UNSPECIFIED
         }
     }
 }
@@ -5733,7 +5763,7 @@ pub mod azure_cluster {
     use super::*;
 
     /// The lifecycle state of the cluster.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -5781,6 +5811,12 @@ pub mod azure_cluster {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -6874,7 +6910,7 @@ pub mod azure_node_pool {
     use super::*;
 
     /// The lifecycle state of the node pool.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -6921,6 +6957,12 @@ pub mod azure_node_pool {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -9489,7 +9531,7 @@ pub mod node_taint {
     use super::*;
 
     /// The taint effect.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Effect(std::borrow::Cow<'static, str>);
 
     impl Effect {
@@ -9530,6 +9572,12 @@ pub mod node_taint {
     impl std::convert::From<std::string::String> for Effect {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Effect {
+        fn default() -> Self {
+            effect::EFFECT_UNSPECIFIED
         }
     }
 }
@@ -9782,7 +9830,7 @@ pub mod logging_component_config {
     use super::*;
 
     /// The components of the logging configuration;
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Component(std::borrow::Cow<'static, str>);
 
     impl Component {
@@ -9814,6 +9862,12 @@ pub mod logging_component_config {
     impl std::convert::From<std::string::String> for Component {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Component {
+        fn default() -> Self {
+            component::COMPONENT_UNSPECIFIED
         }
     }
 }
@@ -9969,7 +10023,7 @@ pub mod binary_authorization {
     use super::*;
 
     /// Binary Authorization mode of operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EvaluationMode(std::borrow::Cow<'static, str>);
 
     impl EvaluationMode {
@@ -10004,6 +10058,12 @@ pub mod binary_authorization {
     impl std::convert::From<std::string::String> for EvaluationMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EvaluationMode {
+        fn default() -> Self {
+            evaluation_mode::EVALUATION_MODE_UNSPECIFIED
         }
     }
 }
@@ -10048,7 +10108,7 @@ pub mod security_posture_config {
     use super::*;
 
     /// VulnerabilityMode defines enablement mode for vulnerability scanning.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct VulnerabilityMode(std::borrow::Cow<'static, str>);
 
     impl VulnerabilityMode {
@@ -10084,6 +10144,12 @@ pub mod security_posture_config {
     impl std::convert::From<std::string::String> for VulnerabilityMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for VulnerabilityMode {
+        fn default() -> Self {
+            vulnerability_mode::VULNERABILITY_MODE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/iap/v1/src/model.rs
+++ b/src/generated/cloud/iap/v1/src/model.rs
@@ -824,7 +824,7 @@ pub mod reauth_settings {
     use super::*;
 
     /// Types of reauthentication methods supported by IAP.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Method(std::borrow::Cow<'static, str>);
 
     impl Method {
@@ -864,8 +864,14 @@ pub mod reauth_settings {
         }
     }
 
+    impl std::default::Default for Method {
+        fn default() -> Self {
+            method::METHOD_UNSPECIFIED
+        }
+    }
+
     /// Type of policy in the case of hierarchial policies.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PolicyType(std::borrow::Cow<'static, str>);
 
     impl PolicyType {
@@ -898,6 +904,12 @@ pub mod reauth_settings {
     impl std::convert::From<std::string::String> for PolicyType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PolicyType {
+        fn default() -> Self {
+            policy_type::POLICY_TYPE_UNSPECIFIED
         }
     }
 }
@@ -1230,7 +1242,7 @@ pub mod attribute_propagation_settings {
     /// Supported output credentials for attribute propagation. Each output
     /// credential maps to a "field" in the response. For example, selecting JWT
     /// will propagate all attributes in the IAP JWT, header in the headers, etc.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct OutputCredentials(std::borrow::Cow<'static, str>);
 
     impl OutputCredentials {
@@ -1268,6 +1280,12 @@ pub mod attribute_propagation_settings {
     impl std::convert::From<std::string::String> for OutputCredentials {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for OutputCredentials {
+        fn default() -> Self {
+            output_credentials::OUTPUT_CREDENTIALS_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/ids/v1/src/model.rs
+++ b/src/generated/cloud/ids/v1/src/model.rs
@@ -183,7 +183,7 @@ pub mod endpoint {
     use super::*;
 
     /// Threat severity levels.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Severity(std::borrow::Cow<'static, str>);
 
     impl Severity {
@@ -227,8 +227,14 @@ pub mod endpoint {
         }
     }
 
+    impl std::default::Default for Severity {
+        fn default() -> Self {
+            severity::SEVERITY_UNSPECIFIED
+        }
+    }
+
     /// Endpoint state
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -263,6 +269,12 @@ pub mod endpoint {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/kms/v1/src/model.rs
+++ b/src/generated/cloud/kms/v1/src/model.rs
@@ -548,7 +548,7 @@ pub mod autokey_config {
     use super::*;
 
     /// The states AutokeyConfig can be in.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -585,6 +585,12 @@ pub mod autokey_config {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1450,7 +1456,7 @@ pub mod ekm_connection {
     ///
     /// [google.cloud.kms.v1.EkmConnection]: crate::model::EkmConnection
     /// [google.cloud.kms.v1.EkmConnection.KeyManagementMode]: crate::model::ekm_connection::KeyManagementMode
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct KeyManagementMode(std::borrow::Cow<'static, str>);
 
     impl KeyManagementMode {
@@ -1519,6 +1525,12 @@ pub mod ekm_connection {
     impl std::convert::From<std::string::String> for KeyManagementMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for KeyManagementMode {
+        fn default() -> Self {
+            key_management_mode::KEY_MANAGEMENT_MODE_UNSPECIFIED
         }
     }
 }
@@ -2015,7 +2027,7 @@ pub mod crypto_key {
     ///
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
     /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose]: crate::model::crypto_key::CryptoKeyPurpose
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CryptoKeyPurpose(std::borrow::Cow<'static, str>);
 
     impl CryptoKeyPurpose {
@@ -2093,6 +2105,12 @@ pub mod crypto_key {
     impl std::convert::From<std::string::String> for CryptoKeyPurpose {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CryptoKeyPurpose {
+        fn default() -> Self {
+            crypto_key_purpose::CRYPTO_KEY_PURPOSE_UNSPECIFIED
         }
     }
 
@@ -2334,7 +2352,7 @@ pub mod key_operation_attestation {
     }
 
     /// Attestation formats provided by the HSM.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AttestationFormat(std::borrow::Cow<'static, str>);
 
     impl AttestationFormat {
@@ -2374,6 +2392,12 @@ pub mod key_operation_attestation {
     impl std::convert::From<std::string::String> for AttestationFormat {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AttestationFormat {
+        fn default() -> Self {
+            attestation_format::ATTESTATION_FORMAT_UNSPECIFIED
         }
     }
 }
@@ -2758,7 +2782,7 @@ pub mod crypto_key_version {
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
     /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm.GOOGLE_SYMMETRIC_ENCRYPTION]: crate::model::crypto_key_version::crypto_key_version_algorithm::GOOGLE_SYMMETRIC_ENCRYPTION
     /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm.RSA_SIGN_PSS_2048_SHA256]: crate::model::crypto_key_version::crypto_key_version_algorithm::RSA_SIGN_PSS_2048_SHA256
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CryptoKeyVersionAlgorithm(std::borrow::Cow<'static, str>);
 
     impl CryptoKeyVersionAlgorithm {
@@ -2935,11 +2959,17 @@ pub mod crypto_key_version {
         }
     }
 
+    impl std::default::Default for CryptoKeyVersionAlgorithm {
+        fn default() -> Self {
+            crypto_key_version_algorithm::CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED
+        }
+    }
+
     /// The state of a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion],
     /// indicating if it can be used.
     ///
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CryptoKeyVersionState(std::borrow::Cow<'static, str>);
 
     impl CryptoKeyVersionState {
@@ -3058,6 +3088,12 @@ pub mod crypto_key_version {
         }
     }
 
+    impl std::default::Default for CryptoKeyVersionState {
+        fn default() -> Self {
+            crypto_key_version_state::CRYPTO_KEY_VERSION_STATE_UNSPECIFIED
+        }
+    }
+
     /// A view for [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]s.
     /// Controls the level of detail returned for
     /// [CryptoKeyVersions][google.cloud.kms.v1.CryptoKeyVersion] in
@@ -3068,7 +3104,7 @@ pub mod crypto_key_version {
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
     /// [google.cloud.kms.v1.KeyManagementService.ListCryptoKeyVersions]: crate::client::KeyManagementService::list_crypto_key_versions
     /// [google.cloud.kms.v1.KeyManagementService.ListCryptoKeys]: crate::client::KeyManagementService::list_crypto_keys
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CryptoKeyVersionView(std::borrow::Cow<'static, str>);
 
     impl CryptoKeyVersionView {
@@ -3109,6 +3145,12 @@ pub mod crypto_key_version {
     impl std::convert::From<std::string::String> for CryptoKeyVersionView {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CryptoKeyVersionView {
+        fn default() -> Self {
+            crypto_key_version_view::CRYPTO_KEY_VERSION_VIEW_UNSPECIFIED
         }
     }
 }
@@ -3515,7 +3557,7 @@ pub mod import_job {
     ///
     /// [google.cloud.kms.v1.ImportJob]: crate::model::ImportJob
     /// [google.cloud.kms.v1.ImportJob.ImportMethod]: crate::model::import_job::ImportMethod
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ImportMethod(std::borrow::Cow<'static, str>);
 
     impl ImportMethod {
@@ -3593,11 +3635,17 @@ pub mod import_job {
         }
     }
 
+    impl std::default::Default for ImportMethod {
+        fn default() -> Self {
+            import_method::IMPORT_METHOD_UNSPECIFIED
+        }
+    }
+
     /// The state of the [ImportJob][google.cloud.kms.v1.ImportJob], indicating if
     /// it can be used.
     ///
     /// [google.cloud.kms.v1.ImportJob]: crate::model::ImportJob
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ImportJobState(std::borrow::Cow<'static, str>);
 
     impl ImportJobState {
@@ -3645,6 +3693,12 @@ pub mod import_job {
     impl std::convert::From<std::string::String> for ImportJobState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ImportJobState {
+        fn default() -> Self {
+            import_job_state::IMPORT_JOB_STATE_UNSPECIFIED
         }
     }
 }
@@ -8004,7 +8058,7 @@ impl wkt::message::Message for LocationMetadata {
 /// levels] (<https://cloud.google.com/kms/docs/algorithms#protection_levels>).
 ///
 /// [google.cloud.kms.v1.ProtectionLevel]: crate::model::ProtectionLevel
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ProtectionLevel(std::borrow::Cow<'static, str>);
 
 impl ProtectionLevel {
@@ -8046,10 +8100,16 @@ impl std::convert::From<std::string::String> for ProtectionLevel {
     }
 }
 
+impl std::default::Default for ProtectionLevel {
+    fn default() -> Self {
+        protection_level::PROTECTION_LEVEL_UNSPECIFIED
+    }
+}
+
 /// Describes the reason for a data access. Please refer to
 /// <https://cloud.google.com/assured-workloads/key-access-justifications/docs/justification-codes>
 /// for the detailed semantic meaning of justification reason codes.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct AccessReason(std::borrow::Cow<'static, str>);
 
 impl AccessReason {
@@ -8143,5 +8203,11 @@ pub mod access_reason {
 impl std::convert::From<std::string::String> for AccessReason {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for AccessReason {
+    fn default() -> Self {
+        access_reason::REASON_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/language/v2/src/model.rs
+++ b/src/generated/cloud/language/v2/src/model.rs
@@ -141,7 +141,7 @@ pub mod document {
     use super::*;
 
     /// The document types enum.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -173,6 +173,12 @@ pub mod document {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 
@@ -342,7 +348,7 @@ pub mod entity {
     /// The type of the entity. The table
     /// below lists the associated fields for entities that have different
     /// metadata.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -438,6 +444,12 @@ pub mod entity {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::UNKNOWN
         }
     }
 }
@@ -563,7 +575,7 @@ pub mod entity_mention {
     use super::*;
 
     /// The supported types of mentions.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -595,6 +607,12 @@ pub mod entity_mention {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNKNOWN
         }
     }
 }
@@ -1050,7 +1068,7 @@ pub mod moderate_text_request {
     use super::*;
 
     /// The model version to use for ModerateText.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ModelVersion(std::borrow::Cow<'static, str>);
 
     impl ModelVersion {
@@ -1087,6 +1105,12 @@ pub mod moderate_text_request {
     impl std::convert::From<std::string::String> for ModelVersion {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ModelVersion {
+        fn default() -> Self {
+            model_version::MODEL_VERSION_UNSPECIFIED
         }
     }
 }
@@ -1404,7 +1428,7 @@ impl wkt::message::Message for AnnotateTextResponse {
 /// beginning offsets for various outputs, such as tokens and mentions, and
 /// languages that natively use different text encodings may access offsets
 /// differently.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct EncodingType(std::borrow::Cow<'static, str>);
 
 impl EncodingType {
@@ -1446,5 +1470,11 @@ pub mod encoding_type {
 impl std::convert::From<std::string::String> for EncodingType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for EncodingType {
+    fn default() -> Self {
+        encoding_type::NONE
     }
 }

--- a/src/generated/cloud/managedidentities/v1/src/model.rs
+++ b/src/generated/cloud/managedidentities/v1/src/model.rs
@@ -903,7 +903,7 @@ pub mod domain {
     use super::*;
 
     /// Represents the different states of a managed domain.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -951,6 +951,12 @@ pub mod domain {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1124,7 +1130,7 @@ pub mod trust {
     use super::*;
 
     /// Represents the different states of a domain trust.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1168,8 +1174,14 @@ pub mod trust {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Represents the different inter-forest trust types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TrustType(std::borrow::Cow<'static, str>);
 
     impl TrustType {
@@ -1204,11 +1216,17 @@ pub mod trust {
         }
     }
 
+    impl std::default::Default for TrustType {
+        fn default() -> Self {
+            trust_type::TRUST_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Represents the direction of trust.
     /// See
     /// [System.DirectoryServices.ActiveDirectory.TrustDirection](https://docs.microsoft.com/en-us/dotnet/api/system.directoryservices.activedirectory.trustdirection?view=netframework-4.7.2)
     /// for more information.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TrustDirection(std::borrow::Cow<'static, str>);
 
     impl TrustDirection {
@@ -1244,6 +1262,12 @@ pub mod trust {
     impl std::convert::From<std::string::String> for TrustDirection {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for TrustDirection {
+        fn default() -> Self {
+            trust_direction::TRUST_DIRECTION_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/memcache/v1/src/model.rs
+++ b/src/generated/cloud/memcache/v1/src/model.rs
@@ -453,7 +453,7 @@ pub mod instance {
         use super::*;
 
         /// Different states of a Memcached node.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct State(std::borrow::Cow<'static, str>);
 
         impl State {
@@ -491,6 +491,12 @@ pub mod instance {
         impl std::convert::From<std::string::String> for State {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for State {
+            fn default() -> Self {
+                state::STATE_UNSPECIFIED
             }
         }
     }
@@ -540,7 +546,7 @@ pub mod instance {
         #[allow(unused_imports)]
         use super::*;
 
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Code(std::borrow::Cow<'static, str>);
 
         impl Code {
@@ -572,10 +578,16 @@ pub mod instance {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for Code {
+            fn default() -> Self {
+                code::CODE_UNSPECIFIED
+            }
+        }
     }
 
     /// Different states of a Memcached instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -617,6 +629,12 @@ pub mod instance {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -877,7 +895,7 @@ pub mod reschedule_maintenance_request {
     use super::*;
 
     /// Reschedule options.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RescheduleType(std::borrow::Cow<'static, str>);
 
     impl RescheduleType {
@@ -915,6 +933,12 @@ pub mod reschedule_maintenance_request {
     impl std::convert::From<std::string::String> for RescheduleType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RescheduleType {
+        fn default() -> Self {
+            reschedule_type::RESCHEDULE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -1583,7 +1607,7 @@ impl wkt::message::Message for ZoneMetadata {
 }
 
 /// Memcached versions supported by our service.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct MemcacheVersion(std::borrow::Cow<'static, str>);
 
 impl MemcacheVersion {
@@ -1612,5 +1636,11 @@ pub mod memcache_version {
 impl std::convert::From<std::string::String> for MemcacheVersion {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for MemcacheVersion {
+    fn default() -> Self {
+        memcache_version::MEMCACHE_VERSION_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/memorystore/v1/src/model.rs
+++ b/src/generated/cloud/memorystore/v1/src/model.rs
@@ -630,7 +630,7 @@ pub mod instance {
     }
 
     /// Possible states of the instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -671,8 +671,14 @@ pub mod instance {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Possible authorization modes of the instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AuthorizationMode(std::borrow::Cow<'static, str>);
 
     impl AuthorizationMode {
@@ -708,8 +714,14 @@ pub mod instance {
         }
     }
 
+    impl std::default::Default for AuthorizationMode {
+        fn default() -> Self {
+            authorization_mode::AUTHORIZATION_MODE_UNSPECIFIED
+        }
+    }
+
     /// Possible in-transit encryption modes of the instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TransitEncryptionMode(std::borrow::Cow<'static, str>);
 
     impl TransitEncryptionMode {
@@ -747,10 +759,16 @@ pub mod instance {
         }
     }
 
+    impl std::default::Default for TransitEncryptionMode {
+        fn default() -> Self {
+            transit_encryption_mode::TRANSIT_ENCRYPTION_MODE_UNSPECIFIED
+        }
+    }
+
     /// Possible node types of the instance. See
     /// <https://cloud.google.com/memorystore/docs/valkey/instance-node-specification>
     /// for more information.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct NodeType(std::borrow::Cow<'static, str>);
 
     impl NodeType {
@@ -791,8 +809,14 @@ pub mod instance {
         }
     }
 
+    impl std::default::Default for NodeType {
+        fn default() -> Self {
+            node_type::NODE_TYPE_UNSPECIFIED
+        }
+    }
+
     /// The mode config, which is used to enable/disable cluster mode.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Mode(std::borrow::Cow<'static, str>);
 
     impl Mode {
@@ -827,6 +851,12 @@ pub mod instance {
     impl std::convert::From<std::string::String> for Mode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Mode {
+        fn default() -> Self {
+            mode::MODE_UNSPECIFIED
         }
     }
 }
@@ -1296,7 +1326,7 @@ pub mod persistence_config {
         use super::*;
 
         /// Possible snapshot periods.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct SnapshotPeriod(std::borrow::Cow<'static, str>);
 
         impl SnapshotPeriod {
@@ -1335,6 +1365,12 @@ pub mod persistence_config {
         impl std::convert::From<std::string::String> for SnapshotPeriod {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for SnapshotPeriod {
+            fn default() -> Self {
+                snapshot_period::SNAPSHOT_PERIOD_UNSPECIFIED
             }
         }
     }
@@ -1378,7 +1414,7 @@ pub mod persistence_config {
         use super::*;
 
         /// Possible fsync modes.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct AppendFsync(std::borrow::Cow<'static, str>);
 
         impl AppendFsync {
@@ -1419,10 +1455,16 @@ pub mod persistence_config {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for AppendFsync {
+            fn default() -> Self {
+                append_fsync::APPEND_FSYNC_UNSPECIFIED
+            }
+        }
     }
 
     /// Possible persistence modes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PersistenceMode(std::borrow::Cow<'static, str>);
 
     impl PersistenceMode {
@@ -1458,6 +1500,12 @@ pub mod persistence_config {
     impl std::convert::From<std::string::String> for PersistenceMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PersistenceMode {
+        fn default() -> Self {
+            persistence_mode::PERSISTENCE_MODE_UNSPECIFIED
         }
     }
 }
@@ -1540,7 +1588,7 @@ pub mod zone_distribution_config {
     use super::*;
 
     /// Possible zone distribution modes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ZoneDistributionMode(std::borrow::Cow<'static, str>);
 
     impl ZoneDistributionMode {
@@ -1574,6 +1622,12 @@ pub mod zone_distribution_config {
     impl std::convert::From<std::string::String> for ZoneDistributionMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ZoneDistributionMode {
+        fn default() -> Self {
+            zone_distribution_mode::ZONE_DISTRIBUTION_MODE_UNSPECIFIED
         }
     }
 }
@@ -2267,7 +2321,7 @@ impl wkt::message::Message for OperationMetadata {
 }
 
 /// Status of the PSC connection.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct PscConnectionStatus(std::borrow::Cow<'static, str>);
 
 impl PscConnectionStatus {
@@ -2303,8 +2357,14 @@ impl std::convert::From<std::string::String> for PscConnectionStatus {
     }
 }
 
+impl std::default::Default for PscConnectionStatus {
+    fn default() -> Self {
+        psc_connection_status::PSC_CONNECTION_STATUS_UNSPECIFIED
+    }
+}
+
 /// Type of a PSC connection
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ConnectionType(std::borrow::Cow<'static, str>);
 
 impl ConnectionType {
@@ -2343,5 +2403,11 @@ pub mod connection_type {
 impl std::convert::From<std::string::String> for ConnectionType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for ConnectionType {
+    fn default() -> Self {
+        connection_type::CONNECTION_TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/metastore/v1/src/model.rs
+++ b/src/generated/cloud/metastore/v1/src/model.rs
@@ -369,7 +369,7 @@ pub mod service {
     use super::*;
 
     /// The current state of the metastore service.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -422,8 +422,14 @@ pub mod service {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Available service tiers.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Tier(std::borrow::Cow<'static, str>);
 
     impl Tier {
@@ -460,10 +466,16 @@ pub mod service {
         }
     }
 
+    impl std::default::Default for Tier {
+        fn default() -> Self {
+            tier::TIER_UNSPECIFIED
+        }
+    }
+
     /// Release channels bundle features of varying levels of stability. Newer
     /// features may be introduced initially into less stable release channels and
     /// can be automatically promoted into more stable release channels.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ReleaseChannel(std::borrow::Cow<'static, str>);
 
     impl ReleaseChannel {
@@ -502,8 +514,14 @@ pub mod service {
         }
     }
 
+    impl std::default::Default for ReleaseChannel {
+        fn default() -> Self {
+            release_channel::RELEASE_CHANNEL_UNSPECIFIED
+        }
+    }
+
     /// The backend database type for the metastore service.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DatabaseType(std::borrow::Cow<'static, str>);
 
     impl DatabaseType {
@@ -536,6 +554,12 @@ pub mod service {
     impl std::convert::From<std::string::String> for DatabaseType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DatabaseType {
+        fn default() -> Self {
+            database_type::DATABASE_TYPE_UNSPECIFIED
         }
     }
 
@@ -707,7 +731,7 @@ pub mod hive_metastore_config {
     use super::*;
 
     /// Protocols available for serving the metastore service endpoint.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EndpointProtocol(std::borrow::Cow<'static, str>);
 
     impl EndpointProtocol {
@@ -740,6 +764,12 @@ pub mod hive_metastore_config {
     impl std::convert::From<std::string::String> for EndpointProtocol {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EndpointProtocol {
+        fn default() -> Self {
+            endpoint_protocol::ENDPOINT_PROTOCOL_UNSPECIFIED
         }
     }
 }
@@ -1161,7 +1191,7 @@ pub mod telemetry_config {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LogFormat(std::borrow::Cow<'static, str>);
 
     impl LogFormat {
@@ -1193,6 +1223,12 @@ pub mod telemetry_config {
     impl std::convert::From<std::string::String> for LogFormat {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for LogFormat {
+        fn default() -> Self {
+            log_format::LOG_FORMAT_UNSPECIFIED
         }
     }
 }
@@ -1468,7 +1504,7 @@ pub mod metadata_import {
         use super::*;
 
         /// The type of the database.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct DatabaseType(std::borrow::Cow<'static, str>);
 
         impl DatabaseType {
@@ -1500,10 +1536,16 @@ pub mod metadata_import {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for DatabaseType {
+            fn default() -> Self {
+                database_type::DATABASE_TYPE_UNSPECIFIED
+            }
+        }
     }
 
     /// The current state of the metadata import.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1542,6 +1584,12 @@ pub mod metadata_import {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -1672,7 +1720,7 @@ pub mod metadata_export {
     use super::*;
 
     /// The current state of the metadata export.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1710,6 +1758,12 @@ pub mod metadata_export {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -1837,7 +1891,7 @@ pub mod backup {
     use super::*;
 
     /// The current state of the backup.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1878,6 +1932,12 @@ pub mod backup {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1979,7 +2039,7 @@ pub mod restore {
     use super::*;
 
     /// The current state of the restore.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2020,8 +2080,14 @@ pub mod restore {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// The type of restore. If unspecified, defaults to `METADATA_ONLY`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RestoreType(std::borrow::Cow<'static, str>);
 
     impl RestoreType {
@@ -2054,6 +2120,12 @@ pub mod restore {
     impl std::convert::From<std::string::String> for RestoreType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RestoreType {
+        fn default() -> Self {
+            restore_type::RESTORE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -2154,7 +2226,7 @@ pub mod scaling_config {
     use super::*;
 
     /// Metastore instance sizes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct InstanceSize(std::borrow::Cow<'static, str>);
 
     impl InstanceSize {
@@ -2196,6 +2268,12 @@ pub mod scaling_config {
     impl std::convert::From<std::string::String> for InstanceSize {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for InstanceSize {
+        fn default() -> Self {
+            instance_size::INSTANCE_SIZE_UNSPECIFIED
         }
     }
 
@@ -3754,7 +3832,7 @@ pub mod database_dump_spec {
     use super::*;
 
     /// The type of the database dump.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -3786,6 +3864,12 @@ pub mod database_dump_spec {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -4243,7 +4327,7 @@ pub mod federation {
     use super::*;
 
     /// The current state of the federation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -4286,6 +4370,12 @@ pub mod federation {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -4346,7 +4436,7 @@ pub mod backend_metastore {
     use super::*;
 
     /// The type of the backend metastore.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MetastoreType(std::borrow::Cow<'static, str>);
 
     impl MetastoreType {
@@ -4379,6 +4469,12 @@ pub mod backend_metastore {
     impl std::convert::From<std::string::String> for MetastoreType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for MetastoreType {
+        fn default() -> Self {
+            metastore_type::METASTORE_TYPE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/migrationcenter/v1/src/model.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/model.rs
@@ -528,7 +528,7 @@ pub mod import_job {
     use super::*;
 
     /// Enumerates possible states of an import job.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ImportJobState(std::borrow::Cow<'static, str>);
 
     impl ImportJobState {
@@ -583,6 +583,12 @@ pub mod import_job {
     impl std::convert::From<std::string::String> for ImportJobState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ImportJobState {
+        fn default() -> Self {
+            import_job_state::IMPORT_JOB_STATE_UNSPECIFIED
         }
     }
 
@@ -726,7 +732,7 @@ pub mod import_data_file {
     use super::*;
 
     /// Enumerates possible states of an import data file.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -758,6 +764,12 @@ pub mod import_data_file {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -1077,7 +1089,7 @@ pub mod source {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SourceType(std::borrow::Cow<'static, str>);
 
     impl SourceType {
@@ -1120,8 +1132,14 @@ pub mod source {
         }
     }
 
+    impl std::default::Default for SourceType {
+        fn default() -> Self {
+            source_type::SOURCE_TYPE_UNKNOWN
+        }
+    }
+
     /// Enumerates possible states of a source.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1157,6 +1175,12 @@ pub mod source {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1414,7 +1438,7 @@ pub mod report {
     use super::*;
 
     /// Report type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -1446,8 +1470,14 @@ pub mod report {
         }
     }
 
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
+        }
+    }
+
     /// Report creation state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1482,6 +1512,12 @@ pub mod report {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -5525,7 +5561,7 @@ pub mod machine_details {
     use super::*;
 
     /// Machine power state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PowerState(std::borrow::Cow<'static, str>);
 
     impl PowerState {
@@ -5571,6 +5607,12 @@ pub mod machine_details {
     impl std::convert::From<std::string::String> for PowerState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PowerState {
+        fn default() -> Self {
+            power_state::POWER_STATE_UNSPECIFIED
         }
     }
 }
@@ -5692,7 +5734,7 @@ pub mod machine_architecture_details {
     use super::*;
 
     /// Firmware type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct FirmwareType(std::borrow::Cow<'static, str>);
 
     impl FirmwareType {
@@ -5728,8 +5770,14 @@ pub mod machine_architecture_details {
         }
     }
 
+    impl std::default::Default for FirmwareType {
+        fn default() -> Self {
+            firmware_type::FIRMWARE_TYPE_UNSPECIFIED
+        }
+    }
+
     /// CPU hyper-threading support.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CpuHyperThreading(std::borrow::Cow<'static, str>);
 
     impl CpuHyperThreading {
@@ -5762,6 +5810,12 @@ pub mod machine_architecture_details {
     impl std::convert::From<std::string::String> for CpuHyperThreading {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CpuHyperThreading {
+        fn default() -> Self {
+            cpu_hyper_threading::CPU_HYPER_THREADING_UNSPECIFIED
         }
     }
 }
@@ -6124,7 +6178,7 @@ pub mod network_address {
     use super::*;
 
     /// Network address assignment.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AddressAssignment(std::borrow::Cow<'static, str>);
 
     impl AddressAssignment {
@@ -6159,6 +6213,12 @@ pub mod network_address {
     impl std::convert::From<std::string::String> for AddressAssignment {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AddressAssignment {
+        fn default() -> Self {
+            address_assignment::ADDRESS_ASSIGNMENT_UNSPECIFIED
         }
     }
 }
@@ -6393,7 +6453,7 @@ pub mod disk_entry {
     use super::*;
 
     /// Disks interface type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct InterfaceType(std::borrow::Cow<'static, str>);
 
     impl InterfaceType {
@@ -6441,6 +6501,12 @@ pub mod disk_entry {
     impl std::convert::From<std::string::String> for InterfaceType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for InterfaceType {
+        fn default() -> Self {
+            interface_type::INTERFACE_TYPE_UNSPECIFIED
         }
     }
 
@@ -6657,7 +6723,7 @@ pub mod vmware_disk_config {
     use super::*;
 
     /// VMDK backing type possible values.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct BackingType(std::borrow::Cow<'static, str>);
 
     impl BackingType {
@@ -6713,8 +6779,14 @@ pub mod vmware_disk_config {
         }
     }
 
+    impl std::default::Default for BackingType {
+        fn default() -> Self {
+            backing_type::BACKING_TYPE_UNSPECIFIED
+        }
+    }
+
     /// VMDK disk mode.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct VmdkMode(std::borrow::Cow<'static, str>);
 
     impl VmdkMode {
@@ -6752,8 +6824,14 @@ pub mod vmware_disk_config {
         }
     }
 
+    impl std::default::Default for VmdkMode {
+        fn default() -> Self {
+            vmdk_mode::VMDK_MODE_UNSPECIFIED
+        }
+    }
+
     /// RDM compatibility mode.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RdmCompatibility(std::borrow::Cow<'static, str>);
 
     impl RdmCompatibility {
@@ -6788,6 +6866,12 @@ pub mod vmware_disk_config {
     impl std::convert::From<std::string::String> for RdmCompatibility {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RdmCompatibility {
+        fn default() -> Self {
+            rdm_compatibility::RDM_COMPATIBILITY_UNSPECIFIED
         }
     }
 }
@@ -6963,7 +7047,7 @@ pub mod guest_config_details {
     use super::*;
 
     /// Security-Enhanced Linux (SELinux) mode.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SeLinuxMode(std::borrow::Cow<'static, str>);
 
     impl SeLinuxMode {
@@ -7001,6 +7085,12 @@ pub mod guest_config_details {
     impl std::convert::From<std::string::String> for SeLinuxMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SeLinuxMode {
+        fn default() -> Self {
+            se_linux_mode::SE_LINUX_MODE_UNSPECIFIED
         }
     }
 }
@@ -7526,7 +7616,7 @@ pub mod running_service {
     use super::*;
 
     /// Service state (OS-agnostic).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -7564,8 +7654,14 @@ pub mod running_service {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Service start mode (OS-agnostic).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct StartMode(std::borrow::Cow<'static, str>);
 
     impl StartMode {
@@ -7606,6 +7702,12 @@ pub mod running_service {
     impl std::convert::From<std::string::String> for StartMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for StartMode {
+        fn default() -> Self {
+            start_mode::START_MODE_UNSPECIFIED
         }
     }
 }
@@ -7910,7 +8012,7 @@ pub mod network_connection {
     use super::*;
 
     /// Network connection state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -7951,6 +8053,12 @@ pub mod network_connection {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -9686,7 +9794,7 @@ pub mod fit_descriptor {
     use super::*;
 
     /// Fit level.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct FitLevel(std::borrow::Cow<'static, str>);
 
     impl FitLevel {
@@ -9721,6 +9829,12 @@ pub mod fit_descriptor {
     impl std::convert::From<std::string::String> for FitLevel {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for FitLevel {
+        fn default() -> Self {
+            fit_level::FIT_LEVEL_UNSPECIFIED
         }
     }
 }
@@ -10586,7 +10700,7 @@ pub mod import_error {
     use super::*;
 
     /// Enumerate possible error severity.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Severity(std::borrow::Cow<'static, str>);
 
     impl Severity {
@@ -10617,6 +10731,12 @@ pub mod import_error {
     impl std::convert::From<std::string::String> for Severity {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Severity {
+        fn default() -> Self {
+            severity::SEVERITY_UNSPECIFIED
         }
     }
 }
@@ -11148,7 +11268,7 @@ pub mod vmware_engine_preferences {
     use super::*;
 
     /// Type of committed use discount.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CommitmentPlan(std::borrow::Cow<'static, str>);
 
     impl CommitmentPlan {
@@ -11194,6 +11314,12 @@ pub mod vmware_engine_preferences {
     impl std::convert::From<std::string::String> for CommitmentPlan {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CommitmentPlan {
+        fn default() -> Self {
+            commitment_plan::COMMITMENT_PLAN_UNSPECIFIED
         }
     }
 }
@@ -11280,7 +11406,7 @@ pub mod sole_tenancy_preferences {
     use super::*;
 
     /// Sole Tenancy nodes maintenance policy.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct HostMaintenancePolicy(std::borrow::Cow<'static, str>);
 
     impl HostMaintenancePolicy {
@@ -11322,8 +11448,14 @@ pub mod sole_tenancy_preferences {
         }
     }
 
+    impl std::default::Default for HostMaintenancePolicy {
+        fn default() -> Self {
+            host_maintenance_policy::HOST_MAINTENANCE_POLICY_UNSPECIFIED
+        }
+    }
+
     /// Type of committed use discount.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CommitmentPlan(std::borrow::Cow<'static, str>);
 
     impl CommitmentPlan {
@@ -11359,6 +11491,12 @@ pub mod sole_tenancy_preferences {
     impl std::convert::From<std::string::String> for CommitmentPlan {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CommitmentPlan {
+        fn default() -> Self {
+            commitment_plan::COMMITMENT_PLAN_UNSPECIFIED
         }
     }
 }
@@ -12573,7 +12711,7 @@ pub mod report_summary {
 
 /// Specifies the types of asset views that provide complete or partial details
 /// of an asset.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct AssetView(std::borrow::Cow<'static, str>);
 
 impl AssetView {
@@ -12609,8 +12747,14 @@ impl std::convert::From<std::string::String> for AssetView {
     }
 }
 
+impl std::default::Default for AssetView {
+    fn default() -> Self {
+        asset_view::ASSET_VIEW_UNSPECIFIED
+    }
+}
+
 /// Known categories of operating systems.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct OperatingSystemFamily(std::borrow::Cow<'static, str>);
 
 impl OperatingSystemFamily {
@@ -12650,8 +12794,14 @@ impl std::convert::From<std::string::String> for OperatingSystemFamily {
     }
 }
 
+impl std::default::Default for OperatingSystemFamily {
+    fn default() -> Self {
+        operating_system_family::OS_FAMILY_UNKNOWN
+    }
+}
+
 /// Specifies the data formats supported by Migration Center.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ImportJobFormat(std::borrow::Cow<'static, str>);
 
 impl ImportJobFormat {
@@ -12707,9 +12857,15 @@ impl std::convert::From<std::string::String> for ImportJobFormat {
     }
 }
 
+impl std::default::Default for ImportJobFormat {
+    fn default() -> Self {
+        import_job_format::IMPORT_JOB_FORMAT_UNSPECIFIED
+    }
+}
+
 /// Specifies the types of import job views that provide complete or partial
 /// details of an import job.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ImportJobView(std::borrow::Cow<'static, str>);
 
 impl ImportJobView {
@@ -12747,9 +12903,15 @@ impl std::convert::From<std::string::String> for ImportJobView {
     }
 }
 
+impl std::default::Default for ImportJobView {
+    fn default() -> Self {
+        import_job_view::IMPORT_JOB_VIEW_UNSPECIFIED
+    }
+}
+
 /// ErrorFrameView can be specified in ErrorFrames List and Get requests to
 /// control the level of details that is returned for the original frame.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ErrorFrameView(std::borrow::Cow<'static, str>);
 
 impl ErrorFrameView {
@@ -12786,8 +12948,14 @@ impl std::convert::From<std::string::String> for ErrorFrameView {
     }
 }
 
+impl std::default::Default for ErrorFrameView {
+    fn default() -> Self {
+        error_frame_view::ERROR_FRAME_VIEW_UNSPECIFIED
+    }
+}
+
 /// The persistent disk (PD) types of Compute Engine virtual machines.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct PersistentDiskType(std::borrow::Cow<'static, str>);
 
 impl PersistentDiskType {
@@ -12831,9 +12999,15 @@ impl std::convert::From<std::string::String> for PersistentDiskType {
     }
 }
 
+impl std::default::Default for PersistentDiskType {
+    fn default() -> Self {
+        persistent_disk_type::PERSISTENT_DISK_TYPE_UNSPECIFIED
+    }
+}
+
 /// The License type for premium images (RHEL, RHEL for SAP, SLES, SLES for SAP,
 /// Windows Server).
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct LicenseType(std::borrow::Cow<'static, str>);
 
 impl LicenseType {
@@ -12870,10 +13044,16 @@ impl std::convert::From<std::string::String> for LicenseType {
     }
 }
 
+impl std::default::Default for LicenseType {
+    fn default() -> Self {
+        license_type::LICENSE_TYPE_UNSPECIFIED
+    }
+}
+
 /// The sizing optimization strategy preferences of a virtual machine. This
 /// strategy, in addition to actual usage data of the virtual machine, can help
 /// determine the recommended shape on the target platform.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SizingOptimizationStrategy(std::borrow::Cow<'static, str>);
 
 impl SizingOptimizationStrategy {
@@ -12919,8 +13099,14 @@ impl std::convert::From<std::string::String> for SizingOptimizationStrategy {
     }
 }
 
+impl std::default::Default for SizingOptimizationStrategy {
+    fn default() -> Self {
+        sizing_optimization_strategy::SIZING_OPTIMIZATION_STRATEGY_UNSPECIFIED
+    }
+}
+
 /// The plan of commitments for VM resource-based committed use discount (CUD).
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct CommitmentPlan(std::borrow::Cow<'static, str>);
 
 impl CommitmentPlan {
@@ -12961,8 +13147,14 @@ impl std::convert::From<std::string::String> for CommitmentPlan {
     }
 }
 
+impl std::default::Default for CommitmentPlan {
+    fn default() -> Self {
+        commitment_plan::COMMITMENT_PLAN_UNSPECIFIED
+    }
+}
+
 /// The preference for a specific Google Cloud product platform.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ComputeMigrationTargetProduct(std::borrow::Cow<'static, str>);
 
 impl ComputeMigrationTargetProduct {
@@ -13004,9 +13196,15 @@ impl std::convert::From<std::string::String> for ComputeMigrationTargetProduct {
     }
 }
 
+impl std::default::Default for ComputeMigrationTargetProduct {
+    fn default() -> Self {
+        compute_migration_target_product::COMPUTE_MIGRATION_TARGET_PRODUCT_UNSPECIFIED
+    }
+}
+
 /// Specifies the types of views that provide complete or partial details
 /// of a Report.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ReportView(std::borrow::Cow<'static, str>);
 
 impl ReportView {
@@ -13045,5 +13243,11 @@ pub mod report_view {
 impl std::convert::From<std::string::String> for ReportView {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for ReportView {
+    fn default() -> Self {
+        report_view::REPORT_VIEW_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/modelarmor/v1/src/model.rs
+++ b/src/generated/cloud/modelarmor/v1/src/model.rs
@@ -917,7 +917,7 @@ pub mod pi_and_jailbreak_filter_settings {
 
     /// Option to specify the state of Prompt Injection and Jailbreak filter
     /// (ENABLED/DISABLED).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PiAndJailbreakFilterEnforcement(std::borrow::Cow<'static, str>);
 
     impl PiAndJailbreakFilterEnforcement {
@@ -952,6 +952,12 @@ pub mod pi_and_jailbreak_filter_settings {
     impl std::convert::From<std::string::String> for PiAndJailbreakFilterEnforcement {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PiAndJailbreakFilterEnforcement {
+        fn default() -> Self {
+            pi_and_jailbreak_filter_enforcement::PI_AND_JAILBREAK_FILTER_ENFORCEMENT_UNSPECIFIED
         }
     }
 }
@@ -998,7 +1004,7 @@ pub mod malicious_uri_filter_settings {
     use super::*;
 
     /// Option to specify the state of Malicious URI filter (ENABLED/DISABLED).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MaliciousUriFilterEnforcement(std::borrow::Cow<'static, str>);
 
     impl MaliciousUriFilterEnforcement {
@@ -1033,6 +1039,12 @@ pub mod malicious_uri_filter_settings {
     impl std::convert::From<std::string::String> for MaliciousUriFilterEnforcement {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for MaliciousUriFilterEnforcement {
+        fn default() -> Self {
+            malicious_uri_filter_enforcement::MALICIOUS_URI_FILTER_ENFORCEMENT_UNSPECIFIED
         }
     }
 }
@@ -1290,7 +1302,7 @@ pub mod sdp_basic_config {
 
     /// Option to specify the state of Sensitive Data Protection basic config
     /// (ENABLED/DISABLED).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SdpBasicConfigEnforcement(std::borrow::Cow<'static, str>);
 
     impl SdpBasicConfigEnforcement {
@@ -1323,6 +1335,12 @@ pub mod sdp_basic_config {
     impl std::convert::From<std::string::String> for SdpBasicConfigEnforcement {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SdpBasicConfigEnforcement {
+        fn default() -> Self {
+            sdp_basic_config_enforcement::SDP_BASIC_CONFIG_ENFORCEMENT_UNSPECIFIED
         }
     }
 }
@@ -2457,7 +2475,7 @@ pub mod byte_data_item {
     use super::*;
 
     /// Option to specify the type of byte data.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ByteItemType(std::borrow::Cow<'static, str>);
 
     impl ByteItemType {
@@ -2490,6 +2508,12 @@ pub mod byte_data_item {
     impl std::convert::From<std::string::String> for ByteItemType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ByteItemType {
+        fn default() -> Self {
+            byte_item_type::BYTE_ITEM_TYPE_UNSPECIFIED
         }
     }
 }
@@ -3014,7 +3038,7 @@ pub mod virus_scan_filter_result {
     use super::*;
 
     /// Type of content scanned.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ScannedContentType(std::borrow::Cow<'static, str>);
 
     impl ScannedContentType {
@@ -3051,6 +3075,12 @@ pub mod virus_scan_filter_result {
     impl std::convert::From<std::string::String> for ScannedContentType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ScannedContentType {
+        fn default() -> Self {
+            scanned_content_type::SCANNED_CONTENT_TYPE_UNSPECIFIED
         }
     }
 }
@@ -3117,7 +3147,7 @@ pub mod virus_detail {
     use super::*;
 
     /// Defines all the threat types of a virus
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ThreatType(std::borrow::Cow<'static, str>);
 
     impl ThreatType {
@@ -3160,6 +3190,12 @@ pub mod virus_detail {
     impl std::convert::From<std::string::String> for ThreatType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ThreatType {
+        fn default() -> Self {
+            threat_type::THREAT_TYPE_UNSPECIFIED
         }
     }
 }
@@ -3273,7 +3309,7 @@ pub mod message_item {
     use super::*;
 
     /// Option to specify the type of message.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MessageType(std::borrow::Cow<'static, str>);
 
     impl MessageType {
@@ -3309,6 +3345,12 @@ pub mod message_item {
     impl std::convert::From<std::string::String> for MessageType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for MessageType {
+        fn default() -> Self {
+            message_type::MESSAGE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -3357,7 +3399,7 @@ impl wkt::message::Message for RangeInfo {
 }
 
 /// Option to specify filter match state.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct FilterMatchState(std::borrow::Cow<'static, str>);
 
 impl FilterMatchState {
@@ -3393,8 +3435,14 @@ impl std::convert::From<std::string::String> for FilterMatchState {
     }
 }
 
+impl std::default::Default for FilterMatchState {
+    fn default() -> Self {
+        filter_match_state::FILTER_MATCH_STATE_UNSPECIFIED
+    }
+}
+
 /// Enum which reports whether a specific filter executed successfully or not.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct FilterExecutionState(std::borrow::Cow<'static, str>);
 
 impl FilterExecutionState {
@@ -3433,8 +3481,14 @@ impl std::convert::From<std::string::String> for FilterExecutionState {
     }
 }
 
+impl std::default::Default for FilterExecutionState {
+    fn default() -> Self {
+        filter_execution_state::FILTER_EXECUTION_STATE_UNSPECIFIED
+    }
+}
+
 /// Options for responsible AI Filter Types.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct RaiFilterType(std::borrow::Cow<'static, str>);
 
 impl RaiFilterType {
@@ -3476,10 +3530,16 @@ impl std::convert::From<std::string::String> for RaiFilterType {
     }
 }
 
+impl std::default::Default for RaiFilterType {
+    fn default() -> Self {
+        rai_filter_type::RAI_FILTER_TYPE_UNSPECIFIED
+    }
+}
+
 /// Confidence levels for detectors.
 /// Higher value maps to a greater confidence level. To enforce stricter level a
 /// lower value should be used.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DetectionConfidenceLevel(std::borrow::Cow<'static, str>);
 
 impl DetectionConfidenceLevel {
@@ -3520,9 +3580,15 @@ impl std::convert::From<std::string::String> for DetectionConfidenceLevel {
     }
 }
 
+impl std::default::Default for DetectionConfidenceLevel {
+    fn default() -> Self {
+        detection_confidence_level::DETECTION_CONFIDENCE_LEVEL_UNSPECIFIED
+    }
+}
+
 /// For more information about each Sensitive Data Protection likelihood level,
 /// see <https://cloud.google.com/sensitive-data-protection/docs/likelihood>.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SdpFindingLikelihood(std::borrow::Cow<'static, str>);
 
 impl SdpFindingLikelihood {
@@ -3567,9 +3633,15 @@ impl std::convert::From<std::string::String> for SdpFindingLikelihood {
     }
 }
 
+impl std::default::Default for SdpFindingLikelihood {
+    fn default() -> Self {
+        sdp_finding_likelihood::SDP_FINDING_LIKELIHOOD_UNSPECIFIED
+    }
+}
+
 /// A field indicating the outcome of the invocation, irrespective of match
 /// status.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct InvocationResult(std::borrow::Cow<'static, str>);
 
 impl InvocationResult {
@@ -3605,5 +3677,11 @@ pub mod invocation_result {
 impl std::convert::From<std::string::String> for InvocationResult {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for InvocationResult {
+    fn default() -> Self {
+        invocation_result::INVOCATION_RESULT_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/netapp/v1/src/model.rs
+++ b/src/generated/cloud/netapp/v1/src/model.rs
@@ -621,7 +621,7 @@ pub mod active_directory {
     use super::*;
 
     /// The Active Directory States
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -668,6 +668,12 @@ pub mod active_directory {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -840,7 +846,7 @@ pub mod backup {
     use super::*;
 
     /// The Backup States
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -891,8 +897,14 @@ pub mod backup {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Backup types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -924,6 +936,12 @@ pub mod backup {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -1406,7 +1424,7 @@ pub mod backup_policy {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1447,6 +1465,12 @@ pub mod backup_policy {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1853,7 +1877,7 @@ pub mod backup_vault {
     use super::*;
 
     /// The Backup Vault States
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1894,6 +1918,12 @@ pub mod backup_vault {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -2905,7 +2935,7 @@ pub mod kms_config {
     use super::*;
 
     /// The KmsConfig States
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2966,6 +2996,12 @@ pub mod kms_config {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -3402,7 +3438,7 @@ pub mod quota_rule {
     use super::*;
 
     /// Types of Quota Rule
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -3443,8 +3479,14 @@ pub mod quota_rule {
         }
     }
 
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
+        }
+    }
+
     /// Quota Rule states
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3485,6 +3527,12 @@ pub mod quota_rule {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -3877,7 +3925,7 @@ pub mod replication {
 
     /// The replication states
     /// New enum values may be added in future to indicate possible new states.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3927,9 +3975,15 @@ pub mod replication {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// New enum values may be added in future to support different replication
     /// topology.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ReplicationRole(std::borrow::Cow<'static, str>);
 
     impl ReplicationRole {
@@ -3965,10 +4019,16 @@ pub mod replication {
         }
     }
 
+    impl std::default::Default for ReplicationRole {
+        fn default() -> Self {
+            replication_role::REPLICATION_ROLE_UNSPECIFIED
+        }
+    }
+
     /// Schedule for Replication.
     /// New enum values may be added in future to support different frequency of
     /// replication.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ReplicationSchedule(std::borrow::Cow<'static, str>);
 
     impl ReplicationSchedule {
@@ -4008,9 +4068,15 @@ pub mod replication {
         }
     }
 
+    impl std::default::Default for ReplicationSchedule {
+        fn default() -> Self {
+            replication_schedule::REPLICATION_SCHEDULE_UNSPECIFIED
+        }
+    }
+
     /// Mirroring states.
     /// No new value is expected to be added in future.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MirrorState(std::borrow::Cow<'static, str>);
 
     impl MirrorState {
@@ -4059,8 +4125,14 @@ pub mod replication {
         }
     }
 
+    impl std::default::Default for MirrorState {
+        fn default() -> Self {
+            mirror_state::MIRROR_STATE_UNSPECIFIED
+        }
+    }
+
     /// Hybrid replication type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct HybridReplicationType(std::borrow::Cow<'static, str>);
 
     impl HybridReplicationType {
@@ -4094,6 +4166,12 @@ pub mod replication {
     impl std::convert::From<std::string::String> for HybridReplicationType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for HybridReplicationType {
+        fn default() -> Self {
+            hybrid_replication_type::HYBRID_REPLICATION_TYPE_UNSPECIFIED
         }
     }
 }
@@ -5224,7 +5302,7 @@ pub mod snapshot {
     use super::*;
 
     /// The Snapshot States
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -5268,6 +5346,12 @@ pub mod snapshot {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -5879,7 +5963,7 @@ pub mod storage_pool {
     use super::*;
 
     /// The Storage Pool States
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -5926,6 +6010,12 @@ pub mod storage_pool {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -6809,7 +6899,7 @@ pub mod volume {
     use super::*;
 
     /// The volume states
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -6864,6 +6954,12 @@ pub mod volume {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -7702,7 +7798,7 @@ pub mod tiering_policy {
     use super::*;
 
     /// Tier action for the volume.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TierAction(std::borrow::Cow<'static, str>);
 
     impl TierAction {
@@ -7735,6 +7831,12 @@ pub mod tiering_policy {
     impl std::convert::From<std::string::String> for TierAction {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for TierAction {
+        fn default() -> Self {
+            tier_action::TIER_ACTION_UNSPECIFIED
         }
     }
 }
@@ -7863,7 +7965,7 @@ impl wkt::message::Message for HybridReplicationParameters {
 }
 
 /// The service level of a storage pool and its volumes.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ServiceLevel(std::borrow::Cow<'static, str>);
 
 impl ServiceLevel {
@@ -7905,8 +8007,14 @@ impl std::convert::From<std::string::String> for ServiceLevel {
     }
 }
 
+impl std::default::Default for ServiceLevel {
+    fn default() -> Self {
+        service_level::SERVICE_LEVEL_UNSPECIFIED
+    }
+}
+
 /// Flex Storage Pool performance.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct FlexPerformance(std::borrow::Cow<'static, str>);
 
 impl FlexPerformance {
@@ -7944,8 +8052,14 @@ impl std::convert::From<std::string::String> for FlexPerformance {
     }
 }
 
+impl std::default::Default for FlexPerformance {
+    fn default() -> Self {
+        flex_performance::FLEX_PERFORMANCE_UNSPECIFIED
+    }
+}
+
 /// The volume encryption key source.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct EncryptionType(std::borrow::Cow<'static, str>);
 
 impl EncryptionType {
@@ -7981,8 +8095,14 @@ impl std::convert::From<std::string::String> for EncryptionType {
     }
 }
 
+impl std::default::Default for EncryptionType {
+    fn default() -> Self {
+        encryption_type::ENCRYPTION_TYPE_UNSPECIFIED
+    }
+}
+
 /// Type of directory service
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DirectoryServiceType(std::borrow::Cow<'static, str>);
 
 impl DirectoryServiceType {
@@ -8016,8 +8136,14 @@ impl std::convert::From<std::string::String> for DirectoryServiceType {
     }
 }
 
+impl std::default::Default for DirectoryServiceType {
+    fn default() -> Self {
+        directory_service_type::DIRECTORY_SERVICE_TYPE_UNSPECIFIED
+    }
+}
+
 /// Protocols is an enum of all the supported network protocols for a volume.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Protocols(std::borrow::Cow<'static, str>);
 
 impl Protocols {
@@ -8055,8 +8181,14 @@ impl std::convert::From<std::string::String> for Protocols {
     }
 }
 
+impl std::default::Default for Protocols {
+    fn default() -> Self {
+        protocols::PROTOCOLS_UNSPECIFIED
+    }
+}
+
 /// AccessType is an enum of all the supported access types for a volume.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct AccessType(std::borrow::Cow<'static, str>);
 
 impl AccessType {
@@ -8094,9 +8226,15 @@ impl std::convert::From<std::string::String> for AccessType {
     }
 }
 
+impl std::default::Default for AccessType {
+    fn default() -> Self {
+        access_type::ACCESS_TYPE_UNSPECIFIED
+    }
+}
+
 /// SMBSettings
 /// Modifies the behaviour of a SMB volume.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SMBSettings(std::borrow::Cow<'static, str>);
 
 impl SMBSettings {
@@ -8152,8 +8290,14 @@ impl std::convert::From<std::string::String> for SMBSettings {
     }
 }
 
+impl std::default::Default for SMBSettings {
+    fn default() -> Self {
+        smb_settings::SMB_SETTINGS_UNSPECIFIED
+    }
+}
+
 /// The security style of the volume, can be either UNIX or NTFS.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SecurityStyle(std::borrow::Cow<'static, str>);
 
 impl SecurityStyle {
@@ -8189,8 +8333,14 @@ impl std::convert::From<std::string::String> for SecurityStyle {
     }
 }
 
+impl std::default::Default for SecurityStyle {
+    fn default() -> Self {
+        security_style::SECURITY_STYLE_UNSPECIFIED
+    }
+}
+
 /// Actions to be restricted for a volume.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct RestrictedAction(std::borrow::Cow<'static, str>);
 
 impl RestrictedAction {
@@ -8220,5 +8370,11 @@ pub mod restricted_action {
 impl std::convert::From<std::string::String> for RestrictedAction {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for RestrictedAction {
+    fn default() -> Self {
+        restricted_action::RESTRICTED_ACTION_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/networkconnectivity/v1/src/model.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/model.rs
@@ -695,7 +695,7 @@ pub mod spoke {
         use super::*;
 
         /// The Code enum represents the various reasons a state can be `INACTIVE`.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Code(std::borrow::Cow<'static, str>);
 
         impl Code {
@@ -734,6 +734,12 @@ pub mod spoke {
         impl std::convert::From<std::string::String> for Code {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Code {
+            fn default() -> Self {
+                code::CODE_UNSPECIFIED
             }
         }
     }
@@ -1752,7 +1758,7 @@ pub mod list_hub_spokes_request {
     use super::*;
 
     /// Enum that controls which spoke fields are included in the response.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SpokeView(std::borrow::Cow<'static, str>);
 
     impl SpokeView {
@@ -1788,6 +1794,12 @@ pub mod list_hub_spokes_request {
     impl std::convert::From<std::string::String> for SpokeView {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SpokeView {
+        fn default() -> Self {
+            spoke_view::SPOKE_VIEW_UNSPECIFIED
         }
     }
 }
@@ -2201,7 +2213,7 @@ pub mod psc_propagation_status {
 
     /// The Code enum represents the state of the Private Service Connect
     /// propagation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Code(std::borrow::Cow<'static, str>);
 
     impl Code {
@@ -2257,6 +2269,12 @@ pub mod psc_propagation_status {
     impl std::convert::From<std::string::String> for Code {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Code {
+        fn default() -> Self {
+            code::CODE_UNSPECIFIED
         }
     }
 }
@@ -4807,7 +4825,7 @@ pub mod policy_based_route {
         use super::*;
 
         /// The internet protocol version.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct ProtocolVersion(std::borrow::Cow<'static, str>);
 
         impl ProtocolVersion {
@@ -4837,6 +4855,12 @@ pub mod policy_based_route {
         impl std::convert::From<std::string::String> for ProtocolVersion {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for ProtocolVersion {
+            fn default() -> Self {
+                protocol_version::PROTOCOL_VERSION_UNSPECIFIED
             }
         }
     }
@@ -4913,7 +4937,7 @@ pub mod policy_based_route {
 
         /// Warning code for Policy Based Routing. Expect to add values in the
         /// future.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Code(std::borrow::Cow<'static, str>);
 
         impl Code {
@@ -4950,10 +4974,16 @@ pub mod policy_based_route {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for Code {
+            fn default() -> Self {
+                code::WARNING_UNSPECIFIED
+            }
+        }
     }
 
     /// The other routing cases.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct OtherRoutes(std::borrow::Cow<'static, str>);
 
     impl OtherRoutes {
@@ -4986,6 +5016,12 @@ pub mod policy_based_route {
     impl std::convert::From<std::string::String> for OtherRoutes {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for OtherRoutes {
+        fn default() -> Self {
+            other_routes::OTHER_ROUTES_UNSPECIFIED
         }
     }
 
@@ -5319,7 +5355,7 @@ impl wkt::message::Message for DeletePolicyBasedRouteRequest {
 }
 
 /// Supported features for a location
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct LocationFeature(std::borrow::Cow<'static, str>);
 
 impl LocationFeature {
@@ -5355,8 +5391,14 @@ impl std::convert::From<std::string::String> for LocationFeature {
     }
 }
 
+impl std::default::Default for LocationFeature {
+    fn default() -> Self {
+        location_feature::LOCATION_FEATURE_UNSPECIFIED
+    }
+}
+
 /// The route's type
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct RouteType(std::borrow::Cow<'static, str>);
 
 impl RouteType {
@@ -5398,9 +5440,15 @@ impl std::convert::From<std::string::String> for RouteType {
     }
 }
 
+impl std::default::Default for RouteType {
+    fn default() -> Self {
+        route_type::ROUTE_TYPE_UNSPECIFIED
+    }
+}
+
 /// The State enum represents the lifecycle stage of a Network Connectivity
 /// Center resource.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct State(std::borrow::Cow<'static, str>);
 
 impl State {
@@ -5454,9 +5502,15 @@ impl std::convert::From<std::string::String> for State {
     }
 }
 
+impl std::default::Default for State {
+    fn default() -> Self {
+        state::STATE_UNSPECIFIED
+    }
+}
+
 /// The SpokeType enum represents the type of spoke. The type
 /// reflects the kind of resource that a spoke is associated with.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SpokeType(std::borrow::Cow<'static, str>);
 
 impl SpokeType {
@@ -5500,8 +5554,14 @@ impl std::convert::From<std::string::String> for SpokeType {
     }
 }
 
+impl std::default::Default for SpokeType {
+    fn default() -> Self {
+        spoke_type::SPOKE_TYPE_UNSPECIFIED
+    }
+}
+
 /// This enum controls the policy mode used in a hub.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct PolicyMode(std::borrow::Cow<'static, str>);
 
 impl PolicyMode {
@@ -5534,8 +5594,14 @@ impl std::convert::From<std::string::String> for PolicyMode {
     }
 }
 
+impl std::default::Default for PolicyMode {
+    fn default() -> Self {
+        policy_mode::POLICY_MODE_UNSPECIFIED
+    }
+}
+
 /// The list of available preset topologies.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct PresetTopology(std::borrow::Cow<'static, str>);
 
 impl PresetTopology {
@@ -5572,5 +5638,11 @@ pub mod preset_topology {
 impl std::convert::From<std::string::String> for PresetTopology {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for PresetTopology {
+    fn default() -> Self {
+        preset_topology::PRESET_TOPOLOGY_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/networkmanagement/v1/src/model.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/model.rs
@@ -649,7 +649,7 @@ pub mod endpoint {
 
     /// The type definition of an endpoint's network. Use one of the
     /// following choices:
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct NetworkType(std::borrow::Cow<'static, str>);
 
     impl NetworkType {
@@ -689,8 +689,14 @@ pub mod endpoint {
         }
     }
 
+    impl std::default::Default for NetworkType {
+        fn default() -> Self {
+            network_type::NETWORK_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Type of the target of a forwarding rule.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ForwardingRuleTarget(std::borrow::Cow<'static, str>);
 
     impl ForwardingRuleTarget {
@@ -730,6 +736,12 @@ pub mod endpoint {
     impl std::convert::From<std::string::String> for ForwardingRuleTarget {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ForwardingRuleTarget {
+        fn default() -> Self {
+            forwarding_rule_target::FORWARDING_RULE_TARGET_UNSPECIFIED
         }
     }
 }
@@ -814,7 +826,7 @@ pub mod reachability_details {
     use super::*;
 
     /// The overall result of the test's configuration analysis.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Result(std::borrow::Cow<'static, str>);
 
     impl Result {
@@ -870,6 +882,12 @@ pub mod reachability_details {
     impl std::convert::From<std::string::String> for Result {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Result {
+        fn default() -> Self {
+            result::RESULT_UNSPECIFIED
         }
     }
 }
@@ -1129,7 +1147,7 @@ pub mod probing_details {
     }
 
     /// Overall probing result of the test.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ProbingResult(std::borrow::Cow<'static, str>);
 
     impl ProbingResult {
@@ -1177,8 +1195,14 @@ pub mod probing_details {
         }
     }
 
+    impl std::default::Default for ProbingResult {
+        fn default() -> Self {
+            probing_result::PROBING_RESULT_UNSPECIFIED
+        }
+    }
+
     /// Abort cause types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ProbingAbortCause(std::borrow::Cow<'static, str>);
 
     impl ProbingAbortCause {
@@ -1214,6 +1238,12 @@ pub mod probing_details {
     impl std::convert::From<std::string::String> for ProbingAbortCause {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ProbingAbortCause {
+        fn default() -> Self {
+            probing_abort_cause::PROBING_ABORT_CAUSE_UNSPECIFIED
         }
     }
 }
@@ -2577,7 +2607,7 @@ pub mod step {
 
     /// Type of states that are defined in the network state machine.
     /// Each step in the packet trace is in a specific state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2731,6 +2761,12 @@ pub mod step {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -3155,7 +3191,7 @@ pub mod firewall_info {
     use super::*;
 
     /// The firewall rule's type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct FirewallRuleType(std::borrow::Cow<'static, str>);
 
     impl FirewallRuleType {
@@ -3231,6 +3267,12 @@ pub mod firewall_info {
     impl std::convert::From<std::string::String> for FirewallRuleType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for FirewallRuleType {
+        fn default() -> Self {
+            firewall_rule_type::FIREWALL_RULE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -3495,7 +3537,7 @@ pub mod route_info {
     use super::*;
 
     /// Type of route:
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RouteType(std::borrow::Cow<'static, str>);
 
     impl RouteType {
@@ -3550,8 +3592,14 @@ pub mod route_info {
         }
     }
 
+    impl std::default::Default for RouteType {
+        fn default() -> Self {
+            route_type::ROUTE_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Type of next hop:
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct NextHopType(std::borrow::Cow<'static, str>);
 
     impl NextHopType {
@@ -3625,8 +3673,14 @@ pub mod route_info {
         }
     }
 
+    impl std::default::Default for NextHopType {
+        fn default() -> Self {
+            next_hop_type::NEXT_HOP_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Indicates where routes are applicable.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RouteScope(std::borrow::Cow<'static, str>);
 
     impl RouteScope {
@@ -3658,6 +3712,12 @@ pub mod route_info {
     impl std::convert::From<std::string::String> for RouteScope {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RouteScope {
+        fn default() -> Self {
+            route_scope::ROUTE_SCOPE_UNSPECIFIED
         }
     }
 }
@@ -3715,7 +3775,7 @@ pub mod google_service_info {
     use super::*;
 
     /// Recognized type of a Google Service.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct GoogleServiceType(std::borrow::Cow<'static, str>);
 
     impl GoogleServiceType {
@@ -3772,6 +3832,12 @@ pub mod google_service_info {
     impl std::convert::From<std::string::String> for GoogleServiceType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for GoogleServiceType {
+        fn default() -> Self {
+            google_service_type::GOOGLE_SERVICE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -4015,7 +4081,7 @@ pub mod load_balancer_info {
     use super::*;
 
     /// The type definition for a load balancer:
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LoadBalancerType(std::borrow::Cow<'static, str>);
 
     impl LoadBalancerType {
@@ -4060,8 +4126,14 @@ pub mod load_balancer_info {
         }
     }
 
+    impl std::default::Default for LoadBalancerType {
+        fn default() -> Self {
+            load_balancer_type::LOAD_BALANCER_TYPE_UNSPECIFIED
+        }
+    }
+
     /// The type definition for a load balancer backend configuration:
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct BackendType(std::borrow::Cow<'static, str>);
 
     impl BackendType {
@@ -4097,6 +4169,12 @@ pub mod load_balancer_info {
     impl std::convert::From<std::string::String> for BackendType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for BackendType {
+        fn default() -> Self {
+            backend_type::BACKEND_TYPE_UNSPECIFIED
         }
     }
 }
@@ -4190,7 +4268,7 @@ pub mod load_balancer_backend {
     use super::*;
 
     /// State of a health check firewall configuration:
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct HealthCheckFirewallState(std::borrow::Cow<'static, str>);
 
     impl HealthCheckFirewallState {
@@ -4230,6 +4308,12 @@ pub mod load_balancer_backend {
     impl std::convert::From<std::string::String> for HealthCheckFirewallState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for HealthCheckFirewallState {
+        fn default() -> Self {
+            health_check_firewall_state::HEALTH_CHECK_FIREWALL_STATE_UNSPECIFIED
         }
     }
 }
@@ -4439,7 +4523,7 @@ pub mod vpn_tunnel_info {
 
     /// Types of VPN routing policy. For details, refer to [Networks and Tunnel
     /// routing](https://cloud.google.com/network-connectivity/docs/vpn/concepts/choosing-networks-routing/).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RoutingType(std::borrow::Cow<'static, str>);
 
     impl RoutingType {
@@ -4475,6 +4559,12 @@ pub mod vpn_tunnel_info {
     impl std::convert::From<std::string::String> for RoutingType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RoutingType {
+        fn default() -> Self {
+            routing_type::ROUTING_TYPE_UNSPECIFIED
         }
     }
 }
@@ -4668,7 +4758,7 @@ pub mod deliver_info {
     use super::*;
 
     /// Deliver target types:
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Target(std::borrow::Cow<'static, str>);
 
     impl Target {
@@ -4750,6 +4840,12 @@ pub mod deliver_info {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for Target {
+        fn default() -> Self {
+            target::TARGET_UNSPECIFIED
+        }
+    }
 }
 
 /// Details of the final state "forward" and associated resource.
@@ -4809,7 +4905,7 @@ pub mod forward_info {
     use super::*;
 
     /// Forward target types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Target(std::borrow::Cow<'static, str>);
 
     impl Target {
@@ -4863,6 +4959,12 @@ pub mod forward_info {
     impl std::convert::From<std::string::String> for Target {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Target {
+        fn default() -> Self {
+            target::TARGET_UNSPECIFIED
         }
     }
 }
@@ -4940,7 +5042,7 @@ pub mod abort_info {
     use super::*;
 
     /// Abort cause types:
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Cause(std::borrow::Cow<'static, str>);
 
     impl Cause {
@@ -5121,6 +5223,12 @@ pub mod abort_info {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for Cause {
+        fn default() -> Self {
+            cause::CAUSE_UNSPECIFIED
+        }
+    }
 }
 
 /// Details of the final state "drop" and associated resource.
@@ -5200,7 +5308,7 @@ pub mod drop_info {
     use super::*;
 
     /// Drop cause types:
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Cause(std::borrow::Cow<'static, str>);
 
     impl Cause {
@@ -5609,6 +5717,12 @@ pub mod drop_info {
     impl std::convert::From<std::string::String> for Cause {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Cause {
+        fn default() -> Self {
+            cause::CAUSE_UNSPECIFIED
         }
     }
 }
@@ -6327,7 +6441,7 @@ pub mod nat_info {
     use super::*;
 
     /// Types of NAT.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -6365,6 +6479,12 @@ pub mod nat_info {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -6665,7 +6785,7 @@ pub mod load_balancer_backend_info {
     use super::*;
 
     /// Health check firewalls configuration state enum.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct HealthCheckFirewallsConfigState(std::borrow::Cow<'static, str>);
 
     impl HealthCheckFirewallsConfigState {
@@ -6716,6 +6836,12 @@ pub mod load_balancer_backend_info {
     impl std::convert::From<std::string::String> for HealthCheckFirewallsConfigState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for HealthCheckFirewallsConfigState {
+        fn default() -> Self {
+            health_check_firewalls_config_state::HEALTH_CHECK_FIREWALLS_CONFIG_STATE_UNSPECIFIED
         }
     }
 }
@@ -7369,7 +7495,7 @@ pub mod vpc_flow_logs_config {
 
     /// Determines whether this configuration will be generating logs.
     /// Setting state=DISABLED will pause the log generation for this config.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -7404,8 +7530,14 @@ pub mod vpc_flow_logs_config {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Toggles the aggregation interval for collecting flow logs by 5-tuple.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AggregationInterval(std::borrow::Cow<'static, str>);
 
     impl AggregationInterval {
@@ -7456,8 +7588,14 @@ pub mod vpc_flow_logs_config {
         }
     }
 
+    impl std::default::Default for AggregationInterval {
+        fn default() -> Self {
+            aggregation_interval::AGGREGATION_INTERVAL_UNSPECIFIED
+        }
+    }
+
     /// Configures which log fields would be included.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Metadata(std::borrow::Cow<'static, str>);
 
     impl Metadata {
@@ -7495,9 +7633,15 @@ pub mod vpc_flow_logs_config {
         }
     }
 
+    impl std::default::Default for Metadata {
+        fn default() -> Self {
+            metadata::METADATA_UNSPECIFIED
+        }
+    }
+
     /// Optional states of the target resource that are used as part of the
     /// diagnostic bit.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TargetResourceState(std::borrow::Cow<'static, str>);
 
     impl TargetResourceState {
@@ -7535,6 +7679,12 @@ pub mod vpc_flow_logs_config {
         }
     }
 
+    impl std::default::Default for TargetResourceState {
+        fn default() -> Self {
+            target_resource_state::TARGET_RESOURCE_STATE_UNSPECIFIED
+        }
+    }
+
     /// Reference to the resource of the config scope. That is, the scope from
     /// which traffic is logged. The target resource must belong to the same
     /// project as the configuration.
@@ -7555,7 +7705,7 @@ pub mod vpc_flow_logs_config {
 /// Type of a load balancer. For more information, see [Summary of Google Cloud
 /// load
 /// balancers](https://cloud.google.com/load-balancing/docs/load-balancing-overview#summary-of-google-cloud-load-balancers).
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct LoadBalancerType(std::borrow::Cow<'static, str>);
 
 impl LoadBalancerType {
@@ -7622,5 +7772,11 @@ pub mod load_balancer_type {
 impl std::convert::From<std::string::String> for LoadBalancerType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for LoadBalancerType {
+    fn default() -> Self {
+        load_balancer_type::LOAD_BALANCER_TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/networksecurity/v1/src/model.rs
+++ b/src/generated/cloud/networksecurity/v1/src/model.rs
@@ -469,7 +469,7 @@ pub mod authorization_policy {
     }
 
     /// Possible values that define what action to take.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Action(std::borrow::Cow<'static, str>);
 
     impl Action {
@@ -503,6 +503,12 @@ pub mod authorization_policy {
     impl std::convert::From<std::string::String> for Action {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Action {
+        fn default() -> Self {
+            action::ACTION_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/networkservices/v1/src/model.rs
+++ b/src/generated/cloud/networkservices/v1/src/model.rs
@@ -378,7 +378,7 @@ pub mod endpoint_matcher {
         }
 
         /// Possible criteria values that define logic of how matching is made.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct MetadataLabelMatchCriteria(std::borrow::Cow<'static, str>);
 
         impl MetadataLabelMatchCriteria {
@@ -415,6 +415,12 @@ pub mod endpoint_matcher {
         impl std::convert::From<std::string::String> for MetadataLabelMatchCriteria {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for MetadataLabelMatchCriteria {
+            fn default() -> Self {
+                metadata_label_match_criteria::METADATA_LABEL_MATCH_CRITERIA_UNSPECIFIED
             }
         }
     }
@@ -1958,7 +1964,7 @@ pub mod endpoint_policy {
     use super::*;
 
     /// The type of endpoint policy.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EndpointPolicyType(std::borrow::Cow<'static, str>);
 
     impl EndpointPolicyType {
@@ -1991,6 +1997,12 @@ pub mod endpoint_policy {
     impl std::convert::From<std::string::String> for EndpointPolicyType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EndpointPolicyType {
+        fn default() -> Self {
+            endpoint_policy_type::ENDPOINT_POLICY_TYPE_UNSPECIFIED
         }
     }
 }
@@ -2441,7 +2453,7 @@ pub mod gateway {
     ///
     /// * OPEN_MESH
     /// * SECURE_WEB_GATEWAY
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -2474,6 +2486,12 @@ pub mod gateway {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -3032,7 +3050,7 @@ pub mod grpc_route {
         use super::*;
 
         /// The type of the match.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Type(std::borrow::Cow<'static, str>);
 
         impl Type {
@@ -3065,6 +3083,12 @@ pub mod grpc_route {
         impl std::convert::From<std::string::String> for Type {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Type {
+            fn default() -> Self {
+                r#type::TYPE_UNSPECIFIED
             }
         }
     }
@@ -3128,7 +3152,7 @@ pub mod grpc_route {
         use super::*;
 
         /// The type of match.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Type(std::borrow::Cow<'static, str>);
 
         impl Type {
@@ -3161,6 +3185,12 @@ pub mod grpc_route {
         impl std::convert::From<std::string::String> for Type {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Type {
+            fn default() -> Self {
+                r#type::TYPE_UNSPECIFIED
             }
         }
     }
@@ -4963,7 +4993,7 @@ pub mod http_route {
         use super::*;
 
         /// Supported HTTP response code.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct ResponseCode(std::borrow::Cow<'static, str>);
 
         impl ResponseCode {
@@ -5006,6 +5036,12 @@ pub mod http_route {
         impl std::convert::From<std::string::String> for ResponseCode {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for ResponseCode {
+            fn default() -> Self {
+                response_code::RESPONSE_CODE_UNSPECIFIED
             }
         }
     }
@@ -7991,7 +8027,7 @@ impl wkt::message::Message for DeleteTlsRouteRequest {
 }
 
 /// The part of the request or response for which the extension is called.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct EventType(std::borrow::Cow<'static, str>);
 
 impl EventType {
@@ -8044,11 +8080,17 @@ impl std::convert::From<std::string::String> for EventType {
     }
 }
 
+impl std::default::Default for EventType {
+    fn default() -> Self {
+        event_type::EVENT_TYPE_UNSPECIFIED
+    }
+}
+
 /// Load balancing schemes supported by the `LbTrafficExtension` resource and
 /// `LbRouteExtension` resource.
 /// For more information, refer to [Choosing a load
 /// balancer](https://cloud.google.com/load-balancing/docs/backend-service).
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct LoadBalancingScheme(std::borrow::Cow<'static, str>);
 
 impl LoadBalancingScheme {
@@ -8082,5 +8124,11 @@ pub mod load_balancing_scheme {
 impl std::convert::From<std::string::String> for LoadBalancingScheme {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for LoadBalancingScheme {
+    fn default() -> Self {
+        load_balancing_scheme::LOAD_BALANCING_SCHEME_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/notebooks/v2/src/model.rs
+++ b/src/generated/cloud/notebooks/v2/src/model.rs
@@ -180,7 +180,7 @@ pub mod event {
     use super::*;
 
     /// The definition of the event types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EventType(std::borrow::Cow<'static, str>);
 
     impl EventType {
@@ -229,6 +229,12 @@ pub mod event {
     impl std::convert::From<std::string::String> for EventType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EventType {
+        fn default() -> Self {
+            event_type::EVENT_TYPE_UNSPECIFIED
         }
     }
 }
@@ -296,7 +302,7 @@ pub mod network_interface {
 
     /// The type of vNIC driver.
     /// Default should be NIC_TYPE_UNSPECIFIED.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct NicType(std::borrow::Cow<'static, str>);
 
     impl NicType {
@@ -328,6 +334,12 @@ pub mod network_interface {
     impl std::convert::From<std::string::String> for NicType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for NicType {
+        fn default() -> Self {
+            nic_type::NIC_TYPE_UNSPECIFIED
         }
     }
 }
@@ -532,7 +544,7 @@ pub mod accelerator_config {
 
     /// Definition of the types of hardware accelerators that can be used on
     /// this instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AcceleratorType(std::borrow::Cow<'static, str>);
 
     impl AcceleratorType {
@@ -592,6 +604,12 @@ pub mod accelerator_config {
     impl std::convert::From<std::string::String> for AcceleratorType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AcceleratorType {
+        fn default() -> Self {
+            accelerator_type::ACCELERATOR_TYPE_UNSPECIFIED
         }
     }
 }
@@ -1278,7 +1296,7 @@ pub mod upgrade_history_entry {
     use super::*;
 
     /// The definition of the states of this upgrade history entry.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1316,8 +1334,14 @@ pub mod upgrade_history_entry {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// The definition of operations of this upgrade history entry.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Action(std::borrow::Cow<'static, str>);
 
     impl Action {
@@ -1349,6 +1373,12 @@ pub mod upgrade_history_entry {
     impl std::convert::From<std::string::String> for Action {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Action {
+        fn default() -> Self {
+            action::ACTION_UNSPECIFIED
         }
     }
 }
@@ -2370,7 +2400,7 @@ impl wkt::message::Message for DiagnoseInstanceRequest {
 }
 
 /// Definition of the disk encryption options.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DiskEncryption(std::borrow::Cow<'static, str>);
 
 impl DiskEncryption {
@@ -2406,8 +2436,14 @@ impl std::convert::From<std::string::String> for DiskEncryption {
     }
 }
 
+impl std::default::Default for DiskEncryption {
+    fn default() -> Self {
+        disk_encryption::DISK_ENCRYPTION_UNSPECIFIED
+    }
+}
+
 /// Possible disk types.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DiskType(std::borrow::Cow<'static, str>);
 
 impl DiskType {
@@ -2448,8 +2484,14 @@ impl std::convert::From<std::string::String> for DiskType {
     }
 }
 
+impl std::default::Default for DiskType {
+    fn default() -> Self {
+        disk_type::DISK_TYPE_UNSPECIFIED
+    }
+}
+
 /// The definition of the states of this instance.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct State(std::borrow::Cow<'static, str>);
 
 impl State {
@@ -2509,8 +2551,14 @@ impl std::convert::From<std::string::String> for State {
     }
 }
 
+impl std::default::Default for State {
+    fn default() -> Self {
+        state::STATE_UNSPECIFIED
+    }
+}
+
 /// The instance health state.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct HealthState(std::borrow::Cow<'static, str>);
 
 impl HealthState {
@@ -2554,5 +2602,11 @@ pub mod health_state {
 impl std::convert::From<std::string::String> for HealthState {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for HealthState {
+    fn default() -> Self {
+        health_state::HEALTH_STATE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/optimization/v1/src/model.rs
+++ b/src/generated/cloud/optimization/v1/src/model.rs
@@ -348,7 +348,7 @@ pub mod async_model_metadata {
     use super::*;
 
     /// Possible states of the operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -386,6 +386,12 @@ pub mod async_model_metadata {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -814,7 +820,7 @@ pub mod optimize_tours_request {
     /// to cap the number of errors returned.
     ///
     /// [google.cloud.optimization.v1.OptimizeToursRequest.max_validation_errors]: crate::model::OptimizeToursRequest::max_validation_errors
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SolvingMode(std::borrow::Cow<'static, str>);
 
     impl SolvingMode {
@@ -871,9 +877,15 @@ pub mod optimize_tours_request {
         }
     }
 
+    impl std::default::Default for SolvingMode {
+        fn default() -> Self {
+            solving_mode::DEFAULT_SOLVE
+        }
+    }
+
     /// Mode defining the behavior of the search, trading off latency versus
     /// solution quality. In all modes, the global request deadline is enforced.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SearchMode(std::borrow::Cow<'static, str>);
 
     impl SearchMode {
@@ -906,6 +918,12 @@ pub mod optimize_tours_request {
     impl std::convert::From<std::string::String> for SearchMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SearchMode {
+        fn default() -> Self {
+            search_mode::SEARCH_MODE_UNSPECIFIED
         }
     }
 }
@@ -2780,7 +2798,7 @@ pub mod shipment_type_incompatibility {
 
     /// Modes defining how the appearance of incompatible shipments are restricted
     /// on the same route.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct IncompatibilityMode(std::borrow::Cow<'static, str>);
 
     impl IncompatibilityMode {
@@ -2823,6 +2841,12 @@ pub mod shipment_type_incompatibility {
     impl std::convert::From<std::string::String> for IncompatibilityMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for IncompatibilityMode {
+        fn default() -> Self {
+            incompatibility_mode::INCOMPATIBILITY_MODE_UNSPECIFIED
         }
     }
 }
@@ -2903,7 +2927,7 @@ pub mod shipment_type_requirement {
     use super::*;
 
     /// Modes defining the appearance of dependent shipments on a route.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RequirementMode(std::borrow::Cow<'static, str>);
 
     impl RequirementMode {
@@ -2953,6 +2977,12 @@ pub mod shipment_type_requirement {
     impl std::convert::From<std::string::String> for RequirementMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RequirementMode {
+        fn default() -> Self {
+            requirement_mode::REQUIREMENT_MODE_UNSPECIFIED
         }
     }
 }
@@ -3883,7 +3913,7 @@ pub mod vehicle {
     /// These should be a subset of the Google Maps Platform Routes Preferred API
     /// travel modes, see:
     /// <https://developers.google.com/maps/documentation/routes_preferred/reference/rest/Shared.Types/RouteTravelMode>.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TravelMode(std::borrow::Cow<'static, str>);
 
     impl TravelMode {
@@ -3918,12 +3948,18 @@ pub mod vehicle {
         }
     }
 
+    impl std::default::Default for TravelMode {
+        fn default() -> Self {
+            travel_mode::TRAVEL_MODE_UNSPECIFIED
+        }
+    }
+
     /// Policy on how a vehicle can be unloaded. Applies only to shipments having
     /// both a pickup and a delivery.
     ///
     /// Other shipments are free to occur anywhere on the route independent of
     /// `unloading_policy`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct UnloadingPolicy(std::borrow::Cow<'static, str>);
 
     impl UnloadingPolicy {
@@ -3957,6 +3993,12 @@ pub mod vehicle {
     impl std::convert::From<std::string::String> for UnloadingPolicy {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for UnloadingPolicy {
+        fn default() -> Self {
+            unloading_policy::UNLOADING_POLICY_UNSPECIFIED
         }
     }
 }
@@ -6066,7 +6108,7 @@ pub mod skipped_shipment {
         /// Code identifying the reason type. The order here is meaningless. In
         /// particular, it gives no indication of whether a given reason will
         /// appear before another in the solution, if both apply.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Code(std::borrow::Cow<'static, str>);
 
         impl Code {
@@ -6135,6 +6177,12 @@ pub mod skipped_shipment {
         impl std::convert::From<std::string::String> for Code {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Code {
+            fn default() -> Self {
+                code::CODE_UNSPECIFIED
             }
         }
     }
@@ -6593,7 +6641,7 @@ pub mod injected_solution_constraint {
             /// threshold conditions.
             ///
             /// The enumeration below is in order of increasing relaxation.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct Level(std::borrow::Cow<'static, str>);
 
             impl Level {
@@ -6641,6 +6689,12 @@ pub mod injected_solution_constraint {
             impl std::convert::From<std::string::String> for Level {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for Level {
+                fn default() -> Self {
+                    level::LEVEL_UNSPECIFIED
                 }
             }
         }
@@ -7159,7 +7213,7 @@ pub mod optimize_tours_validation_error {
 }
 
 /// Data formats for input and output files.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DataFormat(std::borrow::Cow<'static, str>);
 
 impl DataFormat {
@@ -7191,5 +7245,11 @@ pub mod data_format {
 impl std::convert::From<std::string::String> for DataFormat {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for DataFormat {
+    fn default() -> Self {
+        data_format::DATA_FORMAT_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/oracledatabase/v1/src/model.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/model.rs
@@ -938,7 +938,7 @@ pub mod autonomous_database_properties {
     use super::*;
 
     /// The editions available for the Autonomous Database.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DatabaseEdition(std::borrow::Cow<'static, str>);
 
     impl DatabaseEdition {
@@ -974,8 +974,14 @@ pub mod autonomous_database_properties {
         }
     }
 
+    impl std::default::Default for DatabaseEdition {
+        fn default() -> Self {
+            database_edition::DATABASE_EDITION_UNSPECIFIED
+        }
+    }
+
     /// The license types available for the Autonomous Database.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LicenseType(std::borrow::Cow<'static, str>);
 
     impl LicenseType {
@@ -1011,8 +1017,14 @@ pub mod autonomous_database_properties {
         }
     }
 
+    impl std::default::Default for LicenseType {
+        fn default() -> Self {
+            license_type::LICENSE_TYPE_UNSPECIFIED
+        }
+    }
+
     /// The available maintenance schedules for the Autonomous Database.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MaintenanceScheduleType(std::borrow::Cow<'static, str>);
 
     impl MaintenanceScheduleType {
@@ -1049,8 +1061,14 @@ pub mod autonomous_database_properties {
         }
     }
 
+    impl std::default::Default for MaintenanceScheduleType {
+        fn default() -> Self {
+            maintenance_schedule_type::MAINTENANCE_SCHEDULE_TYPE_UNSPECIFIED
+        }
+    }
+
     /// The types of local disaster recovery available for an Autonomous Database.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LocalDisasterRecoveryType(std::borrow::Cow<'static, str>);
 
     impl LocalDisasterRecoveryType {
@@ -1087,8 +1105,14 @@ pub mod autonomous_database_properties {
         }
     }
 
+    impl std::default::Default for LocalDisasterRecoveryType {
+        fn default() -> Self {
+            local_disaster_recovery_type::LOCAL_DISASTER_RECOVERY_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Varies states of the Data Safe registration for the Autonomous Database.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DataSafeState(std::borrow::Cow<'static, str>);
 
     impl DataSafeState {
@@ -1133,8 +1157,14 @@ pub mod autonomous_database_properties {
         }
     }
 
+    impl std::default::Default for DataSafeState {
+        fn default() -> Self {
+            data_safe_state::DATA_SAFE_STATE_UNSPECIFIED
+        }
+    }
+
     /// The different states of database management for an Autonomous Database.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DatabaseManagementState(std::borrow::Cow<'static, str>);
 
     impl DatabaseManagementState {
@@ -1185,8 +1215,14 @@ pub mod autonomous_database_properties {
         }
     }
 
+    impl std::default::Default for DatabaseManagementState {
+        fn default() -> Self {
+            database_management_state::DATABASE_MANAGEMENT_STATE_UNSPECIFIED
+        }
+    }
+
     /// This field indicates the modes of an Autonomous Database.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct OpenMode(std::borrow::Cow<'static, str>);
 
     impl OpenMode {
@@ -1221,8 +1257,14 @@ pub mod autonomous_database_properties {
         }
     }
 
+    impl std::default::Default for OpenMode {
+        fn default() -> Self {
+            open_mode::OPEN_MODE_UNSPECIFIED
+        }
+    }
+
     /// The types of permission levels for an Autonomous Database.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PermissionLevel(std::borrow::Cow<'static, str>);
 
     impl PermissionLevel {
@@ -1258,8 +1300,14 @@ pub mod autonomous_database_properties {
         }
     }
 
+    impl std::default::Default for PermissionLevel {
+        fn default() -> Self {
+            permission_level::PERMISSION_LEVEL_UNSPECIFIED
+        }
+    }
+
     /// The refresh mode of the cloned Autonomous Database.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RefreshableMode(std::borrow::Cow<'static, str>);
 
     impl RefreshableMode {
@@ -1297,8 +1345,14 @@ pub mod autonomous_database_properties {
         }
     }
 
+    impl std::default::Default for RefreshableMode {
+        fn default() -> Self {
+            refreshable_mode::REFRESHABLE_MODE_UNSPECIFIED
+        }
+    }
+
     /// The refresh state of the cloned Autonomous Database.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RefreshableState(std::borrow::Cow<'static, str>);
 
     impl RefreshableState {
@@ -1334,8 +1388,14 @@ pub mod autonomous_database_properties {
         }
     }
 
+    impl std::default::Default for RefreshableState {
+        fn default() -> Self {
+            refreshable_state::REFRESHABLE_STATE_UNSPECIFIED
+        }
+    }
+
     /// The Data Guard role of the Autonomous Database.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Role(std::borrow::Cow<'static, str>);
 
     impl Role {
@@ -1376,6 +1436,12 @@ pub mod autonomous_database_properties {
     impl std::convert::From<std::string::String> for Role {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Role {
+        fn default() -> Self {
+            role::ROLE_UNSPECIFIED
         }
     }
 }
@@ -1659,7 +1725,7 @@ pub mod database_connection_string_profile {
     use super::*;
 
     /// The various consumer groups available in the connection string profile.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ConsumerGroup(std::borrow::Cow<'static, str>);
 
     impl ConsumerGroup {
@@ -1704,8 +1770,14 @@ pub mod database_connection_string_profile {
         }
     }
 
+    impl std::default::Default for ConsumerGroup {
+        fn default() -> Self {
+            consumer_group::CONSUMER_GROUP_UNSPECIFIED
+        }
+    }
+
     /// The host name format being used in the connection string.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct HostFormat(std::borrow::Cow<'static, str>);
 
     impl HostFormat {
@@ -1740,8 +1812,14 @@ pub mod database_connection_string_profile {
         }
     }
 
+    impl std::default::Default for HostFormat {
+        fn default() -> Self {
+            host_format::HOST_FORMAT_UNSPECIFIED
+        }
+    }
+
     /// The protocol being used by the connection.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Protocol(std::borrow::Cow<'static, str>);
 
     impl Protocol {
@@ -1776,8 +1854,14 @@ pub mod database_connection_string_profile {
         }
     }
 
+    impl std::default::Default for Protocol {
+        fn default() -> Self {
+            protocol::PROTOCOL_UNSPECIFIED
+        }
+    }
+
     /// The session mode of the connection.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SessionMode(std::borrow::Cow<'static, str>);
 
     impl SessionMode {
@@ -1813,8 +1897,14 @@ pub mod database_connection_string_profile {
         }
     }
 
+    impl std::default::Default for SessionMode {
+        fn default() -> Self {
+            session_mode::SESSION_MODE_UNSPECIFIED
+        }
+    }
+
     /// Specifies syntax of the connection string.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SyntaxFormat(std::borrow::Cow<'static, str>);
 
     impl SyntaxFormat {
@@ -1853,8 +1943,14 @@ pub mod database_connection_string_profile {
         }
     }
 
+    impl std::default::Default for SyntaxFormat {
+        fn default() -> Self {
+            syntax_format::SYNTAX_FORMAT_UNSPECIFIED
+        }
+    }
+
     /// This field indicates the TLS authentication type of the connection.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TLSAuthentication(std::borrow::Cow<'static, str>);
 
     impl TLSAuthentication {
@@ -1887,6 +1983,12 @@ pub mod database_connection_string_profile {
     impl std::convert::From<std::string::String> for TLSAuthentication {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for TLSAuthentication {
+        fn default() -> Self {
+            tls_authentication::TLS_AUTHENTICATION_UNSPECIFIED
         }
     }
 }
@@ -2269,7 +2371,7 @@ pub mod autonomous_database_character_set {
     use super::*;
 
     /// The type of character set an Autonomous Database can have.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CharacterSetType(std::borrow::Cow<'static, str>);
 
     impl CharacterSetType {
@@ -2302,6 +2404,12 @@ pub mod autonomous_database_character_set {
     impl std::convert::From<std::string::String> for CharacterSetType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CharacterSetType {
+        fn default() -> Self {
+            character_set_type::CHARACTER_SET_TYPE_UNSPECIFIED
         }
     }
 }
@@ -2649,7 +2757,7 @@ pub mod autonomous_database_backup_properties {
     use super::*;
 
     /// // The various lifecycle states of the Autonomous Database Backup.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2696,8 +2804,14 @@ pub mod autonomous_database_backup_properties {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// The type of the backup.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -2732,6 +2846,12 @@ pub mod autonomous_database_backup_properties {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -2981,7 +3101,7 @@ pub mod db_node_properties {
     use super::*;
 
     /// The various lifecycle states of the database node.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3034,6 +3154,12 @@ pub mod db_node_properties {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -3219,7 +3345,7 @@ pub mod db_server_properties {
     use super::*;
 
     /// The various lifecycle states of the database server.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3260,6 +3386,12 @@ pub mod db_server_properties {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -3468,7 +3600,7 @@ pub mod entitlement {
     use super::*;
 
     /// The various lifecycle states of the subscription.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3506,6 +3638,12 @@ pub mod entitlement {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -4020,7 +4158,7 @@ pub mod cloud_exadata_infrastructure_properties {
     use super::*;
 
     /// The various lifecycle states of the Exadata Infrastructure.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -4067,6 +4205,12 @@ pub mod cloud_exadata_infrastructure_properties {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -4231,7 +4375,7 @@ pub mod maintenance_window {
     use super::*;
 
     /// Maintenance window preference.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MaintenanceWindowPreference(std::borrow::Cow<'static, str>);
 
     impl MaintenanceWindowPreference {
@@ -4269,8 +4413,14 @@ pub mod maintenance_window {
         }
     }
 
+    impl std::default::Default for MaintenanceWindowPreference {
+        fn default() -> Self {
+            maintenance_window_preference::MAINTENANCE_WINDOW_PREFERENCE_UNSPECIFIED
+        }
+    }
+
     /// Patching mode.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PatchingMode(std::borrow::Cow<'static, str>);
 
     impl PatchingMode {
@@ -4304,6 +4454,12 @@ pub mod maintenance_window {
     impl std::convert::From<std::string::String> for PatchingMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PatchingMode {
+        fn default() -> Self {
+            patching_mode::PATCHING_MODE_UNSPECIFIED
         }
     }
 }
@@ -6889,7 +7045,7 @@ pub mod cloud_vm_cluster_properties {
     use super::*;
 
     /// Different licenses supported.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LicenseType(std::borrow::Cow<'static, str>);
 
     impl LicenseType {
@@ -6925,8 +7081,14 @@ pub mod cloud_vm_cluster_properties {
         }
     }
 
+    impl std::default::Default for LicenseType {
+        fn default() -> Self {
+            license_type::LICENSE_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Types of disk redundancy provided by Oracle.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DiskRedundancy(std::borrow::Cow<'static, str>);
 
     impl DiskRedundancy {
@@ -6962,8 +7124,14 @@ pub mod cloud_vm_cluster_properties {
         }
     }
 
+    impl std::default::Default for DiskRedundancy {
+        fn default() -> Self {
+            disk_redundancy::DISK_REDUNDANCY_UNSPECIFIED
+        }
+    }
+
     /// The various lifecycle states of the VM cluster.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -7010,6 +7178,12 @@ pub mod cloud_vm_cluster_properties {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -7063,7 +7237,7 @@ impl wkt::message::Message for DataCollectionOptions {
 }
 
 /// The type of wallet generation.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct GenerateType(std::borrow::Cow<'static, str>);
 
 impl GenerateType {
@@ -7099,8 +7273,14 @@ impl std::convert::From<std::string::String> for GenerateType {
     }
 }
 
+impl std::default::Default for GenerateType {
+    fn default() -> Self {
+        generate_type::GENERATE_TYPE_UNSPECIFIED
+    }
+}
+
 /// The various lifecycle states of the Autonomous Database.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct State(std::borrow::Cow<'static, str>);
 
 impl State {
@@ -7193,8 +7373,14 @@ impl std::convert::From<std::string::String> for State {
     }
 }
 
+impl std::default::Default for State {
+    fn default() -> Self {
+        state::STATE_UNSPECIFIED
+    }
+}
+
 /// The state of the Operations Insights for this Autonomous Database.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct OperationsInsightsState(std::borrow::Cow<'static, str>);
 
 impl OperationsInsightsState {
@@ -7244,8 +7430,14 @@ impl std::convert::From<std::string::String> for OperationsInsightsState {
     }
 }
 
+impl std::default::Default for OperationsInsightsState {
+    fn default() -> Self {
+        operations_insights_state::OPERATIONS_INSIGHTS_STATE_UNSPECIFIED
+    }
+}
+
 /// The various states available for the Autonomous Database workload type.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DBWorkload(std::borrow::Cow<'static, str>);
 
 impl DBWorkload {
@@ -7284,5 +7476,11 @@ pub mod db_workload {
 impl std::convert::From<std::string::String> for DBWorkload {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for DBWorkload {
+    fn default() -> Self {
+        db_workload::DB_WORKLOAD_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/model.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/model.rs
@@ -1736,7 +1736,7 @@ pub mod list_workloads_response {
     }
 
     /// Supported workload types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ComposerWorkloadType(std::borrow::Cow<'static, str>);
 
     impl ComposerWorkloadType {
@@ -1792,8 +1792,14 @@ pub mod list_workloads_response {
         }
     }
 
+    impl std::default::Default for ComposerWorkloadType {
+        fn default() -> Self {
+            composer_workload_type::COMPOSER_WORKLOAD_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Workload states.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ComposerWorkloadState(std::borrow::Cow<'static, str>);
 
     impl ComposerWorkloadState {
@@ -1838,6 +1844,12 @@ pub mod list_workloads_response {
     impl std::convert::From<std::string::String> for ComposerWorkloadState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ComposerWorkloadState {
+        fn default() -> Self {
+            composer_workload_state::COMPOSER_WORKLOAD_STATE_UNSPECIFIED
         }
     }
 }
@@ -2530,7 +2542,7 @@ pub mod environment_config {
     use super::*;
 
     /// The size of the Cloud Composer environment.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EnvironmentSize(std::borrow::Cow<'static, str>);
 
     impl EnvironmentSize {
@@ -2572,8 +2584,14 @@ pub mod environment_config {
         }
     }
 
+    impl std::default::Default for EnvironmentSize {
+        fn default() -> Self {
+            environment_size::ENVIRONMENT_SIZE_UNSPECIFIED
+        }
+    }
+
     /// Resilience mode of the Cloud Composer Environment.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ResilienceMode(std::borrow::Cow<'static, str>);
 
     impl ResilienceMode {
@@ -2603,6 +2621,12 @@ pub mod environment_config {
     impl std::convert::From<std::string::String> for ResilienceMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ResilienceMode {
+        fn default() -> Self {
+            resilience_mode::RESILIENCE_MODE_UNSPECIFIED
         }
     }
 }
@@ -3097,7 +3121,7 @@ pub mod software_config {
     use super::*;
 
     /// Web server plugins mode of the Cloud Composer environment.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct WebServerPluginsMode(std::borrow::Cow<'static, str>);
 
     impl WebServerPluginsMode {
@@ -3132,6 +3156,12 @@ pub mod software_config {
     impl std::convert::From<std::string::String> for WebServerPluginsMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for WebServerPluginsMode {
+        fn default() -> Self {
+            web_server_plugins_mode::WEB_SERVER_PLUGINS_MODE_UNSPECIFIED
         }
     }
 }
@@ -3746,7 +3776,7 @@ pub mod networking_config {
     /// Represents connection type between Composer environment in Customer
     /// Project and the corresponding Tenant project, from a predefined list
     /// of available connection modes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ConnectionType(std::borrow::Cow<'static, str>);
 
     impl ConnectionType {
@@ -3783,6 +3813,12 @@ pub mod networking_config {
     impl std::convert::From<std::string::String> for ConnectionType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ConnectionType {
+        fn default() -> Self {
+            connection_type::CONNECTION_TYPE_UNSPECIFIED
         }
     }
 }
@@ -4757,7 +4793,7 @@ pub mod environment {
     use super::*;
 
     /// State of the environment.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -4799,6 +4835,12 @@ pub mod environment {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -4958,7 +5000,7 @@ pub mod check_upgrade_response {
     use super::*;
 
     /// Whether there were python modules conflict during image build.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ConflictResult(std::borrow::Cow<'static, str>);
 
     impl ConflictResult {
@@ -4991,6 +5033,12 @@ pub mod check_upgrade_response {
     impl std::convert::From<std::string::String> for ConflictResult {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ConflictResult {
+        fn default() -> Self {
+            conflict_result::CONFLICT_RESULT_UNSPECIFIED
         }
     }
 }
@@ -5084,7 +5132,7 @@ pub mod task_logs_retention_config {
     use super::*;
 
     /// The definition of task_logs_storage_mode.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TaskLogsStorageMode(std::borrow::Cow<'static, str>);
 
     impl TaskLogsStorageMode {
@@ -5120,6 +5168,12 @@ pub mod task_logs_retention_config {
     impl std::convert::From<std::string::String> for TaskLogsStorageMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for TaskLogsStorageMode {
+        fn default() -> Self {
+            task_logs_storage_mode::TASK_LOGS_STORAGE_MODE_UNSPECIFIED
         }
     }
 }
@@ -5172,7 +5226,7 @@ pub mod airflow_metadata_retention_policy_config {
     use super::*;
 
     /// Describes retention policy.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RetentionMode(std::borrow::Cow<'static, str>);
 
     impl RetentionMode {
@@ -5207,6 +5261,12 @@ pub mod airflow_metadata_retention_policy_config {
     impl std::convert::From<std::string::String> for RetentionMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RetentionMode {
+        fn default() -> Self {
+            retention_mode::RETENTION_MODE_UNSPECIFIED
         }
     }
 }
@@ -5513,7 +5573,7 @@ pub mod operation_metadata {
     use super::*;
 
     /// An enum describing the overall state of an operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -5556,8 +5616,14 @@ pub mod operation_metadata {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Type of longrunning operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -5605,6 +5671,12 @@ pub mod operation_metadata {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/orgpolicy/v1/src/model.rs
+++ b/src/generated/cloud/orgpolicy/v1/src/model.rs
@@ -444,7 +444,7 @@ pub mod policy {
         /// set to either `ALLOW` or `DENY,  `allowed_values` and `denied_values`
         /// must be unset. Setting this to `ALL_VALUES_UNSPECIFIED` allows for
         /// setting `allowed_values` and `denied_values`.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct AllValues(std::borrow::Cow<'static, str>);
 
         impl AllValues {
@@ -476,6 +476,12 @@ pub mod policy {
         impl std::convert::From<std::string::String> for AllValues {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for AllValues {
+            fn default() -> Self {
+                all_values::ALL_VALUES_UNSPECIFIED
             }
         }
     }

--- a/src/generated/cloud/orgpolicy/v2/src/model.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/model.rs
@@ -283,7 +283,7 @@ pub mod constraint {
     /// constraint. This must not be `CONSTRAINT_DEFAULT_UNSPECIFIED`.
     ///
     /// Immutable after creation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ConstraintDefault(std::borrow::Cow<'static, str>);
 
     impl ConstraintDefault {
@@ -319,6 +319,12 @@ pub mod constraint {
     impl std::convert::From<std::string::String> for ConstraintDefault {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ConstraintDefault {
+        fn default() -> Self {
+            constraint_default::CONSTRAINT_DEFAULT_UNSPECIFIED
         }
     }
 
@@ -486,7 +492,7 @@ pub mod custom_constraint {
     ///
     /// `UPDATE` only custom constraints are not supported. Use `CREATE` or
     /// `CREATE, UPDATE`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MethodType(std::borrow::Cow<'static, str>);
 
     impl MethodType {
@@ -531,8 +537,14 @@ pub mod custom_constraint {
         }
     }
 
+    impl std::default::Default for MethodType {
+        fn default() -> Self {
+            method_type::METHOD_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Allow or deny type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ActionType(std::borrow::Cow<'static, str>);
 
     impl ActionType {
@@ -564,6 +576,12 @@ pub mod custom_constraint {
     impl std::convert::From<std::string::String> for ActionType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ActionType {
+        fn default() -> Self {
+            action_type::ACTION_TYPE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/osconfig/v1/src/model.rs
+++ b/src/generated/cloud/osconfig/v1/src/model.rs
@@ -405,7 +405,7 @@ pub mod inventory {
         use super::*;
 
         /// The origin of a specific inventory item.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct OriginType(std::borrow::Cow<'static, str>);
 
         impl OriginType {
@@ -439,8 +439,14 @@ pub mod inventory {
             }
         }
 
+        impl std::default::Default for OriginType {
+            fn default() -> Self {
+                origin_type::ORIGIN_TYPE_UNSPECIFIED
+            }
+        }
+
         /// The different types of inventory that are tracked on a VM.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Type(std::borrow::Cow<'static, str>);
 
         impl Type {
@@ -472,6 +478,12 @@ pub mod inventory {
         impl std::convert::From<std::string::String> for Type {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Type {
+            fn default() -> Self {
+                r#type::TYPE_UNSPECIFIED
             }
         }
 
@@ -2716,7 +2728,7 @@ pub mod os_policy {
             }
 
             /// The desired state that the OS Config agent maintains on the VM.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct DesiredState(std::borrow::Cow<'static, str>);
 
             impl DesiredState {
@@ -2750,6 +2762,12 @@ pub mod os_policy {
             impl std::convert::From<std::string::String> for DesiredState {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for DesiredState {
+                fn default() -> Self {
+                    desired_state::DESIRED_STATE_UNSPECIFIED
                 }
             }
 
@@ -3082,9 +3100,7 @@ pub mod os_policy {
                 use super::*;
 
                 /// Type of archive.
-                #[derive(
-                    Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize,
-                )]
+                #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
                 pub struct ArchiveType(std::borrow::Cow<'static, str>);
 
                 impl ArchiveType {
@@ -3117,6 +3133,12 @@ pub mod os_policy {
                 impl std::convert::From<std::string::String> for ArchiveType {
                     fn from(value: std::string::String) -> Self {
                         Self(std::borrow::Cow::Owned(value))
+                    }
+                }
+
+                impl std::default::Default for ArchiveType {
+                    fn default() -> Self {
+                        archive_type::ARCHIVE_TYPE_UNSPECIFIED
                     }
                 }
             }
@@ -3598,9 +3620,7 @@ pub mod os_policy {
                 use super::*;
 
                 /// The interpreter to use.
-                #[derive(
-                    Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize,
-                )]
+                #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
                 pub struct Interpreter(std::borrow::Cow<'static, str>);
 
                 impl Interpreter {
@@ -3641,6 +3661,12 @@ pub mod os_policy {
                 impl std::convert::From<std::string::String> for Interpreter {
                     fn from(value: std::string::String) -> Self {
                         Self(std::borrow::Cow::Owned(value))
+                    }
+                }
+
+                impl std::default::Default for Interpreter {
+                    fn default() -> Self {
+                        interpreter::INTERPRETER_UNSPECIFIED
                     }
                 }
 
@@ -3808,7 +3834,7 @@ pub mod os_policy {
             use super::*;
 
             /// Desired state of the file.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct DesiredState(std::borrow::Cow<'static, str>);
 
             impl DesiredState {
@@ -3845,6 +3871,12 @@ pub mod os_policy {
             impl std::convert::From<std::string::String> for DesiredState {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for DesiredState {
+                fn default() -> Self {
+                    desired_state::DESIRED_STATE_UNSPECIFIED
                 }
             }
 
@@ -3947,7 +3979,7 @@ pub mod os_policy {
     }
 
     /// Policy mode
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Mode(std::borrow::Cow<'static, str>);
 
     impl Mode {
@@ -3982,6 +4014,12 @@ pub mod os_policy {
     impl std::convert::From<std::string::String> for Mode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Mode {
+        fn default() -> Self {
+            mode::MODE_UNSPECIFIED
         }
     }
 }
@@ -4550,9 +4588,7 @@ pub mod os_policy_assignment_report {
                 use super::*;
 
                 /// Supported configuration step types
-                #[derive(
-                    Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize,
-                )]
+                #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
                 pub struct Type(std::borrow::Cow<'static, str>);
 
                 impl Type {
@@ -4601,6 +4637,12 @@ pub mod os_policy_assignment_report {
                         Self(std::borrow::Cow::Owned(value))
                     }
                 }
+
+                impl std::default::Default for Type {
+                    fn default() -> Self {
+                        r#type::TYPE_UNSPECIFIED
+                    }
+                }
             }
 
             /// ExecResource specific output.
@@ -4638,7 +4680,7 @@ pub mod os_policy_assignment_report {
             }
 
             /// Possible compliance states for a resource.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct ComplianceState(std::borrow::Cow<'static, str>);
 
             impl ComplianceState {
@@ -4676,6 +4718,12 @@ pub mod os_policy_assignment_report {
                 }
             }
 
+            impl std::default::Default for ComplianceState {
+                fn default() -> Self {
+                    compliance_state::UNKNOWN
+                }
+            }
+
             /// Resource specific output.
             #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             #[serde(rename_all = "camelCase")]
@@ -4687,7 +4735,7 @@ pub mod os_policy_assignment_report {
         }
 
         /// Possible compliance states for an os policy.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct ComplianceState(std::borrow::Cow<'static, str>);
 
         impl ComplianceState {
@@ -4728,6 +4776,12 @@ pub mod os_policy_assignment_report {
         impl std::convert::From<std::string::String> for ComplianceState {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for ComplianceState {
+            fn default() -> Self {
+                compliance_state::UNKNOWN
             }
         }
     }
@@ -5186,7 +5240,7 @@ pub mod os_policy_assignment {
     }
 
     /// OS policy assignment rollout state
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RolloutState(std::borrow::Cow<'static, str>);
 
     impl RolloutState {
@@ -5225,6 +5279,12 @@ pub mod os_policy_assignment {
     impl std::convert::From<std::string::String> for RolloutState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RolloutState {
+        fn default() -> Self {
+            rollout_state::ROLLOUT_STATE_UNSPECIFIED
         }
     }
 }
@@ -5325,7 +5385,7 @@ pub mod os_policy_assignment_operation_metadata {
     use super::*;
 
     /// The OS policy assignment API method.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct APIMethod(std::borrow::Cow<'static, str>);
 
     impl APIMethod {
@@ -5363,8 +5423,14 @@ pub mod os_policy_assignment_operation_metadata {
         }
     }
 
+    impl std::default::Default for APIMethod {
+        fn default() -> Self {
+            api_method::API_METHOD_UNSPECIFIED
+        }
+    }
+
     /// State of the rollout
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RolloutState(std::borrow::Cow<'static, str>);
 
     impl RolloutState {
@@ -5403,6 +5469,12 @@ pub mod os_policy_assignment_operation_metadata {
     impl std::convert::From<std::string::String> for RolloutState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RolloutState {
+        fn default() -> Self {
+            rollout_state::ROLLOUT_STATE_UNSPECIFIED
         }
     }
 }
@@ -6137,7 +6209,7 @@ pub mod patch_deployment {
     use super::*;
 
     /// Represents state of patch peployment.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -6170,6 +6242,12 @@ pub mod patch_deployment {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -6412,7 +6490,7 @@ pub mod recurring_schedule {
     use super::*;
 
     /// Specifies the frequency of the recurring patch deployments.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Frequency(std::borrow::Cow<'static, str>);
 
     impl Frequency {
@@ -6450,6 +6528,12 @@ pub mod recurring_schedule {
     impl std::convert::From<std::string::String> for Frequency {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Frequency {
+        fn default() -> Self {
+            frequency::FREQUENCY_UNSPECIFIED
         }
     }
 
@@ -7876,7 +7960,7 @@ pub mod patch_job {
 
     /// Enumeration of the various states a patch job passes through as it
     /// executes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -7923,6 +8007,12 @@ pub mod patch_job {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -8071,7 +8161,7 @@ pub mod patch_config {
     use super::*;
 
     /// Post-patch reboot settings.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RebootConfig(std::borrow::Cow<'static, str>);
 
     impl RebootConfig {
@@ -8112,6 +8202,12 @@ pub mod patch_config {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for RebootConfig {
+        fn default() -> Self {
+            reboot_config::REBOOT_CONFIG_UNSPECIFIED
+        }
+    }
 }
 
 /// Namespace for instance state enums.
@@ -8139,7 +8235,7 @@ pub mod instance {
     use super::*;
 
     /// Patch state of an instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PatchState(std::borrow::Cow<'static, str>);
 
     impl PatchState {
@@ -8213,6 +8309,12 @@ pub mod instance {
     impl std::convert::From<std::string::String> for PatchState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PatchState {
+        fn default() -> Self {
+            patch_state::PATCH_STATE_UNSPECIFIED
         }
     }
 }
@@ -8319,7 +8421,7 @@ pub mod apt_settings {
     use super::*;
 
     /// Apt patch type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -8351,6 +8453,12 @@ pub mod apt_settings {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -8626,7 +8734,7 @@ pub mod windows_update_settings {
     /// Microsoft Windows update classifications as defined in
     /// [1]
     /// <https://support.microsoft.com/en-us/help/824684/description-of-the-standard-terminology-that-is-used-to-describe-micro>
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Classification(std::borrow::Cow<'static, str>);
 
     impl Classification {
@@ -8697,6 +8805,12 @@ pub mod windows_update_settings {
     impl std::convert::From<std::string::String> for Classification {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Classification {
+        fn default() -> Self {
+            classification::CLASSIFICATION_UNSPECIFIED
         }
     }
 }
@@ -8874,7 +8988,7 @@ pub mod exec_step_config {
     use super::*;
 
     /// The interpreter used to execute the a file.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Interpreter(std::borrow::Cow<'static, str>);
 
     impl Interpreter {
@@ -8911,6 +9025,12 @@ pub mod exec_step_config {
     impl std::convert::From<std::string::String> for Interpreter {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Interpreter {
+        fn default() -> Self {
+            interpreter::INTERPRETER_UNSPECIFIED
         }
     }
 
@@ -9199,7 +9319,7 @@ pub mod patch_rollout {
     use super::*;
 
     /// Type of the rollout.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Mode(std::borrow::Cow<'static, str>);
 
     impl Mode {
@@ -9236,6 +9356,12 @@ pub mod patch_rollout {
     impl std::convert::From<std::string::String> for Mode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Mode {
+        fn default() -> Self {
+            mode::MODE_UNSPECIFIED
         }
     }
 }
@@ -9990,7 +10116,7 @@ pub mod cvs_sv_3 {
 
     /// This metric reflects the context by which vulnerability exploitation is
     /// possible.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AttackVector(std::borrow::Cow<'static, str>);
 
     impl AttackVector {
@@ -10039,9 +10165,15 @@ pub mod cvs_sv_3 {
         }
     }
 
+    impl std::default::Default for AttackVector {
+        fn default() -> Self {
+            attack_vector::ATTACK_VECTOR_UNSPECIFIED
+        }
+    }
+
     /// This metric describes the conditions beyond the attacker's control that
     /// must exist in order to exploit the vulnerability.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AttackComplexity(std::borrow::Cow<'static, str>);
 
     impl AttackComplexity {
@@ -10085,9 +10217,15 @@ pub mod cvs_sv_3 {
         }
     }
 
+    impl std::default::Default for AttackComplexity {
+        fn default() -> Self {
+            attack_complexity::ATTACK_COMPLEXITY_UNSPECIFIED
+        }
+    }
+
     /// This metric describes the level of privileges an attacker must possess
     /// before successfully exploiting the vulnerability.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PrivilegesRequired(std::borrow::Cow<'static, str>);
 
     impl PrivilegesRequired {
@@ -10136,10 +10274,16 @@ pub mod cvs_sv_3 {
         }
     }
 
+    impl std::default::Default for PrivilegesRequired {
+        fn default() -> Self {
+            privileges_required::PRIVILEGES_REQUIRED_UNSPECIFIED
+        }
+    }
+
     /// This metric captures the requirement for a human user, other than the
     /// attacker, to participate in the successful compromise of the vulnerable
     /// component.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct UserInteraction(std::borrow::Cow<'static, str>);
 
     impl UserInteraction {
@@ -10178,9 +10322,15 @@ pub mod cvs_sv_3 {
         }
     }
 
+    impl std::default::Default for UserInteraction {
+        fn default() -> Self {
+            user_interaction::USER_INTERACTION_UNSPECIFIED
+        }
+    }
+
     /// The Scope metric captures whether a vulnerability in one vulnerable
     /// component impacts resources in components beyond its security scope.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Scope(std::borrow::Cow<'static, str>);
 
     impl Scope {
@@ -10217,10 +10367,16 @@ pub mod cvs_sv_3 {
         }
     }
 
+    impl std::default::Default for Scope {
+        fn default() -> Self {
+            scope::SCOPE_UNSPECIFIED
+        }
+    }
+
     /// The Impact metrics capture the effects of a successfully exploited
     /// vulnerability on the component that suffers the worst outcome that is most
     /// directly and predictably associated with the attack.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Impact(std::borrow::Cow<'static, str>);
 
     impl Impact {
@@ -10257,10 +10413,16 @@ pub mod cvs_sv_3 {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for Impact {
+        fn default() -> Self {
+            impact::IMPACT_UNSPECIFIED
+        }
+    }
 }
 
 /// The view for inventory objects.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct InventoryView(std::borrow::Cow<'static, str>);
 
 impl InventoryView {
@@ -10294,5 +10456,11 @@ pub mod inventory_view {
 impl std::convert::From<std::string::String> for InventoryView {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for InventoryView {
+    fn default() -> Self {
+        inventory_view::INVENTORY_VIEW_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/parallelstore/v1/src/model.rs
+++ b/src/generated/cloud/parallelstore/v1/src/model.rs
@@ -267,7 +267,7 @@ pub mod instance {
     use super::*;
 
     /// The possible states of a Parallelstore instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -312,6 +312,12 @@ pub mod instance {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -2024,7 +2030,7 @@ impl wkt::message::Message for TransferCounters {
 }
 
 /// Type of transfer that occurred.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TransferType(std::borrow::Cow<'static, str>);
 
 impl TransferType {
@@ -2060,8 +2066,14 @@ impl std::convert::From<std::string::String> for TransferType {
     }
 }
 
+impl std::default::Default for TransferType {
+    fn default() -> Self {
+        transfer_type::TRANSFER_TYPE_UNSPECIFIED
+    }
+}
+
 /// Represents the striping options for files.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct FileStripeLevel(std::borrow::Cow<'static, str>);
 
 impl FileStripeLevel {
@@ -2103,8 +2115,14 @@ impl std::convert::From<std::string::String> for FileStripeLevel {
     }
 }
 
+impl std::default::Default for FileStripeLevel {
+    fn default() -> Self {
+        file_stripe_level::FILE_STRIPE_LEVEL_UNSPECIFIED
+    }
+}
+
 /// Represents the striping options for directories.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DirectoryStripeLevel(std::borrow::Cow<'static, str>);
 
 impl DirectoryStripeLevel {
@@ -2146,8 +2164,14 @@ impl std::convert::From<std::string::String> for DirectoryStripeLevel {
     }
 }
 
+impl std::default::Default for DirectoryStripeLevel {
+    fn default() -> Self {
+        directory_stripe_level::DIRECTORY_STRIPE_LEVEL_UNSPECIFIED
+    }
+}
+
 /// Represents the deployment type for the instance.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DeploymentType(std::borrow::Cow<'static, str>);
 
 impl DeploymentType {
@@ -2181,5 +2205,11 @@ pub mod deployment_type {
 impl std::convert::From<std::string::String> for DeploymentType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for DeploymentType {
+    fn default() -> Self {
+        deployment_type::DEPLOYMENT_TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/policysimulator/v1/src/model.rs
+++ b/src/generated/cloud/policysimulator/v1/src/model.rs
@@ -424,7 +424,7 @@ pub mod binding_explanation {
     }
 
     /// Whether a role includes a specific permission.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RolePermission(std::borrow::Cow<'static, str>);
 
     impl RolePermission {
@@ -470,8 +470,14 @@ pub mod binding_explanation {
         }
     }
 
+    impl std::default::Default for RolePermission {
+        fn default() -> Self {
+            role_permission::ROLE_PERMISSION_UNSPECIFIED
+        }
+    }
+
     /// Whether the binding includes the principal.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Membership(std::borrow::Cow<'static, str>);
 
     impl Membership {
@@ -522,6 +528,12 @@ pub mod binding_explanation {
     impl std::convert::From<std::string::String> for Membership {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Membership {
+        fn default() -> Self {
+            membership::MEMBERSHIP_UNSPECIFIED
         }
     }
 }
@@ -691,7 +703,7 @@ pub mod replay {
     /// The current state of the [Replay][google.cloud.policysimulator.v1.Replay].
     ///
     /// [google.cloud.policysimulator.v1.Replay]: crate::model::Replay
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -729,6 +741,12 @@ pub mod replay {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1249,7 +1267,7 @@ pub mod replay_config {
     /// [Replay][google.cloud.policysimulator.v1.Replay].
     ///
     /// [google.cloud.policysimulator.v1.Replay]: crate::model::Replay
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LogSource(std::borrow::Cow<'static, str>);
 
     impl LogSource {
@@ -1284,6 +1302,12 @@ pub mod replay_config {
     impl std::convert::From<std::string::String> for LogSource {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for LogSource {
+        fn default() -> Self {
+            log_source::LOG_SOURCE_UNSPECIFIED
         }
     }
 }
@@ -1414,7 +1438,7 @@ pub mod access_state_diff {
 
     /// How the principal's access, specified in the AccessState field, changed
     /// between the current (baseline) policies and proposed (simulated) policies.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AccessChangeType(std::borrow::Cow<'static, str>);
 
     impl AccessChangeType {
@@ -1483,6 +1507,12 @@ pub mod access_state_diff {
     impl std::convert::From<std::string::String> for AccessChangeType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AccessChangeType {
+        fn default() -> Self {
+            access_change_type::ACCESS_CHANGE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -1569,7 +1599,7 @@ impl wkt::message::Message for ExplainedAccess {
 }
 
 /// Whether a principal has a permission for a resource.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct AccessState(std::borrow::Cow<'static, str>);
 
 impl AccessState {
@@ -1615,10 +1645,16 @@ impl std::convert::From<std::string::String> for AccessState {
     }
 }
 
+impl std::default::Default for AccessState {
+    fn default() -> Self {
+        access_state::ACCESS_STATE_UNSPECIFIED
+    }
+}
+
 /// The extent to which a single data point, such as the existence of a binding
 /// or whether a binding includes a specific principal, contributes to an overall
 /// determination.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct HeuristicRelevance(std::borrow::Cow<'static, str>);
 
 impl HeuristicRelevance {
@@ -1653,5 +1689,11 @@ pub mod heuristic_relevance {
 impl std::convert::From<std::string::String> for HeuristicRelevance {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for HeuristicRelevance {
+    fn default() -> Self {
+        heuristic_relevance::HEURISTIC_RELEVANCE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/model.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/model.rs
@@ -163,7 +163,7 @@ pub mod troubleshoot_iam_policy_response {
     use super::*;
 
     /// Whether the principal has the permission on the resource.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct OverallAccessState(std::borrow::Cow<'static, str>);
 
     impl OverallAccessState {
@@ -206,6 +206,12 @@ pub mod troubleshoot_iam_policy_response {
     impl std::convert::From<std::string::String> for OverallAccessState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for OverallAccessState {
+        fn default() -> Self {
+            overall_access_state::OVERALL_ACCESS_STATE_UNSPECIFIED
         }
     }
 }
@@ -1846,7 +1852,7 @@ pub mod condition_explanation {
 }
 
 /// Whether IAM allow policies gives the principal the permission.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct AllowAccessState(std::borrow::Cow<'static, str>);
 
 impl AllowAccessState {
@@ -1896,8 +1902,14 @@ impl std::convert::From<std::string::String> for AllowAccessState {
     }
 }
 
+impl std::default::Default for AllowAccessState {
+    fn default() -> Self {
+        allow_access_state::ALLOW_ACCESS_STATE_UNSPECIFIED
+    }
+}
+
 /// Whether IAM deny policies deny the principal the permission.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DenyAccessState(std::borrow::Cow<'static, str>);
 
 impl DenyAccessState {
@@ -1947,8 +1959,14 @@ impl std::convert::From<std::string::String> for DenyAccessState {
     }
 }
 
+impl std::default::Default for DenyAccessState {
+    fn default() -> Self {
+        deny_access_state::DENY_ACCESS_STATE_UNSPECIFIED
+    }
+}
+
 /// Whether a role includes a specific permission.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct RolePermissionInclusionState(std::borrow::Cow<'static, str>);
 
 impl RolePermissionInclusionState {
@@ -1990,8 +2008,14 @@ impl std::convert::From<std::string::String> for RolePermissionInclusionState {
     }
 }
 
+impl std::default::Default for RolePermissionInclusionState {
+    fn default() -> Self {
+        role_permission_inclusion_state::ROLE_PERMISSION_INCLUSION_STATE_UNSPECIFIED
+    }
+}
+
 /// Whether the permission in the request matches the permission in the policy.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct PermissionPatternMatchingState(std::borrow::Cow<'static, str>);
 
 impl PermissionPatternMatchingState {
@@ -2029,8 +2053,14 @@ impl std::convert::From<std::string::String> for PermissionPatternMatchingState 
     }
 }
 
+impl std::default::Default for PermissionPatternMatchingState {
+    fn default() -> Self {
+        permission_pattern_matching_state::PERMISSION_PATTERN_MATCHING_STATE_UNSPECIFIED
+    }
+}
+
 /// Whether the principal in the request matches the principal in the policy.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct MembershipMatchingState(std::borrow::Cow<'static, str>);
 
 impl MembershipMatchingState {
@@ -2085,9 +2115,15 @@ impl std::convert::From<std::string::String> for MembershipMatchingState {
     }
 }
 
+impl std::default::Default for MembershipMatchingState {
+    fn default() -> Self {
+        membership_matching_state::MEMBERSHIP_MATCHING_STATE_UNSPECIFIED
+    }
+}
+
 /// The extent to which a single data point contributes to an overall
 /// determination.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct HeuristicRelevance(std::borrow::Cow<'static, str>);
 
 impl HeuristicRelevance {
@@ -2124,5 +2160,11 @@ pub mod heuristic_relevance {
 impl std::convert::From<std::string::String> for HeuristicRelevance {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for HeuristicRelevance {
+    fn default() -> Self {
+        heuristic_relevance::HEURISTIC_RELEVANCE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/policytroubleshooter/v1/src/model.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/model.rs
@@ -519,7 +519,7 @@ pub mod binding_explanation {
     }
 
     /// Whether a role includes a specific permission.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RolePermission(std::borrow::Cow<'static, str>);
 
     impl RolePermission {
@@ -561,8 +561,14 @@ pub mod binding_explanation {
         }
     }
 
+    impl std::default::Default for RolePermission {
+        fn default() -> Self {
+            role_permission::ROLE_PERMISSION_UNSPECIFIED
+        }
+    }
+
     /// Whether the binding includes the principal.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Membership(std::borrow::Cow<'static, str>);
 
     impl Membership {
@@ -611,10 +617,16 @@ pub mod binding_explanation {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for Membership {
+        fn default() -> Self {
+            membership::MEMBERSHIP_UNSPECIFIED
+        }
+    }
 }
 
 /// Whether a principal has a permission for a resource.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct AccessState(std::borrow::Cow<'static, str>);
 
 impl AccessState {
@@ -657,10 +669,16 @@ impl std::convert::From<std::string::String> for AccessState {
     }
 }
 
+impl std::default::Default for AccessState {
+    fn default() -> Self {
+        access_state::ACCESS_STATE_UNSPECIFIED
+    }
+}
+
 /// The extent to which a single data point, such as the existence of a binding
 /// or whether a binding includes a specific principal, contributes to an overall
 /// determination.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct HeuristicRelevance(std::borrow::Cow<'static, str>);
 
 impl HeuristicRelevance {
@@ -695,5 +713,11 @@ pub mod heuristic_relevance {
 impl std::convert::From<std::string::String> for HeuristicRelevance {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for HeuristicRelevance {
+    fn default() -> Self {
+        heuristic_relevance::HEURISTIC_RELEVANCE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/model.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/model.rs
@@ -688,7 +688,7 @@ pub mod entitlement {
     }
 
     /// Different states an entitlement can be in.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -729,6 +729,12 @@ pub mod entitlement {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1394,7 +1400,7 @@ pub mod search_entitlements_request {
     use super::*;
 
     /// Different types of access a user can have on the entitlement resource.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CallerAccessType(std::borrow::Cow<'static, str>);
 
     impl CallerAccessType {
@@ -1428,6 +1434,12 @@ pub mod search_entitlements_request {
     impl std::convert::From<std::string::String> for CallerAccessType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CallerAccessType {
+        fn default() -> Self {
+            caller_access_type::CALLER_ACCESS_TYPE_UNSPECIFIED
         }
     }
 }
@@ -2757,7 +2769,7 @@ pub mod grant {
     }
 
     /// Different states a grant can be in.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2819,6 +2831,12 @@ pub mod grant {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -3120,7 +3138,7 @@ pub mod search_grants_request {
     use super::*;
 
     /// Different types of relationships a user can have with a grant.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CallerRelationshipType(std::borrow::Cow<'static, str>);
 
     impl CallerRelationshipType {
@@ -3158,6 +3176,12 @@ pub mod search_grants_request {
     impl std::convert::From<std::string::String> for CallerRelationshipType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CallerRelationshipType {
+        fn default() -> Self {
+            caller_relationship_type::CALLER_RELATIONSHIP_TYPE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/model.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/model.rs
@@ -294,7 +294,7 @@ pub mod collector {
     /// States are used for internal purposes and named to keep
     /// convention of legacy product:
     /// <https://cloud.google.com/migrate/stratozone/docs/about-stratoprobe>.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -346,6 +346,12 @@ pub mod collector {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -437,7 +443,7 @@ pub mod annotation {
     use super::*;
 
     /// Types for project level setting.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -469,6 +475,12 @@ pub mod annotation {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
@@ -149,7 +149,7 @@ pub mod transaction_event {
     use super::*;
 
     /// Enum that represents an event in the payment transaction lifecycle.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TransactionEventType(std::borrow::Cow<'static, str>);
 
     impl TransactionEventType {
@@ -282,6 +282,12 @@ pub mod transaction_event {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for TransactionEventType {
+        fn default() -> Self {
+            transaction_event_type::TRANSACTION_EVENT_TYPE_UNSPECIFIED
+        }
+    }
 }
 
 /// The request message to annotate an Assessment.
@@ -393,7 +399,7 @@ pub mod annotate_assessment_request {
     use super::*;
 
     /// Enum that represents the types of annotations.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Annotation(std::borrow::Cow<'static, str>);
 
     impl Annotation {
@@ -438,8 +444,14 @@ pub mod annotate_assessment_request {
         }
     }
 
+    impl std::default::Default for Annotation {
+        fn default() -> Self {
+            annotation::ANNOTATION_UNSPECIFIED
+        }
+    }
+
     /// Enum that represents potential reasons for annotating an assessment.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Reason(std::borrow::Cow<'static, str>);
 
     impl Reason {
@@ -524,6 +536,12 @@ pub mod annotate_assessment_request {
     impl std::convert::From<std::string::String> for Reason {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Reason {
+        fn default() -> Self {
+            reason::REASON_UNSPECIFIED
         }
     }
 }
@@ -751,7 +769,7 @@ pub mod account_verification_info {
 
     /// Result of the account verification as contained in the verdict token issued
     /// at the end of the verification flow.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Result(std::borrow::Cow<'static, str>);
 
     impl Result {
@@ -816,6 +834,12 @@ pub mod account_verification_info {
     impl std::convert::From<std::string::String> for Result {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Result {
+        fn default() -> Self {
+            result::RESULT_UNSPECIFIED
         }
     }
 }
@@ -1313,7 +1337,7 @@ pub mod event {
     use super::*;
 
     /// Setting that controls Fraud Prevention assessments.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct FraudPrevention(std::borrow::Cow<'static, str>);
 
     impl FraudPrevention {
@@ -1350,6 +1374,12 @@ pub mod event {
     impl std::convert::From<std::string::String> for FraudPrevention {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for FraudPrevention {
+        fn default() -> Self {
+            fraud_prevention::FRAUD_PREVENTION_UNSPECIFIED
         }
     }
 }
@@ -2125,7 +2155,7 @@ pub mod risk_analysis {
     use super::*;
 
     /// Reasons contributing to the risk analysis verdict.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ClassificationReason(std::borrow::Cow<'static, str>);
 
     impl ClassificationReason {
@@ -2184,8 +2214,14 @@ pub mod risk_analysis {
         }
     }
 
+    impl std::default::Default for ClassificationReason {
+        fn default() -> Self {
+            classification_reason::CLASSIFICATION_REASON_UNSPECIFIED
+        }
+    }
+
     /// Challenge information for SCORE_AND_CHALLENGE and INVISIBLE keys
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Challenge(std::borrow::Cow<'static, str>);
 
     impl Challenge {
@@ -2221,6 +2257,12 @@ pub mod risk_analysis {
     impl std::convert::From<std::string::String> for Challenge {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Challenge {
+        fn default() -> Self {
+            challenge::CHALLENGE_UNSPECIFIED
         }
     }
 }
@@ -2336,7 +2378,7 @@ pub mod token_properties {
     use super::*;
 
     /// Enum that represents the types of invalid token reasons.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct InvalidReason(std::borrow::Cow<'static, str>);
 
     impl InvalidReason {
@@ -2383,6 +2425,12 @@ pub mod token_properties {
     impl std::convert::From<std::string::String> for InvalidReason {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for InvalidReason {
+        fn default() -> Self {
+            invalid_reason::INVALID_REASON_UNSPECIFIED
         }
     }
 }
@@ -2705,7 +2753,7 @@ pub mod fraud_signals {
 
         /// Risk labels describing the card being assessed, such as its funding
         /// mechanism.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct CardLabel(std::borrow::Cow<'static, str>);
 
         impl CardLabel {
@@ -2742,6 +2790,12 @@ pub mod fraud_signals {
         impl std::convert::From<std::string::String> for CardLabel {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for CardLabel {
+            fn default() -> Self {
+                card_label::CARD_LABEL_UNSPECIFIED
             }
         }
     }
@@ -2797,7 +2851,7 @@ pub mod sms_toll_fraud_verdict {
     use super::*;
 
     /// Reasons contributing to the SMS toll fraud verdict.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SmsTollFraudReason(std::borrow::Cow<'static, str>);
 
     impl SmsTollFraudReason {
@@ -2828,6 +2882,12 @@ pub mod sms_toll_fraud_verdict {
     impl std::convert::From<std::string::String> for SmsTollFraudReason {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SmsTollFraudReason {
+        fn default() -> Self {
+            sms_toll_fraud_reason::SMS_TOLL_FRAUD_REASON_UNSPECIFIED
         }
     }
 }
@@ -2906,7 +2966,7 @@ pub mod account_defender_assessment {
     use super::*;
 
     /// Labels returned by account defender for this request.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AccountDefenderLabel(std::borrow::Cow<'static, str>);
 
     impl AccountDefenderLabel {
@@ -2952,6 +3012,12 @@ pub mod account_defender_assessment {
     impl std::convert::From<std::string::String> for AccountDefenderLabel {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AccountDefenderLabel {
+        fn default() -> Self {
+            account_defender_label::ACCOUNT_DEFENDER_LABEL_UNSPECIFIED
         }
     }
 }
@@ -4068,7 +4134,7 @@ pub mod testing_options {
 
     /// Enum that represents the challenge option for challenge-based (CHECKBOX,
     /// INVISIBLE) testing keys.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TestingChallenge(std::borrow::Cow<'static, str>);
 
     impl TestingChallenge {
@@ -4105,6 +4171,12 @@ pub mod testing_options {
     impl std::convert::From<std::string::String> for TestingChallenge {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for TestingChallenge {
+        fn default() -> Self {
+            testing_challenge::TESTING_CHALLENGE_UNSPECIFIED
         }
     }
 }
@@ -4201,7 +4273,7 @@ pub mod web_key_settings {
     use super::*;
 
     /// Enum that represents the integration types for web keys.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct IntegrationType(std::borrow::Cow<'static, str>);
 
     impl IntegrationType {
@@ -4245,9 +4317,15 @@ pub mod web_key_settings {
         }
     }
 
+    impl std::default::Default for IntegrationType {
+        fn default() -> Self {
+            integration_type::INTEGRATION_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Enum that represents the possible challenge frequency and difficulty
     /// configurations for a web key.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ChallengeSecurityPreference(std::borrow::Cow<'static, str>);
 
     impl ChallengeSecurityPreference {
@@ -4286,6 +4364,12 @@ pub mod web_key_settings {
     impl std::convert::From<std::string::String> for ChallengeSecurityPreference {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ChallengeSecurityPreference {
+        fn default() -> Self {
+            challenge_security_preference::CHALLENGE_SECURITY_PREFERENCE_UNSPECIFIED
         }
     }
 }
@@ -5948,7 +6032,7 @@ pub mod waf_settings {
 
     /// Supported WAF features. For more information, see
     /// <https://cloud.google.com/recaptcha/docs/usecase#comparison_of_features>.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct WafFeature(std::borrow::Cow<'static, str>);
 
     impl WafFeature {
@@ -5991,8 +6075,14 @@ pub mod waf_settings {
         }
     }
 
+    impl std::default::Default for WafFeature {
+        fn default() -> Self {
+            waf_feature::WAF_FEATURE_UNSPECIFIED
+        }
+    }
+
     /// Web Application Firewalls supported by reCAPTCHA.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct WafService(std::borrow::Cow<'static, str>);
 
     impl WafService {
@@ -6030,6 +6120,12 @@ pub mod waf_settings {
     impl std::convert::From<std::string::String> for WafService {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for WafService {
+        fn default() -> Self {
+            waf_service::WAF_SERVICE_UNSPECIFIED
         }
     }
 }
@@ -6136,7 +6232,7 @@ pub mod ip_override_data {
     use super::*;
 
     /// Enum that represents the type of IP override.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct OverrideType(std::borrow::Cow<'static, str>);
 
     impl OverrideType {
@@ -6167,6 +6263,12 @@ pub mod ip_override_data {
     impl std::convert::From<std::string::String> for OverrideType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for OverrideType {
+        fn default() -> Self {
+            override_type::OVERRIDE_TYPE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/recommender/v1/src/model.rs
+++ b/src/generated/cloud/recommender/v1/src/model.rs
@@ -242,7 +242,7 @@ pub mod insight {
     }
 
     /// Insight category.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Category(std::borrow::Cow<'static, str>);
 
     impl Category {
@@ -289,8 +289,14 @@ pub mod insight {
         }
     }
 
+    impl std::default::Default for Category {
+        fn default() -> Self {
+            category::CATEGORY_UNSPECIFIED
+        }
+    }
+
     /// Insight severity levels.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Severity(std::borrow::Cow<'static, str>);
 
     impl Severity {
@@ -328,6 +334,12 @@ pub mod insight {
     impl std::convert::From<std::string::String> for Severity {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Severity {
+        fn default() -> Self {
+            severity::SEVERITY_UNSPECIFIED
         }
     }
 }
@@ -385,7 +397,7 @@ pub mod insight_state_info {
     use super::*;
 
     /// Represents insight state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -426,6 +438,12 @@ pub mod insight_state_info {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -807,7 +825,7 @@ pub mod recommendation {
     }
 
     /// Recommendation priority levels.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Priority(std::borrow::Cow<'static, str>);
 
     impl Priority {
@@ -845,6 +863,12 @@ pub mod recommendation {
     impl std::convert::From<std::string::String> for Priority {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Priority {
+        fn default() -> Self {
+            priority::PRIORITY_UNSPECIFIED
         }
     }
 }
@@ -1456,7 +1480,7 @@ pub mod reliability_projection {
     use super::*;
 
     /// The risk associated with the reliability issue.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RiskType(std::borrow::Cow<'static, str>);
 
     impl RiskType {
@@ -1492,6 +1516,12 @@ pub mod reliability_projection {
     impl std::convert::From<std::string::String> for RiskType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RiskType {
+        fn default() -> Self {
+            risk_type::RISK_TYPE_UNSPECIFIED
         }
     }
 }
@@ -1671,7 +1701,7 @@ pub mod impact {
     use super::*;
 
     /// The category of the impact.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Category(std::borrow::Cow<'static, str>);
 
     impl Category {
@@ -1715,6 +1745,12 @@ pub mod impact {
     impl std::convert::From<std::string::String> for Category {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Category {
+        fn default() -> Self {
+            category::CATEGORY_UNSPECIFIED
         }
     }
 
@@ -1787,7 +1823,7 @@ pub mod recommendation_state_info {
     use super::*;
 
     /// Represents Recommendation State.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1843,6 +1879,12 @@ pub mod recommendation_state_info {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/redis/cluster/v1/src/model.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/model.rs
@@ -1622,7 +1622,7 @@ pub mod cluster {
     }
 
     /// Represents the different states of a Redis cluster.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1660,6 +1660,12 @@ pub mod cluster {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -1820,7 +1826,7 @@ pub mod automated_backup_config {
     }
 
     /// The automated backup mode.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AutomatedBackupMode(std::borrow::Cow<'static, str>);
 
     impl AutomatedBackupMode {
@@ -1853,6 +1859,12 @@ pub mod automated_backup_config {
     impl std::convert::From<std::string::String> for AutomatedBackupMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AutomatedBackupMode {
+        fn default() -> Self {
+            automated_backup_mode::AUTOMATED_BACKUP_MODE_UNSPECIFIED
         }
     }
 
@@ -2132,7 +2144,7 @@ pub mod backup {
     use super::*;
 
     /// Type of the backup.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct BackupType(std::borrow::Cow<'static, str>);
 
     impl BackupType {
@@ -2167,8 +2179,14 @@ pub mod backup {
         }
     }
 
+    impl std::default::Default for BackupType {
+        fn default() -> Self {
+            backup_type::BACKUP_TYPE_UNSPECIFIED
+        }
+    }
+
     /// State of the backup.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2207,6 +2225,12 @@ pub mod backup {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -2523,7 +2547,7 @@ pub mod cross_cluster_replication_config {
     }
 
     /// The role of the cluster in cross cluster replication.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ClusterRole(std::borrow::Cow<'static, str>);
 
     impl ClusterRole {
@@ -2563,6 +2587,12 @@ pub mod cross_cluster_replication_config {
     impl std::convert::From<std::string::String> for ClusterRole {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ClusterRole {
+        fn default() -> Self {
+            cluster_role::CLUSTER_ROLE_UNSPECIFIED
         }
     }
 }
@@ -3608,7 +3638,7 @@ pub mod cluster_persistence_config {
         use super::*;
 
         /// Available snapshot periods.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct SnapshotPeriod(std::borrow::Cow<'static, str>);
 
         impl SnapshotPeriod {
@@ -3647,6 +3677,12 @@ pub mod cluster_persistence_config {
         impl std::convert::From<std::string::String> for SnapshotPeriod {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for SnapshotPeriod {
+            fn default() -> Self {
+                snapshot_period::SNAPSHOT_PERIOD_UNSPECIFIED
             }
         }
     }
@@ -3690,7 +3726,7 @@ pub mod cluster_persistence_config {
         use super::*;
 
         /// Available fsync modes.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct AppendFsync(std::borrow::Cow<'static, str>);
 
         impl AppendFsync {
@@ -3731,10 +3767,16 @@ pub mod cluster_persistence_config {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for AppendFsync {
+            fn default() -> Self {
+                append_fsync::APPEND_FSYNC_UNSPECIFIED
+            }
+        }
     }
 
     /// Available persistence modes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PersistenceMode(std::borrow::Cow<'static, str>);
 
     impl PersistenceMode {
@@ -3770,6 +3812,12 @@ pub mod cluster_persistence_config {
     impl std::convert::From<std::string::String> for PersistenceMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PersistenceMode {
+        fn default() -> Self {
+            persistence_mode::PERSISTENCE_MODE_UNSPECIFIED
         }
     }
 }
@@ -3826,7 +3874,7 @@ pub mod zone_distribution_config {
     use super::*;
 
     /// Defines various modes of zone distribution.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ZoneDistributionMode(std::borrow::Cow<'static, str>);
 
     impl ZoneDistributionMode {
@@ -3861,6 +3909,12 @@ pub mod zone_distribution_config {
     impl std::convert::From<std::string::String> for ZoneDistributionMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ZoneDistributionMode {
+        fn default() -> Self {
+            zone_distribution_mode::ZONE_DISTRIBUTION_MODE_UNSPECIFIED
         }
     }
 }
@@ -3932,7 +3986,7 @@ pub mod reschedule_cluster_maintenance_request {
     use super::*;
 
     /// Reschedule options.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RescheduleType(std::borrow::Cow<'static, str>);
 
     impl RescheduleType {
@@ -3965,6 +4019,12 @@ pub mod reschedule_cluster_maintenance_request {
     impl std::convert::From<std::string::String> for RescheduleType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RescheduleType {
+        fn default() -> Self {
+            reschedule_type::RESCHEDULE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -4050,7 +4110,7 @@ pub mod encryption_info {
     use super::*;
 
     /// Possible encryption types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -4087,9 +4147,15 @@ pub mod encryption_info {
         }
     }
 
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
+        }
+    }
+
     /// The state of the KMS key perceived by the system. Refer to the public
     /// documentation for the impact of each state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct KmsKeyState(std::borrow::Cow<'static, str>);
 
     impl KmsKeyState {
@@ -4143,10 +4209,16 @@ pub mod encryption_info {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for KmsKeyState {
+        fn default() -> Self {
+            kms_key_state::KMS_KEY_STATE_UNSPECIFIED
+        }
+    }
 }
 
 /// Status of the PSC connection.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct PscConnectionStatus(std::borrow::Cow<'static, str>);
 
 impl PscConnectionStatus {
@@ -4184,8 +4256,14 @@ impl std::convert::From<std::string::String> for PscConnectionStatus {
     }
 }
 
+impl std::default::Default for PscConnectionStatus {
+    fn default() -> Self {
+        psc_connection_status::PSC_CONNECTION_STATUS_UNSPECIFIED
+    }
+}
+
 /// Available authorization mode of a Redis cluster.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct AuthorizationMode(std::borrow::Cow<'static, str>);
 
 impl AuthorizationMode {
@@ -4221,8 +4299,14 @@ impl std::convert::From<std::string::String> for AuthorizationMode {
     }
 }
 
+impl std::default::Default for AuthorizationMode {
+    fn default() -> Self {
+        authorization_mode::AUTH_MODE_UNSPECIFIED
+    }
+}
+
 /// NodeType of a redis cluster node,
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct NodeType(std::borrow::Cow<'static, str>);
 
 impl NodeType {
@@ -4263,8 +4347,14 @@ impl std::convert::From<std::string::String> for NodeType {
     }
 }
 
+impl std::default::Default for NodeType {
+    fn default() -> Self {
+        node_type::NODE_TYPE_UNSPECIFIED
+    }
+}
+
 /// Available mode of in-transit encryption.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TransitEncryptionMode(std::borrow::Cow<'static, str>);
 
 impl TransitEncryptionMode {
@@ -4302,8 +4392,14 @@ impl std::convert::From<std::string::String> for TransitEncryptionMode {
     }
 }
 
+impl std::default::Default for TransitEncryptionMode {
+    fn default() -> Self {
+        transit_encryption_mode::TRANSIT_ENCRYPTION_MODE_UNSPECIFIED
+    }
+}
+
 /// Type of a PSC connection, for cluster access purpose.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ConnectionType(std::borrow::Cow<'static, str>);
 
 impl ConnectionType {
@@ -4342,5 +4438,11 @@ pub mod connection_type {
 impl std::convert::From<std::string::String> for ConnectionType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for ConnectionType {
+    fn default() -> Self {
+        connection_type::CONNECTION_TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/redis/v1/src/model.rs
+++ b/src/generated/cloud/redis/v1/src/model.rs
@@ -611,7 +611,7 @@ pub mod instance {
     use super::*;
 
     /// Represents the different states of a Redis instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -666,8 +666,14 @@ pub mod instance {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Available service tiers to choose from
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Tier(std::borrow::Cow<'static, str>);
 
     impl Tier {
@@ -702,8 +708,14 @@ pub mod instance {
         }
     }
 
+    impl std::default::Default for Tier {
+        fn default() -> Self {
+            tier::TIER_UNSPECIFIED
+        }
+    }
+
     /// Available connection modes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ConnectMode(std::borrow::Cow<'static, str>);
 
     impl ConnectMode {
@@ -741,8 +753,14 @@ pub mod instance {
         }
     }
 
+    impl std::default::Default for ConnectMode {
+        fn default() -> Self {
+            connect_mode::CONNECT_MODE_UNSPECIFIED
+        }
+    }
+
     /// Available TLS modes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TransitEncryptionMode(std::borrow::Cow<'static, str>);
 
     impl TransitEncryptionMode {
@@ -779,8 +797,14 @@ pub mod instance {
         }
     }
 
+    impl std::default::Default for TransitEncryptionMode {
+        fn default() -> Self {
+            transit_encryption_mode::TRANSIT_ENCRYPTION_MODE_UNSPECIFIED
+        }
+    }
+
     /// Read replicas mode.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ReadReplicasMode(std::borrow::Cow<'static, str>);
 
     impl ReadReplicasMode {
@@ -821,8 +845,14 @@ pub mod instance {
         }
     }
 
+    impl std::default::Default for ReadReplicasMode {
+        fn default() -> Self {
+            read_replicas_mode::READ_REPLICAS_MODE_UNSPECIFIED
+        }
+    }
+
     /// Possible reasons for the instance to be in a "SUSPENDED" state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SuspensionReason(std::borrow::Cow<'static, str>);
 
     impl SuspensionReason {
@@ -853,6 +883,12 @@ pub mod instance {
     impl std::convert::From<std::string::String> for SuspensionReason {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SuspensionReason {
+        fn default() -> Self {
+            suspension_reason::SUSPENSION_REASON_UNSPECIFIED
         }
     }
 }
@@ -948,7 +984,7 @@ pub mod persistence_config {
     use super::*;
 
     /// Available Persistence modes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PersistenceMode(std::borrow::Cow<'static, str>);
 
     impl PersistenceMode {
@@ -985,8 +1021,14 @@ pub mod persistence_config {
         }
     }
 
+    impl std::default::Default for PersistenceMode {
+        fn default() -> Self {
+            persistence_mode::PERSISTENCE_MODE_UNSPECIFIED
+        }
+    }
+
     /// Available snapshot periods for scheduling.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SnapshotPeriod(std::borrow::Cow<'static, str>);
 
     impl SnapshotPeriod {
@@ -1025,6 +1067,12 @@ pub mod persistence_config {
     impl std::convert::From<std::string::String> for SnapshotPeriod {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SnapshotPeriod {
+        fn default() -> Self {
+            snapshot_period::SNAPSHOT_PERIOD_UNSPECIFIED
         }
     }
 }
@@ -1099,7 +1147,7 @@ pub mod reschedule_maintenance_request {
     use super::*;
 
     /// Reschedule options.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RescheduleType(std::borrow::Cow<'static, str>);
 
     impl RescheduleType {
@@ -1137,6 +1185,12 @@ pub mod reschedule_maintenance_request {
     impl std::convert::From<std::string::String> for RescheduleType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RescheduleType {
+        fn default() -> Self {
+            reschedule_type::RESCHEDULE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -2153,7 +2207,7 @@ pub mod failover_instance_request {
     use super::*;
 
     /// Specifies different modes of operation in relation to the data retention.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DataProtectionMode(std::borrow::Cow<'static, str>);
 
     impl DataProtectionMode {
@@ -2191,6 +2245,12 @@ pub mod failover_instance_request {
     impl std::convert::From<std::string::String> for DataProtectionMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DataProtectionMode {
+        fn default() -> Self {
+            data_protection_mode::DATA_PROTECTION_MODE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/resourcemanager/v3/src/model.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/model.rs
@@ -165,7 +165,7 @@ pub mod folder {
     use super::*;
 
     /// Folder lifecycle states.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -197,6 +197,12 @@ pub mod folder {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1010,7 +1016,7 @@ pub mod organization {
     use super::*;
 
     /// Organization lifecycle states.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1042,6 +1048,12 @@ pub mod organization {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -1432,7 +1444,7 @@ pub mod project {
     use super::*;
 
     /// Project lifecycle states.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1472,6 +1484,12 @@ pub mod project {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -4104,7 +4122,7 @@ impl wkt::message::Message for DeleteTagValueMetadata {
 /// A purpose for each policy engine requiring such an integration. A single
 /// policy engine may have multiple purposes defined, however a TagKey may only
 /// specify a single purpose.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Purpose(std::borrow::Cow<'static, str>);
 
 impl Purpose {
@@ -4148,5 +4166,11 @@ pub mod purpose {
 impl std::convert::From<std::string::String> for Purpose {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for Purpose {
+    fn default() -> Self {
+        purpose::PURPOSE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/retail/v2/src/model.rs
+++ b/src/generated/cloud/retail/v2/src/model.rs
@@ -733,7 +733,7 @@ pub mod catalog_attribute {
     }
 
     /// The type of an attribute.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AttributeType(std::borrow::Cow<'static, str>);
 
     impl AttributeType {
@@ -773,8 +773,14 @@ pub mod catalog_attribute {
         }
     }
 
+    impl std::default::Default for AttributeType {
+        fn default() -> Self {
+            attribute_type::UNKNOWN
+        }
+    }
+
     /// The status of the indexable option of a catalog attribute.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct IndexableOption(std::borrow::Cow<'static, str>);
 
     impl IndexableOption {
@@ -810,8 +816,14 @@ pub mod catalog_attribute {
         }
     }
 
+    impl std::default::Default for IndexableOption {
+        fn default() -> Self {
+            indexable_option::INDEXABLE_OPTION_UNSPECIFIED
+        }
+    }
+
     /// The status of the dynamic facetable option of a catalog attribute.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DynamicFacetableOption(std::borrow::Cow<'static, str>);
 
     impl DynamicFacetableOption {
@@ -849,8 +861,14 @@ pub mod catalog_attribute {
         }
     }
 
+    impl std::default::Default for DynamicFacetableOption {
+        fn default() -> Self {
+            dynamic_facetable_option::DYNAMIC_FACETABLE_OPTION_UNSPECIFIED
+        }
+    }
+
     /// The status of the searchable option of a catalog attribute.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SearchableOption(std::borrow::Cow<'static, str>);
 
     impl SearchableOption {
@@ -888,8 +906,14 @@ pub mod catalog_attribute {
         }
     }
 
+    impl std::default::Default for SearchableOption {
+        fn default() -> Self {
+            searchable_option::SEARCHABLE_OPTION_UNSPECIFIED
+        }
+    }
+
     /// The status of the exact-searchable option of a catalog attribute.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ExactSearchableOption(std::borrow::Cow<'static, str>);
 
     impl ExactSearchableOption {
@@ -927,8 +951,14 @@ pub mod catalog_attribute {
         }
     }
 
+    impl std::default::Default for ExactSearchableOption {
+        fn default() -> Self {
+            exact_searchable_option::EXACT_SEARCHABLE_OPTION_UNSPECIFIED
+        }
+    }
+
     /// The status of the retrievable option of a catalog attribute.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RetrievableOption(std::borrow::Cow<'static, str>);
 
     impl RetrievableOption {
@@ -963,6 +993,12 @@ pub mod catalog_attribute {
     impl std::convert::From<std::string::String> for RetrievableOption {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RetrievableOption {
+        fn default() -> Self {
+            retrievable_option::RETRIEVABLE_OPTION_UNSPECIFIED
         }
     }
 }
@@ -6854,7 +6890,7 @@ pub mod import_products_request {
 
     /// Indicates how imported products are reconciled with the existing products
     /// created or imported before.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ReconciliationMode(std::borrow::Cow<'static, str>);
 
     impl ReconciliationMode {
@@ -6888,6 +6924,12 @@ pub mod import_products_request {
     impl std::convert::From<std::string::String> for ReconciliationMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ReconciliationMode {
+        fn default() -> Self {
+            reconciliation_mode::RECONCILIATION_MODE_UNSPECIFIED
         }
     }
 }
@@ -8169,7 +8211,7 @@ pub mod model {
     }
 
     /// The serving state of the model.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ServingState(std::borrow::Cow<'static, str>);
 
     impl ServingState {
@@ -8209,8 +8251,14 @@ pub mod model {
         }
     }
 
+    impl std::default::Default for ServingState {
+        fn default() -> Self {
+            serving_state::SERVING_STATE_UNSPECIFIED
+        }
+    }
+
     /// The training state of the model.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TrainingState(std::borrow::Cow<'static, str>);
 
     impl TrainingState {
@@ -8246,13 +8294,19 @@ pub mod model {
         }
     }
 
+    impl std::default::Default for TrainingState {
+        fn default() -> Self {
+            training_state::TRAINING_STATE_UNSPECIFIED
+        }
+    }
+
     /// Describes whether periodic tuning is enabled for this model
     /// or not. Periodic tuning is scheduled at most every three months. You can
     /// start a tuning process manually by using the `TuneModel`
     /// method, which starts a tuning process immediately and resets the quarterly
     /// schedule. Enabling or disabling periodic tuning does not affect any
     /// current tuning processes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PeriodicTuningState(std::borrow::Cow<'static, str>);
 
     impl PeriodicTuningState {
@@ -8300,9 +8354,15 @@ pub mod model {
         }
     }
 
+    impl std::default::Default for PeriodicTuningState {
+        fn default() -> Self {
+            periodic_tuning_state::PERIODIC_TUNING_STATE_UNSPECIFIED
+        }
+    }
+
     /// Describes whether this model have sufficient training data
     /// to be continuously trained.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DataState(std::borrow::Cow<'static, str>);
 
     impl DataState {
@@ -8338,8 +8398,14 @@ pub mod model {
         }
     }
 
+    impl std::default::Default for DataState {
+        fn default() -> Self {
+            data_state::DATA_STATE_UNSPECIFIED
+        }
+    }
+
     /// Use single or multiple context products for recommendations.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ContextProductsType(std::borrow::Cow<'static, str>);
 
     impl ContextProductsType {
@@ -8380,6 +8446,12 @@ pub mod model {
     impl std::convert::From<std::string::String> for ContextProductsType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ContextProductsType {
+        fn default() -> Self {
+            context_products_type::CONTEXT_PRODUCTS_TYPE_UNSPECIFIED
         }
     }
 }
@@ -10124,7 +10196,7 @@ pub mod product {
     use super::*;
 
     /// The type of this product.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -10196,9 +10268,15 @@ pub mod product {
         }
     }
 
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
+        }
+    }
+
     /// Product availability. If this field is unspecified, the product is
     /// assumed to be in stock.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Availability(std::borrow::Cow<'static, str>);
 
     impl Availability {
@@ -10241,6 +10319,12 @@ pub mod product {
     impl std::convert::From<std::string::String> for Availability {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Availability {
+        fn default() -> Self {
+            availability::AVAILABILITY_UNSPECIFIED
         }
     }
 
@@ -13290,7 +13374,7 @@ pub mod search_request {
         use super::*;
 
         /// Enum to control DynamicFacet mode
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Mode(std::borrow::Cow<'static, str>);
 
         impl Mode {
@@ -13322,6 +13406,12 @@ pub mod search_request {
         impl std::convert::From<std::string::String> for Mode {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Mode {
+            fn default() -> Self {
+                mode::MODE_UNSPECIFIED
             }
         }
     }
@@ -13514,7 +13604,7 @@ pub mod search_request {
         use super::*;
 
         /// Enum describing under which condition query expansion should occur.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Condition(std::borrow::Cow<'static, str>);
 
         impl Condition {
@@ -13554,6 +13644,12 @@ pub mod search_request {
         impl std::convert::From<std::string::String> for Condition {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Condition {
+            fn default() -> Self {
+                condition::CONDITION_UNSPECIFIED
             }
         }
     }
@@ -13600,7 +13696,7 @@ pub mod search_request {
         use super::*;
 
         /// The personalization mode of each search request.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Mode(std::borrow::Cow<'static, str>);
 
         impl Mode {
@@ -13636,6 +13732,12 @@ pub mod search_request {
         impl std::convert::From<std::string::String> for Mode {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Mode {
+            fn default() -> Self {
+                mode::MODE_UNSPECIFIED
             }
         }
     }
@@ -13683,7 +13785,7 @@ pub mod search_request {
         use super::*;
 
         /// Enum describing under which mode spell correction should occur.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Mode(std::borrow::Cow<'static, str>);
 
         impl Mode {
@@ -13725,6 +13827,12 @@ pub mod search_request {
         impl std::convert::From<std::string::String> for Mode {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Mode {
+            fn default() -> Self {
+                mode::MODE_UNSPECIFIED
             }
         }
     }
@@ -14026,7 +14134,7 @@ pub mod search_request {
     }
 
     /// The search mode of each search request.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SearchMode(std::borrow::Cow<'static, str>);
 
     impl SearchMode {
@@ -14097,6 +14205,12 @@ pub mod search_request {
     impl std::convert::From<std::string::String> for SearchMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SearchMode {
+        fn default() -> Self {
+            search_mode::SEARCH_MODE_UNSPECIFIED
         }
     }
 }
@@ -15710,7 +15824,7 @@ pub mod serving_config {
     use super::*;
 
     /// What type of diversity - data or rule based.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DiversityType(std::borrow::Cow<'static, str>);
 
     impl DiversityType {
@@ -15744,6 +15858,12 @@ pub mod serving_config {
     impl std::convert::From<std::string::String> for DiversityType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DiversityType {
+        fn default() -> Self {
+            diversity_type::DIVERSITY_TYPE_UNSPECIFIED
         }
     }
 }
@@ -17055,7 +17175,7 @@ pub mod rejoin_user_events_request {
     /// events, set `UserEventRejoinScope` to `JOINED_EVENTS`.
     /// If all events needs to be rejoined, set `UserEventRejoinScope` to
     /// `USER_EVENT_REJOIN_SCOPE_UNSPECIFIED`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct UserEventRejoinScope(std::borrow::Cow<'static, str>);
 
     impl UserEventRejoinScope {
@@ -17090,6 +17210,12 @@ pub mod rejoin_user_events_request {
     impl std::convert::From<std::string::String> for UserEventRejoinScope {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for UserEventRejoinScope {
+        fn default() -> Self {
+            user_event_rejoin_scope::USER_EVENT_REJOIN_SCOPE_UNSPECIFIED
         }
     }
 }
@@ -17143,7 +17269,7 @@ impl wkt::message::Message for RejoinUserEventsMetadata {
 }
 
 /// At which level we offer configuration for attributes.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct AttributeConfigLevel(std::borrow::Cow<'static, str>);
 
 impl AttributeConfigLevel {
@@ -17188,8 +17314,14 @@ impl std::convert::From<std::string::String> for AttributeConfigLevel {
     }
 }
 
+impl std::default::Default for AttributeConfigLevel {
+    fn default() -> Self {
+        attribute_config_level::ATTRIBUTE_CONFIG_LEVEL_UNSPECIFIED
+    }
+}
+
 /// The type of solution.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SolutionType(std::borrow::Cow<'static, str>);
 
 impl SolutionType {
@@ -17226,8 +17358,14 @@ impl std::convert::From<std::string::String> for SolutionType {
     }
 }
 
+impl std::default::Default for SolutionType {
+    fn default() -> Self {
+        solution_type::SOLUTION_TYPE_UNSPECIFIED
+    }
+}
+
 /// If filtering for recommendations is enabled.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct RecommendationsFilteringOption(std::borrow::Cow<'static, str>);
 
 impl RecommendationsFilteringOption {
@@ -17269,8 +17407,14 @@ impl std::convert::From<std::string::String> for RecommendationsFilteringOption 
     }
 }
 
+impl std::default::Default for RecommendationsFilteringOption {
+    fn default() -> Self {
+        recommendations_filtering_option::RECOMMENDATIONS_FILTERING_OPTION_UNSPECIFIED
+    }
+}
+
 /// The use case of Cloud Retail Search.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SearchSolutionUseCase(std::borrow::Cow<'static, str>);
 
 impl SearchSolutionUseCase {
@@ -17314,5 +17458,11 @@ pub mod search_solution_use_case {
 impl std::convert::From<std::string::String> for SearchSolutionUseCase {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for SearchSolutionUseCase {
+    fn default() -> Self {
+        search_solution_use_case::SEARCH_SOLUTION_USE_CASE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/run/v2/src/model.rs
+++ b/src/generated/cloud/run/v2/src/model.rs
@@ -700,7 +700,7 @@ pub mod condition {
     use super::*;
 
     /// Represents the possible Condition states.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -741,8 +741,14 @@ pub mod condition {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Represents the severity of the condition failures.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Severity(std::borrow::Cow<'static, str>);
 
     impl Severity {
@@ -780,8 +786,14 @@ pub mod condition {
         }
     }
 
+    impl std::default::Default for Severity {
+        fn default() -> Self {
+            severity::SEVERITY_UNSPECIFIED
+        }
+    }
+
     /// Reasons common to all types of conditions.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CommonReason(std::borrow::Cow<'static, str>);
 
     impl CommonReason {
@@ -860,8 +872,14 @@ pub mod condition {
         }
     }
 
+    impl std::default::Default for CommonReason {
+        fn default() -> Self {
+            common_reason::COMMON_REASON_UNDEFINED
+        }
+    }
+
     /// Reasons specific to Revision resource.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RevisionReason(std::borrow::Cow<'static, str>);
 
     impl RevisionReason {
@@ -940,8 +958,14 @@ pub mod condition {
         }
     }
 
+    impl std::default::Default for RevisionReason {
+        fn default() -> Self {
+            revision_reason::REVISION_REASON_UNDEFINED
+        }
+    }
+
     /// Reasons specific to Execution resource.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ExecutionReason(std::borrow::Cow<'static, str>);
 
     impl ExecutionReason {
@@ -985,6 +1009,12 @@ pub mod condition {
     impl std::convert::From<std::string::String> for ExecutionReason {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ExecutionReason {
+        fn default() -> Self {
+            execution_reason::EXECUTION_REASON_UNDEFINED
         }
     }
 
@@ -2803,7 +2833,7 @@ pub mod execution_reference {
     use super::*;
 
     /// Possible execution completion status.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CompletionStatus(std::borrow::Cow<'static, str>);
 
     impl CompletionStatus {
@@ -2847,6 +2877,12 @@ pub mod execution_reference {
     impl std::convert::From<std::string::String> for CompletionStatus {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CompletionStatus {
+        fn default() -> Self {
+            completion_status::COMPLETION_STATUS_UNSPECIFIED
         }
     }
 }
@@ -3844,7 +3880,7 @@ pub mod empty_dir_volume_source {
     use super::*;
 
     /// The different types of medium supported for EmptyDir.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Medium(std::borrow::Cow<'static, str>);
 
     impl Medium {
@@ -3874,6 +3910,12 @@ pub mod empty_dir_volume_source {
     impl std::convert::From<std::string::String> for Medium {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Medium {
+        fn default() -> Self {
+            medium::MEDIUM_UNSPECIFIED
         }
     }
 }
@@ -7243,7 +7285,7 @@ pub mod vpc_access {
     }
 
     /// Egress options for VPC access.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct VpcEgress(std::borrow::Cow<'static, str>);
 
     impl VpcEgress {
@@ -7275,6 +7317,12 @@ pub mod vpc_access {
     impl std::convert::From<std::string::String> for VpcEgress {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for VpcEgress {
+        fn default() -> Self {
+            vpc_egress::VPC_EGRESS_UNSPECIFIED
         }
     }
 }
@@ -7534,7 +7582,7 @@ pub mod service_scaling {
 
     /// The scaling mode for the service. If not provided, it defaults to
     /// AUTOMATIC.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ScalingMode(std::borrow::Cow<'static, str>);
 
     impl ScalingMode {
@@ -7567,6 +7615,12 @@ pub mod service_scaling {
     impl std::convert::From<std::string::String> for ScalingMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ScalingMode {
+        fn default() -> Self {
+            scaling_mode::SCALING_MODE_UNSPECIFIED
         }
     }
 }
@@ -7728,7 +7782,7 @@ impl wkt::message::Message for BuildConfig {
 }
 
 /// The type of instance allocation.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TrafficTargetAllocationType(std::borrow::Cow<'static, str>);
 
 impl TrafficTargetAllocationType {
@@ -7766,8 +7820,14 @@ impl std::convert::From<std::string::String> for TrafficTargetAllocationType {
     }
 }
 
+impl std::default::Default for TrafficTargetAllocationType {
+    fn default() -> Self {
+        traffic_target_allocation_type::TRAFFIC_TARGET_ALLOCATION_TYPE_UNSPECIFIED
+    }
+}
+
 /// Allowed ingress traffic for the Container.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct IngressTraffic(std::borrow::Cow<'static, str>);
 
 impl IngressTraffic {
@@ -7811,8 +7871,14 @@ impl std::convert::From<std::string::String> for IngressTraffic {
     }
 }
 
+impl std::default::Default for IngressTraffic {
+    fn default() -> Self {
+        ingress_traffic::INGRESS_TRAFFIC_UNSPECIFIED
+    }
+}
+
 /// Alternatives for execution environments.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ExecutionEnvironment(std::borrow::Cow<'static, str>);
 
 impl ExecutionEnvironment {
@@ -7850,8 +7916,14 @@ impl std::convert::From<std::string::String> for ExecutionEnvironment {
     }
 }
 
+impl std::default::Default for ExecutionEnvironment {
+    fn default() -> Self {
+        execution_environment::EXECUTION_ENVIRONMENT_UNSPECIFIED
+    }
+}
+
 /// Specifies behavior if an encryption key used by a resource is revoked.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct EncryptionKeyRevocationAction(std::borrow::Cow<'static, str>);
 
 impl EncryptionKeyRevocationAction {
@@ -7886,5 +7958,11 @@ pub mod encryption_key_revocation_action {
 impl std::convert::From<std::string::String> for EncryptionKeyRevocationAction {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for EncryptionKeyRevocationAction {
+    fn default() -> Self {
+        encryption_key_revocation_action::ENCRYPTION_KEY_REVOCATION_ACTION_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/scheduler/v1/src/model.rs
+++ b/src/generated/cloud/scheduler/v1/src/model.rs
@@ -786,7 +786,7 @@ pub mod job {
     use super::*;
 
     /// State of the job.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -835,6 +835,12 @@ pub mod job {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -1701,7 +1707,7 @@ impl wkt::message::Message for OidcToken {
 }
 
 /// The HTTP method used to execute the job.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct HttpMethod(std::borrow::Cow<'static, str>);
 
 impl HttpMethod {
@@ -1748,5 +1754,11 @@ pub mod http_method {
 impl std::convert::From<std::string::String> for HttpMethod {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for HttpMethod {
+    fn default() -> Self {
+        http_method::HTTP_METHOD_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/secretmanager/v1/src/model.rs
+++ b/src/generated/cloud/secretmanager/v1/src/model.rs
@@ -583,7 +583,7 @@ pub mod secret_version {
     /// it can be accessed.
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -632,6 +632,12 @@ pub mod secret_version {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/securesourcemanager/v1/src/model.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/model.rs
@@ -328,7 +328,7 @@ pub mod instance {
     }
 
     /// Secure Source Manager instance state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -372,8 +372,14 @@ pub mod instance {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Provides information about the current instance state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct StateNote(std::borrow::Cow<'static, str>);
 
     impl StateNote {
@@ -406,6 +412,12 @@ pub mod instance {
     impl std::convert::From<std::string::String> for StateNote {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for StateNote {
+        fn default() -> Self {
+            state_note::STATE_NOTE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/security/privateca/v1/src/model.rs
+++ b/src/generated/cloud/security/privateca/v1/src/model.rs
@@ -570,7 +570,7 @@ pub mod certificate_authority {
     /// indicating its issuing chain.
     ///
     /// [google.cloud.security.privateca.v1.CertificateAuthority]: crate::model::CertificateAuthority
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -609,12 +609,18 @@ pub mod certificate_authority {
         }
     }
 
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
+        }
+    }
+
     /// The state of a
     /// [CertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthority],
     /// indicating if it can be used.
     ///
     /// [google.cloud.security.privateca.v1.CertificateAuthority]: crate::model::CertificateAuthority
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -694,6 +700,12 @@ pub mod certificate_authority {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// The algorithm of a Cloud KMS CryptoKeyVersion of a
     /// [CryptoKey][google.cloud.kms.v1.CryptoKey] with the
     /// [CryptoKeyPurpose][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose] value
@@ -703,7 +715,7 @@ pub mod certificate_authority {
     /// use PKCS1 algorithms if required for compatibility. For further
     /// recommendations, see
     /// <https://cloud.google.com/kms/docs/algorithms#algorithm_recommendations>.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SignHashAlgorithm(std::borrow::Cow<'static, str>);
 
     impl SignHashAlgorithm {
@@ -760,6 +772,12 @@ pub mod certificate_authority {
     impl std::convert::From<std::string::String> for SignHashAlgorithm {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SignHashAlgorithm {
+        fn default() -> Self {
+            sign_hash_algorithm::SIGN_HASH_ALGORITHM_UNSPECIFIED
         }
     }
 }
@@ -981,7 +999,7 @@ pub mod ca_pool {
         use super::*;
 
         /// Supported encoding formats for publishing.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct EncodingFormat(std::borrow::Cow<'static, str>);
 
         impl EncodingFormat {
@@ -1022,6 +1040,12 @@ pub mod ca_pool {
         impl std::convert::From<std::string::String> for EncodingFormat {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for EncodingFormat {
+            fn default() -> Self {
+                encoding_format::ENCODING_FORMAT_UNSPECIFIED
             }
         }
     }
@@ -1438,9 +1462,7 @@ pub mod ca_pool {
                 ///
                 /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
                 /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
-                #[derive(
-                    Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize,
-                )]
+                #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
                 pub struct EcSignatureAlgorithm(std::borrow::Cow<'static, str>);
 
                 impl EcSignatureAlgorithm {
@@ -1482,6 +1504,12 @@ pub mod ca_pool {
                 impl std::convert::From<std::string::String> for EcSignatureAlgorithm {
                     fn from(value: std::string::String) -> Self {
                         Self(std::borrow::Cow::Owned(value))
+                    }
+                }
+
+                impl std::default::Default for EcSignatureAlgorithm {
+                    fn default() -> Self {
+                        ec_signature_algorithm::EC_SIGNATURE_ALGORITHM_UNSPECIFIED
                     }
                 }
             }
@@ -1570,7 +1598,7 @@ pub mod ca_pool {
     /// indicating its supported functionality and/or billing SKU.
     ///
     /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Tier(std::borrow::Cow<'static, str>);
 
     impl Tier {
@@ -1602,6 +1630,12 @@ pub mod ca_pool {
     impl std::convert::From<std::string::String> for Tier {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Tier {
+        fn default() -> Self {
+            tier::TIER_UNSPECIFIED
         }
     }
 }
@@ -1852,7 +1886,7 @@ pub mod certificate_revocation_list {
     /// indicating if it is current.
     ///
     /// [google.cloud.security.privateca.v1.CertificateRevocationList]: crate::model::CertificateRevocationList
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1892,6 +1926,12 @@ pub mod certificate_revocation_list {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -3041,7 +3081,7 @@ pub mod public_key {
 
     /// Types of public keys formats that are supported. Currently, only `PEM`
     /// format is supported.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct KeyFormat(std::borrow::Cow<'static, str>);
 
     impl KeyFormat {
@@ -3082,6 +3122,12 @@ pub mod public_key {
     impl std::convert::From<std::string::String> for KeyFormat {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for KeyFormat {
+        fn default() -> Self {
+            key_format::KEY_FORMAT_UNSPECIFIED
         }
     }
 }
@@ -4319,7 +4365,7 @@ pub mod certificate_extension_constraints {
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
     /// [google.cloud.security.privateca.v1.SubjectAltNames]: crate::model::SubjectAltNames
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct KnownCertificateExtension(std::borrow::Cow<'static, str>);
 
     impl KnownCertificateExtension {
@@ -4407,6 +4453,12 @@ pub mod certificate_extension_constraints {
     impl std::convert::From<std::string::String> for KnownCertificateExtension {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for KnownCertificateExtension {
+        fn default() -> Self {
+            known_certificate_extension::KNOWN_CERTIFICATE_EXTENSION_UNSPECIFIED
         }
     }
 }
@@ -7124,7 +7176,7 @@ impl wkt::message::Message for OperationMetadata {
 ///
 /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
 /// [google.cloud.security.privateca.v1.RevocationReason]: crate::model::RevocationReason
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct RevocationReason(std::borrow::Cow<'static, str>);
 
 impl RevocationReason {
@@ -7210,6 +7262,12 @@ impl std::convert::From<std::string::String> for RevocationReason {
     }
 }
 
+impl std::default::Default for RevocationReason {
+    fn default() -> Self {
+        revocation_reason::REVOCATION_REASON_UNSPECIFIED
+    }
+}
+
 /// Describes the way in which a
 /// [Certificate][google.cloud.security.privateca.v1.Certificate]'s
 /// [Subject][google.cloud.security.privateca.v1.Subject] and/or
@@ -7219,7 +7277,7 @@ impl std::convert::From<std::string::String> for RevocationReason {
 /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
 /// [google.cloud.security.privateca.v1.Subject]: crate::model::Subject
 /// [google.cloud.security.privateca.v1.SubjectAltNames]: crate::model::SubjectAltNames
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SubjectRequestMode(std::borrow::Cow<'static, str>);
 
 impl SubjectRequestMode {
@@ -7270,5 +7328,11 @@ pub mod subject_request_mode {
 impl std::convert::From<std::string::String> for SubjectRequestMode {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for SubjectRequestMode {
+    fn default() -> Self {
+        subject_request_mode::SUBJECT_REQUEST_MODE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/securitycenter/v2/src/model.rs
+++ b/src/generated/cloud/securitycenter/v2/src/model.rs
@@ -444,7 +444,7 @@ pub mod attack_exposure {
     use super::*;
 
     /// This enum defines the various states an AttackExposure can be in.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -476,6 +476,12 @@ pub mod attack_exposure {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -796,7 +802,7 @@ pub mod attack_path {
         }
 
         /// The type of the incoming attack step node.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct NodeType(std::borrow::Cow<'static, str>);
 
         impl NodeType {
@@ -834,6 +840,12 @@ pub mod attack_path {
         impl std::convert::From<std::string::String> for NodeType {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for NodeType {
+            fn default() -> Self {
+                node_type::NODE_TYPE_UNSPECIFIED
             }
         }
     }
@@ -1564,7 +1576,7 @@ pub mod cloud_dlp_data_profile {
     use super::*;
 
     /// Parents for configurations that produce data profile findings.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ParentType(std::borrow::Cow<'static, str>);
 
     impl ParentType {
@@ -1596,6 +1608,12 @@ pub mod cloud_dlp_data_profile {
     impl std::convert::From<std::string::String> for ParentType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ParentType {
+        fn default() -> Self {
+            parent_type::PARENT_TYPE_UNSPECIFIED
         }
     }
 }
@@ -1797,7 +1815,7 @@ pub mod connection {
     use super::*;
 
     /// IANA Internet Protocol Number such as TCP(6) and UDP(17).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Protocol(std::borrow::Cow<'static, str>);
 
     impl Protocol {
@@ -1838,6 +1856,12 @@ pub mod connection {
     impl std::convert::From<std::string::String> for Protocol {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Protocol {
+        fn default() -> Self {
+            protocol::PROTOCOL_UNSPECIFIED
         }
     }
 }
@@ -2056,7 +2080,7 @@ pub mod data_access_event {
     use super::*;
 
     /// The operation of a data access event.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Operation(std::borrow::Cow<'static, str>);
 
     impl Operation {
@@ -2091,6 +2115,12 @@ pub mod data_access_event {
     impl std::convert::From<std::string::String> for Operation {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Operation {
+        fn default() -> Self {
+            operation::OPERATION_UNSPECIFIED
         }
     }
 }
@@ -2181,7 +2211,7 @@ pub mod data_flow_event {
     use super::*;
 
     /// The operation of a data flow event.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Operation(std::borrow::Cow<'static, str>);
 
     impl Operation {
@@ -2216,6 +2246,12 @@ pub mod data_flow_event {
     impl std::convert::From<std::string::String> for Operation {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Operation {
+        fn default() -> Self {
+            operation::OPERATION_UNSPECIFIED
         }
     }
 }
@@ -2311,7 +2347,7 @@ pub mod data_retention_deletion_event {
     use super::*;
 
     /// Type of the DRD event.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EventType(std::borrow::Cow<'static, str>);
 
     impl EventType {
@@ -2341,6 +2377,12 @@ pub mod data_retention_deletion_event {
     impl std::convert::From<std::string::String> for EventType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EventType {
+        fn default() -> Self {
+            event_type::EVENT_TYPE_UNSPECIFIED
         }
     }
 }
@@ -4018,7 +4060,7 @@ pub mod finding {
     }
 
     /// The state of the finding.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -4054,8 +4096,14 @@ pub mod finding {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// The severity of the finding.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Severity(std::borrow::Cow<'static, str>);
 
     impl Severity {
@@ -4138,8 +4186,14 @@ pub mod finding {
         }
     }
 
+    impl std::default::Default for Severity {
+        fn default() -> Self {
+            severity::SEVERITY_UNSPECIFIED
+        }
+    }
+
     /// Mute state a finding can be in.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Mute(std::borrow::Cow<'static, str>);
 
     impl Mute {
@@ -4177,8 +4231,14 @@ pub mod finding {
         }
     }
 
+    impl std::default::Default for Mute {
+        fn default() -> Self {
+            mute::MUTE_UNSPECIFIED
+        }
+    }
+
     /// Represents what kind of Finding it is.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct FindingClass(std::borrow::Cow<'static, str>);
 
     impl FindingClass {
@@ -4234,6 +4294,12 @@ pub mod finding {
     impl std::convert::From<std::string::String> for FindingClass {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for FindingClass {
+        fn default() -> Self {
+            finding_class::FINDING_CLASS_UNSPECIFIED
         }
     }
 }
@@ -4330,7 +4396,7 @@ pub mod group_membership {
     use super::*;
 
     /// Possible types of groups.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct GroupType(std::borrow::Cow<'static, str>);
 
     impl GroupType {
@@ -4360,6 +4426,12 @@ pub mod group_membership {
     impl std::convert::From<std::string::String> for GroupType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for GroupType {
+        fn default() -> Self {
+            group_type::GROUP_TYPE_UNSPECIFIED
         }
     }
 }
@@ -4424,7 +4496,7 @@ pub mod iam_binding {
     use super::*;
 
     /// The type of action performed on a Binding in a policy.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Action(std::borrow::Cow<'static, str>);
 
     impl Action {
@@ -4456,6 +4528,12 @@ pub mod iam_binding {
     impl std::convert::From<std::string::String> for Action {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Action {
+        fn default() -> Self {
+            action::ACTION_UNSPECIFIED
         }
     }
 }
@@ -4814,7 +4892,7 @@ pub mod indicator {
         }
 
         /// Possible resource types to be associated with a signature.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct SignatureType(std::borrow::Cow<'static, str>);
 
         impl SignatureType {
@@ -4849,6 +4927,12 @@ pub mod indicator {
         impl std::convert::From<std::string::String> for SignatureType {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for SignatureType {
+            fn default() -> Self {
+                signature_type::SIGNATURE_TYPE_UNSPECIFIED
             }
         }
 
@@ -5324,7 +5408,7 @@ pub mod kubernetes {
         use super::*;
 
         /// Types of Kubernetes roles.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Kind(std::borrow::Cow<'static, str>);
 
         impl Kind {
@@ -5356,6 +5440,12 @@ pub mod kubernetes {
         impl std::convert::From<std::string::String> for Kind {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Kind {
+            fn default() -> Self {
+                kind::KIND_UNSPECIFIED
             }
         }
     }
@@ -5487,7 +5577,7 @@ pub mod kubernetes {
         use super::*;
 
         /// Auth types that can be used for the subject's kind field.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct AuthType(std::borrow::Cow<'static, str>);
 
         impl AuthType {
@@ -5522,6 +5612,12 @@ pub mod kubernetes {
         impl std::convert::From<std::string::String> for AuthType {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for AuthType {
+            fn default() -> Self {
+                auth_type::AUTH_TYPE_UNSPECIFIED
             }
         }
     }
@@ -6020,7 +6116,7 @@ pub mod mitre_attack {
 
     /// MITRE ATT&CK tactics that can be referenced by SCC findings.
     /// See: <https://attack.mitre.org/tactics/enterprise/>
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Tactic(std::borrow::Cow<'static, str>);
 
     impl Tactic {
@@ -6091,9 +6187,15 @@ pub mod mitre_attack {
         }
     }
 
+    impl std::default::Default for Tactic {
+        fn default() -> Self {
+            tactic::TACTIC_UNSPECIFIED
+        }
+    }
+
     /// MITRE ATT&CK techniques that can be referenced by SCC findings.
     /// See: <https://attack.mitre.org/techniques/enterprise/>
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Technique(std::borrow::Cow<'static, str>);
 
     impl Technique {
@@ -6347,6 +6449,12 @@ pub mod mitre_attack {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for Technique {
+        fn default() -> Self {
+            technique::TECHNIQUE_UNSPECIFIED
+        }
+    }
 }
 
 /// A mute config is a Cloud SCC resource that contains the configuration
@@ -6508,7 +6616,7 @@ pub mod mute_config {
     use super::*;
 
     /// The type of MuteConfig.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MuteConfigType(std::borrow::Cow<'static, str>);
 
     impl MuteConfigType {
@@ -6548,6 +6656,12 @@ pub mod mute_config {
     impl std::convert::From<std::string::String> for MuteConfigType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for MuteConfigType {
+        fn default() -> Self {
+            mute_config_type::MUTE_CONFIG_TYPE_UNSPECIFIED
         }
     }
 }
@@ -7995,7 +8109,7 @@ pub mod resource_path {
     }
 
     /// The type of resource the node represents.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ResourcePathNodeType(std::borrow::Cow<'static, str>);
 
     impl ResourcePathNodeType {
@@ -8055,6 +8169,12 @@ pub mod resource_path {
     impl std::convert::From<std::string::String> for ResourcePathNodeType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ResourcePathNodeType {
+        fn default() -> Self {
+            resource_path_node_type::RESOURCE_PATH_NODE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -8743,7 +8863,7 @@ pub mod bulk_mute_findings_request {
     use super::*;
 
     /// The mute state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MuteState(std::borrow::Cow<'static, str>);
 
     impl MuteState {
@@ -8775,6 +8895,12 @@ pub mod bulk_mute_findings_request {
     impl std::convert::From<std::string::String> for MuteState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for MuteState {
+        fn default() -> Self {
+            mute_state::MUTE_STATE_UNSPECIFIED
         }
     }
 }
@@ -12028,7 +12154,7 @@ pub mod valued_resource {
     use super::*;
 
     /// How valuable the resource is.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ResourceValue(std::borrow::Cow<'static, str>);
 
     impl ResourceValue {
@@ -12065,6 +12191,12 @@ pub mod valued_resource {
     impl std::convert::From<std::string::String> for ResourceValue {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ResourceValue {
+        fn default() -> Self {
+            resource_value::RESOURCE_VALUE_UNSPECIFIED
         }
     }
 }
@@ -12325,7 +12457,7 @@ pub mod cve {
 
     /// The possible values of impact of the vulnerability if it was to be
     /// exploited.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RiskRating(std::borrow::Cow<'static, str>);
 
     impl RiskRating {
@@ -12370,9 +12502,15 @@ pub mod cve {
         }
     }
 
+    impl std::default::Default for RiskRating {
+        fn default() -> Self {
+            risk_rating::RISK_RATING_UNSPECIFIED
+        }
+    }
+
     /// The possible values of exploitation activity of the vulnerability in the
     /// wild.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ExploitationActivity(std::borrow::Cow<'static, str>);
 
     impl ExploitationActivity {
@@ -12415,6 +12553,12 @@ pub mod cve {
     impl std::convert::From<std::string::String> for ExploitationActivity {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ExploitationActivity {
+        fn default() -> Self {
+            exploitation_activity::EXPLOITATION_ACTIVITY_UNSPECIFIED
         }
     }
 }
@@ -12602,7 +12746,7 @@ pub mod cvssv_3 {
 
     /// This metric reflects the context by which vulnerability exploitation is
     /// possible.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AttackVector(std::borrow::Cow<'static, str>);
 
     impl AttackVector {
@@ -12651,9 +12795,15 @@ pub mod cvssv_3 {
         }
     }
 
+    impl std::default::Default for AttackVector {
+        fn default() -> Self {
+            attack_vector::ATTACK_VECTOR_UNSPECIFIED
+        }
+    }
+
     /// This metric describes the conditions beyond the attacker's control that
     /// must exist in order to exploit the vulnerability.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AttackComplexity(std::borrow::Cow<'static, str>);
 
     impl AttackComplexity {
@@ -12697,9 +12847,15 @@ pub mod cvssv_3 {
         }
     }
 
+    impl std::default::Default for AttackComplexity {
+        fn default() -> Self {
+            attack_complexity::ATTACK_COMPLEXITY_UNSPECIFIED
+        }
+    }
+
     /// This metric describes the level of privileges an attacker must possess
     /// before successfully exploiting the vulnerability.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PrivilegesRequired(std::borrow::Cow<'static, str>);
 
     impl PrivilegesRequired {
@@ -12748,10 +12904,16 @@ pub mod cvssv_3 {
         }
     }
 
+    impl std::default::Default for PrivilegesRequired {
+        fn default() -> Self {
+            privileges_required::PRIVILEGES_REQUIRED_UNSPECIFIED
+        }
+    }
+
     /// This metric captures the requirement for a human user, other than the
     /// attacker, to participate in the successful compromise of the vulnerable
     /// component.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct UserInteraction(std::borrow::Cow<'static, str>);
 
     impl UserInteraction {
@@ -12790,9 +12952,15 @@ pub mod cvssv_3 {
         }
     }
 
+    impl std::default::Default for UserInteraction {
+        fn default() -> Self {
+            user_interaction::USER_INTERACTION_UNSPECIFIED
+        }
+    }
+
     /// The Scope metric captures whether a vulnerability in one vulnerable
     /// component impacts resources in components beyond its security scope.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Scope(std::borrow::Cow<'static, str>);
 
     impl Scope {
@@ -12829,10 +12997,16 @@ pub mod cvssv_3 {
         }
     }
 
+    impl std::default::Default for Scope {
+        fn default() -> Self {
+            scope::SCOPE_UNSPECIFIED
+        }
+    }
+
     /// The Impact metrics capture the effects of a successfully exploited
     /// vulnerability on the component that suffers the worst outcome that is most
     /// directly and predictably associated with the attack.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Impact(std::borrow::Cow<'static, str>);
 
     impl Impact {
@@ -12867,6 +13041,12 @@ pub mod cvssv_3 {
     impl std::convert::From<std::string::String> for Impact {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Impact {
+        fn default() -> Self {
+            impact::IMPACT_UNSPECIFIED
         }
     }
 }
@@ -12987,7 +13167,7 @@ impl wkt::message::Message for SecurityBulletin {
 }
 
 /// The cloud provider the finding pertains to.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct CloudProvider(std::borrow::Cow<'static, str>);
 
 impl CloudProvider {
@@ -13026,8 +13206,14 @@ impl std::convert::From<std::string::String> for CloudProvider {
     }
 }
 
+impl std::default::Default for CloudProvider {
+    fn default() -> Self {
+        cloud_provider::CLOUD_PROVIDER_UNSPECIFIED
+    }
+}
+
 /// Value enum to map to a resource
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ResourceValue(std::borrow::Cow<'static, str>);
 
 impl ResourceValue {
@@ -13066,5 +13252,11 @@ pub mod resource_value {
 impl std::convert::From<std::string::String> for ResourceValue {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for ResourceValue {
+    fn default() -> Self {
+        resource_value::RESOURCE_VALUE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/securityposture/v1/src/model.rs
+++ b/src/generated/cloud/securityposture/v1/src/model.rs
@@ -420,7 +420,7 @@ pub mod custom_constraint {
     ///
     /// `UPDATE` only custom constraints are not supported. Use `CREATE` or
     /// `CREATE, UPDATE`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MethodType(std::borrow::Cow<'static, str>);
 
     impl MethodType {
@@ -459,8 +459,14 @@ pub mod custom_constraint {
         }
     }
 
+    impl std::default::Default for MethodType {
+        fn default() -> Self {
+            method_type::METHOD_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Allow or deny type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ActionType(std::borrow::Cow<'static, str>);
 
     impl ActionType {
@@ -492,6 +498,12 @@ pub mod custom_constraint {
     impl std::convert::From<std::string::String> for ActionType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ActionType {
+        fn default() -> Self {
+            action_type::ACTION_TYPE_UNSPECIFIED
         }
     }
 }
@@ -860,7 +872,7 @@ pub mod posture {
     use super::*;
 
     /// State of a Posture.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -895,6 +907,12 @@ pub mod posture {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1937,7 +1955,7 @@ pub mod posture_deployment {
     use super::*;
 
     /// State of a PostureDeployment.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1984,6 +2002,12 @@ pub mod posture_deployment {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -2383,7 +2407,7 @@ pub mod posture_template {
     use super::*;
 
     /// State of a PostureTemplate
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2416,6 +2440,12 @@ pub mod posture_template {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -2923,7 +2953,7 @@ pub mod custom_config {
     }
 
     /// Defines the valid value options for the severity of a finding.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Severity(std::borrow::Cow<'static, str>);
 
     impl Severity {
@@ -2963,10 +2993,16 @@ pub mod custom_config {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for Severity {
+        fn default() -> Self {
+            severity::SEVERITY_UNSPECIFIED
+        }
+    }
 }
 
 /// Possible enablement states of a service or module.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct EnablementState(std::borrow::Cow<'static, str>);
 
 impl EnablementState {
@@ -2999,5 +3035,11 @@ pub mod enablement_state {
 impl std::convert::From<std::string::String> for EnablementState {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for EnablementState {
+    fn default() -> Self {
+        enablement_state::ENABLEMENT_STATE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/servicehealth/v1/src/model.rs
+++ b/src/generated/cloud/servicehealth/v1/src/model.rs
@@ -242,7 +242,7 @@ pub mod event {
 
     /// The category of the event. This enum lists all possible categories of
     /// event.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EventCategory(std::borrow::Cow<'static, str>);
 
     impl EventCategory {
@@ -275,9 +275,15 @@ pub mod event {
         }
     }
 
+    impl std::default::Default for EventCategory {
+        fn default() -> Self {
+            event_category::EVENT_CATEGORY_UNSPECIFIED
+        }
+    }
+
     /// The detailed category of an event. Contains all possible states for all
     /// event categories.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DetailedCategory(std::borrow::Cow<'static, str>);
 
     impl DetailedCategory {
@@ -316,8 +322,14 @@ pub mod event {
         }
     }
 
+    impl std::default::Default for DetailedCategory {
+        fn default() -> Self {
+            detailed_category::DETAILED_CATEGORY_UNSPECIFIED
+        }
+    }
+
     /// The state of the event. This enum lists all possible states of event.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -354,9 +366,15 @@ pub mod event {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// The detailed state of the incident. This enum lists all possible detailed
     /// states of an incident.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DetailedState(std::borrow::Cow<'static, str>);
 
     impl DetailedState {
@@ -417,9 +435,15 @@ pub mod event {
         }
     }
 
+    impl std::default::Default for DetailedState {
+        fn default() -> Self {
+            detailed_state::DETAILED_STATE_UNSPECIFIED
+        }
+    }
+
     /// Communicates why a given incident is deemed relevant in the context of a
     /// given project. This enum lists all possible detailed states of relevance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Relevance(std::borrow::Cow<'static, str>);
 
     impl Relevance {
@@ -464,6 +488,12 @@ pub mod event {
     impl std::convert::From<std::string::String> for Relevance {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Relevance {
+        fn default() -> Self {
+            relevance::RELEVANCE_UNSPECIFIED
         }
     }
 }
@@ -682,7 +712,7 @@ pub mod organization_event {
 
     /// The category of the event. This enum lists all possible categories of
     /// event.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EventCategory(std::borrow::Cow<'static, str>);
 
     impl EventCategory {
@@ -715,9 +745,15 @@ pub mod organization_event {
         }
     }
 
+    impl std::default::Default for EventCategory {
+        fn default() -> Self {
+            event_category::EVENT_CATEGORY_UNSPECIFIED
+        }
+    }
+
     /// The detailed category of an event. Contains all possible states for all
     /// event categories.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DetailedCategory(std::borrow::Cow<'static, str>);
 
     impl DetailedCategory {
@@ -756,9 +792,15 @@ pub mod organization_event {
         }
     }
 
+    impl std::default::Default for DetailedCategory {
+        fn default() -> Self {
+            detailed_category::DETAILED_CATEGORY_UNSPECIFIED
+        }
+    }
+
     /// The state of the organization event. This enum lists all possible states of
     /// event.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -795,9 +837,15 @@ pub mod organization_event {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// The detailed state of the incident. This enum lists all possible detailed
     /// states of an incident.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DetailedState(std::borrow::Cow<'static, str>);
 
     impl DetailedState {
@@ -855,6 +903,12 @@ pub mod organization_event {
     impl std::convert::From<std::string::String> for DetailedState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DetailedState {
+        fn default() -> Self {
+            detailed_state::DETAILED_STATE_UNSPECIFIED
         }
     }
 }
@@ -1801,7 +1855,7 @@ impl wkt::message::Message for GetOrganizationImpactRequest {
 
 /// The event fields to include in ListEvents API response. This enum lists all
 /// possible event views.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct EventView(std::borrow::Cow<'static, str>);
 
 impl EventView {
@@ -1837,9 +1891,15 @@ impl std::convert::From<std::string::String> for EventView {
     }
 }
 
+impl std::default::Default for EventView {
+    fn default() -> Self {
+        event_view::EVENT_VIEW_UNSPECIFIED
+    }
+}
+
 /// The organization event fields to include in ListOrganizationEvents API
 /// response. This enum lists all possible organization event views.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct OrganizationEventView(std::borrow::Cow<'static, str>);
 
 impl OrganizationEventView {
@@ -1875,5 +1935,11 @@ pub mod organization_event_view {
 impl std::convert::From<std::string::String> for OrganizationEventView {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for OrganizationEventView {
+    fn default() -> Self {
+        organization_event_view::ORGANIZATION_EVENT_VIEW_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/shell/v1/src/model.rs
+++ b/src/generated/cloud/shell/v1/src/model.rs
@@ -169,7 +169,7 @@ pub mod environment {
     use super::*;
 
     /// Possible execution states for an environment.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -211,6 +211,12 @@ pub mod environment {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -506,7 +512,7 @@ pub mod start_environment_metadata {
     /// show a progress message to the user. An environment won't necessarily go
     /// through all of these states when starting. More states are likely to be
     /// added in the future.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -552,6 +558,12 @@ pub mod start_environment_metadata {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -823,7 +835,7 @@ pub mod cloud_shell_error_details {
     use super::*;
 
     /// Set of possible errors returned from API calls.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CloudShellErrorCode(std::borrow::Cow<'static, str>);
 
     impl CloudShellErrorCode {
@@ -873,6 +885,12 @@ pub mod cloud_shell_error_details {
     impl std::convert::From<std::string::String> for CloudShellErrorCode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CloudShellErrorCode {
+        fn default() -> Self {
+            cloud_shell_error_code::CLOUD_SHELL_ERROR_CODE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/speech/v2/src/model.rs
+++ b/src/generated/cloud/speech/v2/src/model.rs
@@ -1388,7 +1388,7 @@ pub mod recognizer {
     use super::*;
 
     /// Set of states that define the lifecycle of a Recognizer.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1420,6 +1420,12 @@ pub mod recognizer {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1535,7 +1541,7 @@ pub mod explicit_decoding_config {
     use super::*;
 
     /// Supported audio data encodings.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AudioEncoding(std::borrow::Cow<'static, str>);
 
     impl AudioEncoding {
@@ -1598,6 +1604,12 @@ pub mod explicit_decoding_config {
     impl std::convert::From<std::string::String> for AudioEncoding {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AudioEncoding {
+        fn default() -> Self {
+            audio_encoding::AUDIO_ENCODING_UNSPECIFIED
         }
     }
 }
@@ -1790,7 +1802,7 @@ pub mod recognition_features {
     use super::*;
 
     /// Options for how to recognize multi-channel audio.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MultiChannelMode(std::borrow::Cow<'static, str>);
 
     impl MultiChannelMode {
@@ -1827,6 +1839,12 @@ pub mod recognition_features {
     impl std::convert::From<std::string::String> for MultiChannelMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for MultiChannelMode {
+        fn default() -> Self {
+            multi_channel_mode::MULTI_CHANNEL_MODE_UNSPECIFIED
         }
     }
 }
@@ -3366,7 +3384,7 @@ pub mod batch_recognize_request {
     use super::*;
 
     /// Possible processing strategies for batch requests.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ProcessingStrategy(std::borrow::Cow<'static, str>);
 
     impl ProcessingStrategy {
@@ -3399,6 +3417,12 @@ pub mod batch_recognize_request {
     impl std::convert::From<std::string::String> for ProcessingStrategy {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ProcessingStrategy {
+        fn default() -> Self {
+            processing_strategy::PROCESSING_STRATEGY_UNSPECIFIED
         }
     }
 }
@@ -4573,7 +4597,7 @@ pub mod streaming_recognize_response {
     use super::*;
 
     /// Indicates the type of speech event.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SpeechEventType(std::borrow::Cow<'static, str>);
 
     impl SpeechEventType {
@@ -4625,6 +4649,12 @@ pub mod streaming_recognize_response {
     impl std::convert::From<std::string::String> for SpeechEventType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SpeechEventType {
+        fn default() -> Self {
+            speech_event_type::SPEECH_EVENT_TYPE_UNSPECIFIED
         }
     }
 }
@@ -5012,7 +5042,7 @@ pub mod custom_class {
     }
 
     /// Set of states that define the lifecycle of a CustomClass.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -5045,6 +5075,12 @@ pub mod custom_class {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -5324,7 +5360,7 @@ pub mod phrase_set {
     }
 
     /// Set of states that define the lifecycle of a PhraseSet.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -5357,6 +5393,12 @@ pub mod phrase_set {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -6400,7 +6442,7 @@ pub mod access_metadata {
 
     /// Describes the different types of constraints that can be applied on a
     /// region.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ConstraintType(std::borrow::Cow<'static, str>);
 
     impl ConstraintType {
@@ -6431,6 +6473,12 @@ pub mod access_metadata {
     impl std::convert::From<std::string::String> for ConstraintType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ConstraintType {
+        fn default() -> Self {
+            constraint_type::CONSTRAINT_TYPE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/sql/v1/src/model.rs
+++ b/src/generated/cloud/sql/v1/src/model.rs
@@ -692,7 +692,7 @@ pub mod connect_settings {
 
 
     /// Various Certificate Authority (CA) modes for certificate signing.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CaMode(std::borrow::Cow<'static, str>);
 
     impl CaMode {
@@ -727,6 +727,12 @@ pub mod connect_settings {
       fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
       }
+    }
+
+    impl std::default::Default for CaMode {
+        fn default() -> Self {
+            ca_mode::CA_MODE_UNSPECIFIED
+        }
     }
 }
 
@@ -2667,7 +2673,7 @@ pub mod backup_reencryption_config {
 
 
     /// Backup type for re-encryption
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct BackupType(std::borrow::Cow<'static, str>);
 
     impl BackupType {
@@ -2701,6 +2707,12 @@ pub mod backup_reencryption_config {
       fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
       }
+    }
+
+    impl std::default::Default for BackupType {
+        fn default() -> Self {
+            backup_type::BACKUP_TYPE_UNSPECIFIED
+        }
     }
 }
 
@@ -2873,7 +2885,7 @@ pub mod sql_instances_verify_external_sync_settings_request {
     use super::*;
 
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ExternalSyncMode(std::borrow::Cow<'static, str>);
 
     impl ExternalSyncMode {
@@ -2911,9 +2923,15 @@ pub mod sql_instances_verify_external_sync_settings_request {
       }
     }
 
+    impl std::default::Default for ExternalSyncMode {
+        fn default() -> Self {
+            external_sync_mode::EXTERNAL_SYNC_MODE_UNSPECIFIED
+        }
+    }
+
     /// MigrationType determines whether the migration is a physical file-based
     /// migration or a logical dump file-based migration.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MigrationType(std::borrow::Cow<'static, str>);
 
     impl MigrationType {
@@ -2947,6 +2965,12 @@ pub mod sql_instances_verify_external_sync_settings_request {
       fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
       }
+    }
+
+    impl std::default::Default for MigrationType {
+        fn default() -> Self {
+            migration_type::MIGRATION_TYPE_UNSPECIFIED
+        }
     }
 
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -4713,7 +4737,7 @@ pub mod database_instance {
 
 
         /// This enum lists all possible states regarding out-of-disk issues.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct SqlOutOfDiskState(std::borrow::Cow<'static, str>);
 
         impl SqlOutOfDiskState {
@@ -4749,10 +4773,16 @@ pub mod database_instance {
             Self(std::borrow::Cow::Owned(value))
           }
         }
+
+        impl std::default::Default for SqlOutOfDiskState {
+            fn default() -> Self {
+                sql_out_of_disk_state::SQL_OUT_OF_DISK_STATE_UNSPECIFIED
+            }
+        }
     }
 
     /// The current serving state of the database instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SqlInstanceState(std::borrow::Cow<'static, str>);
 
     impl SqlInstanceState {
@@ -4804,8 +4834,14 @@ pub mod database_instance {
       }
     }
 
+    impl std::default::Default for SqlInstanceState {
+        fn default() -> Self {
+            sql_instance_state::SQL_INSTANCE_STATE_UNSPECIFIED
+        }
+    }
+
     /// The SQL network architecture for the instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SqlNetworkArchitecture(std::borrow::Cow<'static, str>);
 
     impl SqlNetworkArchitecture {
@@ -4838,6 +4874,12 @@ pub mod database_instance {
       fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
       }
+    }
+
+    impl std::default::Default for SqlNetworkArchitecture {
+        fn default() -> Self {
+            sql_network_architecture::SQL_NETWORK_ARCHITECTURE_UNSPECIFIED
+        }
     }
 }
 
@@ -5113,7 +5155,7 @@ pub mod sql_instances_reschedule_maintenance_request_body {
         }
     }
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RescheduleType(std::borrow::Cow<'static, str>);
 
     impl RescheduleType {
@@ -5150,6 +5192,12 @@ pub mod sql_instances_reschedule_maintenance_request_body {
       fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
       }
+    }
+
+    impl std::default::Default for RescheduleType {
+        fn default() -> Self {
+            reschedule_type::RESCHEDULE_TYPE_UNSPECIFIED
+        }
     }
 }
 
@@ -5513,7 +5561,7 @@ pub mod sql_external_sync_setting_error {
     use super::*;
 
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SqlExternalSyncSettingErrorType(std::borrow::Cow<'static, str>);
 
     impl SqlExternalSyncSettingErrorType {
@@ -5704,6 +5752,12 @@ pub mod sql_external_sync_setting_error {
       fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
       }
+    }
+
+    impl std::default::Default for SqlExternalSyncSettingErrorType {
+        fn default() -> Self {
+            sql_external_sync_setting_error_type::SQL_EXTERNAL_SYNC_SETTING_ERROR_TYPE_UNSPECIFIED
+        }
     }
 }
 
@@ -6359,7 +6413,7 @@ pub mod api_warning {
     use super::*;
 
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SqlApiWarningCode(std::borrow::Cow<'static, str>);
 
     impl SqlApiWarningCode {
@@ -6403,6 +6457,12 @@ pub mod api_warning {
       fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
       }
+    }
+
+    impl std::default::Default for SqlApiWarningCode {
+        fn default() -> Self {
+            sql_api_warning_code::SQL_API_WARNING_CODE_UNSPECIFIED
+        }
     }
 }
 
@@ -6455,7 +6515,7 @@ pub mod backup_retention_settings {
 
 
     /// The units that retained_backups specifies, we only support COUNT.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RetentionUnit(std::borrow::Cow<'static, str>);
 
     impl RetentionUnit {
@@ -6486,6 +6546,12 @@ pub mod backup_retention_settings {
       fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
       }
+    }
+
+    impl std::default::Default for RetentionUnit {
+        fn default() -> Self {
+            retention_unit::RETENTION_UNIT_UNSPECIFIED
+        }
     }
 }
 
@@ -6621,7 +6687,7 @@ pub mod backup_configuration {
 
     /// This value contains the storage location of the transactional logs
     /// used to perform point-in-time recovery (PITR) for the database.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TransactionalLogStorageState(std::borrow::Cow<'static, str>);
 
     impl TransactionalLogStorageState {
@@ -6667,6 +6733,12 @@ pub mod backup_configuration {
       fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
       }
+    }
+
+    impl std::default::Default for TransactionalLogStorageState {
+        fn default() -> Self {
+            transactional_log_storage_state::TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED
+        }
     }
 }
 
@@ -8292,7 +8364,7 @@ pub mod ip_configuration {
 
 
     /// The SSL options for database connections.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SslMode(std::borrow::Cow<'static, str>);
 
     impl SslMode {
@@ -8354,8 +8426,14 @@ pub mod ip_configuration {
       }
     }
 
+    impl std::default::Default for SslMode {
+        fn default() -> Self {
+            ssl_mode::SSL_MODE_UNSPECIFIED
+        }
+    }
+
     /// Various Certificate Authority (CA) modes for certificate signing.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CaMode(std::borrow::Cow<'static, str>);
 
     impl CaMode {
@@ -8390,6 +8468,12 @@ pub mod ip_configuration {
       fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
       }
+    }
+
+    impl std::default::Default for CaMode {
+        fn default() -> Self {
+            ca_mode::CA_MODE_UNSPECIFIED
+        }
     }
 }
 
@@ -9207,7 +9291,7 @@ pub mod operation {
 
 
     /// The type of Cloud SQL operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SqlOperationType(std::borrow::Cow<'static, str>);
 
     impl SqlOperationType {
@@ -9386,8 +9470,14 @@ pub mod operation {
       }
     }
 
+    impl std::default::Default for SqlOperationType {
+        fn default() -> Self {
+            sql_operation_type::SQL_OPERATION_TYPE_UNSPECIFIED
+        }
+    }
+
     /// The status of an operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SqlOperationStatus(std::borrow::Cow<'static, str>);
 
     impl SqlOperationStatus {
@@ -9424,6 +9514,12 @@ pub mod operation {
       fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
       }
+    }
+
+    impl std::default::Default for SqlOperationStatus {
+        fn default() -> Self {
+            sql_operation_status::SQL_OPERATION_STATUS_UNSPECIFIED
+        }
     }
 }
 
@@ -9620,7 +9716,7 @@ pub mod password_validation_policy {
 
 
     /// The complexity choices of the password.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Complexity(std::borrow::Cow<'static, str>);
 
     impl Complexity {
@@ -9652,6 +9748,12 @@ pub mod password_validation_policy {
       fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
       }
+    }
+
+    impl std::default::Default for Complexity {
+        fn default() -> Self {
+            complexity::COMPLEXITY_UNSPECIFIED
+        }
     }
 }
 
@@ -10119,7 +10221,7 @@ pub mod settings {
 
 
     /// Specifies when the instance is activated.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SqlActivationPolicy(std::borrow::Cow<'static, str>);
 
     impl SqlActivationPolicy {
@@ -10158,8 +10260,14 @@ pub mod settings {
       }
     }
 
+    impl std::default::Default for SqlActivationPolicy {
+        fn default() -> Self {
+            sql_activation_policy::SQL_ACTIVATION_POLICY_UNSPECIFIED
+        }
+    }
+
     /// The edition of the instance, can be ENTERPRISE or ENTERPRISE_PLUS.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Edition(std::borrow::Cow<'static, str>);
 
     impl Edition {
@@ -10195,8 +10303,14 @@ pub mod settings {
       }
     }
 
+    impl std::default::Default for Edition {
+        fn default() -> Self {
+            edition::EDITION_UNSPECIFIED
+        }
+    }
+
     /// The options for enforcing Cloud SQL connectors in the instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ConnectorEnforcement(std::borrow::Cow<'static, str>);
 
     impl ConnectorEnforcement {
@@ -10232,6 +10346,12 @@ pub mod settings {
       fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
       }
+    }
+
+    impl std::default::Default for ConnectorEnforcement {
+        fn default() -> Self {
+            connector_enforcement::CONNECTOR_ENFORCEMENT_UNSPECIFIED
+        }
     }
 }
 
@@ -11612,7 +11732,7 @@ pub mod user {
 
 
     /// The user type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SqlUserType(std::borrow::Cow<'static, str>);
 
     impl SqlUserType {
@@ -11657,8 +11777,14 @@ pub mod user {
       }
     }
 
+    impl std::default::Default for SqlUserType {
+        fn default() -> Self {
+            sql_user_type::BUILT_IN
+        }
+    }
+
     /// The type of retained password.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DualPasswordType(std::borrow::Cow<'static, str>);
 
     impl DualPasswordType {
@@ -11695,6 +11821,12 @@ pub mod user {
       fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
       }
+    }
+
+    impl std::default::Default for DualPasswordType {
+        fn default() -> Self {
+            dual_password_type::DUAL_PASSWORD_TYPE_UNSPECIFIED
+        }
     }
 
     /// User details for specific database type
@@ -11806,7 +11938,7 @@ impl wkt::message::Message for UsersListResponse {
 }
 
 /// The status of a backup run.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SqlBackupRunStatus(std::borrow::Cow<'static, str>);
 
 impl SqlBackupRunStatus {
@@ -11866,8 +11998,14 @@ impl std::convert::From<std::string::String> for SqlBackupRunStatus {
   }
 }
 
+impl std::default::Default for SqlBackupRunStatus {
+    fn default() -> Self {
+        sql_backup_run_status::SQL_BACKUP_RUN_STATUS_UNSPECIFIED
+    }
+}
+
 /// Defines the supported backup kinds.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SqlBackupKind(std::borrow::Cow<'static, str>);
 
 impl SqlBackupKind {
@@ -11903,8 +12041,14 @@ impl std::convert::From<std::string::String> for SqlBackupKind {
   }
 }
 
+impl std::default::Default for SqlBackupKind {
+    fn default() -> Self {
+        sql_backup_kind::SQL_BACKUP_KIND_UNSPECIFIED
+    }
+}
+
 /// Type of backup (i.e. automated, on demand, etc).
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SqlBackupRunType(std::borrow::Cow<'static, str>);
 
 impl SqlBackupRunType {
@@ -11940,7 +12084,13 @@ impl std::convert::From<std::string::String> for SqlBackupRunType {
   }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+impl std::default::Default for SqlBackupRunType {
+    fn default() -> Self {
+        sql_backup_run_type::SQL_BACKUP_RUN_TYPE_UNSPECIFIED
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SqlFlagType(std::borrow::Cow<'static, str>);
 
 impl SqlFlagType {
@@ -11992,8 +12142,14 @@ impl std::convert::From<std::string::String> for SqlFlagType {
   }
 }
 
+impl std::default::Default for SqlFlagType {
+    fn default() -> Self {
+        sql_flag_type::SQL_FLAG_TYPE_UNSPECIFIED
+    }
+}
+
 /// External Sync parallel level.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ExternalSyncParallelLevel(std::borrow::Cow<'static, str>);
 
 impl ExternalSyncParallelLevel {
@@ -12032,7 +12188,13 @@ impl std::convert::From<std::string::String> for ExternalSyncParallelLevel {
   }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+impl std::default::Default for ExternalSyncParallelLevel {
+    fn default() -> Self {
+        external_sync_parallel_level::EXTERNAL_SYNC_PARALLEL_LEVEL_UNSPECIFIED
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SqlInstanceType(std::borrow::Cow<'static, str>);
 
 impl SqlInstanceType {
@@ -12073,8 +12235,14 @@ impl std::convert::From<std::string::String> for SqlInstanceType {
   }
 }
 
+impl std::default::Default for SqlInstanceType {
+    fn default() -> Self {
+        sql_instance_type::SQL_INSTANCE_TYPE_UNSPECIFIED
+    }
+}
+
 /// The suspension reason of the database instance if the state is SUSPENDED.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SqlSuspensionReason(std::borrow::Cow<'static, str>);
 
 impl SqlSuspensionReason {
@@ -12119,7 +12287,13 @@ impl std::convert::From<std::string::String> for SqlSuspensionReason {
   }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+impl std::default::Default for SqlSuspensionReason {
+    fn default() -> Self {
+        sql_suspension_reason::SQL_SUSPENSION_REASON_UNSPECIFIED
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SqlFileType(std::borrow::Cow<'static, str>);
 
 impl SqlFileType {
@@ -12157,7 +12331,13 @@ impl std::convert::From<std::string::String> for SqlFileType {
   }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+impl std::default::Default for SqlFileType {
+    fn default() -> Self {
+        sql_file_type::SQL_FILE_TYPE_UNSPECIFIED
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct BakType(std::borrow::Cow<'static, str>);
 
 impl BakType {
@@ -12196,7 +12376,13 @@ impl std::convert::From<std::string::String> for BakType {
   }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+impl std::default::Default for BakType {
+    fn default() -> Self {
+        bak_type::BAK_TYPE_UNSPECIFIED
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SqlBackendType(std::borrow::Cow<'static, str>);
 
 impl SqlBackendType {
@@ -12235,7 +12421,13 @@ impl std::convert::From<std::string::String> for SqlBackendType {
   }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+impl std::default::Default for SqlBackendType {
+    fn default() -> Self {
+        sql_backend_type::SQL_BACKEND_TYPE_UNSPECIFIED
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SqlIpAddressType(std::borrow::Cow<'static, str>);
 
 impl SqlIpAddressType {
@@ -12283,8 +12475,14 @@ impl std::convert::From<std::string::String> for SqlIpAddressType {
   }
 }
 
+impl std::default::Default for SqlIpAddressType {
+    fn default() -> Self {
+        sql_ip_address_type::SQL_IP_ADDRESS_TYPE_UNSPECIFIED
+    }
+}
+
 /// The database engine type and version.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SqlDatabaseVersion(std::borrow::Cow<'static, str>);
 
 impl SqlDatabaseVersion {
@@ -12443,8 +12641,14 @@ impl std::convert::From<std::string::String> for SqlDatabaseVersion {
   }
 }
 
+impl std::default::Default for SqlDatabaseVersion {
+    fn default() -> Self {
+        sql_database_version::SQL_DATABASE_VERSION_UNSPECIFIED
+    }
+}
+
 /// The pricing plan for this instance.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SqlPricingPlan(std::borrow::Cow<'static, str>);
 
 impl SqlPricingPlan {
@@ -12480,7 +12684,13 @@ impl std::convert::From<std::string::String> for SqlPricingPlan {
   }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+impl std::default::Default for SqlPricingPlan {
+    fn default() -> Self {
+        sql_pricing_plan::SQL_PRICING_PLAN_UNSPECIFIED
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SqlReplicationType(std::borrow::Cow<'static, str>);
 
 impl SqlReplicationType {
@@ -12520,8 +12730,14 @@ impl std::convert::From<std::string::String> for SqlReplicationType {
   }
 }
 
+impl std::default::Default for SqlReplicationType {
+    fn default() -> Self {
+        sql_replication_type::SQL_REPLICATION_TYPE_UNSPECIFIED
+    }
+}
+
 /// The type of disk that is used for a v2 instance to use.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SqlDataDiskType(std::borrow::Cow<'static, str>);
 
 impl SqlDataDiskType {
@@ -12561,8 +12777,14 @@ impl std::convert::From<std::string::String> for SqlDataDiskType {
   }
 }
 
+impl std::default::Default for SqlDataDiskType {
+    fn default() -> Self {
+        sql_data_disk_type::SQL_DATA_DISK_TYPE_UNSPECIFIED
+    }
+}
+
 /// The availability type of the given Cloud SQL instance.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SqlAvailabilityType(std::borrow::Cow<'static, str>);
 
 impl SqlAvailabilityType {
@@ -12598,7 +12820,13 @@ impl std::convert::From<std::string::String> for SqlAvailabilityType {
   }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+impl std::default::Default for SqlAvailabilityType {
+    fn default() -> Self {
+        sql_availability_type::SQL_AVAILABILITY_TYPE_UNSPECIFIED
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SqlUpdateTrack(std::borrow::Cow<'static, str>);
 
 impl SqlUpdateTrack {
@@ -12643,4 +12871,10 @@ impl std::convert::From<std::string::String> for SqlUpdateTrack {
   fn from(value: std::string::String) -> Self {
     Self(std::borrow::Cow::Owned(value))
   }
+}
+
+impl std::default::Default for SqlUpdateTrack {
+    fn default() -> Self {
+        sql_update_track::SQL_UPDATE_TRACK_UNSPECIFIED
+    }
 }

--- a/src/generated/cloud/storageinsights/v1/src/model.rs
+++ b/src/generated/cloud/storageinsights/v1/src/model.rs
@@ -909,7 +909,7 @@ pub mod frequency_options {
     use super::*;
 
     /// This ENUM specifies possible frequencies of report generation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Frequency(std::borrow::Cow<'static, str>);
 
     impl Frequency {
@@ -941,6 +941,12 @@ pub mod frequency_options {
     impl std::convert::From<std::string::String> for Frequency {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Frequency {
+        fn default() -> Self {
+            frequency::FREQUENCY_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/support/v2/src/model.rs
+++ b/src/generated/cloud/support/v2/src/model.rs
@@ -490,7 +490,7 @@ pub mod case {
     use super::*;
 
     /// The status of a support case.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -534,8 +534,14 @@ pub mod case {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// The case Priority. P0 is most urgent and P4 the least.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Priority(std::borrow::Cow<'static, str>);
 
     impl Priority {
@@ -579,6 +585,12 @@ pub mod case {
     impl std::convert::From<std::string::String> for Priority {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Priority {
+        fn default() -> Self {
+            priority::PRIORITY_UNSPECIFIED
         }
     }
 }
@@ -1496,7 +1508,7 @@ pub mod escalation {
     use super::*;
 
     /// An enum detailing the possible reasons a case may be escalated.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Reason(std::borrow::Cow<'static, str>);
 
     impl Reason {
@@ -1532,6 +1544,12 @@ pub mod escalation {
     impl std::convert::From<std::string::String> for Reason {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Reason {
+        fn default() -> Self {
+            reason::REASON_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/talent/v4/src/model.rs
+++ b/src/generated/cloud/talent/v4/src/model.rs
@@ -170,7 +170,7 @@ pub mod location {
     use super::*;
 
     /// An enum which represents the type of a location.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LocationType(std::borrow::Cow<'static, str>);
 
     impl LocationType {
@@ -232,6 +232,12 @@ pub mod location {
     impl std::convert::From<std::string::String> for LocationType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for LocationType {
+        fn default() -> Self {
+            location_type::LOCATION_TYPE_UNSPECIFIED
         }
     }
 }
@@ -450,7 +456,7 @@ pub mod device_info {
     use super::*;
 
     /// An enumeration describing an API access portal and exposure mechanism.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DeviceType(std::borrow::Cow<'static, str>);
 
     impl DeviceType {
@@ -497,6 +503,12 @@ pub mod device_info {
     impl std::convert::From<std::string::String> for DeviceType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DeviceType {
+        fn default() -> Self {
+            device_type::DEVICE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -1074,7 +1086,7 @@ pub mod compensation_info {
     /// [google.cloud.talent.v4.CompensationInfo.CompensationEntry.description]: crate::model::compensation_info::CompensationEntry::description
     /// [google.cloud.talent.v4.CompensationInfo.CompensationEntry.range]: crate::model::compensation_info::CompensationEntry::compensation_amount
     /// [google.cloud.talent.v4.CompensationInfo.CompensationUnit.COMPENSATION_UNIT_UNSPECIFIED]: crate::model::compensation_info::compensation_unit::COMPENSATION_UNIT_UNSPECIFIED
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CompensationType(std::borrow::Cow<'static, str>);
 
     impl CompensationType {
@@ -1132,8 +1144,14 @@ pub mod compensation_info {
         }
     }
 
+    impl std::default::Default for CompensationType {
+        fn default() -> Self {
+            compensation_type::COMPENSATION_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Pay frequency.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CompensationUnit(std::borrow::Cow<'static, str>);
 
     impl CompensationUnit {
@@ -1182,6 +1200,12 @@ pub mod compensation_info {
     impl std::convert::From<std::string::String> for CompensationUnit {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CompensationUnit {
+        fn default() -> Self {
+            compensation_unit::COMPENSATION_UNIT_UNSPECIFIED
         }
     }
 }
@@ -1313,7 +1337,7 @@ pub mod batch_operation_metadata {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1363,6 +1387,12 @@ pub mod batch_operation_metadata {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -2054,7 +2084,7 @@ pub mod complete_query_request {
     use super::*;
 
     /// Enum to specify the scope of completion.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CompletionScope(std::borrow::Cow<'static, str>);
 
     impl CompletionScope {
@@ -2091,8 +2121,14 @@ pub mod complete_query_request {
         }
     }
 
+    impl std::default::Default for CompletionScope {
+        fn default() -> Self {
+            completion_scope::COMPLETION_SCOPE_UNSPECIFIED
+        }
+    }
+
     /// Enum to specify auto-completion topics.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CompletionType(std::borrow::Cow<'static, str>);
 
     impl CompletionType {
@@ -2157,6 +2193,12 @@ pub mod complete_query_request {
     impl std::convert::From<std::string::String> for CompletionType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CompletionType {
+        fn default() -> Self {
+            completion_type::COMPLETION_TYPE_UNSPECIFIED
         }
     }
 }
@@ -2478,7 +2520,7 @@ pub mod job_event {
 
     /// An enumeration of an event attributed to the behavior of the end user,
     /// such as a job seeker.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct JobEventType(std::borrow::Cow<'static, str>);
 
     impl JobEventType {
@@ -2610,6 +2652,12 @@ pub mod job_event {
     impl std::convert::From<std::string::String> for JobEventType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for JobEventType {
+        fn default() -> Self {
+            job_event_type::JOB_EVENT_TYPE_UNSPECIFIED
         }
     }
 }
@@ -3151,7 +3199,7 @@ pub mod location_filter {
     use super::*;
 
     /// Specify whether to include telecommute jobs.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TelecommutePreference(std::borrow::Cow<'static, str>);
 
     impl TelecommutePreference {
@@ -3191,6 +3239,12 @@ pub mod location_filter {
     impl std::convert::From<std::string::String> for TelecommutePreference {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for TelecommutePreference {
+        fn default() -> Self {
+            telecommute_preference::TELECOMMUTE_PREFERENCE_UNSPECIFIED
         }
     }
 }
@@ -3279,7 +3333,7 @@ pub mod compensation_filter {
     use super::*;
 
     /// Specify the type of filtering.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct FilterType(std::borrow::Cow<'static, str>);
 
     impl FilterType {
@@ -3358,6 +3412,12 @@ pub mod compensation_filter {
     impl std::convert::From<std::string::String> for FilterType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for FilterType {
+        fn default() -> Self {
+            filter_type::FILTER_TYPE_UNSPECIFIED
         }
     }
 }
@@ -3517,7 +3577,7 @@ pub mod commute_filter {
     use super::*;
 
     /// The traffic density to use when calculating commute time.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RoadTraffic(std::borrow::Cow<'static, str>);
 
     impl RoadTraffic {
@@ -3550,6 +3610,12 @@ pub mod commute_filter {
     impl std::convert::From<std::string::String> for RoadTraffic {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RoadTraffic {
+        fn default() -> Self {
+            road_traffic::ROAD_TRAFFIC_UNSPECIFIED
         }
     }
 
@@ -5433,7 +5499,7 @@ pub mod search_jobs_request {
         /// [CustomRankingInfo.ranking_expression][google.cloud.talent.v4.SearchJobsRequest.CustomRankingInfo.ranking_expression].
         ///
         /// [google.cloud.talent.v4.SearchJobsRequest.CustomRankingInfo.ranking_expression]: crate::model::search_jobs_request::CustomRankingInfo::ranking_expression
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct ImportanceLevel(std::borrow::Cow<'static, str>);
 
         impl ImportanceLevel {
@@ -5492,11 +5558,17 @@ pub mod search_jobs_request {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for ImportanceLevel {
+            fn default() -> Self {
+                importance_level::IMPORTANCE_LEVEL_UNSPECIFIED
+            }
+        }
     }
 
     /// A string-represented enumeration of the job search mode. The service
     /// operate differently for different modes of service.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SearchMode(std::borrow::Cow<'static, str>);
 
     impl SearchMode {
@@ -5537,6 +5609,12 @@ pub mod search_jobs_request {
         }
     }
 
+    impl std::default::Default for SearchMode {
+        fn default() -> Self {
+            search_mode::SEARCH_MODE_UNSPECIFIED
+        }
+    }
+
     /// Controls whether highly similar jobs are returned next to each other in
     /// the search results. Jobs are identified as highly similar based on
     /// their titles, job categories, and locations. Highly similar results are
@@ -5548,7 +5626,7 @@ pub mod search_jobs_request {
     /// latency might be lower but we can't guarantee that all results are
     /// returned. If you are using page offset, latency might be higher but all
     /// results are returned.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DiversificationLevel(std::borrow::Cow<'static, str>);
 
     impl DiversificationLevel {
@@ -5612,6 +5690,12 @@ pub mod search_jobs_request {
         }
     }
 
+    impl std::default::Default for DiversificationLevel {
+        fn default() -> Self {
+            diversification_level::DIVERSIFICATION_LEVEL_UNSPECIFIED
+        }
+    }
+
     /// Controls what keyword matching behavior the search has. When keyword
     /// matching is enabled, a keyword match returns jobs that may not match given
     /// category filters when there are matching keywords. For example, for the
@@ -5631,7 +5715,7 @@ pub mod search_jobs_request {
     /// requests.
     ///
     /// [google.cloud.talent.v4.Company.keyword_searchable_job_custom_attributes]: crate::model::Company::keyword_searchable_job_custom_attributes
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct KeywordMatchMode(std::borrow::Cow<'static, str>);
 
     impl KeywordMatchMode {
@@ -5694,10 +5778,16 @@ pub mod search_jobs_request {
         }
     }
 
+    impl std::default::Default for KeywordMatchMode {
+        fn default() -> Self {
+            keyword_match_mode::KEYWORD_MATCH_MODE_UNSPECIFIED
+        }
+    }
+
     /// The relevance threshold of the search results. The higher relevance
     /// threshold is, the higher relevant results are shown and the less number of
     /// results are returned.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RelevanceThreshold(std::borrow::Cow<'static, str>);
 
     impl RelevanceThreshold {
@@ -5737,6 +5827,12 @@ pub mod search_jobs_request {
     impl std::convert::From<std::string::String> for RelevanceThreshold {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RelevanceThreshold {
+        fn default() -> Self {
+            relevance_threshold::RELEVANCE_THRESHOLD_UNSPECIFIED
         }
     }
 }
@@ -6758,7 +6854,7 @@ impl gax::paginator::PageableResponse for ListTenantsResponse {
 }
 
 /// An enum that represents the size of the company.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct CompanySize(std::borrow::Cow<'static, str>);
 
 impl CompanySize {
@@ -6808,8 +6904,14 @@ impl std::convert::From<std::string::String> for CompanySize {
     }
 }
 
+impl std::default::Default for CompanySize {
+    fn default() -> Self {
+        company_size::COMPANY_SIZE_UNSPECIFIED
+    }
+}
+
 /// An enum that represents employee benefits included with the job.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct JobBenefit(std::borrow::Cow<'static, str>);
 
 impl JobBenefit {
@@ -6877,9 +6979,15 @@ impl std::convert::From<std::string::String> for JobBenefit {
     }
 }
 
+impl std::default::Default for JobBenefit {
+    fn default() -> Self {
+        job_benefit::JOB_BENEFIT_UNSPECIFIED
+    }
+}
+
 /// Educational degree level defined in International Standard Classification
 /// of Education (ISCED).
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DegreeType(std::borrow::Cow<'static, str>);
 
 impl DegreeType {
@@ -6956,8 +7064,14 @@ impl std::convert::From<std::string::String> for DegreeType {
     }
 }
 
+impl std::default::Default for DegreeType {
+    fn default() -> Self {
+        degree_type::DEGREE_TYPE_UNSPECIFIED
+    }
+}
+
 /// An enum that represents the employment type of a job.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct EmploymentType(std::borrow::Cow<'static, str>);
 
 impl EmploymentType {
@@ -7033,8 +7147,14 @@ impl std::convert::From<std::string::String> for EmploymentType {
     }
 }
 
+impl std::default::Default for EmploymentType {
+    fn default() -> Self {
+        employment_type::EMPLOYMENT_TYPE_UNSPECIFIED
+    }
+}
+
 /// An enum that represents the required experience level required for the job.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct JobLevel(std::borrow::Cow<'static, str>);
 
 impl JobLevel {
@@ -7080,10 +7200,16 @@ impl std::convert::From<std::string::String> for JobLevel {
     }
 }
 
+impl std::default::Default for JobLevel {
+    fn default() -> Self {
+        job_level::JOB_LEVEL_UNSPECIFIED
+    }
+}
+
 /// An enum that represents the categorization or primary focus of specific
 /// role. This value is different than the "industry" associated with a role,
 /// which is related to the categorization of the company listing the job.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct JobCategory(std::borrow::Cow<'static, str>);
 
 impl JobCategory {
@@ -7213,10 +7339,16 @@ impl std::convert::From<std::string::String> for JobCategory {
     }
 }
 
+impl std::default::Default for JobCategory {
+    fn default() -> Self {
+        job_category::JOB_CATEGORY_UNSPECIFIED
+    }
+}
+
 /// An enum that represents the job posting region. In most cases, job postings
 /// don't need to specify a region. If a region is given, jobs are
 /// eligible for searches in the specified region.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct PostingRegion(std::borrow::Cow<'static, str>);
 
 impl PostingRegion {
@@ -7278,10 +7410,16 @@ impl std::convert::From<std::string::String> for PostingRegion {
     }
 }
 
+impl std::default::Default for PostingRegion {
+    fn default() -> Self {
+        posting_region::POSTING_REGION_UNSPECIFIED
+    }
+}
+
 /// Deprecated. All resources are only visible to the owner.
 ///
 /// An enum that represents who has view access to the resource.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Visibility(std::borrow::Cow<'static, str>);
 
 impl Visibility {
@@ -7321,10 +7459,16 @@ impl std::convert::From<std::string::String> for Visibility {
     }
 }
 
+impl std::default::Default for Visibility {
+    fn default() -> Self {
+        visibility::VISIBILITY_UNSPECIFIED
+    }
+}
+
 /// Option for HTML content sanitization on user input fields, for example, job
 /// description. By setting this option, user can determine whether and how
 /// sanitization is performed on these fields.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct HtmlSanitization(std::borrow::Cow<'static, str>);
 
 impl HtmlSanitization {
@@ -7363,9 +7507,15 @@ impl std::convert::From<std::string::String> for HtmlSanitization {
     }
 }
 
+impl std::default::Default for HtmlSanitization {
+    fn default() -> Self {
+        html_sanitization::HTML_SANITIZATION_UNSPECIFIED
+    }
+}
+
 /// Method for commute. Walking, biking and wheelchair accessible transit is
 /// still in the Preview stage.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct CommuteMethod(std::borrow::Cow<'static, str>);
 
 impl CommuteMethod {
@@ -7412,6 +7562,12 @@ impl std::convert::From<std::string::String> for CommuteMethod {
     }
 }
 
+impl std::default::Default for CommuteMethod {
+    fn default() -> Self {
+        commute_method::COMMUTE_METHOD_UNSPECIFIED
+    }
+}
+
 /// An enum that specifies the job attributes that are returned in the
 /// [MatchingJob.job][google.cloud.talent.v4.SearchJobsResponse.MatchingJob.job]
 /// or [ListJobsResponse.jobs][google.cloud.talent.v4.ListJobsResponse.jobs]
@@ -7419,7 +7575,7 @@ impl std::convert::From<std::string::String> for CommuteMethod {
 ///
 /// [google.cloud.talent.v4.ListJobsResponse.jobs]: crate::model::ListJobsResponse::jobs
 /// [google.cloud.talent.v4.SearchJobsResponse.MatchingJob.job]: crate::model::search_jobs_response::MatchingJob::job
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct JobView(std::borrow::Cow<'static, str>);
 
 impl JobView {
@@ -7494,5 +7650,11 @@ pub mod job_view {
 impl std::convert::From<std::string::String> for JobView {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for JobView {
+    fn default() -> Self {
+        job_view::JOB_VIEW_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/tasks/v2/src/model.rs
+++ b/src/generated/cloud/tasks/v2/src/model.rs
@@ -1125,7 +1125,7 @@ pub mod queue {
     use super::*;
 
     /// State of the queue.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1184,6 +1184,12 @@ pub mod queue {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -2536,7 +2542,7 @@ pub mod task {
     /// contains.
     ///
     /// [google.cloud.tasks.v2.Task]: crate::model::Task
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct View(std::borrow::Cow<'static, str>);
 
     impl View {
@@ -2585,6 +2591,12 @@ pub mod task {
     impl std::convert::From<std::string::String> for View {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for View {
+        fn default() -> Self {
+            view::VIEW_UNSPECIFIED
         }
     }
 
@@ -2691,7 +2703,7 @@ impl wkt::message::Message for Attempt {
 }
 
 /// The HTTP method used to deliver the task.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct HttpMethod(std::borrow::Cow<'static, str>);
 
 impl HttpMethod {
@@ -2738,5 +2750,11 @@ pub mod http_method {
 impl std::convert::From<std::string::String> for HttpMethod {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for HttpMethod {
+    fn default() -> Self {
+        http_method::HTTP_METHOD_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/telcoautomation/v1/src/model.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/model.rs
@@ -148,7 +148,7 @@ pub mod orchestration_cluster {
     use super::*;
 
     /// Possible states that the Orchestration Cluster can be in.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -187,6 +187,12 @@ pub mod orchestration_cluster {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -320,7 +326,7 @@ pub mod edge_slm {
     use super::*;
 
     /// Possible states of the resource.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -362,9 +368,15 @@ pub mod edge_slm {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Workload clusters supported by TNA. New values will be added to the enum
     /// list as TNA adds supports for new workload clusters in future.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct WorkloadClusterType(std::borrow::Cow<'static, str>);
 
     impl WorkloadClusterType {
@@ -397,6 +409,12 @@ pub mod edge_slm {
     impl std::convert::From<std::string::String> for WorkloadClusterType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for WorkloadClusterType {
+        fn default() -> Self {
+            workload_cluster_type::WORKLOAD_CLUSTER_TYPE_UNSPECIFIED
         }
     }
 }
@@ -610,7 +628,7 @@ pub mod blueprint {
 
     /// Approval state indicates the state of a Blueprint in its approval
     /// lifecycle.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ApprovalState(std::borrow::Cow<'static, str>);
 
     impl ApprovalState {
@@ -652,6 +670,12 @@ pub mod blueprint {
     impl std::convert::From<std::string::String> for ApprovalState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ApprovalState {
+        fn default() -> Self {
+            approval_state::APPROVAL_STATE_UNSPECIFIED
         }
     }
 }
@@ -961,7 +985,7 @@ pub mod deployment {
     use super::*;
 
     /// State defines which state the current deployment is in.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1005,6 +1029,12 @@ pub mod deployment {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1089,7 +1119,7 @@ pub mod hydrated_deployment {
     use super::*;
 
     /// State defines which state the current hydrated deployment is in.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1123,6 +1153,12 @@ pub mod hydrated_deployment {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -4484,7 +4520,7 @@ impl wkt::message::Message for WorkloadStatus {
 }
 
 /// BlueprintView defines the type of view of the blueprint.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct BlueprintView(std::borrow::Cow<'static, str>);
 
 impl BlueprintView {
@@ -4520,8 +4556,14 @@ impl std::convert::From<std::string::String> for BlueprintView {
     }
 }
 
+impl std::default::Default for BlueprintView {
+    fn default() -> Self {
+        blueprint_view::BLUEPRINT_VIEW_UNSPECIFIED
+    }
+}
+
 /// DeploymentView defines the type of view of the deployment.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DeploymentView(std::borrow::Cow<'static, str>);
 
 impl DeploymentView {
@@ -4557,8 +4599,14 @@ impl std::convert::From<std::string::String> for DeploymentView {
     }
 }
 
+impl std::default::Default for DeploymentView {
+    fn default() -> Self {
+        deployment_view::DEPLOYMENT_VIEW_UNSPECIFIED
+    }
+}
+
 /// Represent type of CR.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ResourceType(std::borrow::Cow<'static, str>);
 
 impl ResourceType {
@@ -4594,8 +4642,14 @@ impl std::convert::From<std::string::String> for ResourceType {
     }
 }
 
+impl std::default::Default for ResourceType {
+    fn default() -> Self {
+        resource_type::RESOURCE_TYPE_UNSPECIFIED
+    }
+}
+
 /// Status of an entity (resource, deployment).
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Status(std::borrow::Cow<'static, str>);
 
 impl Status {
@@ -4646,9 +4700,15 @@ impl std::convert::From<std::string::String> for Status {
     }
 }
 
+impl std::default::Default for Status {
+    fn default() -> Self {
+        status::STATUS_UNSPECIFIED
+    }
+}
+
 /// DeploymentLevel of a blueprint signifies where the blueprint will be
 /// applied.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DeploymentLevel(std::borrow::Cow<'static, str>);
 
 impl DeploymentLevel {
@@ -4701,5 +4761,11 @@ pub mod deployment_level {
 impl std::convert::From<std::string::String> for DeploymentLevel {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for DeploymentLevel {
+    fn default() -> Self {
+        deployment_level::DEPLOYMENT_LEVEL_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/texttospeech/v1/src/model.rs
+++ b/src/generated/cloud/texttospeech/v1/src/model.rs
@@ -350,7 +350,7 @@ pub mod custom_pronunciation_params {
     use super::*;
 
     /// The phonetic encoding of the phrase.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PhoneticEncoding(std::borrow::Cow<'static, str>);
 
     impl PhoneticEncoding {
@@ -387,6 +387,12 @@ pub mod custom_pronunciation_params {
     impl std::convert::From<std::string::String> for PhoneticEncoding {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PhoneticEncoding {
+        fn default() -> Self {
+            phonetic_encoding::PHONETIC_ENCODING_UNSPECIFIED
         }
     }
 }
@@ -924,7 +930,7 @@ pub mod custom_voice_params {
 
     /// Deprecated. The usage of the synthesized audio. Usage does not affect
     /// billing.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ReportedUsage(std::borrow::Cow<'static, str>);
 
     impl ReportedUsage {
@@ -960,6 +966,12 @@ pub mod custom_voice_params {
     impl std::convert::From<std::string::String> for ReportedUsage {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ReportedUsage {
+        fn default() -> Self {
+            reported_usage::REPORTED_USAGE_UNSPECIFIED
         }
     }
 }
@@ -1518,7 +1530,7 @@ impl wkt::message::Message for SynthesizeLongAudioMetadata {
 
 /// Gender of the voice as described in
 /// [SSML voice element](https://www.w3.org/TR/speech-synthesis11/#edef_voice).
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SsmlVoiceGender(std::borrow::Cow<'static, str>);
 
 impl SsmlVoiceGender {
@@ -1561,9 +1573,15 @@ impl std::convert::From<std::string::String> for SsmlVoiceGender {
     }
 }
 
+impl std::default::Default for SsmlVoiceGender {
+    fn default() -> Self {
+        ssml_voice_gender::SSML_VOICE_GENDER_UNSPECIFIED
+    }
+}
+
 /// Configuration to set up audio encoder. The encoding determines the output
 /// audio format that we'd like.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct AudioEncoding(std::borrow::Cow<'static, str>);
 
 impl AudioEncoding {
@@ -1617,5 +1635,11 @@ pub mod audio_encoding {
 impl std::convert::From<std::string::String> for AudioEncoding {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for AudioEncoding {
+    fn default() -> Self {
+        audio_encoding::AUDIO_ENCODING_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/timeseriesinsights/v1/src/model.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/model.rs
@@ -258,7 +258,7 @@ pub mod data_set {
     use super::*;
 
     /// DataSet state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -306,6 +306,12 @@ pub mod data_set {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1057,7 +1063,7 @@ pub mod forecast_params {
     use super::*;
 
     /// A time period of a fixed interval.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Period(std::borrow::Cow<'static, str>);
 
     impl Period {
@@ -1098,6 +1104,12 @@ pub mod forecast_params {
     impl std::convert::From<std::string::String> for Period {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Period {
+        fn default() -> Self {
+            period::PERIOD_UNSPECIFIED
         }
     }
 }
@@ -1691,7 +1703,7 @@ pub mod timeseries_params {
     /// [metric][google.cloud.timeseriesinsights.v1.TimeseriesParams.metric].
     ///
     /// [google.cloud.timeseriesinsights.v1.TimeseriesParams.metric]: crate::model::TimeseriesParams::metric
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AggregationMethod(std::borrow::Cow<'static, str>);
 
     impl AggregationMethod {
@@ -1730,6 +1742,12 @@ pub mod timeseries_params {
     impl std::convert::From<std::string::String> for AggregationMethod {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AggregationMethod {
+        fn default() -> Self {
+            aggregation_method::AGGREGATION_METHOD_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/tpu/v2/src/model.rs
+++ b/src/generated/cloud/tpu/v2/src/model.rs
@@ -214,7 +214,7 @@ pub mod attached_disk {
     use super::*;
 
     /// The different mode of the attached disk.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DiskMode(std::borrow::Cow<'static, str>);
 
     impl DiskMode {
@@ -248,6 +248,12 @@ pub mod attached_disk {
     impl std::convert::From<std::string::String> for DiskMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DiskMode {
+        fn default() -> Self {
+            disk_mode::DISK_MODE_UNSPECIFIED
         }
     }
 }
@@ -864,7 +870,7 @@ pub mod node {
     use super::*;
 
     /// Represents the different states of a TPU node during its lifecycle.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -940,9 +946,15 @@ pub mod node {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Health defines the status of a TPU node as reported by
     /// Health Monitor.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Health(std::borrow::Cow<'static, str>);
 
     impl Health {
@@ -984,8 +996,14 @@ pub mod node {
         }
     }
 
+    impl std::default::Default for Health {
+        fn default() -> Self {
+            health::HEALTH_UNSPECIFIED
+        }
+    }
+
     /// TPU API Version.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ApiVersion(std::borrow::Cow<'static, str>);
 
     impl ApiVersion {
@@ -1023,6 +1041,12 @@ pub mod node {
     impl std::convert::From<std::string::String> for ApiVersion {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ApiVersion {
+        fn default() -> Self {
+            api_version::API_VERSION_UNSPECIFIED
         }
     }
 }
@@ -2264,7 +2288,7 @@ pub mod queued_resource_state {
     }
 
     /// Output only state of the request
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2339,8 +2363,14 @@ pub mod queued_resource_state {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// The initiator of the QueuedResource's SUSPENDING/SUSPENDED state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct StateInitiator(std::borrow::Cow<'static, str>);
 
     impl StateInitiator {
@@ -2373,6 +2403,12 @@ pub mod queued_resource_state {
     impl std::convert::From<std::string::String> for StateInitiator {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for StateInitiator {
+        fn default() -> Self {
+            state_initiator::STATE_INITIATOR_UNSPECIFIED
         }
     }
 
@@ -3781,7 +3817,7 @@ pub mod symptom {
 
     /// SymptomType represents the different types of Symptoms that a TPU can be
     /// at.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SymptomType(std::borrow::Cow<'static, str>);
 
     impl SymptomType {
@@ -3827,6 +3863,12 @@ pub mod symptom {
     impl std::convert::From<std::string::String> for SymptomType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SymptomType {
+        fn default() -> Self {
+            symptom_type::SYMPTOM_TYPE_UNSPECIFIED
         }
     }
 }
@@ -3973,7 +4015,7 @@ pub mod accelerator_config {
     use super::*;
 
     /// TPU type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -4017,6 +4059,12 @@ pub mod accelerator_config {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/translate/v3/src/model.rs
+++ b/src/generated/cloud/translate/v3/src/model.rs
@@ -5558,7 +5558,7 @@ pub mod batch_translate_metadata {
     use super::*;
 
     /// State of the job.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -5603,6 +5603,12 @@ pub mod batch_translate_metadata {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -6647,7 +6653,7 @@ pub mod create_glossary_metadata {
     use super::*;
 
     /// Enumerates the possible states that the creation request can be in.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -6689,6 +6695,12 @@ pub mod create_glossary_metadata {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -6761,7 +6773,7 @@ pub mod update_glossary_metadata {
     use super::*;
 
     /// Enumerates the possible states that the update request can be in.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -6803,6 +6815,12 @@ pub mod update_glossary_metadata {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -6871,7 +6889,7 @@ pub mod delete_glossary_metadata {
     use super::*;
 
     /// Enumerates the possible states that the creation request can be in.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -6913,6 +6931,12 @@ pub mod delete_glossary_metadata {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -7701,7 +7725,7 @@ pub mod batch_translate_document_metadata {
     use super::*;
 
     /// State of the job.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -7745,6 +7769,12 @@ pub mod batch_translate_document_metadata {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -7805,7 +7835,7 @@ impl wkt::message::Message for TranslateTextGlossaryConfig {
 }
 
 /// Possible states of long running operations.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct OperationState(std::borrow::Cow<'static, str>);
 
 impl OperationState {
@@ -7853,5 +7883,11 @@ pub mod operation_state {
 impl std::convert::From<std::string::String> for OperationState {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for OperationState {
+    fn default() -> Self {
+        operation_state::OPERATION_STATE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/video/livestream/v1/src/model.rs
+++ b/src/generated/cloud/video/livestream/v1/src/model.rs
@@ -425,7 +425,7 @@ pub mod manifest {
     use super::*;
 
     /// The manifest type can be either `HLS` or `DASH`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ManifestType(std::borrow::Cow<'static, str>);
 
     impl ManifestType {
@@ -458,6 +458,12 @@ pub mod manifest {
     impl std::convert::From<std::string::String> for ManifestType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ManifestType {
+        fn default() -> Self {
+            manifest_type::MANIFEST_TYPE_UNSPECIFIED
         }
     }
 }
@@ -1556,7 +1562,7 @@ pub mod timecode_config {
     use super::*;
 
     /// The source of timecode.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TimecodeSource(std::borrow::Cow<'static, str>);
 
     impl TimecodeSource {
@@ -1589,6 +1595,12 @@ pub mod timecode_config {
     impl std::convert::From<std::string::String> for TimecodeSource {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for TimecodeSource {
+        fn default() -> Self {
+            timecode_source::TIMECODE_SOURCE_UNSPECIFIED
         }
     }
 
@@ -1808,7 +1820,7 @@ pub mod input {
     }
 
     /// The type of the input.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -1843,8 +1855,14 @@ pub mod input {
         }
     }
 
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
+        }
+    }
+
     /// Tier of the input specification.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Tier(std::borrow::Cow<'static, str>);
 
     impl Tier {
@@ -1879,6 +1897,12 @@ pub mod input {
     impl std::convert::From<std::string::String> for Tier {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Tier {
+        fn default() -> Self {
+            tier::TIER_UNSPECIFIED
         }
     }
 }
@@ -2228,7 +2252,7 @@ pub mod channel {
     }
 
     /// State of streaming operation that the channel is running.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct StreamingState(std::borrow::Cow<'static, str>);
 
     impl StreamingState {
@@ -2281,6 +2305,12 @@ pub mod channel {
     impl std::convert::From<std::string::String> for StreamingState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for StreamingState {
+        fn default() -> Self {
+            streaming_state::STREAMING_STATE_UNSPECIFIED
         }
     }
 }
@@ -2477,7 +2507,7 @@ pub mod input_config {
     use super::*;
 
     /// Input switch mode.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct InputSwitchMode(std::borrow::Cow<'static, str>);
 
     impl InputSwitchMode {
@@ -2524,6 +2554,12 @@ pub mod input_config {
     impl std::convert::From<std::string::String> for InputSwitchMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for InputSwitchMode {
+        fn default() -> Self {
+            input_switch_mode::INPUT_SWITCH_MODE_UNSPECIFIED
         }
     }
 }
@@ -2575,7 +2611,7 @@ pub mod log_config {
     /// See
     /// [LogSeverity](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity)
     /// for more information.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LogSeverity(std::borrow::Cow<'static, str>);
 
     impl LogSeverity {
@@ -2617,6 +2653,12 @@ pub mod log_config {
     impl std::convert::From<std::string::String> for LogSeverity {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for LogSeverity {
+        fn default() -> Self {
+            log_severity::LOG_SEVERITY_UNSPECIFIED
         }
     }
 }
@@ -3527,7 +3569,7 @@ pub mod event {
     }
 
     /// State of the event
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3571,6 +3613,12 @@ pub mod event {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -3936,7 +3984,7 @@ pub mod clip {
     }
 
     /// State of clipping operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3977,6 +4025,12 @@ pub mod clip {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -4234,7 +4288,7 @@ pub mod asset {
     }
 
     /// State of the asset resource.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -4272,6 +4326,12 @@ pub mod asset {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 

--- a/src/generated/cloud/video/stitcher/v1/src/model.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/model.rs
@@ -687,7 +687,7 @@ pub mod companion_ads {
     use super::*;
 
     /// Indicates how many of the companions should be displayed with the ad.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DisplayRequirement(std::borrow::Cow<'static, str>);
 
     impl DisplayRequirement {
@@ -723,6 +723,12 @@ pub mod companion_ads {
     impl std::convert::From<std::string::String> for DisplayRequirement {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DisplayRequirement {
+        fn default() -> Self {
+            display_requirement::DISPLAY_REQUIREMENT_UNSPECIFIED
         }
     }
 }
@@ -1130,7 +1136,7 @@ pub mod event {
     use super::*;
 
     /// Describes the event that occurred.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EventType(std::borrow::Cow<'static, str>);
 
     impl EventType {
@@ -1228,6 +1234,12 @@ pub mod event {
     impl std::convert::From<std::string::String> for EventType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EventType {
+        fn default() -> Self {
+            event_type::EVENT_TYPE_UNSPECIFIED
         }
     }
 }
@@ -1476,7 +1488,7 @@ pub mod live_config {
     use super::*;
 
     /// State of the live config.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1514,10 +1526,16 @@ pub mod live_config {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Defines the ad stitching behavior in case the ad duration does not align
     /// exactly with the ad break boundaries. If not specified, the default is
     /// `CUT_CURRENT`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct StitchingPolicy(std::borrow::Cow<'static, str>);
 
     impl StitchingPolicy {
@@ -1550,6 +1568,12 @@ pub mod live_config {
     impl std::convert::From<std::string::String> for StitchingPolicy {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for StitchingPolicy {
+        fn default() -> Self {
+            stitching_policy::STITCHING_POLICY_UNSPECIFIED
         }
     }
 }
@@ -2335,7 +2359,7 @@ pub mod manifest_options {
     use super::*;
 
     /// Defines the ordering policy during manifest generation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct OrderPolicy(std::borrow::Cow<'static, str>);
 
     impl OrderPolicy {
@@ -2368,6 +2392,12 @@ pub mod manifest_options {
     impl std::convert::From<std::string::String> for OrderPolicy {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for OrderPolicy {
+        fn default() -> Self {
+            order_policy::ORDER_POLICY_UNSPECIFIED
         }
     }
 }
@@ -4651,7 +4681,7 @@ pub mod vod_config {
     use super::*;
 
     /// State of the VOD config.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -4688,6 +4718,12 @@ pub mod vod_config {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
 }
 
 /// Metadata used for GAM ad decisioning.
@@ -4720,7 +4756,7 @@ impl wkt::message::Message for GamVodConfig {
 }
 
 /// Determines the ad tracking policy.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct AdTracking(std::borrow::Cow<'static, str>);
 
 impl AdTracking {
@@ -4754,5 +4790,11 @@ pub mod ad_tracking {
 impl std::convert::From<std::string::String> for AdTracking {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for AdTracking {
+    fn default() -> Self {
+        ad_tracking::AD_TRACKING_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/video/transcoder/v1/src/model.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/model.rs
@@ -290,7 +290,7 @@ pub mod job {
     use super::*;
 
     /// The current state of the job.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ProcessingState(std::borrow::Cow<'static, str>);
 
     impl ProcessingState {
@@ -333,8 +333,14 @@ pub mod job {
         }
     }
 
+    impl std::default::Default for ProcessingState {
+        fn default() -> Self {
+            processing_state::PROCESSING_STATE_UNSPECIFIED
+        }
+    }
+
     /// The processing mode of the job.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ProcessingMode(std::borrow::Cow<'static, str>);
 
     impl ProcessingMode {
@@ -375,8 +381,14 @@ pub mod job {
         }
     }
 
+    impl std::default::Default for ProcessingMode {
+        fn default() -> Self {
+            processing_mode::PROCESSING_MODE_UNSPECIFIED
+        }
+    }
+
     /// The optimization strategy of the job. The default is `AUTODETECT`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct OptimizationStrategy(std::borrow::Cow<'static, str>);
 
     impl OptimizationStrategy {
@@ -409,6 +421,12 @@ pub mod job {
     impl std::convert::From<std::string::String> for OptimizationStrategy {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for OptimizationStrategy {
+        fn default() -> Self {
+            optimization_strategy::OPTIMIZATION_STRATEGY_UNSPECIFIED
         }
     }
 
@@ -1291,7 +1309,7 @@ pub mod manifest {
         use super::*;
 
         /// The segment reference scheme for a `DASH` manifest.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct SegmentReferenceScheme(std::borrow::Cow<'static, str>);
 
         impl SegmentReferenceScheme {
@@ -1328,10 +1346,16 @@ pub mod manifest {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for SegmentReferenceScheme {
+            fn default() -> Self {
+                segment_reference_scheme::SEGMENT_REFERENCE_SCHEME_UNSPECIFIED
+            }
+        }
     }
 
     /// The manifest type, which corresponds to the adaptive streaming format used.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ManifestType(std::borrow::Cow<'static, str>);
 
     impl ManifestType {
@@ -1364,6 +1388,12 @@ pub mod manifest {
     impl std::convert::From<std::string::String> for ManifestType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ManifestType {
+        fn default() -> Self {
+            manifest_type::MANIFEST_TYPE_UNSPECIFIED
         }
     }
 
@@ -2111,7 +2141,7 @@ pub mod overlay {
     }
 
     /// Fade type for the overlay: `FADE_IN` or `FADE_OUT`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct FadeType(std::borrow::Cow<'static, str>);
 
     impl FadeType {
@@ -2143,6 +2173,12 @@ pub mod overlay {
     impl std::convert::From<std::string::String> for FadeType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for FadeType {
+        fn default() -> Self {
+            fade_type::FADE_TYPE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/videointelligence/v1/src/model.rs
+++ b/src/generated/cloud/videointelligence/v1/src/model.rs
@@ -2892,7 +2892,7 @@ impl wkt::message::Message for LogoRecognitionAnnotation {
 }
 
 /// Video annotation feature.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Feature(std::borrow::Cow<'static, str>);
 
 impl Feature {
@@ -2948,8 +2948,14 @@ impl std::convert::From<std::string::String> for Feature {
     }
 }
 
+impl std::default::Default for Feature {
+    fn default() -> Self {
+        feature::FEATURE_UNSPECIFIED
+    }
+}
+
 /// Label detection mode.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct LabelDetectionMode(std::borrow::Cow<'static, str>);
 
 impl LabelDetectionMode {
@@ -2989,8 +2995,14 @@ impl std::convert::From<std::string::String> for LabelDetectionMode {
     }
 }
 
+impl std::default::Default for LabelDetectionMode {
+    fn default() -> Self {
+        label_detection_mode::LABEL_DETECTION_MODE_UNSPECIFIED
+    }
+}
+
 /// Bucketized representation of likelihood.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Likelihood(std::borrow::Cow<'static, str>);
 
 impl Likelihood {
@@ -3031,5 +3043,11 @@ pub mod likelihood {
 impl std::convert::From<std::string::String> for Likelihood {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for Likelihood {
+    fn default() -> Self {
+        likelihood::LIKELIHOOD_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/vision/v1/src/model.rs
+++ b/src/generated/cloud/vision/v1/src/model.rs
@@ -267,7 +267,7 @@ pub mod feature {
     use super::*;
 
     /// Type of Google Cloud Vision API feature to be extracted.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -334,6 +334,12 @@ pub mod feature {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -717,7 +723,7 @@ pub mod face_annotation {
         /// Left and right are defined from the vantage of the viewer of the image
         /// without considering mirror projections typical of photos. So, `LEFT_EYE`,
         /// typically, is the person's right eye.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Type(std::borrow::Cow<'static, str>);
 
         impl Type {
@@ -852,6 +858,12 @@ pub mod face_annotation {
         impl std::convert::From<std::string::String> for Type {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Type {
+            fn default() -> Self {
+                r#type::UNKNOWN_LANDMARK
             }
         }
     }
@@ -3048,7 +3060,7 @@ pub mod operation_metadata {
     use super::*;
 
     /// Batch operation states.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3086,6 +3098,12 @@ pub mod operation_metadata {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -5102,7 +5120,7 @@ pub mod batch_operation_metadata {
     use super::*;
 
     /// Enumerates the possible states that the batch request can be in.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -5143,6 +5161,12 @@ pub mod batch_operation_metadata {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -5459,7 +5483,7 @@ pub mod text_annotation {
         use super::*;
 
         /// Enum to denote the type of break found. New line, space etc.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct BreakType(std::borrow::Cow<'static, str>);
 
         impl BreakType {
@@ -5501,6 +5525,12 @@ pub mod text_annotation {
         impl std::convert::From<std::string::String> for BreakType {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for BreakType {
+            fn default() -> Self {
+                break_type::UNKNOWN
             }
         }
     }
@@ -5748,7 +5778,7 @@ pub mod block {
     use super::*;
 
     /// Type of a block (text, image etc) as identified by OCR.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct BlockType(std::borrow::Cow<'static, str>);
 
     impl BlockType {
@@ -5789,6 +5819,12 @@ pub mod block {
     impl std::convert::From<std::string::String> for BlockType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for BlockType {
+        fn default() -> Self {
+            block_type::UNKNOWN
         }
     }
 }
@@ -6387,7 +6423,7 @@ pub mod web_detection {
 
 /// A bucketized representation of likelihood, which is intended to give clients
 /// highly stable results across model upgrades.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Likelihood(std::borrow::Cow<'static, str>);
 
 impl Likelihood {
@@ -6428,5 +6464,11 @@ pub mod likelihood {
 impl std::convert::From<std::string::String> for Likelihood {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for Likelihood {
+    fn default() -> Self {
+        likelihood::UNKNOWN
     }
 }

--- a/src/generated/cloud/vmmigration/v1/src/model.rs
+++ b/src/generated/cloud/vmmigration/v1/src/model.rs
@@ -168,7 +168,7 @@ pub mod replication_cycle {
     use super::*;
 
     /// Possible states of a replication cycle.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -207,6 +207,12 @@ pub mod replication_cycle {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -858,7 +864,7 @@ pub mod migrating_vm {
     use super::*;
 
     /// The possible values of the state/health of source VM.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -923,6 +929,12 @@ pub mod migrating_vm {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -1120,7 +1132,7 @@ pub mod clone_job {
     use super::*;
 
     /// Possible states of the clone job.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1168,6 +1180,12 @@ pub mod clone_job {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -1585,7 +1603,7 @@ pub mod cutover_job {
     use super::*;
 
     /// Possible states of the cutover job.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1633,6 +1651,12 @@ pub mod cutover_job {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -2680,7 +2704,7 @@ pub mod aws_source_details {
     }
 
     /// The possible values of the state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2718,6 +2742,12 @@ pub mod aws_source_details {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -2940,7 +2970,7 @@ pub mod datacenter_connector {
     use super::*;
 
     /// The possible values of the state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2981,6 +3011,12 @@ pub mod datacenter_connector {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -3071,7 +3107,7 @@ pub mod upgrade_status {
     use super::*;
 
     /// The possible values of the state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3106,6 +3142,12 @@ pub mod upgrade_status {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -3794,7 +3836,7 @@ pub mod vmware_vm_details {
     use super::*;
 
     /// Possible values for the power state of the VM.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PowerState(std::borrow::Cow<'static, str>);
 
     impl PowerState {
@@ -3832,8 +3874,14 @@ pub mod vmware_vm_details {
         }
     }
 
+    impl std::default::Default for PowerState {
+        fn default() -> Self {
+            power_state::POWER_STATE_UNSPECIFIED
+        }
+    }
+
     /// Possible values for vm boot option.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct BootOption(std::borrow::Cow<'static, str>);
 
     impl BootOption {
@@ -3865,6 +3913,12 @@ pub mod vmware_vm_details {
     impl std::convert::From<std::string::String> for BootOption {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for BootOption {
+        fn default() -> Self {
+            boot_option::BOOT_OPTION_UNSPECIFIED
         }
     }
 }
@@ -4095,7 +4149,7 @@ pub mod aws_vm_details {
     use super::*;
 
     /// Possible values for the power state of the VM.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PowerState(std::borrow::Cow<'static, str>);
 
     impl PowerState {
@@ -4137,8 +4191,14 @@ pub mod aws_vm_details {
         }
     }
 
+    impl std::default::Default for PowerState {
+        fn default() -> Self {
+            power_state::POWER_STATE_UNSPECIFIED
+        }
+    }
+
     /// The possible values for the vm boot option.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct BootOption(std::borrow::Cow<'static, str>);
 
     impl BootOption {
@@ -4173,8 +4233,14 @@ pub mod aws_vm_details {
         }
     }
 
+    impl std::default::Default for BootOption {
+        fn default() -> Self {
+            boot_option::BOOT_OPTION_UNSPECIFIED
+        }
+    }
+
     /// Possible values for the virtualization types of the VM.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct VmVirtualizationType(std::borrow::Cow<'static, str>);
 
     impl VmVirtualizationType {
@@ -4210,8 +4276,14 @@ pub mod aws_vm_details {
         }
     }
 
+    impl std::default::Default for VmVirtualizationType {
+        fn default() -> Self {
+            vm_virtualization_type::VM_VIRTUALIZATION_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Possible values for the architectures of the VM.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct VmArchitecture(std::borrow::Cow<'static, str>);
 
     impl VmArchitecture {
@@ -4250,6 +4322,12 @@ pub mod aws_vm_details {
     impl std::convert::From<std::string::String> for VmArchitecture {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for VmArchitecture {
+        fn default() -> Self {
+            vm_architecture::VM_ARCHITECTURE_UNSPECIFIED
         }
     }
 }
@@ -4643,7 +4721,7 @@ pub mod utilization_report {
     use super::*;
 
     /// Utilization report state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -4681,8 +4759,14 @@ pub mod utilization_report {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Report time frame options.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TimeFrame(std::borrow::Cow<'static, str>);
 
     impl TimeFrame {
@@ -4717,6 +4801,12 @@ pub mod utilization_report {
     impl std::convert::From<std::string::String> for TimeFrame {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for TimeFrame {
+        fn default() -> Self {
+            time_frame::TIME_FRAME_UNSPECIFIED
         }
     }
 }
@@ -6246,7 +6336,7 @@ pub mod applied_license {
     use super::*;
 
     /// License types used in OS adaptation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -6281,6 +6371,12 @@ pub mod applied_license {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -6351,7 +6447,7 @@ pub mod scheduling_node_affinity {
 
     /// Possible types of node selection operators. Valid operators are IN for
     /// affinity and NOT_IN for anti-affinity.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Operator(std::borrow::Cow<'static, str>);
 
     impl Operator {
@@ -6383,6 +6479,12 @@ pub mod scheduling_node_affinity {
     impl std::convert::From<std::string::String> for Operator {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Operator {
+        fn default() -> Self {
+            operator::OPERATOR_UNSPECIFIED
         }
     }
 }
@@ -6473,7 +6575,7 @@ pub mod compute_scheduling {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct OnHostMaintenance(std::borrow::Cow<'static, str>);
 
     impl OnHostMaintenance {
@@ -6509,9 +6611,15 @@ pub mod compute_scheduling {
         }
     }
 
+    impl std::default::Default for OnHostMaintenance {
+        fn default() -> Self {
+            on_host_maintenance::ON_HOST_MAINTENANCE_UNSPECIFIED
+        }
+    }
+
     /// Defines whether the Instance should be automatically restarted whenever
     /// it is terminated by Compute Engine (not terminated by user).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RestartType(std::borrow::Cow<'static, str>);
 
     impl RestartType {
@@ -6546,6 +6654,12 @@ pub mod compute_scheduling {
     impl std::convert::From<std::string::String> for RestartType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RestartType {
+        fn default() -> Self {
+            restart_type::RESTART_TYPE_UNSPECIFIED
         }
     }
 }
@@ -8677,7 +8791,7 @@ pub mod migration_error {
     use super::*;
 
     /// Represents resource error codes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ErrorCode(std::borrow::Cow<'static, str>);
 
     impl ErrorCode {
@@ -8734,6 +8848,12 @@ pub mod migration_error {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for ErrorCode {
+        fn default() -> Self {
+            error_code::ERROR_CODE_UNSPECIFIED
+        }
+    }
 }
 
 /// Represent the source AWS VM details.
@@ -8783,7 +8903,7 @@ pub mod aws_source_vm_details {
     use super::*;
 
     /// Possible values for AWS VM firmware.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Firmware(std::borrow::Cow<'static, str>);
 
     impl Firmware {
@@ -8815,6 +8935,12 @@ pub mod aws_source_vm_details {
     impl std::convert::From<std::string::String> for Firmware {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Firmware {
+        fn default() -> Self {
+            firmware::FIRMWARE_UNSPECIFIED
         }
     }
 }
@@ -8997,7 +9123,7 @@ impl wkt::message::Message for GetReplicationCycleRequest {
 }
 
 /// Controls the level of details of a Utilization Report.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct UtilizationReportView(std::borrow::Cow<'static, str>);
 
 impl UtilizationReportView {
@@ -9036,8 +9162,14 @@ impl std::convert::From<std::string::String> for UtilizationReportView {
     }
 }
 
+impl std::default::Default for UtilizationReportView {
+    fn default() -> Self {
+        utilization_report_view::UTILIZATION_REPORT_VIEW_UNSPECIFIED
+    }
+}
+
 /// Controls the level of details of a Migrating VM.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct MigratingVmView(std::borrow::Cow<'static, str>);
 
 impl MigratingVmView {
@@ -9077,8 +9209,14 @@ impl std::convert::From<std::string::String> for MigratingVmView {
     }
 }
 
+impl std::default::Default for MigratingVmView {
+    fn default() -> Self {
+        migrating_vm_view::MIGRATING_VM_VIEW_UNSPECIFIED
+    }
+}
+
 /// Types of disks supported for Compute Engine VM.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ComputeEngineDiskType(std::borrow::Cow<'static, str>);
 
 impl ComputeEngineDiskType {
@@ -9121,8 +9259,14 @@ impl std::convert::From<std::string::String> for ComputeEngineDiskType {
     }
 }
 
+impl std::default::Default for ComputeEngineDiskType {
+    fn default() -> Self {
+        compute_engine_disk_type::COMPUTE_ENGINE_DISK_TYPE_UNSPECIFIED
+    }
+}
+
 /// Types of licenses used in OS adaptation.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ComputeEngineLicenseType(std::borrow::Cow<'static, str>);
 
 impl ComputeEngineLicenseType {
@@ -9160,8 +9304,14 @@ impl std::convert::From<std::string::String> for ComputeEngineLicenseType {
     }
 }
 
+impl std::default::Default for ComputeEngineLicenseType {
+    fn default() -> Self {
+        compute_engine_license_type::COMPUTE_ENGINE_LICENSE_TYPE_DEFAULT
+    }
+}
+
 /// Possible values for vm boot option.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ComputeEngineBootOption(std::borrow::Cow<'static, str>);
 
 impl ComputeEngineBootOption {
@@ -9196,5 +9346,11 @@ pub mod compute_engine_boot_option {
 impl std::convert::From<std::string::String> for ComputeEngineBootOption {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for ComputeEngineBootOption {
+    fn default() -> Self {
+        compute_engine_boot_option::COMPUTE_ENGINE_BOOT_OPTION_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/vmwareengine/v1/src/model.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/model.rs
@@ -7067,7 +7067,7 @@ pub mod private_cloud {
     }
 
     /// Enum State defines possible states of private clouds.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -7116,8 +7116,14 @@ pub mod private_cloud {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Enum Type defines private cloud type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -7153,6 +7159,12 @@ pub mod private_cloud {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::STANDARD
         }
     }
 }
@@ -7301,7 +7313,7 @@ pub mod cluster {
     use super::*;
 
     /// Enum State defines possible states of private cloud clusters.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -7344,6 +7356,12 @@ pub mod cluster {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -7449,7 +7467,7 @@ pub mod node {
     use super::*;
 
     /// Enum State defines possible states of a node in a cluster.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -7487,6 +7505,12 @@ pub mod node {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -7609,7 +7633,7 @@ pub mod external_address {
     use super::*;
 
     /// Enum State defines possible states of external addresses.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -7647,6 +7671,12 @@ pub mod external_address {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -7742,7 +7772,7 @@ pub mod subnet {
     use super::*;
 
     /// Defines possible states of subnets.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -7787,6 +7817,12 @@ pub mod subnet {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -8147,7 +8183,7 @@ pub mod external_access_rule {
 
     /// Action determines whether the external access rule permits or blocks
     /// traffic, subject to the other components of the rule matching the traffic.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Action(std::borrow::Cow<'static, str>);
 
     impl Action {
@@ -8182,8 +8218,14 @@ pub mod external_access_rule {
         }
     }
 
+    impl std::default::Default for Action {
+        fn default() -> Self {
+            action::ACTION_UNSPECIFIED
+        }
+    }
+
     /// Defines possible states of external access firewall rules.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -8221,6 +8263,12 @@ pub mod external_access_rule {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -8346,7 +8394,7 @@ pub mod logging_server {
 
     /// Defines possible protocols used to send logs to
     /// a logging server.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Protocol(std::borrow::Cow<'static, str>);
 
     impl Protocol {
@@ -8390,8 +8438,14 @@ pub mod logging_server {
         }
     }
 
+    impl std::default::Default for Protocol {
+        fn default() -> Self {
+            protocol::PROTOCOL_UNSPECIFIED
+        }
+    }
+
     /// Defines possible types of component that produces logs.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SourceType(std::borrow::Cow<'static, str>);
 
     impl SourceType {
@@ -8423,6 +8477,12 @@ pub mod logging_server {
     impl std::convert::From<std::string::String> for SourceType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SourceType {
+        fn default() -> Self {
+            source_type::SOURCE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -8580,7 +8640,7 @@ pub mod node_type {
     use super::*;
 
     /// Enum Kind defines possible types of a NodeType.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Kind(std::borrow::Cow<'static, str>);
 
     impl Kind {
@@ -8615,8 +8675,14 @@ pub mod node_type {
         }
     }
 
+    impl std::default::Default for Kind {
+        fn default() -> Self {
+            kind::KIND_UNSPECIFIED
+        }
+    }
+
     /// Capability of a node type.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Capability(std::borrow::Cow<'static, str>);
 
     impl Capability {
@@ -8646,6 +8712,12 @@ pub mod node_type {
     impl std::convert::From<std::string::String> for Capability {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Capability {
+        fn default() -> Self {
+            capability::CAPABILITY_UNSPECIFIED
         }
     }
 }
@@ -8783,7 +8855,7 @@ pub mod hcx_activation_key {
     use super::*;
 
     /// State of HCX activation key
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -8818,6 +8890,12 @@ pub mod hcx_activation_key {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -8886,7 +8964,7 @@ pub mod hcx {
     use super::*;
 
     /// State of the appliance
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -8921,6 +8999,12 @@ pub mod hcx {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -8989,7 +9073,7 @@ pub mod nsx {
     use super::*;
 
     /// State of the appliance
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -9021,6 +9105,12 @@ pub mod nsx {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -9089,7 +9179,7 @@ pub mod vcenter {
     use super::*;
 
     /// State of the appliance
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -9121,6 +9211,12 @@ pub mod vcenter {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -9748,7 +9844,7 @@ pub mod network_peering {
     use super::*;
 
     /// Possible states of a network peering.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -9789,8 +9885,14 @@ pub mod network_peering {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Type or purpose of the network peering connection.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PeerNetworkType(std::borrow::Cow<'static, str>);
 
     impl PeerNetworkType {
@@ -9848,6 +9950,12 @@ pub mod network_peering {
     impl std::convert::From<std::string::String> for PeerNetworkType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PeerNetworkType {
+        fn default() -> Self {
+            peer_network_type::PEER_NETWORK_TYPE_UNSPECIFIED
         }
     }
 }
@@ -9951,7 +10059,7 @@ pub mod peering_route {
     use super::*;
 
     /// The type of the peering route.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -9990,8 +10098,14 @@ pub mod peering_route {
         }
     }
 
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
+        }
+    }
+
     /// The direction of the exchanged routes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Direction(std::borrow::Cow<'static, str>);
 
     impl Direction {
@@ -10023,6 +10137,12 @@ pub mod peering_route {
     impl std::convert::From<std::string::String> for Direction {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Direction {
+        fn default() -> Self {
+            direction::DIRECTION_UNSPECIFIED
         }
     }
 }
@@ -10248,7 +10368,7 @@ pub mod network_policy {
 
         /// Enum State defines possible states of a network policy controlled
         /// service.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct State(std::borrow::Cow<'static, str>);
 
         impl State {
@@ -10283,6 +10403,12 @@ pub mod network_policy {
         impl std::convert::From<std::string::String> for State {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for State {
+            fn default() -> Self {
+                state::STATE_UNSPECIFIED
             }
         }
     }
@@ -10462,7 +10588,7 @@ pub mod management_dns_zone_binding {
 
     /// Enum State defines possible states of binding between the consumer VPC
     /// network and the management DNS zone.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -10503,6 +10629,12 @@ pub mod management_dns_zone_binding {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -10721,7 +10853,7 @@ pub mod vmware_engine_network {
 
         /// Enum Type defines possible types of a VMware Engine network controlled
         /// service.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Type(std::borrow::Cow<'static, str>);
 
         impl Type {
@@ -10762,10 +10894,16 @@ pub mod vmware_engine_network {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for Type {
+            fn default() -> Self {
+                r#type::TYPE_UNSPECIFIED
+            }
+        }
     }
 
     /// Enum State defines possible states of VMware Engine network.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -10806,8 +10944,14 @@ pub mod vmware_engine_network {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Enum Type defines possible types of VMware Engine network.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -10841,6 +10985,12 @@ pub mod vmware_engine_network {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -11053,7 +11203,7 @@ pub mod private_connection {
     use super::*;
 
     /// Enum State defines possible states of private connection.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -11101,8 +11251,14 @@ pub mod private_connection {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Enum Type defines possible types of private connection.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -11144,8 +11300,14 @@ pub mod private_connection {
         }
     }
 
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
+        }
+    }
+
     /// Possible types for RoutingMode
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RoutingMode(std::borrow::Cow<'static, str>);
 
     impl RoutingMode {
@@ -11181,9 +11343,15 @@ pub mod private_connection {
         }
     }
 
+    impl std::default::Default for RoutingMode {
+        fn default() -> Self {
+            routing_mode::ROUTING_MODE_UNSPECIFIED
+        }
+    }
+
     /// Enum PeeringState defines the possible states of peering between service
     /// network and the vpc network peered to service network
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PeeringState(std::borrow::Cow<'static, str>);
 
     impl PeeringState {
@@ -11217,6 +11385,12 @@ pub mod private_connection {
     impl std::convert::From<std::string::String> for PeeringState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PeeringState {
+        fn default() -> Self {
+            peering_state::PEERING_STATE_UNSPECIFIED
         }
     }
 }
@@ -11265,7 +11439,7 @@ pub mod location_metadata {
     use super::*;
 
     /// Capability of a location.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Capability(std::borrow::Cow<'static, str>);
 
     impl Capability {
@@ -11295,6 +11469,12 @@ pub mod location_metadata {
     impl std::convert::From<std::string::String> for Capability {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Capability {
+        fn default() -> Self {
+            capability::CAPABILITY_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/vpcaccess/v1/src/model.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/model.rs
@@ -220,7 +220,7 @@ pub mod connector {
     }
 
     /// State of a connector.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -261,6 +261,12 @@ pub mod connector {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/webrisk/v1/src/model.rs
+++ b/src/generated/cloud/webrisk/v1/src/model.rs
@@ -309,7 +309,7 @@ pub mod compute_threat_list_diff_response {
     }
 
     /// The type of response sent to the client.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ResponseType(std::borrow::Cow<'static, str>);
 
     impl ResponseType {
@@ -344,6 +344,12 @@ pub mod compute_threat_list_diff_response {
     impl std::convert::From<std::string::String> for ResponseType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ResponseType {
+        fn default() -> Self {
+            response_type::RESPONSE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -1106,7 +1112,7 @@ pub mod threat_info {
         use super::*;
 
         /// Enum representation of confidence.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct ConfidenceLevel(std::borrow::Cow<'static, str>);
 
         impl ConfidenceLevel {
@@ -1142,6 +1148,12 @@ pub mod threat_info {
         impl std::convert::From<std::string::String> for ConfidenceLevel {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for ConfidenceLevel {
+            fn default() -> Self {
+                confidence_level::CONFIDENCE_LEVEL_UNSPECIFIED
             }
         }
 
@@ -1216,7 +1228,7 @@ pub mod threat_info {
         use super::*;
 
         /// Labels that explain how the URI was classified.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct JustificationLabel(std::borrow::Cow<'static, str>);
 
         impl JustificationLabel {
@@ -1256,10 +1268,16 @@ pub mod threat_info {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for JustificationLabel {
+            fn default() -> Self {
+                justification_label::JUSTIFICATION_LABEL_UNSPECIFIED
+            }
+        }
     }
 
     /// The abuse type found on the URI.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AbuseType(std::borrow::Cow<'static, str>);
 
     impl AbuseType {
@@ -1294,6 +1312,12 @@ pub mod threat_info {
     impl std::convert::From<std::string::String> for AbuseType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AbuseType {
+        fn default() -> Self {
+            abuse_type::ABUSE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -1351,7 +1375,7 @@ pub mod threat_discovery {
     use super::*;
 
     /// Platform types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Platform(std::borrow::Cow<'static, str>);
 
     impl Platform {
@@ -1389,6 +1413,12 @@ pub mod threat_discovery {
     impl std::convert::From<std::string::String> for Platform {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Platform {
+        fn default() -> Self {
+            platform::PLATFORM_UNSPECIFIED
         }
     }
 }
@@ -1571,7 +1601,7 @@ pub mod submit_uri_metadata {
     use super::*;
 
     /// Enum that represents the state of the long-running operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1614,11 +1644,17 @@ pub mod submit_uri_metadata {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
 }
 
 /// The type of threat. This maps directly to the threat list a threat may
 /// belong to.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ThreatType(std::borrow::Cow<'static, str>);
 
 impl ThreatType {
@@ -1661,8 +1697,14 @@ impl std::convert::From<std::string::String> for ThreatType {
     }
 }
 
+impl std::default::Default for ThreatType {
+    fn default() -> Self {
+        threat_type::THREAT_TYPE_UNSPECIFIED
+    }
+}
+
 /// The ways in which threat entry sets can be compressed.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct CompressionType(std::borrow::Cow<'static, str>);
 
 impl CompressionType {
@@ -1695,5 +1737,11 @@ pub mod compression_type {
 impl std::convert::From<std::string::String> for CompressionType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for CompressionType {
+    fn default() -> Self {
+        compression_type::COMPRESSION_TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/websecurityscanner/v1/src/model.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/model.rs
@@ -333,7 +333,7 @@ pub mod finding {
     use super::*;
 
     /// The severity level of a vulnerability.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Severity(std::borrow::Cow<'static, str>);
 
     impl Severity {
@@ -371,6 +371,12 @@ pub mod finding {
     impl std::convert::From<std::string::String> for Severity {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Severity {
+        fn default() -> Self {
+            severity::SEVERITY_UNSPECIFIED
         }
     }
 }
@@ -716,7 +722,7 @@ pub mod xss {
     use super::*;
 
     /// Types of XSS attack vector.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AttackVector(std::borrow::Cow<'static, str>);
 
     impl AttackVector {
@@ -791,6 +797,12 @@ pub mod xss {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for AttackVector {
+        fn default() -> Self {
+            attack_vector::ATTACK_VECTOR_UNSPECIFIED
+        }
+    }
 }
 
 /// Information reported for an XXE.
@@ -841,7 +853,7 @@ pub mod xxe {
     use super::*;
 
     /// Locations within a request where XML was substituted.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Location(std::borrow::Cow<'static, str>);
 
     impl Location {
@@ -870,6 +882,12 @@ pub mod xxe {
     impl std::convert::From<std::string::String> for Location {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Location {
+        fn default() -> Self {
+            location::LOCATION_UNSPECIFIED
         }
     }
 }
@@ -1538,7 +1556,7 @@ pub mod scan_config {
     }
 
     /// Type of user agents used for scanning.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct UserAgent(std::borrow::Cow<'static, str>);
 
     impl UserAgent {
@@ -1576,10 +1594,16 @@ pub mod scan_config {
         }
     }
 
+    impl std::default::Default for UserAgent {
+        fn default() -> Self {
+            user_agent::USER_AGENT_UNSPECIFIED
+        }
+    }
+
     /// Scan risk levels supported by Web Security Scanner. LOW impact
     /// scanning will minimize requests with the potential to modify data. To
     /// achieve the maximum scan coverage, NORMAL risk level is recommended.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RiskLevel(std::borrow::Cow<'static, str>);
 
     impl RiskLevel {
@@ -1614,9 +1638,15 @@ pub mod scan_config {
         }
     }
 
+    impl std::default::Default for RiskLevel {
+        fn default() -> Self {
+            risk_level::RISK_LEVEL_UNSPECIFIED
+        }
+    }
+
     /// Controls export of scan configurations and results to Security
     /// Command Center.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ExportToSecurityCommandCenter(std::borrow::Cow<'static, str>);
 
     impl ExportToSecurityCommandCenter {
@@ -1651,6 +1681,12 @@ pub mod scan_config {
     impl std::convert::From<std::string::String> for ExportToSecurityCommandCenter {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ExportToSecurityCommandCenter {
+        fn default() -> Self {
+            export_to_security_command_center::EXPORT_TO_SECURITY_COMMAND_CENTER_UNSPECIFIED
         }
     }
 }
@@ -1710,7 +1746,7 @@ pub mod scan_config_error {
     /// Output only.
     /// Defines an error reason code.
     /// Next id: 44
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Code(std::borrow::Cow<'static, str>);
 
     impl Code {
@@ -1893,6 +1929,12 @@ pub mod scan_config_error {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for Code {
+        fn default() -> Self {
+            code::CODE_UNSPECIFIED
+        }
+    }
 }
 
 /// A ScanRun is a output-only resource representing an actual run of the scan.
@@ -2061,7 +2103,7 @@ pub mod scan_run {
     use super::*;
 
     /// Types of ScanRun execution state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ExecutionState(std::borrow::Cow<'static, str>);
 
     impl ExecutionState {
@@ -2101,8 +2143,14 @@ pub mod scan_run {
         }
     }
 
+    impl std::default::Default for ExecutionState {
+        fn default() -> Self {
+            execution_state::EXECUTION_STATE_UNSPECIFIED
+        }
+    }
+
     /// Types of ScanRun result state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ResultState(std::borrow::Cow<'static, str>);
 
     impl ResultState {
@@ -2139,6 +2187,12 @@ pub mod scan_run {
     impl std::convert::From<std::string::String> for ResultState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ResultState {
+        fn default() -> Self {
+            result_state::RESULT_STATE_UNSPECIFIED
         }
     }
 }
@@ -2211,7 +2265,7 @@ pub mod scan_run_error_trace {
     /// Output only.
     /// Defines an error reason code.
     /// Next id: 8
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Code(std::borrow::Cow<'static, str>);
 
     impl Code {
@@ -2260,6 +2314,12 @@ pub mod scan_run_error_trace {
     impl std::convert::From<std::string::String> for Code {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Code {
+        fn default() -> Self {
+            code::CODE_UNSPECIFIED
         }
     }
 }
@@ -2412,7 +2472,7 @@ pub mod scan_run_warning_trace {
     /// Output only.
     /// Defines a warning message code.
     /// Next id: 6
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Code(std::borrow::Cow<'static, str>);
 
     impl Code {
@@ -2459,6 +2519,12 @@ pub mod scan_run_warning_trace {
     impl std::convert::From<std::string::String> for Code {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Code {
+        fn default() -> Self {
+            code::CODE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/cloud/workflows/executions/v1/src/model.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/model.rs
@@ -573,7 +573,7 @@ pub mod execution {
         use super::*;
 
         /// Describes the possible types of a state error.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Type(std::borrow::Cow<'static, str>);
 
         impl Type {
@@ -604,11 +604,17 @@ pub mod execution {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for Type {
+            fn default() -> Self {
+                r#type::TYPE_UNSPECIFIED
+            }
+        }
     }
 
     /// Describes the current state of the execution. More states might be added
     /// in the future.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -655,9 +661,15 @@ pub mod execution {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Describes the level of platform logging to apply to calls and call
     /// responses during workflow executions.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CallLogLevel(std::borrow::Cow<'static, str>);
 
     impl CallLogLevel {
@@ -694,6 +706,12 @@ pub mod execution {
     impl std::convert::From<std::string::String> for CallLogLevel {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CallLogLevel {
+        fn default() -> Self {
+            call_log_level::CALL_LOG_LEVEL_UNSPECIFIED
         }
     }
 }
@@ -987,7 +1005,7 @@ impl wkt::message::Message for CancelExecutionRequest {
 }
 
 /// Defines possible views for execution resource.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ExecutionView(std::borrow::Cow<'static, str>);
 
 impl ExecutionView {
@@ -1022,5 +1040,11 @@ pub mod execution_view {
 impl std::convert::From<std::string::String> for ExecutionView {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for ExecutionView {
+    fn default() -> Self {
+        execution_view::EXECUTION_VIEW_UNSPECIFIED
     }
 }

--- a/src/generated/cloud/workflows/v1/src/model.rs
+++ b/src/generated/cloud/workflows/v1/src/model.rs
@@ -349,7 +349,7 @@ pub mod workflow {
         use super::*;
 
         /// Describes the possibled types of a state error.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Type(std::borrow::Cow<'static, str>);
 
         impl Type {
@@ -380,10 +380,16 @@ pub mod workflow {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for Type {
+            fn default() -> Self {
+                r#type::TYPE_UNSPECIFIED
+            }
+        }
     }
 
     /// Describes the current state of workflow deployment.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -418,9 +424,15 @@ pub mod workflow {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Describes the level of platform logging to apply to calls and call
     /// responses during workflow executions.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CallLogLevel(std::borrow::Cow<'static, str>);
 
     impl CallLogLevel {
@@ -457,6 +469,12 @@ pub mod workflow {
     impl std::convert::From<std::string::String> for CallLogLevel {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CallLogLevel {
+        fn default() -> Self {
+            call_log_level::CALL_LOG_LEVEL_UNSPECIFIED
         }
     }
 

--- a/src/generated/cloud/workstations/v1/src/model.rs
+++ b/src/generated/cloud/workstations/v1/src/model.rs
@@ -1330,7 +1330,7 @@ pub mod workstation_config {
 
             /// Value representing what should happen to the disk after the workstation
             /// is deleted.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct ReclaimPolicy(std::borrow::Cow<'static, str>);
 
             impl ReclaimPolicy {
@@ -1364,6 +1364,12 @@ pub mod workstation_config {
             impl std::convert::From<std::string::String> for ReclaimPolicy {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for ReclaimPolicy {
+                fn default() -> Self {
+                    reclaim_policy::RECLAIM_POLICY_UNSPECIFIED
                 }
             }
         }
@@ -1770,7 +1776,7 @@ pub mod workstation {
     use super::*;
 
     /// Whether a workstation is running and ready to receive user requests.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1810,6 +1816,12 @@ pub mod workstation {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/container/v1/src/model.rs
+++ b/src/generated/container/v1/src/model.rs
@@ -163,7 +163,7 @@ pub mod linux_node_config {
     }
 
     /// Possible cgroup modes that can be used.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CgroupMode(std::borrow::Cow<'static, str>);
 
     impl CgroupMode {
@@ -198,6 +198,12 @@ pub mod linux_node_config {
     impl std::convert::From<std::string::String> for CgroupMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CgroupMode {
+        fn default() -> Self {
+            cgroup_mode::CGROUP_MODE_UNSPECIFIED
         }
     }
 }
@@ -241,7 +247,7 @@ pub mod windows_node_config {
     use super::*;
 
     /// Possible OS version that can be used.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct OSVersion(std::borrow::Cow<'static, str>);
 
     impl OSVersion {
@@ -273,6 +279,12 @@ pub mod windows_node_config {
     impl std::convert::From<std::string::String> for OSVersion {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for OSVersion {
+        fn default() -> Self {
+            os_version::OS_VERSION_UNSPECIFIED
         }
     }
 }
@@ -1097,7 +1109,7 @@ pub mod node_config {
 
     /// LocalSsdEncryptionMode specifies the method used for encrypting the Local
     /// SSDs attached to the node.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LocalSsdEncryptionMode(std::borrow::Cow<'static, str>);
 
     impl LocalSsdEncryptionMode {
@@ -1142,8 +1154,14 @@ pub mod node_config {
         }
     }
 
+    impl std::default::Default for LocalSsdEncryptionMode {
+        fn default() -> Self {
+            local_ssd_encryption_mode::LOCAL_SSD_ENCRYPTION_MODE_UNSPECIFIED
+        }
+    }
+
     /// Possible effective cgroup modes for the node.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EffectiveCgroupMode(std::borrow::Cow<'static, str>);
 
     impl EffectiveCgroupMode {
@@ -1181,6 +1199,12 @@ pub mod node_config {
     impl std::convert::From<std::string::String> for EffectiveCgroupMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EffectiveCgroupMode {
+        fn default() -> Self {
+            effective_cgroup_mode::EFFECTIVE_CGROUP_MODE_UNSPECIFIED
         }
     }
 }
@@ -1470,7 +1494,7 @@ pub mod node_network_config {
         use super::*;
 
         /// Node network tier
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Tier(std::borrow::Cow<'static, str>);
 
         impl Tier {
@@ -1499,6 +1523,12 @@ pub mod node_network_config {
         impl std::convert::From<std::string::String> for Tier {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Tier {
+            fn default() -> Self {
+                tier::TIER_UNSPECIFIED
             }
         }
     }
@@ -1687,7 +1717,7 @@ pub mod sandbox_config {
     use super::*;
 
     /// Possible types of sandboxes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -1716,6 +1746,12 @@ pub mod sandbox_config {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::UNSPECIFIED
         }
     }
 }
@@ -1818,7 +1854,7 @@ pub mod reservation_affinity {
     use super::*;
 
     /// Indicates whether to consume capacity from a reservation or not.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -1854,6 +1890,12 @@ pub mod reservation_affinity {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::UNSPECIFIED
         }
     }
 }
@@ -1965,7 +2007,7 @@ pub mod sole_tenant_config {
 
         /// Operator allows user to specify affinity or anti-affinity for the
         /// given key values.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Operator(std::borrow::Cow<'static, str>);
 
         impl Operator {
@@ -1997,6 +2039,12 @@ pub mod sole_tenant_config {
         impl std::convert::From<std::string::String> for Operator {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Operator {
+            fn default() -> Self {
+                operator::OPERATOR_UNSPECIFIED
             }
         }
     }
@@ -2291,7 +2339,7 @@ pub mod node_taint {
     use super::*;
 
     /// Possible values for Effect in taint.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Effect(std::borrow::Cow<'static, str>);
 
     impl Effect {
@@ -2326,6 +2374,12 @@ pub mod node_taint {
     impl std::convert::From<std::string::String> for Effect {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Effect {
+        fn default() -> Self {
+            effect::EFFECT_UNSPECIFIED
         }
     }
 }
@@ -3277,7 +3331,7 @@ pub mod cloud_run_config {
     use super::*;
 
     /// Load balancer type of ingress service of Cloud Run.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LoadBalancerType(std::borrow::Cow<'static, str>);
 
     impl LoadBalancerType {
@@ -3312,6 +3366,12 @@ pub mod cloud_run_config {
     impl std::convert::From<std::string::String> for LoadBalancerType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for LoadBalancerType {
+        fn default() -> Self {
+            load_balancer_type::LOAD_BALANCER_TYPE_UNSPECIFIED
         }
     }
 }
@@ -3774,7 +3834,7 @@ pub mod network_policy {
     use super::*;
 
     /// Allowed Network Policy providers.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Provider(std::borrow::Cow<'static, str>);
 
     impl Provider {
@@ -3803,6 +3863,12 @@ pub mod network_policy {
     impl std::convert::From<std::string::String> for Provider {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Provider {
+        fn default() -> Self {
+            provider::PROVIDER_UNSPECIFIED
         }
     }
 }
@@ -3858,7 +3924,7 @@ pub mod binary_authorization {
     use super::*;
 
     /// Binary Authorization mode of operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EvaluationMode(std::borrow::Cow<'static, str>);
 
     impl EvaluationMode {
@@ -3894,6 +3960,12 @@ pub mod binary_authorization {
     impl std::convert::From<std::string::String> for EvaluationMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EvaluationMode {
+        fn default() -> Self {
+            evaluation_mode::EVALUATION_MODE_UNSPECIFIED
         }
     }
 }
@@ -5425,7 +5497,7 @@ pub mod cluster {
     use super::*;
 
     /// The current status of the cluster.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Status(std::borrow::Cow<'static, str>);
 
     impl Status {
@@ -5474,6 +5546,12 @@ pub mod cluster {
     impl std::convert::From<std::string::String> for Status {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Status {
+        fn default() -> Self {
+            status::STATUS_UNSPECIFIED
         }
     }
 }
@@ -5749,7 +5827,7 @@ pub mod compliance_posture_config {
     }
 
     /// Mode defines enablement mode for Compliance Posture.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Mode(std::borrow::Cow<'static, str>);
 
     impl Mode {
@@ -5781,6 +5859,12 @@ pub mod compliance_posture_config {
     impl std::convert::From<std::string::String> for Mode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Mode {
+        fn default() -> Self {
+            mode::MODE_UNSPECIFIED
         }
     }
 }
@@ -5878,7 +5962,7 @@ pub mod security_posture_config {
     use super::*;
 
     /// Mode defines enablement mode for GKE Security posture features.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Mode(std::borrow::Cow<'static, str>);
 
     impl Mode {
@@ -5916,8 +6000,14 @@ pub mod security_posture_config {
         }
     }
 
+    impl std::default::Default for Mode {
+        fn default() -> Self {
+            mode::MODE_UNSPECIFIED
+        }
+    }
+
     /// VulnerabilityMode defines enablement mode for vulnerability scanning.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct VulnerabilityMode(std::borrow::Cow<'static, str>);
 
     impl VulnerabilityMode {
@@ -5957,6 +6047,12 @@ pub mod security_posture_config {
     impl std::convert::From<std::string::String> for VulnerabilityMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for VulnerabilityMode {
+        fn default() -> Self {
+            vulnerability_mode::VULNERABILITY_MODE_UNSPECIFIED
         }
     }
 }
@@ -7573,7 +7669,7 @@ pub mod operation {
     use super::*;
 
     /// Current status of the operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Status(std::borrow::Cow<'static, str>);
 
     impl Status {
@@ -7614,8 +7710,14 @@ pub mod operation {
         }
     }
 
+    impl std::default::Default for Status {
+        fn default() -> Self {
+            status::STATUS_UNSPECIFIED
+        }
+    }
+
     /// Operation type categorizes the operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -7781,6 +7883,12 @@ pub mod operation {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -9328,7 +9436,7 @@ pub mod set_master_auth_request {
     use super::*;
 
     /// Operation type: what type update to perform.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Action(std::borrow::Cow<'static, str>);
 
     impl Action {
@@ -9366,6 +9474,12 @@ pub mod set_master_auth_request {
     impl std::convert::From<std::string::String> for Action {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Action {
+        fn default() -> Self {
+            action::UNKNOWN
         }
     }
 }
@@ -11135,7 +11249,7 @@ pub mod node_pool {
             use super::*;
 
             /// Phase represents the different stages blue-green upgrade is running in.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct Phase(std::borrow::Cow<'static, str>);
 
             impl Phase {
@@ -11182,6 +11296,12 @@ pub mod node_pool {
             impl std::convert::From<std::string::String> for Phase {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for Phase {
+                fn default() -> Self {
+                    phase::PHASE_UNSPECIFIED
                 }
             }
         }
@@ -11251,7 +11371,7 @@ pub mod node_pool {
         use super::*;
 
         /// Type defines the type of placement policy.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Type(std::borrow::Cow<'static, str>);
 
         impl Type {
@@ -11282,6 +11402,12 @@ pub mod node_pool {
         impl std::convert::From<std::string::String> for Type {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Type {
+            fn default() -> Self {
+                r#type::TYPE_UNSPECIFIED
             }
         }
     }
@@ -11317,7 +11443,7 @@ pub mod node_pool {
     }
 
     /// The current status of the node pool instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Status(std::borrow::Cow<'static, str>);
 
     impl Status {
@@ -11368,6 +11494,12 @@ pub mod node_pool {
     impl std::convert::From<std::string::String> for Status {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Status {
+        fn default() -> Self {
+            status::STATUS_UNSPECIFIED
         }
     }
 }
@@ -11846,7 +11978,7 @@ pub mod maintenance_exclusion_options {
     use super::*;
 
     /// Scope of exclusion.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Scope(std::borrow::Cow<'static, str>);
 
     impl Scope {
@@ -11883,6 +12015,12 @@ pub mod maintenance_exclusion_options {
     impl std::convert::From<std::string::String> for Scope {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Scope {
+        fn default() -> Self {
+            scope::NO_UPGRADES
         }
     }
 }
@@ -12444,7 +12582,7 @@ pub mod cluster_autoscaling {
     use super::*;
 
     /// Defines possible options for autoscaling_profile field.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AutoscalingProfile(std::borrow::Cow<'static, str>);
 
     impl AutoscalingProfile {
@@ -12478,6 +12616,12 @@ pub mod cluster_autoscaling {
     impl std::convert::From<std::string::String> for AutoscalingProfile {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AutoscalingProfile {
+        fn default() -> Self {
+            autoscaling_profile::PROFILE_UNSPECIFIED
         }
     }
 }
@@ -12818,7 +12962,7 @@ pub mod node_pool_autoscaling {
 
     /// Location policy specifies how zones are picked when scaling up the
     /// nodepool.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LocationPolicy(std::borrow::Cow<'static, str>);
 
     impl LocationPolicy {
@@ -12852,6 +12996,12 @@ pub mod node_pool_autoscaling {
     impl std::convert::From<std::string::String> for LocationPolicy {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for LocationPolicy {
+        fn default() -> Self {
+            location_policy::LOCATION_POLICY_UNSPECIFIED
         }
     }
 }
@@ -13319,7 +13469,7 @@ pub mod gpu_sharing_config {
     use super::*;
 
     /// The type of GPU sharing strategy currently provided.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct GPUSharingStrategy(std::borrow::Cow<'static, str>);
 
     impl GPUSharingStrategy {
@@ -13352,6 +13502,12 @@ pub mod gpu_sharing_config {
     impl std::convert::From<std::string::String> for GPUSharingStrategy {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for GPUSharingStrategy {
+        fn default() -> Self {
+            gpu_sharing_strategy::GPU_SHARING_STRATEGY_UNSPECIFIED
         }
     }
 }
@@ -13400,7 +13556,7 @@ pub mod gpu_driver_installation_config {
     use super::*;
 
     /// The GPU driver version to install.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct GPUDriverVersion(std::borrow::Cow<'static, str>);
 
     impl GPUDriverVersion {
@@ -13437,6 +13593,12 @@ pub mod gpu_driver_installation_config {
     impl std::convert::From<std::string::String> for GPUDriverVersion {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for GPUDriverVersion {
+        fn default() -> Self {
+            gpu_driver_version::GPU_DRIVER_VERSION_UNSPECIFIED
         }
     }
 }
@@ -13481,7 +13643,7 @@ pub mod workload_metadata_config {
 
     /// Mode is the configuration for how to expose metadata to workloads running
     /// on the node.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Mode(std::borrow::Cow<'static, str>);
 
     impl Mode {
@@ -13517,6 +13679,12 @@ pub mod workload_metadata_config {
     impl std::convert::From<std::string::String> for Mode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Mode {
+        fn default() -> Self {
+            mode::MODE_UNSPECIFIED
         }
     }
 }
@@ -13740,7 +13908,7 @@ pub mod status_condition {
     use super::*;
 
     /// Code for each condition
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Code(std::borrow::Cow<'static, str>);
 
     impl Code {
@@ -13787,6 +13955,12 @@ pub mod status_condition {
     impl std::convert::From<std::string::String> for Code {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Code {
+        fn default() -> Self {
+            code::UNKNOWN
         }
     }
 }
@@ -14089,7 +14263,7 @@ pub mod network_config {
         use super::*;
 
         /// Node network tier
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Tier(std::borrow::Cow<'static, str>);
 
         impl Tier {
@@ -14118,6 +14292,12 @@ pub mod network_config {
         impl std::convert::From<std::string::String> for Tier {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Tier {
+            fn default() -> Self {
+                tier::TIER_UNSPECIFIED
             }
         }
     }
@@ -14161,7 +14341,7 @@ pub mod gateway_api_config {
 
     /// Channel describes if/how Gateway API should be installed and implemented in
     /// a cluster.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Channel(std::borrow::Cow<'static, str>);
 
     impl Channel {
@@ -14197,6 +14377,12 @@ pub mod gateway_api_config {
     impl std::convert::From<std::string::String> for Channel {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Channel {
+        fn default() -> Self {
+            channel::CHANNEL_UNSPECIFIED
         }
     }
 }
@@ -14685,7 +14871,7 @@ pub mod autopilot_compatibility_issue {
     use super::*;
 
     /// The type of the reported issue.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct IssueType(std::borrow::Cow<'static, str>);
 
     impl IssueType {
@@ -14726,6 +14912,12 @@ pub mod autopilot_compatibility_issue {
     impl std::convert::From<std::string::String> for IssueType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for IssueType {
+        fn default() -> Self {
+            issue_type::UNSPECIFIED
         }
     }
 }
@@ -14816,7 +15008,7 @@ pub mod release_channel {
     use super::*;
 
     /// Possible values for 'channel'.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Channel(std::borrow::Cow<'static, str>);
 
     impl Channel {
@@ -14863,6 +15055,12 @@ pub mod release_channel {
     impl std::convert::From<std::string::String> for Channel {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Channel {
+        fn default() -> Self {
+            channel::UNSPECIFIED
         }
     }
 }
@@ -15028,7 +15226,7 @@ pub mod dns_config {
     use super::*;
 
     /// Provider lists the various in-cluster DNS providers.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Provider(std::borrow::Cow<'static, str>);
 
     impl Provider {
@@ -15066,8 +15264,14 @@ pub mod dns_config {
         }
     }
 
+    impl std::default::Default for Provider {
+        fn default() -> Self {
+            provider::PROVIDER_UNSPECIFIED
+        }
+    }
+
     /// DNSScope lists the various scopes of access to cluster DNS records.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DNSScope(std::borrow::Cow<'static, str>);
 
     impl DNSScope {
@@ -15099,6 +15303,12 @@ pub mod dns_config {
     impl std::convert::From<std::string::String> for DNSScope {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DNSScope {
+        fn default() -> Self {
+            dns_scope::DNS_SCOPE_UNSPECIFIED
         }
     }
 }
@@ -15386,7 +15596,7 @@ pub mod database_encryption {
     }
 
     /// State of etcd encryption.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -15422,8 +15632,14 @@ pub mod database_encryption {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::UNKNOWN
+        }
+    }
+
     /// Current State of etcd encryption.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CurrentState(std::borrow::Cow<'static, str>);
 
     impl CurrentState {
@@ -15477,6 +15693,12 @@ pub mod database_encryption {
     impl std::convert::From<std::string::String> for CurrentState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CurrentState {
+        fn default() -> Self {
+            current_state::CURRENT_STATE_UNSPECIFIED
         }
     }
 }
@@ -15669,7 +15891,7 @@ pub mod usable_subnetwork_secondary_range {
     use super::*;
 
     /// Status shows the current usage of a secondary IP range.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Status(std::borrow::Cow<'static, str>);
 
     impl Status {
@@ -15712,6 +15934,12 @@ pub mod usable_subnetwork_secondary_range {
     impl std::convert::From<std::string::String> for Status {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Status {
+        fn default() -> Self {
+            status::UNKNOWN
         }
     }
 }
@@ -16205,7 +16433,7 @@ pub mod notification_config {
 
     /// Types of notifications currently supported. Can be used to filter what
     /// notifications are sent.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EventType(std::borrow::Cow<'static, str>);
 
     impl EventType {
@@ -16240,6 +16468,12 @@ pub mod notification_config {
     impl std::convert::From<std::string::String> for EventType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EventType {
+        fn default() -> Self {
+            event_type::EVENT_TYPE_UNSPECIFIED
         }
     }
 }
@@ -16486,7 +16720,7 @@ pub mod upgrade_info_event {
     use super::*;
 
     /// The state of the upgrade.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -16524,6 +16758,12 @@ pub mod upgrade_info_event {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -16898,7 +17138,7 @@ pub mod logging_component_config {
     use super::*;
 
     /// GKE components exposing logs
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Component(std::borrow::Cow<'static, str>);
 
     impl Component {
@@ -16945,6 +17185,12 @@ pub mod logging_component_config {
     impl std::convert::From<std::string::String> for Component {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Component {
+        fn default() -> Self {
+            component::COMPONENT_UNSPECIFIED
         }
     }
 }
@@ -17105,7 +17351,7 @@ pub mod advanced_datapath_observability_config {
     use super::*;
 
     /// Supported Relay modes
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RelayMode(std::borrow::Cow<'static, str>);
 
     impl RelayMode {
@@ -17140,6 +17386,12 @@ pub mod advanced_datapath_observability_config {
     impl std::convert::From<std::string::String> for RelayMode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RelayMode {
+        fn default() -> Self {
+            relay_mode::RELAY_MODE_UNSPECIFIED
         }
     }
 }
@@ -17244,7 +17496,7 @@ pub mod logging_variant_config {
     use super::*;
 
     /// Logging component variants.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Variant(std::borrow::Cow<'static, str>);
 
     impl Variant {
@@ -17276,6 +17528,12 @@ pub mod logging_variant_config {
     impl std::convert::From<std::string::String> for Variant {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Variant {
+        fn default() -> Self {
+            variant::VARIANT_UNSPECIFIED
         }
     }
 }
@@ -17321,7 +17579,7 @@ pub mod monitoring_component_config {
     use super::*;
 
     /// GKE components exposing metrics
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Component(std::borrow::Cow<'static, str>);
 
     impl Component {
@@ -17386,6 +17644,12 @@ pub mod monitoring_component_config {
     impl std::convert::From<std::string::String> for Component {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Component {
+        fn default() -> Self {
+            component::COMPONENT_UNSPECIFIED
         }
     }
 }
@@ -17899,7 +18163,7 @@ pub mod enterprise_config {
     use super::*;
 
     /// Premium tiers for GKE Cluster.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ClusterTier(std::borrow::Cow<'static, str>);
 
     impl ClusterTier {
@@ -17932,6 +18196,12 @@ pub mod enterprise_config {
     impl std::convert::From<std::string::String> for ClusterTier {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ClusterTier {
+        fn default() -> Self {
+            cluster_tier::CLUSTER_TIER_UNSPECIFIED
         }
     }
 }
@@ -18014,7 +18284,7 @@ pub mod secondary_boot_disk {
 
     /// Mode specifies how the secondary boot disk will be used.
     /// This triggers mode-specified logic in the control plane.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Mode(std::borrow::Cow<'static, str>);
 
     impl Mode {
@@ -18046,6 +18316,12 @@ pub mod secondary_boot_disk {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for Mode {
+        fn default() -> Self {
+            mode::MODE_UNSPECIFIED
+        }
+    }
 }
 
 /// SecondaryBootDiskUpdateStrategy is a placeholder which will be extended
@@ -18070,7 +18346,7 @@ impl wkt::message::Message for SecondaryBootDiskUpdateStrategy {
 
 /// PrivateIPv6GoogleAccess controls whether and how the pods can communicate
 /// with Google Services through gRPC over IPv6.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct PrivateIPv6GoogleAccess(std::borrow::Cow<'static, str>);
 
 impl PrivateIPv6GoogleAccess {
@@ -18112,9 +18388,15 @@ impl std::convert::From<std::string::String> for PrivateIPv6GoogleAccess {
     }
 }
 
+impl std::default::Default for PrivateIPv6GoogleAccess {
+    fn default() -> Self {
+        private_i_pv_6_google_access::PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED
+    }
+}
+
 /// UpgradeResourceType is the resource type that is upgrading. It is used
 /// in upgrade notifications.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct UpgradeResourceType(std::borrow::Cow<'static, str>);
 
 impl UpgradeResourceType {
@@ -18150,9 +18432,15 @@ impl std::convert::From<std::string::String> for UpgradeResourceType {
     }
 }
 
+impl std::default::Default for UpgradeResourceType {
+    fn default() -> Self {
+        upgrade_resource_type::UPGRADE_RESOURCE_TYPE_UNSPECIFIED
+    }
+}
+
 /// The datapath provider selects the implementation of the Kubernetes networking
 /// model for service resolution and network policy enforcement.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DatapathProvider(std::borrow::Cow<'static, str>);
 
 impl DatapathProvider {
@@ -18191,8 +18479,14 @@ impl std::convert::From<std::string::String> for DatapathProvider {
     }
 }
 
+impl std::default::Default for DatapathProvider {
+    fn default() -> Self {
+        datapath_provider::DATAPATH_PROVIDER_UNSPECIFIED
+    }
+}
+
 /// Strategy used for node pool update.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct NodePoolUpdateStrategy(std::borrow::Cow<'static, str>);
 
 impl NodePoolUpdateStrategy {
@@ -18230,8 +18524,14 @@ impl std::convert::From<std::string::String> for NodePoolUpdateStrategy {
     }
 }
 
+impl std::default::Default for NodePoolUpdateStrategy {
+    fn default() -> Self {
+        node_pool_update_strategy::NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED
+    }
+}
+
 /// Possible values for IP stack type
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct StackType(std::borrow::Cow<'static, str>);
 
 impl StackType {
@@ -18266,8 +18566,14 @@ impl std::convert::From<std::string::String> for StackType {
     }
 }
 
+impl std::default::Default for StackType {
+    fn default() -> Self {
+        stack_type::STACK_TYPE_UNSPECIFIED
+    }
+}
+
 /// Possible values for IPv6 access type
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct IPv6AccessType(std::borrow::Cow<'static, str>);
 
 impl IPv6AccessType {
@@ -18303,8 +18609,14 @@ impl std::convert::From<std::string::String> for IPv6AccessType {
     }
 }
 
+impl std::default::Default for IPv6AccessType {
+    fn default() -> Self {
+        i_pv_6_access_type::IPV6_ACCESS_TYPE_UNSPECIFIED
+    }
+}
+
 /// Options for in-transit encryption.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct InTransitEncryptionConfig(std::borrow::Cow<'static, str>);
 
 impl InTransitEncryptionConfig {
@@ -18340,5 +18652,11 @@ pub mod in_transit_encryption_config {
 impl std::convert::From<std::string::String> for InTransitEncryptionConfig {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for InTransitEncryptionConfig {
+    fn default() -> Self {
+        in_transit_encryption_config::IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED
     }
 }

--- a/src/generated/datastore/admin/v1/src/model.rs
+++ b/src/generated/datastore/admin/v1/src/model.rs
@@ -124,7 +124,7 @@ pub mod common_metadata {
     use super::*;
 
     /// The various possible states for an ongoing Operation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -173,6 +173,12 @@ pub mod common_metadata {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1202,7 +1208,7 @@ pub mod index {
 
     /// For an ordered index, specifies whether each of the entity's ancestors
     /// will be included.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AncestorMode(std::borrow::Cow<'static, str>);
 
     impl AncestorMode {
@@ -1238,8 +1244,14 @@ pub mod index {
         }
     }
 
+    impl std::default::Default for AncestorMode {
+        fn default() -> Self {
+            ancestor_mode::ANCESTOR_MODE_UNSPECIFIED
+        }
+    }
+
     /// The direction determines how a property is indexed.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Direction(std::borrow::Cow<'static, str>);
 
     impl Direction {
@@ -1276,8 +1288,14 @@ pub mod index {
         }
     }
 
+    impl std::default::Default for Direction {
+        fn default() -> Self {
+            direction::DIRECTION_UNSPECIFIED
+        }
+    }
+
     /// The possible set of states of an index.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1328,6 +1346,12 @@ pub mod index {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1559,7 +1583,7 @@ pub mod migration_progress_event {
     }
 
     /// Concurrency modes for transactions in Cloud Firestore.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ConcurrencyMode(std::borrow::Cow<'static, str>);
 
     impl ConcurrencyMode {
@@ -1599,6 +1623,12 @@ pub mod migration_progress_event {
         }
     }
 
+    impl std::default::Default for ConcurrencyMode {
+        fn default() -> Self {
+            concurrency_mode::CONCURRENCY_MODE_UNSPECIFIED
+        }
+    }
+
     /// Details about this step.
     #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     #[serde(rename_all = "camelCase")]
@@ -1616,7 +1646,7 @@ pub mod migration_progress_event {
 }
 
 /// Operation types.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct OperationType(std::borrow::Cow<'static, str>);
 
 impl OperationType {
@@ -1658,8 +1688,14 @@ impl std::convert::From<std::string::String> for OperationType {
     }
 }
 
+impl std::default::Default for OperationType {
+    fn default() -> Self {
+        operation_type::OPERATION_TYPE_UNSPECIFIED
+    }
+}
+
 /// States for a migration.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct MigrationState(std::borrow::Cow<'static, str>);
 
 impl MigrationState {
@@ -1698,8 +1734,14 @@ impl std::convert::From<std::string::String> for MigrationState {
     }
 }
 
+impl std::default::Default for MigrationState {
+    fn default() -> Self {
+        migration_state::MIGRATION_STATE_UNSPECIFIED
+    }
+}
+
 /// Steps in a migration.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct MigrationStep(std::borrow::Cow<'static, str>);
 
 impl MigrationStep {
@@ -1751,5 +1793,11 @@ pub mod migration_step {
 impl std::convert::From<std::string::String> for MigrationStep {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for MigrationStep {
+    fn default() -> Self {
+        migration_step::MIGRATION_STEP_UNSPECIFIED
     }
 }

--- a/src/generated/devtools/artifactregistry/v1/src/model.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/model.rs
@@ -125,7 +125,7 @@ pub mod apt_artifact {
     use super::*;
 
     /// Package type is either binary or source.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PackageType(std::borrow::Cow<'static, str>);
 
     impl PackageType {
@@ -158,6 +158,12 @@ pub mod apt_artifact {
     impl std::convert::From<std::string::String> for PackageType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PackageType {
+        fn default() -> Self {
+            package_type::PACKAGE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -1875,7 +1881,7 @@ pub mod hash {
     use super::*;
 
     /// The algorithm used to compute the hash.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct HashType(std::borrow::Cow<'static, str>);
 
     impl HashType {
@@ -1907,6 +1913,12 @@ pub mod hash {
     impl std::convert::From<std::string::String> for HashType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for HashType {
+        fn default() -> Self {
+            hash_type::HASH_TYPE_UNSPECIFIED
         }
     }
 }
@@ -2904,7 +2916,7 @@ pub mod cleanup_policy_condition {
     use super::*;
 
     /// Statuses applying to versions.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TagState(std::borrow::Cow<'static, str>);
 
     impl TagState {
@@ -2939,6 +2951,12 @@ pub mod cleanup_policy_condition {
     impl std::convert::From<std::string::String> for TagState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for TagState {
+        fn default() -> Self {
+            tag_state::TAG_STATE_UNSPECIFIED
         }
     }
 }
@@ -3113,7 +3131,7 @@ pub mod cleanup_policy {
     use super::*;
 
     /// Action type for a cleanup policy.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Action(std::borrow::Cow<'static, str>);
 
     impl Action {
@@ -3145,6 +3163,12 @@ pub mod cleanup_policy {
     impl std::convert::From<std::string::String> for Action {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Action {
+        fn default() -> Self {
+            action::ACTION_UNSPECIFIED
         }
     }
 
@@ -3795,7 +3819,7 @@ pub mod remote_repository_config {
 
         /// Predefined list of publicly available Docker repositories like Docker
         /// Hub.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct PublicRepository(std::borrow::Cow<'static, str>);
 
         impl PublicRepository {
@@ -3825,6 +3849,12 @@ pub mod remote_repository_config {
         impl std::convert::From<std::string::String> for PublicRepository {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for PublicRepository {
+            fn default() -> Self {
+                public_repository::PUBLIC_REPOSITORY_UNSPECIFIED
             }
         }
 
@@ -3999,7 +4029,7 @@ pub mod remote_repository_config {
 
         /// Predefined list of publicly available Maven repositories like Maven
         /// Central.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct PublicRepository(std::borrow::Cow<'static, str>);
 
         impl PublicRepository {
@@ -4029,6 +4059,12 @@ pub mod remote_repository_config {
         impl std::convert::From<std::string::String> for PublicRepository {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for PublicRepository {
+            fn default() -> Self {
+                public_repository::PUBLIC_REPOSITORY_UNSPECIFIED
             }
         }
 
@@ -4202,7 +4238,7 @@ pub mod remote_repository_config {
         }
 
         /// Predefined list of publicly available NPM repositories like npmjs.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct PublicRepository(std::borrow::Cow<'static, str>);
 
         impl PublicRepository {
@@ -4232,6 +4268,12 @@ pub mod remote_repository_config {
         impl std::convert::From<std::string::String> for PublicRepository {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for PublicRepository {
+            fn default() -> Self {
+                public_repository::PUBLIC_REPOSITORY_UNSPECIFIED
             }
         }
 
@@ -4406,7 +4448,7 @@ pub mod remote_repository_config {
         }
 
         /// Predefined list of publicly available Python repositories like PyPI.org.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct PublicRepository(std::borrow::Cow<'static, str>);
 
         impl PublicRepository {
@@ -4436,6 +4478,12 @@ pub mod remote_repository_config {
         impl std::convert::From<std::string::String> for PublicRepository {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for PublicRepository {
+            fn default() -> Self {
+                public_repository::PUBLIC_REPOSITORY_UNSPECIFIED
             }
         }
 
@@ -4631,7 +4679,7 @@ pub mod remote_repository_config {
             use super::*;
 
             /// Predefined list of publicly available repository bases for Apt.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct RepositoryBase(std::borrow::Cow<'static, str>);
 
             impl RepositoryBase {
@@ -4667,6 +4715,12 @@ pub mod remote_repository_config {
             impl std::convert::From<std::string::String> for RepositoryBase {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for RepositoryBase {
+                fn default() -> Self {
+                    repository_base::REPOSITORY_BASE_UNSPECIFIED
                 }
             }
         }
@@ -4895,7 +4949,7 @@ pub mod remote_repository_config {
             use super::*;
 
             /// Predefined list of publicly available repository bases for Yum.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct RepositoryBase(std::borrow::Cow<'static, str>);
 
             impl RepositoryBase {
@@ -4940,6 +4994,12 @@ pub mod remote_repository_config {
             impl std::convert::From<std::string::String> for RepositoryBase {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for RepositoryBase {
+                fn default() -> Self {
+                    repository_base::REPOSITORY_BASE_UNSPECIFIED
                 }
             }
         }
@@ -5472,7 +5532,7 @@ pub mod repository {
         use super::*;
 
         /// VersionPolicy is the version policy for the repository.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct VersionPolicy(std::borrow::Cow<'static, str>);
 
         impl VersionPolicy {
@@ -5507,6 +5567,12 @@ pub mod repository {
         impl std::convert::From<std::string::String> for VersionPolicy {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for VersionPolicy {
+            fn default() -> Self {
+                version_policy::VERSION_POLICY_UNSPECIFIED
             }
         }
     }
@@ -5631,7 +5697,7 @@ pub mod repository {
         use super::*;
 
         /// Config for vulnerability scanning of resources in this repository.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct EnablementConfig(std::borrow::Cow<'static, str>);
 
         impl EnablementConfig {
@@ -5668,9 +5734,15 @@ pub mod repository {
             }
         }
 
+        impl std::default::Default for EnablementConfig {
+            fn default() -> Self {
+                enablement_config::ENABLEMENT_CONFIG_UNSPECIFIED
+            }
+        }
+
         /// Describes the state of vulnerability scanning in this repository,
         /// including both repository enablement and API enablement.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct EnablementState(std::borrow::Cow<'static, str>);
 
         impl EnablementState {
@@ -5710,10 +5782,16 @@ pub mod repository {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for EnablementState {
+            fn default() -> Self {
+                enablement_state::ENABLEMENT_STATE_UNSPECIFIED
+            }
+        }
     }
 
     /// A package format.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Format(std::borrow::Cow<'static, str>);
 
     impl Format {
@@ -5769,9 +5847,15 @@ pub mod repository {
         }
     }
 
+    impl std::default::Default for Format {
+        fn default() -> Self {
+            format::FORMAT_UNSPECIFIED
+        }
+    }
+
     /// The mode configures the repository to serve artifacts from different
     /// sources.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Mode(std::borrow::Cow<'static, str>);
 
     impl Mode {
@@ -5806,6 +5890,12 @@ pub mod repository {
     impl std::convert::From<std::string::String> for Mode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Mode {
+        fn default() -> Self {
+            mode::MODE_UNSPECIFIED
         }
     }
 
@@ -6221,7 +6311,7 @@ pub mod rule {
     use super::*;
 
     /// Defines the action of the rule.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Action(std::borrow::Cow<'static, str>);
 
     impl Action {
@@ -6256,8 +6346,14 @@ pub mod rule {
         }
     }
 
+    impl std::default::Default for Action {
+        fn default() -> Self {
+            action::ACTION_UNSPECIFIED
+        }
+    }
+
     /// The operation the rule applies to.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Operation(std::borrow::Cow<'static, str>);
 
     impl Operation {
@@ -6286,6 +6382,12 @@ pub mod rule {
     impl std::convert::From<std::string::String> for Operation {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Operation {
+        fn default() -> Self {
+            operation::OPERATION_UNSPECIFIED
         }
     }
 }
@@ -6639,7 +6741,7 @@ pub mod project_settings {
     use super::*;
 
     /// The possible redirection states for legacy repositories.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RedirectionState(std::borrow::Cow<'static, str>);
 
     impl RedirectionState {
@@ -6686,6 +6788,12 @@ pub mod project_settings {
     impl std::convert::From<std::string::String> for RedirectionState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RedirectionState {
+        fn default() -> Self {
+            redirection_state::REDIRECTION_STATE_UNSPECIFIED
         }
     }
 }
@@ -7681,7 +7789,7 @@ pub mod vpcsc_config {
     use super::*;
 
     /// VPCSCPolicy is the VPC SC policy for project and location.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct VPCSCPolicy(std::borrow::Cow<'static, str>);
 
     impl VPCSCPolicy {
@@ -7718,6 +7826,12 @@ pub mod vpcsc_config {
     impl std::convert::From<std::string::String> for VPCSCPolicy {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for VPCSCPolicy {
+        fn default() -> Self {
+            vpcsc_policy::VPCSC_POLICY_UNSPECIFIED
         }
     }
 }
@@ -7865,7 +7979,7 @@ pub mod yum_artifact {
     use super::*;
 
     /// Package type is either binary or source.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PackageType(std::borrow::Cow<'static, str>);
 
     impl PackageType {
@@ -7898,6 +8012,12 @@ pub mod yum_artifact {
     impl std::convert::From<std::string::String> for PackageType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PackageType {
+        fn default() -> Self {
+            package_type::PACKAGE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -8202,7 +8322,7 @@ impl wkt::message::Message for ImportYumArtifactsMetadata {
 
 /// The view, which determines what version information is returned in a
 /// response.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct VersionView(std::borrow::Cow<'static, str>);
 
 impl VersionView {
@@ -8235,5 +8355,11 @@ pub mod version_view {
 impl std::convert::From<std::string::String> for VersionView {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for VersionView {
+    fn default() -> Self {
+        version_view::VERSION_VIEW_UNSPECIFIED
     }
 }

--- a/src/generated/devtools/cloudbuild/v1/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/model.rs
@@ -221,7 +221,7 @@ pub mod storage_source {
     use super::*;
 
     /// Specifies the tool to fetch the source file for the build.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SourceFetcher(std::borrow::Cow<'static, str>);
 
     impl SourceFetcher {
@@ -254,6 +254,12 @@ pub mod storage_source {
     impl std::convert::From<std::string::String> for SourceFetcher {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SourceFetcher {
+        fn default() -> Self {
+            source_fetcher::SOURCE_FETCHER_UNSPECIFIED
         }
     }
 }
@@ -2111,7 +2117,7 @@ pub mod build {
         use super::*;
 
         /// The relative importance of this warning.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Priority(std::borrow::Cow<'static, str>);
 
         impl Priority {
@@ -2146,6 +2152,12 @@ pub mod build {
         impl std::convert::From<std::string::String> for Priority {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Priority {
+            fn default() -> Self {
+                priority::PRIORITY_UNSPECIFIED
             }
         }
     }
@@ -2199,7 +2211,7 @@ pub mod build {
 
         /// The name of a fatal problem encountered during the execution of the
         /// build.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct FailureType(std::borrow::Cow<'static, str>);
 
         impl FailureType {
@@ -2246,10 +2258,16 @@ pub mod build {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for FailureType {
+            fn default() -> Self {
+                failure_type::FAILURE_TYPE_UNSPECIFIED
+            }
+        }
     }
 
     /// Possible status of a build or build step.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Status(std::borrow::Cow<'static, str>);
 
     impl Status {
@@ -2303,6 +2321,12 @@ pub mod build {
     impl std::convert::From<std::string::String> for Status {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Status {
+        fn default() -> Self {
+            status::STATUS_UNKNOWN
         }
     }
 }
@@ -3425,7 +3449,7 @@ pub mod hash {
     use super::*;
 
     /// Specifies the hash algorithm, if any.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct HashType(std::borrow::Cow<'static, str>);
 
     impl HashType {
@@ -3463,6 +3487,12 @@ pub mod hash {
     impl std::convert::From<std::string::String> for HashType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for HashType {
+        fn default() -> Self {
+            hash_type::NONE
         }
     }
 }
@@ -4064,7 +4094,7 @@ pub mod build_approval {
     use super::*;
 
     /// Specifies the current state of a build's approval.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -4102,6 +4132,12 @@ pub mod build_approval {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -4225,7 +4261,7 @@ pub mod approval_result {
 
     /// Specifies whether or not this manual approval result is to approve
     /// or reject a build.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Decision(std::borrow::Cow<'static, str>);
 
     impl Decision {
@@ -4257,6 +4293,12 @@ pub mod approval_result {
     impl std::convert::From<std::string::String> for Decision {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Decision {
+        fn default() -> Self {
+            decision::DECISION_UNSPECIFIED
         }
     }
 }
@@ -4582,7 +4624,7 @@ pub mod git_file_source {
 
     /// The type of the repo, since it may not be explicit from the `repo` field
     /// (e.g from a URL).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RepoType(std::borrow::Cow<'static, str>);
 
     impl RepoType {
@@ -4622,6 +4664,12 @@ pub mod git_file_source {
     impl std::convert::From<std::string::String> for RepoType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RepoType {
+        fn default() -> Self {
+            repo_type::UNKNOWN
         }
     }
 
@@ -5224,7 +5272,7 @@ pub mod repository_event_config {
     use super::*;
 
     /// All possible SCM repo types from Repo API.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RepositoryType(std::borrow::Cow<'static, str>);
 
     impl RepositoryType {
@@ -5260,6 +5308,12 @@ pub mod repository_event_config {
     impl std::convert::From<std::string::String> for RepositoryType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RepositoryType {
+        fn default() -> Self {
+            repository_type::REPOSITORY_TYPE_UNSPECIFIED
         }
     }
 
@@ -5494,7 +5548,7 @@ pub mod pubsub_config {
 
     /// Enumerates potential issues with the underlying Pub/Sub subscription
     /// configuration.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -5532,6 +5586,12 @@ pub mod pubsub_config {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -5613,7 +5673,7 @@ pub mod webhook_config {
 
     /// Enumerates potential issues with the Secret Manager secret provided by the
     /// user.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -5645,6 +5705,12 @@ pub mod webhook_config {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -5760,7 +5826,7 @@ pub mod pull_request_filter {
     /// [Bitbucket](https://cloud.google.com/build/docs/automating-builds/bitbucket/build-repos-from-bitbucket-server#creating_a_bitbucket_server_trigger),
     /// [GitLab](https://cloud.google.com/build/docs/automating-builds/gitlab/build-repos-from-gitlab#creating_a_gitlab_trigger)
     /// for details.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CommentControl(std::borrow::Cow<'static, str>);
 
     impl CommentControl {
@@ -5805,6 +5871,12 @@ pub mod pull_request_filter {
     impl std::convert::From<std::string::String> for CommentControl {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CommentControl {
+        fn default() -> Self {
+            comment_control::COMMENTS_DISABLED
         }
     }
 
@@ -6581,7 +6653,7 @@ pub mod build_options {
     ///
     /// For more information, see [Viewing Build
     /// Provenance](https://cloud.google.com/build/docs/securing-builds/view-build-provenance).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct VerifyOption(std::borrow::Cow<'static, str>);
 
     impl VerifyOption {
@@ -6613,10 +6685,16 @@ pub mod build_options {
         }
     }
 
+    impl std::default::Default for VerifyOption {
+        fn default() -> Self {
+            verify_option::NOT_VERIFIED
+        }
+    }
+
     /// Supported Compute Engine machine types.
     /// For more information, see [Machine
     /// types](https://cloud.google.com/compute/docs/machine-types).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MachineType(std::borrow::Cow<'static, str>);
 
     impl MachineType {
@@ -6660,8 +6738,14 @@ pub mod build_options {
         }
     }
 
+    impl std::default::Default for MachineType {
+        fn default() -> Self {
+            machine_type::UNSPECIFIED
+        }
+    }
+
     /// Specifies the behavior when there is an error in the substitution checks.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SubstitutionOption(std::borrow::Cow<'static, str>);
 
     impl SubstitutionOption {
@@ -6694,8 +6778,14 @@ pub mod build_options {
         }
     }
 
+    impl std::default::Default for SubstitutionOption {
+        fn default() -> Self {
+            substitution_option::MUST_MATCH
+        }
+    }
+
     /// Specifies the behavior when writing build logs to Cloud Storage.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LogStreamingOption(std::borrow::Cow<'static, str>);
 
     impl LogStreamingOption {
@@ -6731,8 +6821,14 @@ pub mod build_options {
         }
     }
 
+    impl std::default::Default for LogStreamingOption {
+        fn default() -> Self {
+            log_streaming_option::STREAM_DEFAULT
+        }
+    }
+
     /// Specifies the logging mode.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LoggingMode(std::borrow::Cow<'static, str>);
 
     impl LoggingMode {
@@ -6779,8 +6875,14 @@ pub mod build_options {
         }
     }
 
+    impl std::default::Default for LoggingMode {
+        fn default() -> Self {
+            logging_mode::LOGGING_UNSPECIFIED
+        }
+    }
+
     /// Default Cloud Storage log bucket behavior options.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DefaultLogsBucketBehavior(std::borrow::Cow<'static, str>);
 
     impl DefaultLogsBucketBehavior {
@@ -6817,6 +6919,12 @@ pub mod build_options {
     impl std::convert::From<std::string::String> for DefaultLogsBucketBehavior {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DefaultLogsBucketBehavior {
+        fn default() -> Self {
+            default_logs_bucket_behavior::DEFAULT_LOGS_BUCKET_BEHAVIOR_UNSPECIFIED
         }
     }
 }
@@ -7321,7 +7429,7 @@ pub mod worker_pool {
     use super::*;
 
     /// State of the `WorkerPool`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -7362,6 +7470,12 @@ pub mod worker_pool {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -7580,7 +7694,7 @@ pub mod private_pool_v_1_config {
         use super::*;
 
         /// Defines the egress option for the pool.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct EgressOption(std::borrow::Cow<'static, str>);
 
         impl EgressOption {
@@ -7615,6 +7729,12 @@ pub mod private_pool_v_1_config {
         impl std::convert::From<std::string::String> for EgressOption {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for EgressOption {
+            fn default() -> Self {
+                egress_option::EGRESS_OPTION_UNSPECIFIED
             }
         }
     }

--- a/src/generated/devtools/cloudbuild/v2/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/model.rs
@@ -610,7 +610,7 @@ pub mod installation_state {
     use super::*;
 
     /// Stage of the installation process.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Stage(std::borrow::Cow<'static, str>);
 
     impl Stage {
@@ -649,6 +649,12 @@ pub mod installation_state {
     impl std::convert::From<std::string::String> for Stage {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Stage {
+        fn default() -> Self {
+            stage::STAGE_UNSPECIFIED
         }
     }
 }
@@ -2374,7 +2380,7 @@ pub mod fetch_git_refs_request {
     use super::*;
 
     /// Type of refs
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RefType(std::borrow::Cow<'static, str>);
 
     impl RefType {
@@ -2406,6 +2412,12 @@ pub mod fetch_git_refs_request {
     impl std::convert::From<std::string::String> for RefType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RefType {
+        fn default() -> Self {
+            ref_type::REF_TYPE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/devtools/cloudprofiler/v2/src/model.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/model.rs
@@ -500,7 +500,7 @@ impl gax::paginator::PageableResponse for ListProfilesResponse {
 /// ProfileType is type of profiling data.
 /// NOTE: the enumeration member names are used (in lowercase) as unique string
 /// identifiers of profile types, so they must not be renamed.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ProfileType(std::borrow::Cow<'static, str>);
 
 impl ProfileType {
@@ -553,5 +553,11 @@ pub mod profile_type {
 impl std::convert::From<std::string::String> for ProfileType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for ProfileType {
+    fn default() -> Self {
+        profile_type::PROFILE_TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/devtools/cloudtrace/v2/src/model.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/model.rs
@@ -570,7 +570,7 @@ pub mod span {
             use super::*;
 
             /// Indicates whether the message was sent or received.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct Type(std::borrow::Cow<'static, str>);
 
             impl Type {
@@ -602,6 +602,12 @@ pub mod span {
             impl std::convert::From<std::string::String> for Type {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for Type {
+                fn default() -> Self {
+                    r#type::TYPE_UNSPECIFIED
                 }
             }
         }
@@ -756,7 +762,7 @@ pub mod span {
 
         /// The relationship of the current span relative to the linked span: child,
         /// parent, or unspecified.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Type(std::borrow::Cow<'static, str>);
 
         impl Type {
@@ -788,6 +794,12 @@ pub mod span {
         impl std::convert::From<std::string::String> for Type {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Type {
+            fn default() -> Self {
+                r#type::TYPE_UNSPECIFIED
             }
         }
     }
@@ -839,7 +851,7 @@ pub mod span {
 
     /// Type of span. Can be used to specify additional relationships between spans
     /// in addition to a parent/child relationship.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SpanKind(std::borrow::Cow<'static, str>);
 
     impl SpanKind {
@@ -889,6 +901,12 @@ pub mod span {
     impl std::convert::From<std::string::String> for SpanKind {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SpanKind {
+        fn default() -> Self {
+            span_kind::SPAN_KIND_UNSPECIFIED
         }
     }
 }

--- a/src/generated/firestore/admin/v1/src/model.rs
+++ b/src/generated/firestore/admin/v1/src/model.rs
@@ -197,7 +197,7 @@ pub mod backup {
     }
 
     /// Indicate the current state of the backup.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -233,6 +233,12 @@ pub mod backup {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -983,7 +989,7 @@ pub mod database {
     /// information about how to choose.
     ///
     /// Mode changes are only allowed if the database is empty.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DatabaseType(std::borrow::Cow<'static, str>);
 
     impl DatabaseType {
@@ -1019,8 +1025,14 @@ pub mod database {
         }
     }
 
+    impl std::default::Default for DatabaseType {
+        fn default() -> Self {
+            database_type::DATABASE_TYPE_UNSPECIFIED
+        }
+    }
+
     /// The type of concurrency control mode for transactions.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ConcurrencyMode(std::borrow::Cow<'static, str>);
 
     impl ConcurrencyMode {
@@ -1069,8 +1081,14 @@ pub mod database {
         }
     }
 
+    impl std::default::Default for ConcurrencyMode {
+        fn default() -> Self {
+            concurrency_mode::CONCURRENCY_MODE_UNSPECIFIED
+        }
+    }
+
     /// Point In Time Recovery feature enablement.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PointInTimeRecoveryEnablement(std::borrow::Cow<'static, str>);
 
     impl PointInTimeRecoveryEnablement {
@@ -1116,8 +1134,14 @@ pub mod database {
         }
     }
 
+    impl std::default::Default for PointInTimeRecoveryEnablement {
+        fn default() -> Self {
+            point_in_time_recovery_enablement::POINT_IN_TIME_RECOVERY_ENABLEMENT_UNSPECIFIED
+        }
+    }
+
     /// The type of App Engine integration mode.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AppEngineIntegrationMode(std::borrow::Cow<'static, str>);
 
     impl AppEngineIntegrationMode {
@@ -1159,8 +1183,14 @@ pub mod database {
         }
     }
 
+    impl std::default::Default for AppEngineIntegrationMode {
+        fn default() -> Self {
+            app_engine_integration_mode::APP_ENGINE_INTEGRATION_MODE_UNSPECIFIED
+        }
+    }
+
     /// The delete protection state of the database.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DeleteProtectionState(std::borrow::Cow<'static, str>);
 
     impl DeleteProtectionState {
@@ -1195,6 +1225,12 @@ pub mod database {
     impl std::convert::From<std::string::String> for DeleteProtectionState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DeleteProtectionState {
+        fn default() -> Self {
+            delete_protection_state::DELETE_PROTECTION_STATE_UNSPECIFIED
         }
     }
 }
@@ -1412,7 +1448,7 @@ pub mod field {
         use super::*;
 
         /// The state of applying the TTL configuration to all documents.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct State(std::borrow::Cow<'static, str>);
 
         impl State {
@@ -1454,6 +1490,12 @@ pub mod field {
         impl std::convert::From<std::string::String> for State {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for State {
+            fn default() -> Self {
+                state::STATE_UNSPECIFIED
             }
         }
     }
@@ -3439,7 +3481,7 @@ pub mod index {
         }
 
         /// The supported orderings.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Order(std::borrow::Cow<'static, str>);
 
         impl Order {
@@ -3474,8 +3516,14 @@ pub mod index {
             }
         }
 
+        impl std::default::Default for Order {
+            fn default() -> Self {
+                order::ORDER_UNSPECIFIED
+            }
+        }
+
         /// The supported array value configurations.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct ArrayConfig(std::borrow::Cow<'static, str>);
 
         impl ArrayConfig {
@@ -3508,6 +3556,12 @@ pub mod index {
             }
         }
 
+        impl std::default::Default for ArrayConfig {
+            fn default() -> Self {
+                array_config::ARRAY_CONFIG_UNSPECIFIED
+            }
+        }
+
         /// How the field value is indexed.
         #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         #[serde(rename_all = "camelCase")]
@@ -3526,7 +3580,7 @@ pub mod index {
 
     /// Query Scope defines the scope at which a query is run. This is specified on
     /// a StructuredQuery's `from` field.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct QueryScope(std::borrow::Cow<'static, str>);
 
     impl QueryScope {
@@ -3569,9 +3623,15 @@ pub mod index {
         }
     }
 
+    impl std::default::Default for QueryScope {
+        fn default() -> Self {
+            query_scope::QUERY_SCOPE_UNSPECIFIED
+        }
+    }
+
     /// API Scope defines the APIs (Firestore Native, or Firestore in
     /// Datastore Mode) that are supported for queries.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ApiScope(std::borrow::Cow<'static, str>);
 
     impl ApiScope {
@@ -3604,11 +3664,17 @@ pub mod index {
         }
     }
 
+    impl std::default::Default for ApiScope {
+        fn default() -> Self {
+            api_scope::ANY_API
+        }
+    }
+
     /// The state of an index. During index creation, an index will be in the
     /// `CREATING` state. If the index is created successfully, it will transition
     /// to the `READY` state. If the index creation encounters a problem, the index
     /// will transition to the `NEEDS_REPAIR` state.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3655,6 +3721,12 @@ pub mod index {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -3980,7 +4052,7 @@ pub mod field_operation_metadata {
         use super::*;
 
         /// Specifies how the index is changing.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct ChangeType(std::borrow::Cow<'static, str>);
 
         impl ChangeType {
@@ -4013,6 +4085,12 @@ pub mod field_operation_metadata {
         impl std::convert::From<std::string::String> for ChangeType {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for ChangeType {
+            fn default() -> Self {
+                change_type::CHANGE_TYPE_UNSPECIFIED
             }
         }
     }
@@ -4058,7 +4136,7 @@ pub mod field_operation_metadata {
         use super::*;
 
         /// Specifies how the TTL config is changing.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct ChangeType(std::borrow::Cow<'static, str>);
 
         impl ChangeType {
@@ -4091,6 +4169,12 @@ pub mod field_operation_metadata {
         impl std::convert::From<std::string::String> for ChangeType {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for ChangeType {
+            fn default() -> Self {
+                change_type::CHANGE_TYPE_UNSPECIFIED
             }
         }
     }
@@ -4932,7 +5016,7 @@ impl wkt::message::Message for WeeklyRecurrence {
 }
 
 /// Describes the state of the operation.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct OperationState(std::borrow::Cow<'static, str>);
 
 impl OperationState {
@@ -4982,5 +5066,11 @@ pub mod operation_state {
 impl std::convert::From<std::string::String> for OperationState {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for OperationState {
+    fn default() -> Self {
+        operation_state::OPERATION_STATE_UNSPECIFIED
     }
 }

--- a/src/generated/grafeas/v1/src/model.rs
+++ b/src/generated/grafeas/v1/src/model.rs
@@ -1227,7 +1227,7 @@ pub mod cvs_sv_3 {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AttackVector(std::borrow::Cow<'static, str>);
 
     impl AttackVector {
@@ -1266,7 +1266,13 @@ pub mod cvs_sv_3 {
         }
     }
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    impl std::default::Default for AttackVector {
+        fn default() -> Self {
+            attack_vector::ATTACK_VECTOR_UNSPECIFIED
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AttackComplexity(std::borrow::Cow<'static, str>);
 
     impl AttackComplexity {
@@ -1301,7 +1307,13 @@ pub mod cvs_sv_3 {
         }
     }
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    impl std::default::Default for AttackComplexity {
+        fn default() -> Self {
+            attack_complexity::ATTACK_COMPLEXITY_UNSPECIFIED
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PrivilegesRequired(std::borrow::Cow<'static, str>);
 
     impl PrivilegesRequired {
@@ -1339,7 +1351,13 @@ pub mod cvs_sv_3 {
         }
     }
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    impl std::default::Default for PrivilegesRequired {
+        fn default() -> Self {
+            privileges_required::PRIVILEGES_REQUIRED_UNSPECIFIED
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct UserInteraction(std::borrow::Cow<'static, str>);
 
     impl UserInteraction {
@@ -1374,7 +1392,13 @@ pub mod cvs_sv_3 {
         }
     }
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    impl std::default::Default for UserInteraction {
+        fn default() -> Self {
+            user_interaction::USER_INTERACTION_UNSPECIFIED
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Scope(std::borrow::Cow<'static, str>);
 
     impl Scope {
@@ -1406,7 +1430,13 @@ pub mod cvs_sv_3 {
         }
     }
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    impl std::default::Default for Scope {
+        fn default() -> Self {
+            scope::SCOPE_UNSPECIFIED
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Impact(std::borrow::Cow<'static, str>);
 
     impl Impact {
@@ -1437,6 +1467,12 @@ pub mod cvs_sv_3 {
     impl std::convert::From<std::string::String> for Impact {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Impact {
+        fn default() -> Self {
+            impact::IMPACT_UNSPECIFIED
         }
     }
 }
@@ -1594,7 +1630,7 @@ pub mod cvss {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AttackVector(std::borrow::Cow<'static, str>);
 
     impl AttackVector {
@@ -1633,7 +1669,13 @@ pub mod cvss {
         }
     }
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    impl std::default::Default for AttackVector {
+        fn default() -> Self {
+            attack_vector::ATTACK_VECTOR_UNSPECIFIED
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AttackComplexity(std::borrow::Cow<'static, str>);
 
     impl AttackComplexity {
@@ -1671,7 +1713,13 @@ pub mod cvss {
         }
     }
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    impl std::default::Default for AttackComplexity {
+        fn default() -> Self {
+            attack_complexity::ATTACK_COMPLEXITY_UNSPECIFIED
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Authentication(std::borrow::Cow<'static, str>);
 
     impl Authentication {
@@ -1708,7 +1756,13 @@ pub mod cvss {
         }
     }
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    impl std::default::Default for Authentication {
+        fn default() -> Self {
+            authentication::AUTHENTICATION_UNSPECIFIED
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PrivilegesRequired(std::borrow::Cow<'static, str>);
 
     impl PrivilegesRequired {
@@ -1746,7 +1800,13 @@ pub mod cvss {
         }
     }
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    impl std::default::Default for PrivilegesRequired {
+        fn default() -> Self {
+            privileges_required::PRIVILEGES_REQUIRED_UNSPECIFIED
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct UserInteraction(std::borrow::Cow<'static, str>);
 
     impl UserInteraction {
@@ -1781,7 +1841,13 @@ pub mod cvss {
         }
     }
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    impl std::default::Default for UserInteraction {
+        fn default() -> Self {
+            user_interaction::USER_INTERACTION_UNSPECIFIED
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Scope(std::borrow::Cow<'static, str>);
 
     impl Scope {
@@ -1813,7 +1879,13 @@ pub mod cvss {
         }
     }
 
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    impl std::default::Default for Scope {
+        fn default() -> Self {
+            scope::SCOPE_UNSPECIFIED
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Impact(std::borrow::Cow<'static, str>);
 
     impl Impact {
@@ -1848,6 +1920,12 @@ pub mod cvss {
     impl std::convert::From<std::string::String> for Impact {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Impact {
+        fn default() -> Self {
+            impact::IMPACT_UNSPECIFIED
         }
     }
 }
@@ -1995,7 +2073,7 @@ pub mod deployment_occurrence {
     use super::*;
 
     /// Types of platforms.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Platform(std::borrow::Cow<'static, str>);
 
     impl Platform {
@@ -2030,6 +2108,12 @@ pub mod deployment_occurrence {
     impl std::convert::From<std::string::String> for Platform {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Platform {
+        fn default() -> Self {
+            platform::PLATFORM_UNSPECIFIED
         }
     }
 }
@@ -2323,7 +2407,7 @@ pub mod discovery_occurrence {
         use super::*;
 
         /// An enum indicating the progress of the SBOM generation.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct SBOMState(std::borrow::Cow<'static, str>);
 
         impl SBOMState {
@@ -2355,6 +2439,12 @@ pub mod discovery_occurrence {
         impl std::convert::From<std::string::String> for SBOMState {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for SBOMState {
+            fn default() -> Self {
+                sbom_state::SBOM_STATE_UNSPECIFIED
             }
         }
     }
@@ -2417,7 +2507,7 @@ pub mod discovery_occurrence {
         use super::*;
 
         /// An enum indicating the state of the attestation generation.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct VulnerabilityAttestationState(std::borrow::Cow<'static, str>);
 
         impl VulnerabilityAttestationState {
@@ -2454,10 +2544,16 @@ pub mod discovery_occurrence {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for VulnerabilityAttestationState {
+            fn default() -> Self {
+                vulnerability_attestation_state::VULNERABILITY_ATTESTATION_STATE_UNSPECIFIED
+            }
+        }
     }
 
     /// Whether the resource is continuously analyzed.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ContinuousAnalysis(std::borrow::Cow<'static, str>);
 
     impl ContinuousAnalysis {
@@ -2493,9 +2589,15 @@ pub mod discovery_occurrence {
         }
     }
 
+    impl std::default::Default for ContinuousAnalysis {
+        fn default() -> Self {
+            continuous_analysis::CONTINUOUS_ANALYSIS_UNSPECIFIED
+        }
+    }
+
     /// Analysis status for a resource. Currently for initial analysis only (not
     /// updated in continuous analysis).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AnalysisStatus(std::borrow::Cow<'static, str>);
 
     impl AnalysisStatus {
@@ -2542,6 +2644,12 @@ pub mod discovery_occurrence {
     impl std::convert::From<std::string::String> for AnalysisStatus {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for AnalysisStatus {
+        fn default() -> Self {
+            analysis_status::ANALYSIS_STATUS_UNSPECIFIED
         }
     }
 }
@@ -6325,7 +6433,7 @@ pub mod version {
     use super::*;
 
     /// Whether this is an ordinary package version or a sentinel MIN/MAX version.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct VersionKind(std::borrow::Cow<'static, str>);
 
     impl VersionKind {
@@ -6361,6 +6469,12 @@ pub mod version {
     impl std::convert::From<std::string::String> for VersionKind {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for VersionKind {
+        fn default() -> Self {
+            version_kind::VERSION_KIND_UNSPECIFIED
         }
     }
 }
@@ -7066,7 +7180,7 @@ pub mod alias_context {
     use super::*;
 
     /// The type of an alias.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Kind(std::borrow::Cow<'static, str>);
 
     impl Kind {
@@ -7102,6 +7216,12 @@ pub mod alias_context {
     impl std::convert::From<std::string::String> for Kind {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Kind {
+        fn default() -> Self {
+            kind::KIND_UNSPECIFIED
         }
     }
 }
@@ -9513,7 +9633,7 @@ pub mod vulnerability_assessment_note {
             use super::*;
 
             /// Provides the type of justification.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct JustificationType(std::borrow::Cow<'static, str>);
 
             impl JustificationType {
@@ -9569,6 +9689,12 @@ pub mod vulnerability_assessment_note {
             impl std::convert::From<std::string::String> for JustificationType {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for JustificationType {
+                fn default() -> Self {
+                    justification_type::JUSTIFICATION_TYPE_UNSPECIFIED
                 }
             }
         }
@@ -9633,7 +9759,7 @@ pub mod vulnerability_assessment_note {
             use super::*;
 
             /// The type of remediation that can be applied.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct RemediationType(std::borrow::Cow<'static, str>);
 
             impl RemediationType {
@@ -9677,10 +9803,16 @@ pub mod vulnerability_assessment_note {
                     Self(std::borrow::Cow::Owned(value))
                 }
             }
+
+            impl std::default::Default for RemediationType {
+                fn default() -> Self {
+                    remediation_type::REMEDIATION_TYPE_UNSPECIFIED
+                }
+            }
         }
 
         /// Provides the state of this Vulnerability assessment.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct State(std::borrow::Cow<'static, str>);
 
         impl State {
@@ -9719,6 +9851,12 @@ pub mod vulnerability_assessment_note {
         impl std::convert::From<std::string::String> for State {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for State {
+            fn default() -> Self {
+                state::STATE_UNSPECIFIED
             }
         }
     }
@@ -10702,7 +10840,7 @@ pub mod vulnerability_occurrence {
 }
 
 /// Kind represents the kinds of notes supported.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct NoteKind(std::borrow::Cow<'static, str>);
 
 impl NoteKind {
@@ -10767,8 +10905,14 @@ impl std::convert::From<std::string::String> for NoteKind {
     }
 }
 
+impl std::default::Default for NoteKind {
+    fn default() -> Self {
+        note_kind::NOTE_KIND_UNSPECIFIED
+    }
+}
+
 /// CVSS Version.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct CVSSVersion(std::borrow::Cow<'static, str>);
 
 impl CVSSVersion {
@@ -10800,8 +10944,14 @@ impl std::convert::From<std::string::String> for CVSSVersion {
     }
 }
 
+impl std::default::Default for CVSSVersion {
+    fn default() -> Self {
+        cvss_version::CVSS_VERSION_UNSPECIFIED
+    }
+}
+
 /// Instruction set architectures supported by various package managers.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Architecture(std::borrow::Cow<'static, str>);
 
 impl Architecture {
@@ -10837,8 +10987,14 @@ impl std::convert::From<std::string::String> for Architecture {
     }
 }
 
+impl std::default::Default for Architecture {
+    fn default() -> Self {
+        architecture::ARCHITECTURE_UNSPECIFIED
+    }
+}
+
 /// Note provider assigned severity/impact ranking.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Severity(std::borrow::Cow<'static, str>);
 
 impl Severity {
@@ -10879,5 +11035,11 @@ pub mod severity {
 impl std::convert::From<std::string::String> for Severity {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for Severity {
+    fn default() -> Self {
+        severity::SEVERITY_UNSPECIFIED
     }
 }

--- a/src/generated/iam/admin/v1/src/model.rs
+++ b/src/generated/iam/admin/v1/src/model.rs
@@ -758,7 +758,7 @@ pub mod list_service_account_keys_request {
 
     /// `KeyType` filters to selectively retrieve certain varieties
     /// of keys.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct KeyType(std::borrow::Cow<'static, str>);
 
     impl KeyType {
@@ -791,6 +791,12 @@ pub mod list_service_account_keys_request {
     impl std::convert::From<std::string::String> for KeyType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for KeyType {
+        fn default() -> Self {
+            key_type::KEY_TYPE_UNSPECIFIED
         }
     }
 }
@@ -1586,7 +1592,7 @@ pub mod role {
     use super::*;
 
     /// A stage representing a role's lifecycle phase.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RoleLaunchStage(std::borrow::Cow<'static, str>);
 
     impl RoleLaunchStage {
@@ -1630,6 +1636,12 @@ pub mod role {
     impl std::convert::From<std::string::String> for RoleLaunchStage {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for RoleLaunchStage {
+        fn default() -> Self {
+            role_launch_stage::ALPHA
         }
     }
 }
@@ -2373,7 +2385,7 @@ pub mod permission {
     use super::*;
 
     /// A stage representing a permission's lifecycle phase.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PermissionLaunchStage(std::borrow::Cow<'static, str>);
 
     impl PermissionLaunchStage {
@@ -2411,8 +2423,14 @@ pub mod permission {
         }
     }
 
+    impl std::default::Default for PermissionLaunchStage {
+        fn default() -> Self {
+            permission_launch_stage::ALPHA
+        }
+    }
+
     /// The state of the permission with regards to custom roles.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CustomRolesSupportLevel(std::borrow::Cow<'static, str>);
 
     impl CustomRolesSupportLevel {
@@ -2445,6 +2463,12 @@ pub mod permission {
     impl std::convert::From<std::string::String> for CustomRolesSupportLevel {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CustomRolesSupportLevel {
+        fn default() -> Self {
+            custom_roles_support_level::SUPPORTED
         }
     }
 }
@@ -2872,7 +2896,7 @@ pub mod lint_result {
 
     /// Possible Level values of a validation unit corresponding to its domain
     /// of discourse.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Level(std::borrow::Cow<'static, str>);
 
     impl Level {
@@ -2905,8 +2929,14 @@ pub mod lint_result {
         }
     }
 
+    impl std::default::Default for Level {
+        fn default() -> Self {
+            level::LEVEL_UNSPECIFIED
+        }
+    }
+
     /// Possible Severity values of an issued result.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Severity(std::borrow::Cow<'static, str>);
 
     impl Severity {
@@ -2964,6 +2994,12 @@ pub mod lint_result {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for Severity {
+        fn default() -> Self {
+            severity::SEVERITY_UNSPECIFIED
+        }
+    }
 }
 
 /// The response of a lint operation. An empty response indicates
@@ -3002,7 +3038,7 @@ impl wkt::message::Message for LintPolicyResponse {
 }
 
 /// Supported key algorithms.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ServiceAccountKeyAlgorithm(std::borrow::Cow<'static, str>);
 
 impl ServiceAccountKeyAlgorithm {
@@ -3040,8 +3076,14 @@ impl std::convert::From<std::string::String> for ServiceAccountKeyAlgorithm {
     }
 }
 
+impl std::default::Default for ServiceAccountKeyAlgorithm {
+    fn default() -> Self {
+        service_account_key_algorithm::KEY_ALG_UNSPECIFIED
+    }
+}
+
 /// Supported private key output formats.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ServiceAccountPrivateKeyType(std::borrow::Cow<'static, str>);
 
 impl ServiceAccountPrivateKeyType {
@@ -3081,8 +3123,14 @@ impl std::convert::From<std::string::String> for ServiceAccountPrivateKeyType {
     }
 }
 
+impl std::default::Default for ServiceAccountPrivateKeyType {
+    fn default() -> Self {
+        service_account_private_key_type::TYPE_UNSPECIFIED
+    }
+}
+
 /// Supported public key output formats.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ServiceAccountPublicKeyType(std::borrow::Cow<'static, str>);
 
 impl ServiceAccountPublicKeyType {
@@ -3120,8 +3168,14 @@ impl std::convert::From<std::string::String> for ServiceAccountPublicKeyType {
     }
 }
 
+impl std::default::Default for ServiceAccountPublicKeyType {
+    fn default() -> Self {
+        service_account_public_key_type::TYPE_NONE
+    }
+}
+
 /// Service Account Key Origin.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ServiceAccountKeyOrigin(std::borrow::Cow<'static, str>);
 
 impl ServiceAccountKeyOrigin {
@@ -3159,8 +3213,14 @@ impl std::convert::From<std::string::String> for ServiceAccountKeyOrigin {
     }
 }
 
+impl std::default::Default for ServiceAccountKeyOrigin {
+    fn default() -> Self {
+        service_account_key_origin::ORIGIN_UNSPECIFIED
+    }
+}
+
 /// A view for Role objects.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct RoleView(std::borrow::Cow<'static, str>);
 
 impl RoleView {
@@ -3190,5 +3250,11 @@ pub mod role_view {
 impl std::convert::From<std::string::String> for RoleView {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for RoleView {
+    fn default() -> Self {
+        role_view::BASIC
     }
 }

--- a/src/generated/iam/v1/src/model.rs
+++ b/src/generated/iam/v1/src/model.rs
@@ -736,7 +736,7 @@ pub mod audit_log_config {
 
     /// The list of valid permission types for which logging can be configured.
     /// Admin writes are always logged, and are not configurable.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LogType(std::borrow::Cow<'static, str>);
 
     impl LogType {
@@ -771,6 +771,12 @@ pub mod audit_log_config {
     impl std::convert::From<std::string::String> for LogType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for LogType {
+        fn default() -> Self {
+            log_type::LOG_TYPE_UNSPECIFIED
         }
     }
 }
@@ -900,7 +906,7 @@ pub mod binding_delta {
     use super::*;
 
     /// The type of action performed on a Binding in a policy.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Action(std::borrow::Cow<'static, str>);
 
     impl Action {
@@ -932,6 +938,12 @@ pub mod binding_delta {
     impl std::convert::From<std::string::String> for Action {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Action {
+        fn default() -> Self {
+            action::ACTION_UNSPECIFIED
         }
     }
 }
@@ -1012,7 +1024,7 @@ pub mod audit_config_delta {
     use super::*;
 
     /// The type of action performed on an audit configuration in a policy.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Action(std::borrow::Cow<'static, str>);
 
     impl Action {
@@ -1044,6 +1056,12 @@ pub mod audit_config_delta {
     impl std::convert::From<std::string::String> for Action {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Action {
+        fn default() -> Self {
+            action::ACTION_UNSPECIFIED
         }
     }
 }

--- a/src/generated/iam/v3/src/model.rs
+++ b/src/generated/iam/v3/src/model.rs
@@ -444,7 +444,7 @@ pub mod policy_binding {
     }
 
     /// Different policy kinds supported in this binding.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PolicyKind(std::borrow::Cow<'static, str>);
 
     impl PolicyKind {
@@ -474,6 +474,12 @@ pub mod policy_binding {
     impl std::convert::From<std::string::String> for PolicyKind {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PolicyKind {
+        fn default() -> Self {
+            policy_kind::POLICY_KIND_UNSPECIFIED
         }
     }
 }
@@ -1727,7 +1733,7 @@ pub mod principal_access_boundary_policy_rule {
     use super::*;
 
     /// An effect to describe the access relationship.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Effect(std::borrow::Cow<'static, str>);
 
     impl Effect {
@@ -1756,6 +1762,12 @@ pub mod principal_access_boundary_policy_rule {
     impl std::convert::From<std::string::String> for Effect {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Effect {
+        fn default() -> Self {
+            effect::EFFECT_UNSPECIFIED
         }
     }
 }

--- a/src/generated/identity/accesscontextmanager/type/src/model.rs
+++ b/src/generated/identity/accesscontextmanager/type/src/model.rs
@@ -24,7 +24,7 @@ extern crate std;
 extern crate wkt;
 
 /// The encryption state of the device.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DeviceEncryptionStatus(std::borrow::Cow<'static, str>);
 
 impl DeviceEncryptionStatus {
@@ -64,9 +64,15 @@ impl std::convert::From<std::string::String> for DeviceEncryptionStatus {
     }
 }
 
+impl std::default::Default for DeviceEncryptionStatus {
+    fn default() -> Self {
+        device_encryption_status::ENCRYPTION_UNSPECIFIED
+    }
+}
+
 /// The operating system type of the device.
 /// Next id: 7
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct OsType(std::borrow::Cow<'static, str>);
 
 impl OsType {
@@ -113,8 +119,14 @@ impl std::convert::From<std::string::String> for OsType {
     }
 }
 
+impl std::default::Default for OsType {
+    fn default() -> Self {
+        os_type::OS_UNSPECIFIED
+    }
+}
+
 /// The degree to which the device is managed by the Cloud organization.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DeviceManagementLevel(std::borrow::Cow<'static, str>);
 
 impl DeviceManagementLevel {
@@ -153,5 +165,11 @@ pub mod device_management_level {
 impl std::convert::From<std::string::String> for DeviceManagementLevel {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for DeviceManagementLevel {
+    fn default() -> Self {
+        device_management_level::MANAGEMENT_UNSPECIFIED
     }
 }

--- a/src/generated/identity/accesscontextmanager/v1/src/model.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/model.rs
@@ -1684,7 +1684,7 @@ pub mod basic_level {
 
     /// Options for how the `conditions` list should be combined to determine if
     /// this `AccessLevel` is applied. Default is AND.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ConditionCombiningFunction(std::borrow::Cow<'static, str>);
 
     impl ConditionCombiningFunction {
@@ -1713,6 +1713,12 @@ pub mod basic_level {
     impl std::convert::From<std::string::String> for ConditionCombiningFunction {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ConditionCombiningFunction {
+        fn default() -> Self {
+            condition_combining_function::AND
         }
     }
 }
@@ -2408,7 +2414,7 @@ pub mod service_perimeter {
     /// Perimeter Bridges are typically useful when building more complex toplogies
     /// with many independent perimeters that need to share some data with a common
     /// perimeter, but should not be able to share data among themselves.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PerimeterType(std::borrow::Cow<'static, str>);
 
     impl PerimeterType {
@@ -2439,6 +2445,12 @@ pub mod service_perimeter {
     impl std::convert::From<std::string::String> for PerimeterType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PerimeterType {
+        fn default() -> Self {
+            perimeter_type::PERIMETER_TYPE_REGULAR
         }
     }
 }
@@ -3411,7 +3423,7 @@ pub mod service_perimeter_config {
     /// or [EgressFrom]
     /// [google.identity.accesscontextmanager.v1.ServicePerimeterConfig.EgressFrom]
     /// rules.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct IdentityType(std::borrow::Cow<'static, str>);
 
     impl IdentityType {
@@ -3449,10 +3461,16 @@ pub mod service_perimeter_config {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for IdentityType {
+        fn default() -> Self {
+            identity_type::IDENTITY_TYPE_UNSPECIFIED
+        }
+    }
 }
 
 /// The format used in an `AccessLevel`.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct LevelFormat(std::borrow::Cow<'static, str>);
 
 impl LevelFormat {
@@ -3486,5 +3504,11 @@ pub mod level_format {
 impl std::convert::From<std::string::String> for LevelFormat {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for LevelFormat {
+    fn default() -> Self {
+        level_format::LEVEL_FORMAT_UNSPECIFIED
     }
 }

--- a/src/generated/logging/type/src/model.rs
+++ b/src/generated/logging/type/src/model.rs
@@ -231,7 +231,7 @@ impl wkt::message::Message for HttpRequest {
 /// one of these standard levels. For example, you might map all of Java's FINE,
 /// FINER, and FINEST levels to `LogSeverity.DEBUG`. You can preserve the
 /// original severity level in the log entry payload if you wish.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct LogSeverity(std::borrow::Cow<'static, str>);
 
 impl LogSeverity {
@@ -282,5 +282,11 @@ pub mod log_severity {
 impl std::convert::From<std::string::String> for LogSeverity {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for LogSeverity {
+    fn default() -> Self {
+        log_severity::DEFAULT
     }
 }

--- a/src/generated/logging/v2/src/model.rs
+++ b/src/generated/logging/v2/src/model.rs
@@ -1479,7 +1479,7 @@ pub mod tail_log_entries_response {
         use super::*;
 
         /// An indicator of why entries were omitted.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Reason(std::borrow::Cow<'static, str>);
 
         impl Reason {
@@ -1515,6 +1515,12 @@ pub mod tail_log_entries_response {
         impl std::convert::From<std::string::String> for Reason {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Reason {
+            fn default() -> Self {
+                reason::REASON_UNSPECIFIED
             }
         }
     }
@@ -2121,7 +2127,7 @@ pub mod log_sink {
     use super::*;
 
     /// Deprecated. This is unused.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct VersionFormat(std::borrow::Cow<'static, str>);
 
     impl VersionFormat {
@@ -2154,6 +2160,12 @@ pub mod log_sink {
     impl std::convert::From<std::string::String> for VersionFormat {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for VersionFormat {
+        fn default() -> Self {
+            version_format::VERSION_FORMAT_UNSPECIFIED
         }
     }
 
@@ -5424,7 +5436,7 @@ pub mod log_metric {
     use super::*;
 
     /// Logging API version.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ApiVersion(std::borrow::Cow<'static, str>);
 
     impl ApiVersion {
@@ -5453,6 +5465,12 @@ pub mod log_metric {
     impl std::convert::From<std::string::String> for ApiVersion {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ApiVersion {
+        fn default() -> Self {
+            api_version::V2
         }
     }
 }
@@ -5743,7 +5761,7 @@ impl wkt::message::Message for DeleteLogMetricRequest {
 /// current state to the user. Once a long running operation is created,
 /// the current state of the operation can be queried even before the
 /// operation is finished and the final result is available.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct OperationState(std::borrow::Cow<'static, str>);
 
 impl OperationState {
@@ -5797,8 +5815,14 @@ impl std::convert::From<std::string::String> for OperationState {
     }
 }
 
+impl std::default::Default for OperationState {
+    fn default() -> Self {
+        operation_state::OPERATION_STATE_UNSPECIFIED
+    }
+}
+
 /// LogBucket lifecycle states.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct LifecycleState(std::borrow::Cow<'static, str>);
 
 impl LifecycleState {
@@ -5847,9 +5871,15 @@ impl std::convert::From<std::string::String> for LifecycleState {
     }
 }
 
+impl std::default::Default for LifecycleState {
+    fn default() -> Self {
+        lifecycle_state::LIFECYCLE_STATE_UNSPECIFIED
+    }
+}
+
 /// IndexType is used for custom indexing. It describes the type of an indexed
 /// field.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct IndexType(std::borrow::Cow<'static, str>);
 
 impl IndexType {
@@ -5881,5 +5911,11 @@ pub mod index_type {
 impl std::convert::From<std::string::String> for IndexType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for IndexType {
+    fn default() -> Self {
+        index_type::INDEX_TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/monitoring/dashboard/v1/src/model.rs
+++ b/src/generated/monitoring/dashboard/v1/src/model.rs
@@ -258,7 +258,7 @@ pub mod aggregation {
     /// example, if you apply a counting operation to boolean values, the data
     /// `value_type` in the original time series is `BOOLEAN`, but the `value_type`
     /// in the aligned result is `INT64`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Aligner(std::borrow::Cow<'static, str>);
 
     impl Aligner {
@@ -429,11 +429,17 @@ pub mod aggregation {
         }
     }
 
+    impl std::default::Default for Aligner {
+        fn default() -> Self {
+            aligner::ALIGN_NONE
+        }
+    }
+
     /// A Reducer operation describes how to aggregate data points from multiple
     /// time series into a single time series, where the value of each data point
     /// in the resulting series is a function of all the already aligned values in
     /// the input time series.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Reducer(std::borrow::Cow<'static, str>);
 
     impl Reducer {
@@ -547,6 +553,12 @@ pub mod aggregation {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for Reducer {
+        fn default() -> Self {
+            reducer::REDUCE_NONE
+        }
+    }
 }
 
 /// Describes a ranking-based time series filter. Each input time series is
@@ -632,7 +644,7 @@ pub mod pick_time_series_filter {
     use super::*;
 
     /// The value reducers that can be applied to a `PickTimeSeriesFilter`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Method(std::borrow::Cow<'static, str>);
 
     impl Method {
@@ -677,8 +689,14 @@ pub mod pick_time_series_filter {
         }
     }
 
+    impl std::default::Default for Method {
+        fn default() -> Self {
+            method::METHOD_UNSPECIFIED
+        }
+    }
+
     /// Describes the ranking directions.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Direction(std::borrow::Cow<'static, str>);
 
     impl Direction {
@@ -711,6 +729,12 @@ pub mod pick_time_series_filter {
     impl std::convert::From<std::string::String> for Direction {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Direction {
+        fn default() -> Self {
+            direction::DIRECTION_UNSPECIFIED
         }
     }
 }
@@ -769,7 +793,7 @@ pub mod statistical_time_series_filter {
     use super::*;
 
     /// The filter methods that can be applied to a stream.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Method(std::borrow::Cow<'static, str>);
 
     impl Method {
@@ -798,6 +822,12 @@ pub mod statistical_time_series_filter {
     impl std::convert::From<std::string::String> for Method {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Method {
+        fn default() -> Self {
+            method::METHOD_UNSPECIFIED
         }
     }
 }
@@ -1137,7 +1167,7 @@ pub mod dashboard_filter {
     use super::*;
 
     /// The type for the dashboard filter
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct FilterType(std::borrow::Cow<'static, str>);
 
     impl FilterType {
@@ -1178,6 +1208,12 @@ pub mod dashboard_filter {
     impl std::convert::From<std::string::String> for FilterType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for FilterType {
+        fn default() -> Self {
+            filter_type::FILTER_TYPE_UNSPECIFIED
         }
     }
 
@@ -2672,7 +2708,7 @@ pub mod threshold {
     /// The color suggests an interpretation to the viewer when actual values cross
     /// the threshold. Comments on each color provide UX guidance on how users can
     /// be expected to interpret a given state color.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Color(std::borrow::Cow<'static, str>);
 
     impl Color {
@@ -2707,9 +2743,15 @@ pub mod threshold {
         }
     }
 
+    impl std::default::Default for Color {
+        fn default() -> Self {
+            color::COLOR_UNSPECIFIED
+        }
+    }
+
     /// Whether the threshold is considered crossed by an actual value above or
     /// below its threshold value.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Direction(std::borrow::Cow<'static, str>);
 
     impl Direction {
@@ -2746,8 +2788,14 @@ pub mod threshold {
         }
     }
 
+    impl std::default::Default for Direction {
+        fn default() -> Self {
+            direction::DIRECTION_UNSPECIFIED
+        }
+    }
+
     /// An axis identifier.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TargetAxis(std::borrow::Cow<'static, str>);
 
     impl TargetAxis {
@@ -2779,6 +2827,12 @@ pub mod threshold {
     impl std::convert::From<std::string::String> for TargetAxis {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for TargetAxis {
+        fn default() -> Self {
+            target_axis::TARGET_AXIS_UNSPECIFIED
         }
     }
 }
@@ -2916,7 +2970,7 @@ pub mod pie_chart {
     }
 
     /// Types for the pie chart.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PieChartType(std::borrow::Cow<'static, str>);
 
     impl PieChartType {
@@ -2949,6 +3003,12 @@ pub mod pie_chart {
     impl std::convert::From<std::string::String> for PieChartType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PieChartType {
+        fn default() -> Self {
+            pie_chart_type::PIE_CHART_TYPE_UNSPECIFIED
         }
     }
 }
@@ -3508,7 +3568,7 @@ pub mod time_series_table {
     }
 
     /// Enum for metric metric_visualization
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct MetricVisualization(std::borrow::Cow<'static, str>);
 
     impl MetricVisualization {
@@ -3541,6 +3601,12 @@ pub mod time_series_table {
     impl std::convert::From<std::string::String> for MetricVisualization {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for MetricVisualization {
+        fn default() -> Self {
+            metric_visualization::METRIC_VISUALIZATION_UNSPECIFIED
         }
     }
 }
@@ -3751,7 +3817,7 @@ pub mod text {
         use super::*;
 
         /// The horizontal alignment of both the title and content on a text widget
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct HorizontalAlignment(std::borrow::Cow<'static, str>);
 
         impl HorizontalAlignment {
@@ -3790,8 +3856,14 @@ pub mod text {
             }
         }
 
+        impl std::default::Default for HorizontalAlignment {
+            fn default() -> Self {
+                horizontal_alignment::HORIZONTAL_ALIGNMENT_UNSPECIFIED
+            }
+        }
+
         /// The vertical alignment of both the title and content on a text widget
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct VerticalAlignment(std::borrow::Cow<'static, str>);
 
         impl VerticalAlignment {
@@ -3830,8 +3902,14 @@ pub mod text {
             }
         }
 
+        impl std::default::Default for VerticalAlignment {
+            fn default() -> Self {
+                vertical_alignment::VERTICAL_ALIGNMENT_UNSPECIFIED
+            }
+        }
+
         /// Specifies padding size around a text widget
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct PaddingSize(std::borrow::Cow<'static, str>);
 
         impl PaddingSize {
@@ -3876,8 +3954,14 @@ pub mod text {
             }
         }
 
+        impl std::default::Default for PaddingSize {
+            fn default() -> Self {
+                padding_size::PADDING_SIZE_UNSPECIFIED
+            }
+        }
+
         /// Specifies a font size for the title and content of a text widget
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct FontSize(std::borrow::Cow<'static, str>);
 
         impl FontSize {
@@ -3921,9 +4005,15 @@ pub mod text {
             }
         }
 
+        impl std::default::Default for FontSize {
+            fn default() -> Self {
+                font_size::FONT_SIZE_UNSPECIFIED
+            }
+        }
+
         /// Specifies where a visual pointer is placed on a text widget (also
         /// sometimes called a "tail")
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct PointerLocation(std::borrow::Cow<'static, str>);
 
         impl PointerLocation {
@@ -3988,10 +4078,16 @@ pub mod text {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for PointerLocation {
+            fn default() -> Self {
+                pointer_location::POINTER_LOCATION_UNSPECIFIED
+            }
+        }
     }
 
     /// The format type of the text content.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Format(std::borrow::Cow<'static, str>);
 
     impl Format {
@@ -4023,6 +4119,12 @@ pub mod text {
     impl std::convert::From<std::string::String> for Format {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Format {
+        fn default() -> Self {
+            format::FORMAT_UNSPECIFIED
         }
     }
 }
@@ -4692,7 +4794,7 @@ pub mod xy_chart {
         use super::*;
 
         /// The types of plotting strategies for data sets.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct PlotType(std::borrow::Cow<'static, str>);
 
         impl PlotType {
@@ -4742,8 +4844,14 @@ pub mod xy_chart {
             }
         }
 
+        impl std::default::Default for PlotType {
+            fn default() -> Self {
+                plot_type::PLOT_TYPE_UNSPECIFIED
+            }
+        }
+
         /// An axis identifier.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct TargetAxis(std::borrow::Cow<'static, str>);
 
         impl TargetAxis {
@@ -4776,6 +4884,12 @@ pub mod xy_chart {
         impl std::convert::From<std::string::String> for TargetAxis {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for TargetAxis {
+            fn default() -> Self {
+                target_axis::TARGET_AXIS_UNSPECIFIED
             }
         }
     }
@@ -4827,7 +4941,7 @@ pub mod xy_chart {
         use super::*;
 
         /// Types of scales used in axes.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct Scale(std::borrow::Cow<'static, str>);
 
         impl Scale {
@@ -4859,6 +4973,12 @@ pub mod xy_chart {
         impl std::convert::From<std::string::String> for Scale {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for Scale {
+            fn default() -> Self {
+                scale::SCALE_UNSPECIFIED
             }
         }
     }
@@ -4901,7 +5021,7 @@ pub mod chart_options {
     use super::*;
 
     /// Chart mode options.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Mode(std::borrow::Cow<'static, str>);
 
     impl Mode {
@@ -4941,10 +5061,16 @@ pub mod chart_options {
             Self(std::borrow::Cow::Owned(value))
         }
     }
+
+    impl std::default::Default for Mode {
+        fn default() -> Self {
+            mode::MODE_UNSPECIFIED
+        }
+    }
 }
 
 /// Defines the possible types of spark chart supported by the `Scorecard`.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SparkChartType(std::borrow::Cow<'static, str>);
 
 impl SparkChartType {
@@ -4977,5 +5103,11 @@ pub mod spark_chart_type {
 impl std::convert::From<std::string::String> for SparkChartType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for SparkChartType {
+    fn default() -> Self {
+        spark_chart_type::SPARK_CHART_TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/monitoring/metricsscope/v1/src/model.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/model.rs
@@ -406,7 +406,7 @@ pub mod operation_metadata {
     use super::*;
 
     /// Batch operation states.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -444,6 +444,12 @@ pub mod operation_metadata {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }

--- a/src/generated/monitoring/v3/src/model.rs
+++ b/src/generated/monitoring/v3/src/model.rs
@@ -2109,7 +2109,7 @@ pub mod alert_policy {
         /// A condition control that determines how metric-threshold conditions
         /// are evaluated when data stops arriving.
         /// This control doesn't affect metric-absence policies.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct EvaluationMissingData(std::borrow::Cow<'static, str>);
 
         impl EvaluationMissingData {
@@ -2151,6 +2151,12 @@ pub mod alert_policy {
         impl std::convert::From<std::string::String> for EvaluationMissingData {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for EvaluationMissingData {
+            fn default() -> Self {
+                evaluation_missing_data::EVALUATION_MISSING_DATA_UNSPECIFIED
             }
         }
 
@@ -2379,7 +2385,7 @@ pub mod alert_policy {
         }
 
         /// Control when notifications will be sent out.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct NotificationPrompt(std::borrow::Cow<'static, str>);
 
         impl NotificationPrompt {
@@ -2414,10 +2420,16 @@ pub mod alert_policy {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for NotificationPrompt {
+            fn default() -> Self {
+                notification_prompt::NOTIFICATION_PROMPT_UNSPECIFIED
+            }
+        }
     }
 
     /// Operators for combining conditions.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ConditionCombinerType(std::borrow::Cow<'static, str>);
 
     impl ConditionCombinerType {
@@ -2463,8 +2475,14 @@ pub mod alert_policy {
         }
     }
 
+    impl std::default::Default for ConditionCombinerType {
+        fn default() -> Self {
+            condition_combiner_type::COMBINE_UNSPECIFIED
+        }
+    }
+
     /// An enumeration of possible severity level for an alerting policy.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Severity(std::borrow::Cow<'static, str>);
 
     impl Severity {
@@ -2503,6 +2521,12 @@ pub mod alert_policy {
     impl std::convert::From<std::string::String> for Severity {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Severity {
+        fn default() -> Self {
+            severity::SEVERITY_UNSPECIFIED
         }
     }
 }
@@ -3299,7 +3323,7 @@ pub mod aggregation {
     /// example, if you apply a counting operation to boolean values, the data
     /// `value_type` in the original time series is `BOOLEAN`, but the `value_type`
     /// in the aligned result is `INT64`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Aligner(std::borrow::Cow<'static, str>);
 
     impl Aligner {
@@ -3473,11 +3497,17 @@ pub mod aggregation {
         }
     }
 
+    impl std::default::Default for Aligner {
+        fn default() -> Self {
+            aligner::ALIGN_NONE
+        }
+    }
+
     /// A Reducer operation describes how to aggregate data points from multiple
     /// time series into a single time series, where the value of each data point
     /// in the resulting series is a function of all the already aligned values in
     /// the input time series.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Reducer(std::borrow::Cow<'static, str>);
 
     impl Reducer {
@@ -3593,6 +3623,12 @@ pub mod aggregation {
     impl std::convert::From<std::string::String> for Reducer {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Reducer {
+        fn default() -> Self {
+            reducer::REDUCE_NONE
         }
     }
 }
@@ -5729,7 +5765,7 @@ pub mod list_time_series_request {
     use super::*;
 
     /// Controls which fields are returned by `ListTimeSeries*`.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TimeSeriesView(std::borrow::Cow<'static, str>);
 
     impl TimeSeriesView {
@@ -5760,6 +5796,12 @@ pub mod list_time_series_request {
     impl std::convert::From<std::string::String> for TimeSeriesView {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for TimeSeriesView {
+        fn default() -> Self {
+            time_series_view::FULL
         }
     }
 }
@@ -6648,7 +6690,7 @@ pub mod notification_channel {
     ///
     /// [google.monitoring.v3.NotificationChannelService.CreateNotificationChannel]: crate::client::NotificationChannelService::create_notification_channel
     /// [google.monitoring.v3.NotificationChannelService.UpdateNotificationChannel]: crate::client::NotificationChannelService::update_notification_channel
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct VerificationStatus(std::borrow::Cow<'static, str>);
 
     impl VerificationStatus {
@@ -6688,6 +6730,12 @@ pub mod notification_channel {
     impl std::convert::From<std::string::String> for VerificationStatus {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for VerificationStatus {
+        fn default() -> Self {
+            verification_status::VERIFICATION_STATUS_UNSPECIFIED
         }
     }
 }
@@ -8657,7 +8705,7 @@ pub mod service_level_objective {
     /// `ServiceLevelObjective.View` determines what form of
     /// `ServiceLevelObjective` is returned from `GetServiceLevelObjective`,
     /// `ListServiceLevelObjectives`, and `ListServiceLevelObjectiveVersions` RPCs.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct View(std::borrow::Cow<'static, str>);
 
     impl View {
@@ -8694,6 +8742,12 @@ pub mod service_level_objective {
     impl std::convert::From<std::string::String> for View {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for View {
+        fn default() -> Self {
+            view::VIEW_UNSPECIFIED
         }
     }
 
@@ -11022,7 +11076,7 @@ pub mod internal_checker {
     use super::*;
 
     /// Operational states for an internal checker.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -11064,6 +11118,12 @@ pub mod internal_checker {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::UNSPECIFIED
         }
     }
 }
@@ -12106,7 +12166,7 @@ pub mod uptime_check_config {
             use super::*;
 
             /// An HTTP status code class.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct StatusClass(std::borrow::Cow<'static, str>);
 
             impl StatusClass {
@@ -12151,6 +12211,12 @@ pub mod uptime_check_config {
             impl std::convert::From<std::string::String> for StatusClass {
                 fn from(value: std::string::String) -> Self {
                     Self(std::borrow::Cow::Owned(value))
+                }
+            }
+
+            impl std::default::Default for StatusClass {
+                fn default() -> Self {
+                    status_class::STATUS_CLASS_UNSPECIFIED
                 }
             }
 
@@ -12207,7 +12273,7 @@ pub mod uptime_check_config {
             use super::*;
 
             /// Type of authentication.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct ServiceAgentAuthenticationType(std::borrow::Cow<'static, str>);
 
             impl ServiceAgentAuthenticationType {
@@ -12242,10 +12308,16 @@ pub mod uptime_check_config {
                     Self(std::borrow::Cow::Owned(value))
                 }
             }
+
+            impl std::default::Default for ServiceAgentAuthenticationType {
+                fn default() -> Self {
+                    service_agent_authentication_type::SERVICE_AGENT_AUTHENTICATION_TYPE_UNSPECIFIED
+                }
+            }
         }
 
         /// The HTTP request method options.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct RequestMethod(std::borrow::Cow<'static, str>);
 
         impl RequestMethod {
@@ -12280,8 +12352,14 @@ pub mod uptime_check_config {
             }
         }
 
+        impl std::default::Default for RequestMethod {
+            fn default() -> Self {
+                request_method::METHOD_UNSPECIFIED
+            }
+        }
+
         /// Header options corresponding to the content type of a HTTP request body.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct ContentType(std::borrow::Cow<'static, str>);
 
         impl ContentType {
@@ -12316,6 +12394,12 @@ pub mod uptime_check_config {
         impl std::convert::From<std::string::String> for ContentType {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for ContentType {
+            fn default() -> Self {
+                content_type::TYPE_UNSPECIFIED
             }
         }
 
@@ -12551,7 +12635,7 @@ pub mod uptime_check_config {
             use super::*;
 
             /// Options to perform JSONPath content matching.
-            #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
             pub struct JsonPathMatcherOption(std::borrow::Cow<'static, str>);
 
             impl JsonPathMatcherOption {
@@ -12592,10 +12676,16 @@ pub mod uptime_check_config {
                     Self(std::borrow::Cow::Owned(value))
                 }
             }
+
+            impl std::default::Default for JsonPathMatcherOption {
+                fn default() -> Self {
+                    json_path_matcher_option::JSON_PATH_MATCHER_OPTION_UNSPECIFIED
+                }
+            }
         }
 
         /// Options to perform content matching.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct ContentMatcherOption(std::borrow::Cow<'static, str>);
 
         impl ContentMatcherOption {
@@ -12664,6 +12754,12 @@ pub mod uptime_check_config {
             }
         }
 
+        impl std::default::Default for ContentMatcherOption {
+            fn default() -> Self {
+                content_matcher_option::CONTENT_MATCHER_OPTION_UNSPECIFIED
+            }
+        }
+
         /// Certain `ContentMatcherOption` types require additional information.
         /// `MATCHES_JSON_PATH` or `NOT_MATCHES_JSON_PATH` require a
         /// `JsonPathMatcher`; not used for other options.
@@ -12681,7 +12777,7 @@ pub mod uptime_check_config {
     }
 
     /// What kind of checkers are available to be used by the check.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CheckerType(std::borrow::Cow<'static, str>);
 
     impl CheckerType {
@@ -12719,6 +12815,12 @@ pub mod uptime_check_config {
     impl std::convert::From<std::string::String> for CheckerType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CheckerType {
+        fn default() -> Self {
+            checker_type::CHECKER_TYPE_UNSPECIFIED
         }
     }
 
@@ -13246,7 +13348,7 @@ impl gax::paginator::PageableResponse for ListUptimeCheckIpsResponse {
 
 /// Specifies an ordering relationship on two arguments, called `left` and
 /// `right`.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ComparisonType(std::borrow::Cow<'static, str>);
 
 impl ComparisonType {
@@ -13294,11 +13396,17 @@ impl std::convert::From<std::string::String> for ComparisonType {
     }
 }
 
+impl std::default::Default for ComparisonType {
+    fn default() -> Self {
+        comparison_type::COMPARISON_UNSPECIFIED
+    }
+}
+
 /// The tier of service for a Metrics Scope. Please see the
 /// [service tiers
 /// documentation](https://cloud.google.com/monitoring/workspaces/tiers) for more
 /// details.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ServiceTier(std::borrow::Cow<'static, str>);
 
 impl ServiceTier {
@@ -13342,8 +13450,14 @@ impl std::convert::From<std::string::String> for ServiceTier {
     }
 }
 
+impl std::default::Default for ServiceTier {
+    fn default() -> Self {
+        service_tier::SERVICE_TIER_UNSPECIFIED
+    }
+}
+
 /// The regions from which an Uptime check can be run.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct UptimeCheckRegion(std::borrow::Cow<'static, str>);
 
 impl UptimeCheckRegion {
@@ -13399,12 +13513,18 @@ impl std::convert::From<std::string::String> for UptimeCheckRegion {
     }
 }
 
+impl std::default::Default for UptimeCheckRegion {
+    fn default() -> Self {
+        uptime_check_region::REGION_UNSPECIFIED
+    }
+}
+
 /// The supported resource types that can be used as values of
 /// `group_resource.resource_type`.
 /// `INSTANCE` includes `gce_instance` and `aws_ec2_instance` resource types.
 /// The resource types `gae_app` and `uptime_url` are not valid here because
 /// group checks on App Engine modules and URLs are not allowed.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct GroupResourceType(std::borrow::Cow<'static, str>);
 
 impl GroupResourceType {
@@ -13439,5 +13559,11 @@ pub mod group_resource_type {
 impl std::convert::From<std::string::String> for GroupResourceType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for GroupResourceType {
+    fn default() -> Self {
+        group_resource_type::RESOURCE_TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/oslogin/common/src/model.rs
+++ b/src/generated/oslogin/common/src/model.rs
@@ -216,7 +216,7 @@ impl wkt::message::Message for SshPublicKey {
 }
 
 /// The operating system options for account entries.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct OperatingSystemType(std::borrow::Cow<'static, str>);
 
 impl OperatingSystemType {
@@ -250,5 +250,11 @@ pub mod operating_system_type {
 impl std::convert::From<std::string::String> for OperatingSystemType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for OperatingSystemType {
+    fn default() -> Self {
+        operating_system_type::OPERATING_SYSTEM_TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/privacy/dlp/v2/src/model.rs
+++ b/src/generated/privacy/dlp/v2/src/model.rs
@@ -914,7 +914,7 @@ pub mod byte_content_item {
     /// The type of data being sent for inspection. To learn more, see
     /// [Supported file
     /// types](https://cloud.google.com/sensitive-data-protection/docs/supported-file-types).
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct BytesType(std::borrow::Cow<'static, str>);
 
     impl BytesType {
@@ -988,6 +988,12 @@ pub mod byte_content_item {
     impl std::convert::From<std::string::String> for BytesType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for BytesType {
+        fn default() -> Self {
+            bytes_type::BYTES_TYPE_UNSPECIFIED
         }
     }
 }
@@ -3215,7 +3221,7 @@ pub mod output_storage_config {
 
     /// Predefined schemas for storing findings.
     /// Only for use with external storage.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct OutputSchema(std::borrow::Cow<'static, str>);
 
     impl OutputSchema {
@@ -3258,6 +3264,12 @@ pub mod output_storage_config {
     impl std::convert::From<std::string::String> for OutputSchema {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for OutputSchema {
+        fn default() -> Self {
+            output_schema::OUTPUT_SCHEMA_UNSPECIFIED
         }
     }
 
@@ -4239,7 +4251,7 @@ pub mod info_type_category {
 
     /// Enum of the current locations.
     /// We might add more locations in the future.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LocationCategory(std::borrow::Cow<'static, str>);
 
     impl LocationCategory {
@@ -4420,9 +4432,15 @@ pub mod info_type_category {
         }
     }
 
+    impl std::default::Default for LocationCategory {
+        fn default() -> Self {
+            location_category::LOCATION_UNSPECIFIED
+        }
+    }
+
     /// Enum of the current industries in the category.
     /// We might add more industries in the future.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct IndustryCategory(std::borrow::Cow<'static, str>);
 
     impl IndustryCategory {
@@ -4462,9 +4480,15 @@ pub mod info_type_category {
         }
     }
 
+    impl std::default::Default for IndustryCategory {
+        fn default() -> Self {
+            industry_category::INDUSTRY_UNSPECIFIED
+        }
+    }
+
     /// Enum of the current types in the category.
     /// We might add more types in the future.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TypeCategory(std::borrow::Cow<'static, str>);
 
     impl TypeCategory {
@@ -4516,6 +4540,12 @@ pub mod info_type_category {
     impl std::convert::From<std::string::String> for TypeCategory {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for TypeCategory {
+        fn default() -> Self {
+            type_category::TYPE_UNSPECIFIED
         }
     }
 
@@ -8814,7 +8844,7 @@ pub mod time_part_config {
     use super::*;
 
     /// Components that make up time.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TimePart(std::borrow::Cow<'static, str>);
 
     impl TimePart {
@@ -8858,6 +8888,12 @@ pub mod time_part_config {
     impl std::convert::From<std::string::String> for TimePart {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for TimePart {
+        fn default() -> Self {
+            time_part::TIME_PART_UNSPECIFIED
         }
     }
 }
@@ -9270,7 +9306,7 @@ pub mod chars_to_ignore {
     use super::*;
 
     /// Convenience enum for indicating common characters to not transform.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CommonCharsToIgnore(std::borrow::Cow<'static, str>);
 
     impl CommonCharsToIgnore {
@@ -9314,6 +9350,12 @@ pub mod chars_to_ignore {
     impl std::convert::From<std::string::String> for CommonCharsToIgnore {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CommonCharsToIgnore {
+        fn default() -> Self {
+            common_chars_to_ignore::COMMON_CHARS_TO_IGNORE_UNSPECIFIED
         }
     }
 
@@ -9840,7 +9882,7 @@ pub mod crypto_replace_ffx_fpe_config {
     /// These are commonly used subsets of the alphabet that the FFX mode
     /// natively supports. In the algorithm, the alphabet is selected using
     /// the "radix". Therefore each corresponds to a particular radix.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct FfxCommonNativeAlphabet(std::borrow::Cow<'static, str>);
 
     impl FfxCommonNativeAlphabet {
@@ -9882,6 +9924,12 @@ pub mod crypto_replace_ffx_fpe_config {
     impl std::convert::From<std::string::String> for FfxCommonNativeAlphabet {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for FfxCommonNativeAlphabet {
+        fn default() -> Self {
+            ffx_common_native_alphabet::FFX_COMMON_NATIVE_ALPHABET_UNSPECIFIED
         }
     }
 
@@ -10867,7 +10915,7 @@ pub mod record_condition {
         use super::*;
 
         /// Logical operators for conditional checks.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct LogicalOperator(std::borrow::Cow<'static, str>);
 
         impl LogicalOperator {
@@ -10897,6 +10945,12 @@ pub mod record_condition {
         impl std::convert::From<std::string::String> for LogicalOperator {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for LogicalOperator {
+            fn default() -> Self {
+                logical_operator::LOGICAL_OPERATOR_UNSPECIFIED
             }
         }
 
@@ -11135,7 +11189,7 @@ pub mod transformation_summary {
     }
 
     /// Possible outcomes of transformations.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TransformationResultCode(std::borrow::Cow<'static, str>);
 
     impl TransformationResultCode {
@@ -11168,6 +11222,12 @@ pub mod transformation_summary {
     impl std::convert::From<std::string::String> for TransformationResultCode {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for TransformationResultCode {
+        fn default() -> Self {
+            transformation_result_code::TRANSFORMATION_RESULT_CODE_UNSPECIFIED
         }
     }
 }
@@ -12040,7 +12100,7 @@ pub mod error {
     use super::*;
 
     /// Additional information about the error.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ErrorExtraInfo(std::borrow::Cow<'static, str>);
 
     impl ErrorExtraInfo {
@@ -12075,6 +12135,12 @@ pub mod error {
     impl std::convert::From<std::string::String> for ErrorExtraInfo {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ErrorExtraInfo {
+        fn default() -> Self {
+            error_extra_info::ERROR_INFO_UNSPECIFIED
         }
     }
 }
@@ -12378,7 +12444,7 @@ pub mod job_trigger {
     /// will be created with this configuration. The service may automatically
     /// pause triggers experiencing frequent errors. To restart a job, set the
     /// status to HEALTHY after correcting user errors.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Status(std::borrow::Cow<'static, str>);
 
     impl Status {
@@ -12413,6 +12479,12 @@ pub mod job_trigger {
     impl std::convert::From<std::string::String> for Status {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Status {
+        fn default() -> Self {
+            status::STATUS_UNSPECIFIED
         }
     }
 
@@ -14822,7 +14894,7 @@ pub mod data_profile_action {
         use super::*;
 
         /// The levels of detail that can be included in the Pub/Sub message.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct DetailLevel(std::borrow::Cow<'static, str>);
 
         impl DetailLevel {
@@ -14858,6 +14930,12 @@ pub mod data_profile_action {
         impl std::convert::From<std::string::String> for DetailLevel {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for DetailLevel {
+            fn default() -> Self {
+                detail_level::DETAIL_LEVEL_UNSPECIFIED
             }
         }
     }
@@ -15175,7 +15253,7 @@ pub mod data_profile_action {
     }
 
     /// Types of event that can trigger an action.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EventType(std::borrow::Cow<'static, str>);
 
     impl EventType {
@@ -15215,6 +15293,12 @@ pub mod data_profile_action {
     impl std::convert::From<std::string::String> for EventType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EventType {
+        fn default() -> Self {
+            event_type::EVENT_TYPE_UNSPECIFIED
         }
     }
 
@@ -15864,7 +15948,7 @@ pub mod discovery_config {
 
     /// Whether the discovery config is currently active. New options may be added
     /// at a later time.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Status(std::borrow::Cow<'static, str>);
 
     impl Status {
@@ -15896,6 +15980,12 @@ pub mod discovery_config {
     impl std::convert::From<std::string::String> for Status {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Status {
+        fn default() -> Self {
+            status::STATUS_UNSPECIFIED
         }
     }
 }
@@ -17612,7 +17702,7 @@ pub mod discovery_cloud_sql_conditions {
     use super::*;
 
     /// The database engines that should be profiled.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DatabaseEngine(std::borrow::Cow<'static, str>);
 
     impl DatabaseEngine {
@@ -17652,8 +17742,14 @@ pub mod discovery_cloud_sql_conditions {
         }
     }
 
+    impl std::default::Default for DatabaseEngine {
+        fn default() -> Self {
+            database_engine::DATABASE_ENGINE_UNSPECIFIED
+        }
+    }
+
     /// Cloud SQL database resource types. New values can be added at a later time.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DatabaseResourceType(std::borrow::Cow<'static, str>);
 
     impl DatabaseResourceType {
@@ -17688,6 +17784,12 @@ pub mod discovery_cloud_sql_conditions {
     impl std::convert::From<std::string::String> for DatabaseResourceType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DatabaseResourceType {
+        fn default() -> Self {
+            database_resource_type::DATABASE_RESOURCE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -17831,7 +17933,7 @@ pub mod discovery_cloud_sql_generation_cadence {
         use super::*;
 
         /// The type of modification that causes a profile update.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct CloudSqlSchemaModification(std::borrow::Cow<'static, str>);
 
         impl CloudSqlSchemaModification {
@@ -17866,6 +17968,12 @@ pub mod discovery_cloud_sql_generation_cadence {
         impl std::convert::From<std::string::String> for CloudSqlSchemaModification {
             fn from(value: std::string::String) -> Self {
                 Self(std::borrow::Cow::Owned(value))
+            }
+        }
+
+        impl std::default::Default for CloudSqlSchemaModification {
+            fn default() -> Self {
+                cloud_sql_schema_modification::SQL_SCHEMA_MODIFICATION_UNSPECIFIED
             }
         }
     }
@@ -18635,7 +18743,7 @@ pub mod discovery_cloud_storage_conditions {
     /// The attribute of an object. See
     /// <https://cloud.google.com/storage/docs/storage-classes> for more information
     /// on storage classes.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CloudStorageObjectAttribute(std::borrow::Cow<'static, str>);
 
     impl CloudStorageObjectAttribute {
@@ -18701,8 +18809,14 @@ pub mod discovery_cloud_storage_conditions {
         }
     }
 
+    impl std::default::Default for CloudStorageObjectAttribute {
+        fn default() -> Self {
+            cloud_storage_object_attribute::CLOUD_STORAGE_OBJECT_ATTRIBUTE_UNSPECIFIED
+        }
+    }
+
     /// The attribute of a bucket.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct CloudStorageBucketAttribute(std::borrow::Cow<'static, str>);
 
     impl CloudStorageBucketAttribute {
@@ -18746,6 +18860,12 @@ pub mod discovery_cloud_storage_conditions {
     impl std::convert::From<std::string::String> for CloudStorageBucketAttribute {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for CloudStorageBucketAttribute {
+        fn default() -> Self {
+            cloud_storage_bucket_attribute::CLOUD_STORAGE_BUCKET_ATTRIBUTE_UNSPECIFIED
         }
     }
 }
@@ -19792,7 +19912,7 @@ pub mod amazon_s_3_bucket_conditions {
 
     /// Supported Amazon S3 bucket types.
     /// Defaults to TYPE_ALL_SUPPORTED.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct BucketType(std::borrow::Cow<'static, str>);
 
     impl BucketType {
@@ -19827,9 +19947,15 @@ pub mod amazon_s_3_bucket_conditions {
         }
     }
 
+    impl std::default::Default for BucketType {
+        fn default() -> Self {
+            bucket_type::TYPE_UNSPECIFIED
+        }
+    }
+
     /// Supported Amazon S3 object storage classes.
     /// Defaults to ALL_SUPPORTED_CLASSES.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ObjectStorageClass(std::borrow::Cow<'static, str>);
 
     impl ObjectStorageClass {
@@ -19874,6 +20000,12 @@ pub mod amazon_s_3_bucket_conditions {
     impl std::convert::From<std::string::String> for ObjectStorageClass {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ObjectStorageClass {
+        fn default() -> Self {
+            object_storage_class::UNSPECIFIED
         }
     }
 }
@@ -20481,7 +20613,7 @@ pub mod dlp_job {
     use super::*;
 
     /// Possible states of a job. New items may be added.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct JobState(std::borrow::Cow<'static, str>);
 
     impl JobState {
@@ -20529,6 +20661,12 @@ pub mod dlp_job {
     impl std::convert::From<std::string::String> for JobState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for JobState {
+        fn default() -> Self {
+            job_state::JOB_STATE_UNSPECIFIED
         }
     }
 
@@ -23007,7 +23145,7 @@ pub mod data_risk_level {
     use super::*;
 
     /// Various score levels for resources.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DataRiskLevelScore(std::borrow::Cow<'static, str>);
 
     impl DataRiskLevelScore {
@@ -23052,6 +23190,12 @@ pub mod data_risk_level {
     impl std::convert::From<std::string::String> for DataRiskLevelScore {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DataRiskLevelScore {
+        fn default() -> Self {
+            data_risk_level_score::RISK_SCORE_UNSPECIFIED
         }
     }
 }
@@ -23634,7 +23778,7 @@ pub mod table_data_profile {
     use super::*;
 
     /// Possible states of a profile. New items may be added.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -23669,6 +23813,12 @@ pub mod table_data_profile {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -24104,7 +24254,7 @@ pub mod column_data_profile {
     use super::*;
 
     /// Possible states of a profile. New items may be added.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -24142,8 +24292,14 @@ pub mod column_data_profile {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Data types of the data in a column. Types may be added over time.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ColumnDataType(std::borrow::Cow<'static, str>);
 
     impl ColumnDataType {
@@ -24229,8 +24385,14 @@ pub mod column_data_profile {
         }
     }
 
+    impl std::default::Default for ColumnDataType {
+        fn default() -> Self {
+            column_data_type::COLUMN_DATA_TYPE_UNSPECIFIED
+        }
+    }
+
     /// The possible policy states for a column.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ColumnPolicyState(std::borrow::Cow<'static, str>);
 
     impl ColumnPolicyState {
@@ -24261,6 +24423,12 @@ pub mod column_data_profile {
     impl std::convert::From<std::string::String> for ColumnPolicyState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ColumnPolicyState {
+        fn default() -> Self {
+            column_policy_state::COLUMN_POLICY_STATE_UNSPECIFIED
         }
     }
 }
@@ -24620,7 +24788,7 @@ pub mod file_store_data_profile {
     use super::*;
 
     /// Possible states of a profile. New items may be added.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -24655,6 +24823,12 @@ pub mod file_store_data_profile {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -25408,7 +25582,7 @@ pub mod data_profile_pub_sub_condition {
         use super::*;
 
         /// Logical operators for conditional checks.
-        #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
         pub struct PubSubLogicalOperator(std::borrow::Cow<'static, str>);
 
         impl PubSubLogicalOperator {
@@ -25443,10 +25617,16 @@ pub mod data_profile_pub_sub_condition {
                 Self(std::borrow::Cow::Owned(value))
             }
         }
+
+        impl std::default::Default for PubSubLogicalOperator {
+            fn default() -> Self {
+                pub_sub_logical_operator::LOGICAL_OPERATOR_UNSPECIFIED
+            }
+        }
     }
 
     /// Various score levels for resources.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ProfileScoreBucket(std::borrow::Cow<'static, str>);
 
     impl ProfileScoreBucket {
@@ -25479,6 +25659,12 @@ pub mod data_profile_pub_sub_condition {
     impl std::convert::From<std::string::String> for ProfileScoreBucket {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ProfileScoreBucket {
+        fn default() -> Self {
+            profile_score_bucket::PROFILE_SCORE_BUCKET_UNSPECIFIED
         }
     }
 }
@@ -26288,7 +26474,7 @@ pub mod cloud_sql_properties {
 
     /// Database engine of a Cloud SQL instance.
     /// New values may be added over time.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DatabaseEngine(std::borrow::Cow<'static, str>);
 
     impl DatabaseEngine {
@@ -26323,6 +26509,12 @@ pub mod cloud_sql_properties {
     impl std::convert::From<std::string::String> for DatabaseEngine {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DatabaseEngine {
+        fn default() -> Self {
+            database_engine::DATABASE_ENGINE_UNKNOWN
         }
     }
 
@@ -26471,7 +26663,7 @@ pub mod file_cluster_type {
 
     /// Cluster type. Each cluster corresponds to a set of file types.
     /// Over time, new types may be added and files may move between clusters.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Cluster(std::borrow::Cow<'static, str>);
 
     impl Cluster {
@@ -26524,6 +26716,12 @@ pub mod file_cluster_type {
     impl std::convert::From<std::string::String> for Cluster {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Cluster {
+        fn default() -> Self {
+            cluster::CLUSTER_UNSPECIFIED
         }
     }
 
@@ -26638,7 +26836,7 @@ pub mod sensitivity_score {
     use super::*;
 
     /// Various sensitivity score levels for resources.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SensitivityScoreLevel(std::borrow::Cow<'static, str>);
 
     impl SensitivityScoreLevel {
@@ -26688,6 +26886,12 @@ pub mod sensitivity_score {
     impl std::convert::From<std::string::String> for SensitivityScoreLevel {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SensitivityScoreLevel {
+        fn default() -> Self {
+            sensitivity_score_level::SENSITIVITY_SCORE_UNSPECIFIED
         }
     }
 }
@@ -27556,7 +27760,7 @@ pub mod custom_info_type {
     }
 
     /// Type of exclusion rule.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ExclusionType(std::borrow::Cow<'static, str>);
 
     impl ExclusionType {
@@ -27588,6 +27792,12 @@ pub mod custom_info_type {
     impl std::convert::From<std::string::String> for ExclusionType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ExclusionType {
+        fn default() -> Self {
+            exclusion_type::EXCLUSION_TYPE_UNSPECIFIED
         }
     }
 
@@ -28038,7 +28248,7 @@ pub mod cloud_storage_options {
     /// How to sample bytes if not all bytes are scanned. Meaningful only when used
     /// in conjunction with bytes_limit_per_file. If not specified, scanning would
     /// start from the top.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SampleMethod(std::borrow::Cow<'static, str>);
 
     impl SampleMethod {
@@ -28072,6 +28282,12 @@ pub mod cloud_storage_options {
     impl std::convert::From<std::string::String> for SampleMethod {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SampleMethod {
+        fn default() -> Self {
+            sample_method::SAMPLE_METHOD_UNSPECIFIED
         }
     }
 }
@@ -28279,7 +28495,7 @@ pub mod big_query_options {
     /// How to sample rows if not all rows are scanned. Meaningful only when used
     /// in conjunction with either rows_limit or rows_limit_percent. If not
     /// specified, rows are scanned in the order BigQuery reads them.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct SampleMethod(std::borrow::Cow<'static, str>);
 
     impl SampleMethod {
@@ -28314,6 +28530,12 @@ pub mod big_query_options {
     impl std::convert::From<std::string::String> for SampleMethod {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for SampleMethod {
+        fn default() -> Self {
+            sample_method::SAMPLE_METHOD_UNSPECIFIED
         }
     }
 }
@@ -29327,7 +29549,7 @@ impl wkt::message::Message for TableOptions {
 /// Enum of possible outcomes of transformations. SUCCESS if transformation and
 /// storing of transformation was successful, otherwise, reason for not
 /// transforming.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TransformationResultStatusType(std::borrow::Cow<'static, str>);
 
 impl TransformationResultStatusType {
@@ -29378,8 +29600,14 @@ impl std::convert::From<std::string::String> for TransformationResultStatusType 
     }
 }
 
+impl std::default::Default for TransformationResultStatusType {
+    fn default() -> Self {
+        transformation_result_status_type::STATE_TYPE_UNSPECIFIED
+    }
+}
+
 /// Describes functionality of a given container in its original format.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TransformationContainerType(std::borrow::Cow<'static, str>);
 
 impl TransformationContainerType {
@@ -29421,10 +29649,16 @@ impl std::convert::From<std::string::String> for TransformationContainerType {
     }
 }
 
+impl std::default::Default for TransformationContainerType {
+    fn default() -> Self {
+        transformation_container_type::TRANSFORM_UNKNOWN_CONTAINER
+    }
+}
+
 /// An enum of rules that can be used to transform a value. Can be a
 /// record suppression, or one of the transformation rules specified under
 /// `PrimitiveTransformation`.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TransformationType(std::borrow::Cow<'static, str>);
 
 impl TransformationType {
@@ -29502,8 +29736,14 @@ impl std::convert::From<std::string::String> for TransformationType {
     }
 }
 
+impl std::default::Default for TransformationType {
+    fn default() -> Self {
+        transformation_type::TRANSFORMATION_TYPE_UNSPECIFIED
+    }
+}
+
 /// Whether a profile being created is the first generation or an update.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ProfileGeneration(std::borrow::Cow<'static, str>);
 
 impl ProfileGeneration {
@@ -29541,9 +29781,15 @@ impl std::convert::From<std::string::String> for ProfileGeneration {
     }
 }
 
+impl std::default::Default for ProfileGeneration {
+    fn default() -> Self {
+        profile_generation::PROFILE_GENERATION_UNSPECIFIED
+    }
+}
+
 /// Over time new types may be added. Currently VIEW, MATERIALIZED_VIEW, and
 /// non-BigLake external tables are not supported.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct BigQueryTableTypeCollection(std::borrow::Cow<'static, str>);
 
 impl BigQueryTableTypeCollection {
@@ -29587,9 +29833,15 @@ impl std::convert::From<std::string::String> for BigQueryTableTypeCollection {
     }
 }
 
+impl std::default::Default for BigQueryTableTypeCollection {
+    fn default() -> Self {
+        big_query_table_type_collection::BIG_QUERY_COLLECTION_UNSPECIFIED
+    }
+}
+
 /// Over time new types may be added. Currently VIEW, MATERIALIZED_VIEW, and
 /// non-BigLake external tables are not supported.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct BigQueryTableType(std::borrow::Cow<'static, str>);
 
 impl BigQueryTableType {
@@ -29631,9 +29883,15 @@ impl std::convert::From<std::string::String> for BigQueryTableType {
     }
 }
 
+impl std::default::Default for BigQueryTableType {
+    fn default() -> Self {
+        big_query_table_type::BIG_QUERY_TABLE_TYPE_UNSPECIFIED
+    }
+}
+
 /// How frequently data profiles can be updated. New options can be added at a
 /// later time.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DataProfileUpdateFrequency(std::borrow::Cow<'static, str>);
 
 impl DataProfileUpdateFrequency {
@@ -29675,9 +29933,15 @@ impl std::convert::From<std::string::String> for DataProfileUpdateFrequency {
     }
 }
 
+impl std::default::Default for DataProfileUpdateFrequency {
+    fn default() -> Self {
+        data_profile_update_frequency::UPDATE_FREQUENCY_UNSPECIFIED
+    }
+}
+
 /// Attributes evaluated to determine if a table has been modified. New values
 /// may be added at a later time.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct BigQueryTableModification(std::borrow::Cow<'static, str>);
 
 impl BigQueryTableModification {
@@ -29712,9 +29976,15 @@ impl std::convert::From<std::string::String> for BigQueryTableModification {
     }
 }
 
+impl std::default::Default for BigQueryTableModification {
+    fn default() -> Self {
+        big_query_table_modification::TABLE_MODIFICATION_UNSPECIFIED
+    }
+}
+
 /// Attributes evaluated to determine if a schema has been modified. New values
 /// may be added at a later time.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct BigQuerySchemaModification(std::borrow::Cow<'static, str>);
 
 impl BigQuerySchemaModification {
@@ -29753,8 +30023,14 @@ impl std::convert::From<std::string::String> for BigQuerySchemaModification {
     }
 }
 
+impl std::default::Default for BigQuerySchemaModification {
+    fn default() -> Self {
+        big_query_schema_modification::SCHEMA_MODIFICATION_UNSPECIFIED
+    }
+}
+
 /// Operators available for comparing the value of fields.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct RelationalOperator(std::borrow::Cow<'static, str>);
 
 impl RelationalOperator {
@@ -29807,10 +30083,16 @@ impl std::convert::From<std::string::String> for RelationalOperator {
     }
 }
 
+impl std::default::Default for RelationalOperator {
+    fn default() -> Self {
+        relational_operator::RELATIONAL_OPERATOR_UNSPECIFIED
+    }
+}
+
 /// Type of the match which can be applied to different ways of matching, like
 /// Dictionary, regular expression and intersecting with findings of another
 /// info type.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct MatchingType(std::borrow::Cow<'static, str>);
 
 impl MatchingType {
@@ -29864,8 +30146,14 @@ impl std::convert::From<std::string::String> for MatchingType {
     }
 }
 
+impl std::default::Default for MatchingType {
+    fn default() -> Self {
+        matching_type::MATCHING_TYPE_UNSPECIFIED
+    }
+}
+
 /// Deprecated and unused.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ContentOption(std::borrow::Cow<'static, str>);
 
 impl ContentOption {
@@ -29900,8 +30188,14 @@ impl std::convert::From<std::string::String> for ContentOption {
     }
 }
 
+impl std::default::Default for ContentOption {
+    fn default() -> Self {
+        content_option::CONTENT_UNSPECIFIED
+    }
+}
+
 /// Type of metadata containing the finding.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct MetadataType(std::borrow::Cow<'static, str>);
 
 impl MetadataType {
@@ -29934,8 +30228,14 @@ impl std::convert::From<std::string::String> for MetadataType {
     }
 }
 
+impl std::default::Default for MetadataType {
+    fn default() -> Self {
+        metadata_type::METADATATYPE_UNSPECIFIED
+    }
+}
+
 /// Parts of the APIs which use certain infoTypes.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct InfoTypeSupportedBy(std::borrow::Cow<'static, str>);
 
 impl InfoTypeSupportedBy {
@@ -29971,8 +30271,14 @@ impl std::convert::From<std::string::String> for InfoTypeSupportedBy {
     }
 }
 
+impl std::default::Default for InfoTypeSupportedBy {
+    fn default() -> Self {
+        info_type_supported_by::ENUM_TYPE_UNSPECIFIED
+    }
+}
+
 /// An enum to represent the various types of DLP jobs.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DlpJobType(std::borrow::Cow<'static, str>);
 
 impl DlpJobType {
@@ -30007,8 +30313,14 @@ impl std::convert::From<std::string::String> for DlpJobType {
     }
 }
 
+impl std::default::Default for DlpJobType {
+    fn default() -> Self {
+        dlp_job_type::DLP_JOB_TYPE_UNSPECIFIED
+    }
+}
+
 /// State of a StoredInfoType version.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct StoredInfoTypeState(std::borrow::Cow<'static, str>);
 
 impl StoredInfoTypeState {
@@ -30053,9 +30365,15 @@ impl std::convert::From<std::string::String> for StoredInfoTypeState {
     }
 }
 
+impl std::default::Default for StoredInfoTypeState {
+    fn default() -> Self {
+        stored_info_type_state::STORED_INFO_TYPE_STATE_UNSPECIFIED
+    }
+}
+
 /// How broadly the data in the resource has been shared. New items may be added
 /// over time. A higher number means more restricted.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ResourceVisibility(std::borrow::Cow<'static, str>);
 
 impl ResourceVisibility {
@@ -30099,8 +30417,14 @@ impl std::convert::From<std::string::String> for ResourceVisibility {
     }
 }
 
+impl std::default::Default for ResourceVisibility {
+    fn default() -> Self {
+        resource_visibility::RESOURCE_VISIBILITY_UNSPECIFIED
+    }
+}
+
 /// How a resource is encrypted.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct EncryptionStatus(std::borrow::Cow<'static, str>);
 
 impl EncryptionStatus {
@@ -30138,9 +30462,15 @@ impl std::convert::From<std::string::String> for EncryptionStatus {
     }
 }
 
+impl std::default::Default for EncryptionStatus {
+    fn default() -> Self {
+        encryption_status::ENCRYPTION_STATUS_UNSPECIFIED
+    }
+}
+
 /// Bucketized nullness percentage levels. A higher level means a higher
 /// percentage of the column is null.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct NullPercentageLevel(std::borrow::Cow<'static, str>);
 
 impl NullPercentageLevel {
@@ -30186,11 +30516,17 @@ impl std::convert::From<std::string::String> for NullPercentageLevel {
     }
 }
 
+impl std::default::Default for NullPercentageLevel {
+    fn default() -> Self {
+        null_percentage_level::NULL_PERCENTAGE_LEVEL_UNSPECIFIED
+    }
+}
+
 /// Bucketized uniqueness score levels. A higher uniqueness score is a strong
 /// signal that the column may contain a unique identifier like user id. A low
 /// value indicates that the column contains few unique values like booleans or
 /// other classifiers.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct UniquenessScoreLevel(std::borrow::Cow<'static, str>);
 
 impl UniquenessScoreLevel {
@@ -30233,9 +30569,15 @@ impl std::convert::From<std::string::String> for UniquenessScoreLevel {
     }
 }
 
+impl std::default::Default for UniquenessScoreLevel {
+    fn default() -> Self {
+        uniqueness_score_level::UNIQUENESS_SCORE_LEVEL_UNSPECIFIED
+    }
+}
+
 /// State of the connection.
 /// New values may be added over time.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ConnectionState(std::borrow::Cow<'static, str>);
 
 impl ConnectionState {
@@ -30281,6 +30623,12 @@ impl std::convert::From<std::string::String> for ConnectionState {
     }
 }
 
+impl std::default::Default for ConnectionState {
+    fn default() -> Self {
+        connection_state::CONNECTION_STATE_UNSPECIFIED
+    }
+}
+
 /// Coarse-grained confidence level of how well a particular finding
 /// satisfies the criteria to match a particular infoType.
 ///
@@ -30296,7 +30644,7 @@ impl std::convert::From<std::string::String> for ConnectionState {
 /// For more information about each likelihood level
 /// and how likelihood works, see [Match
 /// likelihood](https://cloud.google.com/sensitive-data-protection/docs/likelihood).
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Likelihood(std::borrow::Cow<'static, str>);
 
 impl Likelihood {
@@ -30340,9 +30688,15 @@ impl std::convert::From<std::string::String> for Likelihood {
     }
 }
 
+impl std::default::Default for Likelihood {
+    fn default() -> Self {
+        likelihood::LIKELIHOOD_UNSPECIFIED
+    }
+}
+
 /// Definitions of file type groups to scan. New types will be added to this
 /// list.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct FileType(std::borrow::Cow<'static, str>);
 
 impl FileType {
@@ -30432,5 +30786,11 @@ pub mod file_type {
 impl std::convert::From<std::string::String> for FileType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for FileType {
+    fn default() -> Self {
+        file_type::FILE_TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/rpc/types/src/model.rs
+++ b/src/generated/rpc/types/src/model.rs
@@ -1039,7 +1039,7 @@ impl wkt::message::Message for Status {
 /// the most specific error code that applies.  For example, prefer
 /// `OUT_OF_RANGE` over `FAILED_PRECONDITION` if both codes apply.
 /// Similarly prefer `NOT_FOUND` or `ALREADY_EXISTS` over `FAILED_PRECONDITION`.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Code(std::borrow::Cow<'static, str>);
 
 impl Code {
@@ -1216,5 +1216,11 @@ pub mod code {
 impl std::convert::From<std::string::String> for Code {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for Code {
+    fn default() -> Self {
+        code::OK
     }
 }

--- a/src/generated/spanner/admin/database/v1/src/model.rs
+++ b/src/generated/spanner/admin/database/v1/src/model.rs
@@ -390,7 +390,7 @@ pub mod backup {
     use super::*;
 
     /// Indicates the current state of the backup.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -423,6 +423,12 @@ pub mod backup {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -1466,7 +1472,7 @@ pub mod create_backup_encryption_config {
     use super::*;
 
     /// Encryption types for the backup.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EncryptionType(std::borrow::Cow<'static, str>);
 
     impl EncryptionType {
@@ -1513,6 +1519,12 @@ pub mod create_backup_encryption_config {
     impl std::convert::From<std::string::String> for EncryptionType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EncryptionType {
+        fn default() -> Self {
+            encryption_type::ENCRYPTION_TYPE_UNSPECIFIED
         }
     }
 }
@@ -1603,7 +1615,7 @@ pub mod copy_backup_encryption_config {
     use super::*;
 
     /// Encryption types for the backup.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EncryptionType(std::borrow::Cow<'static, str>);
 
     impl EncryptionType {
@@ -1652,6 +1664,12 @@ pub mod copy_backup_encryption_config {
     impl std::convert::From<std::string::String> for EncryptionType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EncryptionType {
+        fn default() -> Self {
+            encryption_type::ENCRYPTION_TYPE_UNSPECIFIED
         }
     }
 }
@@ -2579,7 +2597,7 @@ pub mod encryption_info {
     use super::*;
 
     /// Possible encryption types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -2615,6 +2633,12 @@ pub mod encryption_info {
     impl std::convert::From<std::string::String> for Type {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -2912,7 +2936,7 @@ pub mod database {
     use super::*;
 
     /// Indicates the current state of the database.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2955,6 +2979,12 @@ pub mod database {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -4218,7 +4248,7 @@ pub mod restore_database_encryption_config {
     use super::*;
 
     /// Encryption types for the database to be restored.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EncryptionType(std::borrow::Cow<'static, str>);
 
     impl EncryptionType {
@@ -4262,6 +4292,12 @@ pub mod restore_database_encryption_config {
     impl std::convert::From<std::string::String> for EncryptionType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for EncryptionType {
+        fn default() -> Self {
+            encryption_type::ENCRYPTION_TYPE_UNSPECIFIED
         }
     }
 }
@@ -4848,7 +4884,7 @@ pub mod split_points {
 }
 
 /// Indicates the dialect type of a database.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DatabaseDialect(std::borrow::Cow<'static, str>);
 
 impl DatabaseDialect {
@@ -4885,8 +4921,14 @@ impl std::convert::From<std::string::String> for DatabaseDialect {
     }
 }
 
+impl std::default::Default for DatabaseDialect {
+    fn default() -> Self {
+        database_dialect::DATABASE_DIALECT_UNSPECIFIED
+    }
+}
+
 /// Indicates the type of the restore source.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct RestoreSourceType(std::borrow::Cow<'static, str>);
 
 impl RestoreSourceType {
@@ -4915,5 +4957,11 @@ pub mod restore_source_type {
 impl std::convert::From<std::string::String> for RestoreSourceType {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for RestoreSourceType {
+    fn default() -> Self {
+        restore_source_type::TYPE_UNSPECIFIED
     }
 }

--- a/src/generated/spanner/admin/instance/v1/src/model.rs
+++ b/src/generated/spanner/admin/instance/v1/src/model.rs
@@ -179,7 +179,7 @@ pub mod replica_info {
     /// Indicates the type of replica.  See the [replica types
     /// documentation](https://cloud.google.com/spanner/docs/replication#replica_types)
     /// for more details.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ReplicaType(std::borrow::Cow<'static, str>);
 
     impl ReplicaType {
@@ -231,6 +231,12 @@ pub mod replica_info {
     impl std::convert::From<std::string::String> for ReplicaType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ReplicaType {
+        fn default() -> Self {
+            replica_type::TYPE_UNSPECIFIED
         }
     }
 }
@@ -484,7 +490,7 @@ pub mod instance_config {
     use super::*;
 
     /// The type of this configuration.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Type(std::borrow::Cow<'static, str>);
 
     impl Type {
@@ -519,8 +525,14 @@ pub mod instance_config {
         }
     }
 
+    impl std::default::Default for Type {
+        fn default() -> Self {
+            r#type::TYPE_UNSPECIFIED
+        }
+    }
+
     /// Indicates the current state of the instance configuration.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -556,9 +568,15 @@ pub mod instance_config {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// Describes the availability for free instances to be created in an instance
     /// configuration.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct FreeInstanceAvailability(std::borrow::Cow<'static, str>);
 
     impl FreeInstanceAvailability {
@@ -607,8 +625,14 @@ pub mod instance_config {
         }
     }
 
+    impl std::default::Default for FreeInstanceAvailability {
+        fn default() -> Self {
+            free_instance_availability::FREE_INSTANCE_AVAILABILITY_UNSPECIFIED
+        }
+    }
+
     /// Indicates the quorum type of this instance configuration.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct QuorumType(std::borrow::Cow<'static, str>);
 
     impl QuorumType {
@@ -651,6 +675,12 @@ pub mod instance_config {
     impl std::convert::From<std::string::String> for QuorumType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for QuorumType {
+        fn default() -> Self {
+            quorum_type::QUORUM_TYPE_UNSPECIFIED
         }
     }
 }
@@ -1530,7 +1560,7 @@ pub mod instance {
     use super::*;
 
     /// Indicates the current state of the instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -1568,11 +1598,17 @@ pub mod instance {
         }
     }
 
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
+        }
+    }
+
     /// The type of this instance. The type can be used to distinguish product
     /// variants, that can affect aspects like: usage restrictions, quotas and
     /// billing. Currently this is used to distinguish FREE_INSTANCE vs PROVISIONED
     /// instances.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct InstanceType(std::borrow::Cow<'static, str>);
 
     impl InstanceType {
@@ -1611,9 +1647,15 @@ pub mod instance {
         }
     }
 
+    impl std::default::Default for InstanceType {
+        fn default() -> Self {
+            instance_type::INSTANCE_TYPE_UNSPECIFIED
+        }
+    }
+
     /// The edition selected for this instance. Different editions provide
     /// different capabilities at different price points.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Edition(std::borrow::Cow<'static, str>);
 
     impl Edition {
@@ -1651,11 +1693,17 @@ pub mod instance {
         }
     }
 
+    impl std::default::Default for Edition {
+        fn default() -> Self {
+            edition::EDITION_UNSPECIFIED
+        }
+    }
+
     /// Indicates the
     /// [default backup
     /// schedule](https://cloud.google.com/spanner/docs/backup#default-backup-schedules)
     /// behavior for new databases within the instance.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct DefaultBackupScheduleType(std::borrow::Cow<'static, str>);
 
     impl DefaultBackupScheduleType {
@@ -1693,6 +1741,12 @@ pub mod instance {
     impl std::convert::From<std::string::String> for DefaultBackupScheduleType {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for DefaultBackupScheduleType {
+        fn default() -> Self {
+            default_backup_schedule_type::DEFAULT_BACKUP_SCHEDULE_TYPE_UNSPECIFIED
         }
     }
 }
@@ -2903,7 +2957,7 @@ pub mod free_instance_metadata {
     use super::*;
 
     /// Allows users to change behavior when a free instance expires.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ExpireBehavior(std::borrow::Cow<'static, str>);
 
     impl ExpireBehavior {
@@ -2939,6 +2993,12 @@ pub mod free_instance_metadata {
     impl std::convert::From<std::string::String> for ExpireBehavior {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ExpireBehavior {
+        fn default() -> Self {
+            expire_behavior::EXPIRE_BEHAVIOR_UNSPECIFIED
         }
     }
 }
@@ -3314,7 +3374,7 @@ pub mod instance_partition {
     use super::*;
 
     /// Indicates the current state of the instance partition.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -3349,6 +3409,12 @@ pub mod instance_partition {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 
@@ -4281,7 +4347,7 @@ impl wkt::message::Message for MoveInstanceMetadata {
 }
 
 /// Indicates the expected fulfillment period of an operation.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct FulfillmentPeriod(std::borrow::Cow<'static, str>);
 
 impl FulfillmentPeriod {
@@ -4318,5 +4384,11 @@ pub mod fulfillment_period {
 impl std::convert::From<std::string::String> for FulfillmentPeriod {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for FulfillmentPeriod {
+    fn default() -> Self {
+        fulfillment_period::FULFILLMENT_PERIOD_UNSPECIFIED
     }
 }

--- a/src/generated/storagetransfer/v1/src/model.rs
+++ b/src/generated/storagetransfer/v1/src/model.rs
@@ -1912,7 +1912,7 @@ pub mod s_3_compatible_metadata {
     use super::*;
 
     /// The authentication and authorization method used by the storage service.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct AuthMethod(std::borrow::Cow<'static, str>);
 
     impl AuthMethod {
@@ -1949,8 +1949,14 @@ pub mod s_3_compatible_metadata {
         }
     }
 
+    impl std::default::Default for AuthMethod {
+        fn default() -> Self {
+            auth_method::AUTH_METHOD_UNSPECIFIED
+        }
+    }
+
     /// The request model of the API.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct RequestModel(std::borrow::Cow<'static, str>);
 
     impl RequestModel {
@@ -1990,8 +1996,14 @@ pub mod s_3_compatible_metadata {
         }
     }
 
+    impl std::default::Default for RequestModel {
+        fn default() -> Self {
+            request_model::REQUEST_MODEL_UNSPECIFIED
+        }
+    }
+
     /// The agent network protocol to access the storage service.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct NetworkProtocol(std::borrow::Cow<'static, str>);
 
     impl NetworkProtocol {
@@ -2031,8 +2043,14 @@ pub mod s_3_compatible_metadata {
         }
     }
 
+    impl std::default::Default for NetworkProtocol {
+        fn default() -> Self {
+            network_protocol::NETWORK_PROTOCOL_UNSPECIFIED
+        }
+    }
+
     /// The Listing API to use for discovering objects.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct ListApi(std::borrow::Cow<'static, str>);
 
     impl ListApi {
@@ -2064,6 +2082,12 @@ pub mod s_3_compatible_metadata {
     impl std::convert::From<std::string::String> for ListApi {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for ListApi {
+        fn default() -> Self {
+            list_api::LIST_API_UNSPECIFIED
         }
     }
 }
@@ -2173,7 +2197,7 @@ pub mod agent_pool {
     }
 
     /// The state of an AgentPool.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct State(std::borrow::Cow<'static, str>);
 
     impl State {
@@ -2211,6 +2235,12 @@ pub mod agent_pool {
     impl std::convert::From<std::string::String> for State {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for State {
+        fn default() -> Self {
+            state::STATE_UNSPECIFIED
         }
     }
 }
@@ -2323,7 +2353,7 @@ pub mod transfer_options {
 
     /// Specifies when to overwrite an object in the sink when an object with
     /// matching name is found in the source.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct OverwriteWhen(std::borrow::Cow<'static, str>);
 
     impl OverwriteWhen {
@@ -2362,6 +2392,12 @@ pub mod transfer_options {
     impl std::convert::From<std::string::String> for OverwriteWhen {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for OverwriteWhen {
+        fn default() -> Self {
+            overwrite_when::OVERWRITE_WHEN_UNSPECIFIED
         }
     }
 }
@@ -3214,7 +3250,7 @@ pub mod metadata_options {
     use super::*;
 
     /// Whether symlinks should be skipped or preserved during a transfer job.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Symlink(std::borrow::Cow<'static, str>);
 
     impl Symlink {
@@ -3249,8 +3285,14 @@ pub mod metadata_options {
         }
     }
 
+    impl std::default::Default for Symlink {
+        fn default() -> Self {
+            symlink::SYMLINK_UNSPECIFIED
+        }
+    }
+
     /// Options for handling file mode attribute.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Mode(std::borrow::Cow<'static, str>);
 
     impl Mode {
@@ -3285,8 +3327,14 @@ pub mod metadata_options {
         }
     }
 
+    impl std::default::Default for Mode {
+        fn default() -> Self {
+            mode::MODE_UNSPECIFIED
+        }
+    }
+
     /// Options for handling file GID attribute.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Gid(std::borrow::Cow<'static, str>);
 
     impl Gid {
@@ -3321,8 +3369,14 @@ pub mod metadata_options {
         }
     }
 
+    impl std::default::Default for Gid {
+        fn default() -> Self {
+            gid::GID_UNSPECIFIED
+        }
+    }
+
     /// Options for handling file UID attribute.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Uid(std::borrow::Cow<'static, str>);
 
     impl Uid {
@@ -3357,8 +3411,14 @@ pub mod metadata_options {
         }
     }
 
+    impl std::default::Default for Uid {
+        fn default() -> Self {
+            uid::UID_UNSPECIFIED
+        }
+    }
+
     /// Options for handling Cloud Storage object ACLs.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Acl(std::borrow::Cow<'static, str>);
 
     impl Acl {
@@ -3397,8 +3457,14 @@ pub mod metadata_options {
         }
     }
 
+    impl std::default::Default for Acl {
+        fn default() -> Self {
+            acl::ACL_UNSPECIFIED
+        }
+    }
+
     /// Options for handling Google Cloud Storage object storage class.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct StorageClass(std::borrow::Cow<'static, str>);
 
     impl StorageClass {
@@ -3454,8 +3520,14 @@ pub mod metadata_options {
         }
     }
 
+    impl std::default::Default for StorageClass {
+        fn default() -> Self {
+            storage_class::STORAGE_CLASS_UNSPECIFIED
+        }
+    }
+
     /// Options for handling temporary holds for Google Cloud Storage objects.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TemporaryHold(std::borrow::Cow<'static, str>);
 
     impl TemporaryHold {
@@ -3492,8 +3564,14 @@ pub mod metadata_options {
         }
     }
 
+    impl std::default::Default for TemporaryHold {
+        fn default() -> Self {
+            temporary_hold::TEMPORARY_HOLD_UNSPECIFIED
+        }
+    }
+
     /// Options for handling the KmsKey setting for Google Cloud Storage objects.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct KmsKey(std::borrow::Cow<'static, str>);
 
     impl KmsKey {
@@ -3531,9 +3609,15 @@ pub mod metadata_options {
         }
     }
 
+    impl std::default::Default for KmsKey {
+        fn default() -> Self {
+            kms_key::KMS_KEY_UNSPECIFIED
+        }
+    }
+
     /// Options for handling `timeCreated` metadata for Google Cloud Storage
     /// objects.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct TimeCreated(std::borrow::Cow<'static, str>);
 
     impl TimeCreated {
@@ -3570,6 +3654,12 @@ pub mod metadata_options {
     impl std::convert::From<std::string::String> for TimeCreated {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for TimeCreated {
+        fn default() -> Self {
+            time_created::TIME_CREATED_UNSPECIFIED
         }
     }
 }
@@ -4087,7 +4177,7 @@ pub mod transfer_job {
     use super::*;
 
     /// The status of the transfer job.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Status(std::borrow::Cow<'static, str>);
 
     impl Status {
@@ -4125,6 +4215,12 @@ pub mod transfer_job {
     impl std::convert::From<std::string::String> for Status {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Status {
+        fn default() -> Self {
+            status::STATUS_UNSPECIFIED
         }
     }
 }
@@ -4604,7 +4700,7 @@ pub mod notification_config {
     /// Additional event types may be added in the future. Clients should either
     /// safely ignore unrecognized event types or explicitly specify which event
     /// types they are prepared to accept.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct EventType(std::borrow::Cow<'static, str>);
 
     impl EventType {
@@ -4654,8 +4750,14 @@ pub mod notification_config {
         }
     }
 
+    impl std::default::Default for EventType {
+        fn default() -> Self {
+            event_type::EVENT_TYPE_UNSPECIFIED
+        }
+    }
+
     /// Enum for specifying the format of a notification message's payload.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct PayloadFormat(std::borrow::Cow<'static, str>);
 
     impl PayloadFormat {
@@ -4690,6 +4792,12 @@ pub mod notification_config {
     impl std::convert::From<std::string::String> for PayloadFormat {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for PayloadFormat {
+        fn default() -> Self {
+            payload_format::PAYLOAD_FORMAT_UNSPECIFIED
         }
     }
 }
@@ -4772,7 +4880,7 @@ pub mod logging_config {
     use super::*;
 
     /// Loggable actions.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LoggableAction(std::borrow::Cow<'static, str>);
 
     impl LoggableAction {
@@ -4811,8 +4919,14 @@ pub mod logging_config {
         }
     }
 
+    impl std::default::Default for LoggableAction {
+        fn default() -> Self {
+            loggable_action::LOGGABLE_ACTION_UNSPECIFIED
+        }
+    }
+
     /// Loggable action states.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct LoggableActionState(std::borrow::Cow<'static, str>);
 
     impl LoggableActionState {
@@ -4847,6 +4961,12 @@ pub mod logging_config {
     impl std::convert::From<std::string::String> for LoggableActionState {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for LoggableActionState {
+        fn default() -> Self {
+            loggable_action_state::LOGGABLE_ACTION_STATE_UNSPECIFIED
         }
     }
 }
@@ -5022,7 +5142,7 @@ pub mod transfer_operation {
     use super::*;
 
     /// The status of a TransferOperation.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Status(std::borrow::Cow<'static, str>);
 
     impl Status {
@@ -5069,6 +5189,12 @@ pub mod transfer_operation {
     impl std::convert::From<std::string::String> for Status {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Status {
+        fn default() -> Self {
+            status::STATUS_UNSPECIFIED
         }
     }
 }

--- a/src/generated/type/src/model.rs
+++ b/src/generated/type/src/model.rs
@@ -1579,7 +1579,7 @@ impl wkt::message::Message for TimeOfDay {
 /// A `CalendarPeriod` represents the abstract concept of a time period that has
 /// a canonical start. Grammatically, "the start of the current
 /// `CalendarPeriod`." All calendar times begin at midnight UTC.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct CalendarPeriod(std::borrow::Cow<'static, str>);
 
 impl CalendarPeriod {
@@ -1634,8 +1634,14 @@ impl std::convert::From<std::string::String> for CalendarPeriod {
     }
 }
 
+impl std::default::Default for CalendarPeriod {
+    fn default() -> Self {
+        calendar_period::CALENDAR_PERIOD_UNSPECIFIED
+    }
+}
+
 /// Represents a day of the week.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct DayOfWeek(std::borrow::Cow<'static, str>);
 
 impl DayOfWeek {
@@ -1685,8 +1691,14 @@ impl std::convert::From<std::string::String> for DayOfWeek {
     }
 }
 
+impl std::default::Default for DayOfWeek {
+    fn default() -> Self {
+        day_of_week::DAY_OF_WEEK_UNSPECIFIED
+    }
+}
+
 /// Represents a month in the Gregorian calendar.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Month(std::borrow::Cow<'static, str>);
 
 impl Month {
@@ -1748,5 +1760,11 @@ pub mod month {
 impl std::convert::From<std::string::String> for Month {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for Month {
+    fn default() -> Self {
+        month::MONTH_UNSPECIFIED
     }
 }

--- a/src/integration-tests/src/workflows.rs
+++ b/src/integration-tests/src/workflows.rs
@@ -73,8 +73,6 @@ main:
         .set_workflow(
             wf::model::Workflow::new()
                 .set_labels([("integration-test", "true")])
-                .set_call_log_level(wf::model::workflow::call_log_level::LOG_ERRORS_ONLY)
-                .set_state(wf::model::workflow::state::UNAVAILABLE)
                 .set_service_account(&workflows_runner)
                 .set_source_code(source_code),
         )
@@ -149,8 +147,6 @@ main:
         .set_workflow(
             wf::model::Workflow::new()
                 .set_labels([("integration-test", "true")])
-                .set_call_log_level(wf::model::workflow::call_log_level::LOG_ERRORS_ONLY)
-                .set_state(wf::model::workflow::state::UNAVAILABLE)
                 .set_service_account(&workflows_runner)
                 .set_source_code(source_code),
         )

--- a/src/integration-tests/tests/enums.rs
+++ b/src/integration-tests/tests/enums.rs
@@ -1,0 +1,36 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(test)]
+mod enums {
+    use sm::model::*;
+
+    #[test]
+    fn test_default_value() {
+        let default = secret_version::State::default();
+        assert_eq!(default, secret_version::state::STATE_UNSPECIFIED);
+    }
+
+    #[test]
+    fn test_deserialize_default() {
+        let input = serde_json::json!({
+            "name": "projects/test-only/secrets/my-secret/versions/my-version",
+        });
+        let secret_version = serde_json::from_value::<SecretVersion>(input).unwrap();
+        assert_eq!(
+            secret_version.state,
+            secret_version::state::STATE_UNSPECIFIED
+        );
+    }
+}

--- a/src/wkt/src/generated/mod.rs
+++ b/src/wkt/src/generated/mod.rs
@@ -648,7 +648,7 @@ pub mod field {
     use super::*;
 
     /// Basic field types.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Kind(std::borrow::Cow<'static, str>);
 
     impl Kind {
@@ -731,8 +731,14 @@ pub mod field {
         }
     }
 
+    impl std::default::Default for Kind {
+        fn default() -> Self {
+            kind::TYPE_UNKNOWN
+        }
+    }
+
     /// Whether a field is optional, required, or repeated.
-    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
     pub struct Cardinality(std::borrow::Cow<'static, str>);
 
     impl Cardinality {
@@ -767,6 +773,12 @@ pub mod field {
     impl std::convert::From<std::string::String> for Cardinality {
         fn from(value: std::string::String) -> Self {
             Self(std::borrow::Cow::Owned(value))
+        }
+    }
+
+    impl std::default::Default for Cardinality {
+        fn default() -> Self {
+            cardinality::CARDINALITY_UNKNOWN
         }
     }
 }
@@ -965,7 +977,7 @@ impl wkt::message::Message for Option {
 }
 
 /// The syntax in which a protocol buffer element is defined.
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Syntax(std::borrow::Cow<'static, str>);
 
 impl Syntax {
@@ -997,5 +1009,11 @@ pub mod syntax {
 impl std::convert::From<std::string::String> for Syntax {
     fn from(value: std::string::String) -> Self {
         Self(std::borrow::Cow::Owned(value))
+    }
+}
+
+impl std::default::Default for Syntax {
+    fn default() -> Self {
+        syntax::SYNTAX_PROTO2
     }
 }


### PR DESCRIPTION
The enums should default to (one of) the values with numeric value 0.  I
included an integration test for the generated code, and simplified some
existing integration tests.

Fixes #1360
