### PR TITLE
feat(generator/dart): support the 'not-for-publication' config setting

### DIFF
--- a/generator/dart/packages/generated/google_cloud_protobuf/.sidekick.toml
+++ b/generator/dart/packages/generated/google_cloud_protobuf/.sidekick.toml
@@ -23,6 +23,5 @@ include-list = "field_mask.proto"
 
 [codec]
 copyright-year = '2025'
-package-name-override = "google_cloud_protobuf"
 part-file = "src/protobuf.p.dart"
 dev-dependencies = "test"

--- a/generator/dart/packages/generated/google_cloud_type/.sidekick.toml
+++ b/generator/dart/packages/generated/google_cloud_type/.sidekick.toml
@@ -21,4 +21,3 @@ include-list = "expr.proto"
 
 [codec]
 copyright-year = '2025'
-package-name-override = "google_cloud_type"

--- a/generator/internal/dart/templates/pubspec.yaml.mustache
+++ b/generator/internal/dart/templates/pubspec.yaml.mustache
@@ -20,7 +20,12 @@ limitations under the License.
 
 name: {{Codec.PackageName}}
 description: The Google Cloud client library for the {{Title}}.
+{{^Codec.DoNotPublish}}
 version: {{Codec.PackageVersion}}
+{{/Codec.DoNotPublish}}
+{{#Codec.DoNotPublish}}
+publish_to: none
+{{/Codec.DoNotPublish}}
 
 environment: 
   sdk: ^3.6.0

--- a/generator/testdata/dart/protobuf/golden/secretmanager/analysis_options.yaml
+++ b/generator/testdata/dart/protobuf/golden/secretmanager/analysis_options.yaml
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[general]
-specification-source = 'google/rpc'
-service-config = 'google/rpc/rpc_publish.yaml'
-
-[codec]
-copyright-year = '2025'
+analyzer:
+  # Exclude lib/secretmanager.dart from analysis; we use this golden output
+  # mostly for git diffs.
+  exclude:
+    - lib/secretmanager.dart

--- a/generator/testdata/dart/protobuf/golden/secretmanager/pubspec.yaml
+++ b/generator/testdata/dart/protobuf/golden/secretmanager/pubspec.yaml
@@ -16,7 +16,7 @@
 
 name: google_cloud_secretmanager
 description: The Google Cloud client library for the Secret Manager API.
-version: 0.1.0
+publish_to: none
 
 environment: 
   sdk: ^3.6.0


### PR DESCRIPTION
- support the 'not-for-publication' config setting; translate this to the Dart `publish_to: none` convention
- remove some unnecessary 'package-name-override' settings; they are the same as the calculated, default name
- ignore analysis for `generator/testdata/dart/protobuf/golden/secretmanager`; we'll get correct analysis (provisioned packages, ...) from `generator/dart/packages/`
