### PR TITLE
feat(generator/dart): calculate dependencies on wkt packages

### DIFF
--- a/generator/dart/.sidekick.toml
+++ b/generator/dart/.sidekick.toml
@@ -30,3 +30,9 @@ version = "0.1.0"
 
 # Default package dependency versions.
 'package:http' = '^1.3.0'
+
+# A mapping from protobuf packages to Dart imports.
+'proto:google.cloud.location' = 'package:google_cloud_location/location.dart'
+'proto:google.protobuf'       = 'package:google_cloud_protobuf/protobuf.dart'
+'proto:google.rpc'            = 'package:google_cloud_rpc/rpc.dart'
+'proto:google.type'           = 'package:google_cloud_type/type.dart'

--- a/generator/dart/packages/generated/google_cloud_protobuf/lib/protobuf.dart
+++ b/generator/dart/packages/generated/google_cloud_protobuf/lib/protobuf.dart
@@ -19,6 +19,7 @@
 /// Core Protobuf types used by most services.
 library;
 
+
 part 'src/protobuf.p.dart';
 
 /// `FieldMask` represents a set of symbolic field paths, for example:

--- a/generator/dart/packages/generated/google_cloud_rpc/lib/rpc.dart
+++ b/generator/dart/packages/generated/google_cloud_rpc/lib/rpc.dart
@@ -21,6 +21,8 @@ library;
 
 import 'dart:typed_data';
 
+import 'package:google_cloud_protobuf/protobuf.dart';
+
 /// Describes the cause of the error with structured details.
 /// 
 /// Example of an error when contacting the "pubsub.googleapis.com" API when it
@@ -96,7 +98,7 @@ class ErrorInfo {
 class RetryInfo {
 
   /// Clients should wait at least this long between retrying the same request.
-  final Duration? retryDelay;
+  final PbDuration? retryDelay;
 
   RetryInfo({
     this.retryDelay,

--- a/generator/dart/packages/generated/google_cloud_rpc/pubspec.yaml
+++ b/generator/dart/packages/generated/google_cloud_rpc/pubspec.yaml
@@ -22,3 +22,6 @@ environment:
   sdk: ^3.6.0
 
 resolution: workspace
+
+dependencies:
+  google_cloud_protobuf: any

--- a/generator/internal/dart/dart.go
+++ b/generator/internal/dart/dart.go
@@ -29,53 +29,20 @@ import (
 //go:embed templates
 var dartTemplates embed.FS
 
-type dartImport struct {
-	// The Protobuf package this message belongs to.
-	Package string
-	// The import url to use, i.e., 'package:foo/foo.dart' or 'dart:typed_data'.
-	DartImport string
-}
-
-// A mapping from protobuf packages to their equivalent Dart import.
-//
-// This covers well-known types and other common imports.
-var wellKnownTypes = map[string]*dartImport{
-	"google.cloud.location": {
-		Package:    "google.cloud.location",
-		DartImport: "package:google_cloud_location/location.dart",
-	},
-	"google.protobuf": {
-		Package:    "google.protobuf",
-		DartImport: "package:google_cloud_protobuf/protobuf.dart",
-	},
-	"google.rpc": {
-		Package:    "google.rpc",
-		DartImport: "package:google_cloud_rpc/rpc.dart",
-	},
-	"google.type": {
-		Package:    "google.type",
-		DartImport: "package:google_cloud_type/type.dart",
-	},
-}
-
 // A map of message ID => name renames.
 //
 // `Duration` in particular is important to rename as this would conflict with
 // the `Duration` class in the 'dart:core' library (imported by default into
 // every library).
+// TODO(#1034): Renaming this class is practical but unlikely to be what we want
+// to do long term. We want a reliable, low-ceremony way of avoiding name
+// conflicts with dart:core types.
 var messageRenames = map[string]string{
 	".google.protobuf.Duration": "PbDuration",
 }
 
-var typedDataImport = &dartImport{
-	Package:    "typed_data",
-	DartImport: "dart:typed_data",
-}
-
-var httpImport = &dartImport{
-	Package:    "http",
-	DartImport: "package:http/http.dart",
-}
+var typedDataImport = "dart:typed_data"
+var httpImport = "package:http/http.dart"
 
 func Generate(model *api.API, outdir string, options map[string]string) error {
 	_, err := annotateModel(model, options)
@@ -106,7 +73,7 @@ func generatedFiles(model *api.API) []language.GeneratedFile {
 	return files
 }
 
-func fieldType(f *api.Field, state *api.APIState, importMap map[string]*dartImport) string {
+func fieldType(f *api.Field, state *api.APIState, packageMapping map[string]string, imports map[string]string) string {
 	var out string
 
 	switch f.Typez {
@@ -129,20 +96,20 @@ func fieldType(f *api.Field, state *api.APIState, importMap map[string]*dartImpo
 	case api.BYTES_TYPE:
 		// TODO(#1034): We should instead reference a custom type (ProtoBuffer or
 		// similar), encode/decode to it, and add Uint8List related utility methods.
-		importMap[typedDataImport.Package] = typedDataImport
+		imports["typed_data"] = typedDataImport
 		out = "Uint8List"
 	case api.MESSAGE_TYPE:
-		m, ok := state.MessageByID[f.TypezID]
+		message, ok := state.MessageByID[f.TypezID]
 		if !ok {
 			slog.Error("unable to lookup type", "id", f.TypezID)
 			return ""
 		}
-		if m.IsMap {
-			key := fieldType(m.Fields[0], state, importMap)
-			val := fieldType(m.Fields[1], state, importMap)
+		if message.IsMap {
+			key := fieldType(message.Fields[0], state, packageMapping, imports)
+			val := fieldType(message.Fields[1], state, packageMapping, imports)
 			out = "Map<" + key + ", " + val + ">"
 		} else {
-			out = resolveTypeName(m.ID, state, importMap)
+			out = resolveTypeName(message, packageMapping, imports)
 		}
 	case api.ENUM_TYPE:
 		e, ok := state.EnumByID[f.TypezID]
@@ -172,35 +139,23 @@ func templatesProvider() language.TemplateProvider {
 	}
 }
 
-func resolveTypeName(id string, state *api.APIState, importMap map[string]*dartImport) string {
-	if id == "" {
+func resolveTypeName(message *api.Message, packageMapping map[string]string, imports map[string]string) string {
+	if message == nil {
+		slog.Error("unable to lookup type")
 		return ""
 	}
 
-	if id == ".google.protobuf.Empty" {
+	if message.ID == ".google.protobuf.Empty" {
 		return "void"
 	}
 
-	// Parse ".google.protobuf.FieldMask" into "google.protobuf" and use
-	// `wellKnownTypes` to add any necessary import.
-	packageName := strings.TrimPrefix(id, ".")
-	index := strings.LastIndex(packageName, ".")
-	if index != -1 {
-		packageName = packageName[:index]
-		importInfo, ok := wellKnownTypes[packageName]
-		if ok {
-			importMap[importInfo.Package] = importInfo
-		}
-	}
-
-	m, ok := state.MessageByID[id]
+	// Use the packageMapping info to add any necessary import.
+	dartImport, ok := packageMapping[message.Package]
 	if ok {
-		return messageName(m)
+		imports[message.Package] = dartImport
 	}
 
-	slog.Error("unable to lookup type", "id", id)
-
-	return ""
+	return messageName(message)
 }
 
 func messageName(m *api.Message) string {

--- a/generator/internal/dart/dart_test.go
+++ b/generator/internal/dart/dart_test.go
@@ -165,11 +165,17 @@ func TestResolveTypeName(t *testing.T) {
 			ID:   ".google.protobuf.Duration",
 			Name: "Duration",
 		}, {
+			ID:   ".google.protobuf.Empty",
+			Name: "Empty",
+		},
+		{
 			ID:   ".google.protobuf.Timestamp",
 			Name: "Timestamp",
 		},
 	}, []*api.Enum{}, []*api.Service{})
+
 	annotateModel(model, map[string]string{})
+	state := model.State
 
 	for _, test := range []struct {
 		typeId string
@@ -180,7 +186,7 @@ func TestResolveTypeName(t *testing.T) {
 		{".google.protobuf.Timestamp", "Timestamp"},
 		{".google.protobuf.Duration", "PbDuration"},
 	} {
-		got := resolveTypeName(test.typeId, model.State, map[string]*dartImport{})
+		got := resolveTypeName(state.MessageByID[test.typeId], map[string]string{}, map[string]string{})
 		if got != test.want {
 			t.Errorf("unexpected type name, got: %s want: %s", got, test.want)
 		}
@@ -188,21 +194,40 @@ func TestResolveTypeName(t *testing.T) {
 }
 
 func TestResolveTypeName_Imports(t *testing.T) {
-	model := api.NewTestAPI([]*api.Message{}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{
+		{
+			ID:      ".google.protobuf.Any",
+			Package: "google.protobuf",
+		},
+		{
+			ID:      ".google.rpc.Status",
+			Package: "google.rpc",
+		},
+		{
+			ID:      ".google.type.Expr",
+			Package: "google.type",
+		},
+	}, []*api.Enum{}, []*api.Service{})
+
 	annotateModel(model, map[string]string{})
+	state := model.State
+
+	packageMapping := map[string]string{
+		"google.protobuf": "package:google_cloud_protobuf/protobuf.dart",
+		"google.rpc":      "package:google_cloud_rpc/rpc.dart",
+		"google.type":     "package:google_cloud_type/type.dart",
+	}
 
 	for _, test := range []struct {
 		typeId string
 		want   string
 	}{
 		{".google.protobuf.Any", "google.protobuf"},
-		{".google.protobuf.Duration", "google.protobuf"},
-		{".google.protobuf.Timestamp", "google.protobuf"},
 		{".google.rpc.Status", "google.rpc"},
 		{".google.type.Expr", "google.type"},
 	} {
-		imports := map[string]*dartImport{}
-		resolveTypeName(test.typeId, model.State, imports)
+		imports := map[string]string{}
+		resolveTypeName(state.MessageByID[test.typeId], packageMapping, imports)
 		if _, ok := imports[test.want]; !ok {
 			t.Errorf("import not added type name, got: %v want: %s", imports, test.want)
 		}
@@ -240,7 +265,7 @@ func TestFieldType(t *testing.T) {
 		model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
 		annotateModel(model, map[string]string{})
 
-		got := fieldType(field, model.State, map[string]*dartImport{})
+		got := fieldType(field, model.State, map[string]string{}, map[string]string{})
 		if got != test.want {
 			t.Errorf("unexpected type name, got: %s want: %s", got, test.want)
 		}
@@ -276,13 +301,13 @@ func TestFieldType(t *testing.T) {
 	)
 	annotateModel(model, map[string]string{})
 
-	got := fieldType(field1, model.State, map[string]*dartImport{})
+	got := fieldType(field1, model.State, map[string]string{}, map[string]string{})
 	want := "CreateSecretRequest"
 	if got != want {
 		t.Errorf("unexpected type name, got: %s want: %s", got, want)
 	}
 
-	got = fieldType(field2, model.State, map[string]*dartImport{})
+	got = fieldType(field2, model.State, map[string]string{}, map[string]string{})
 	want = "State"
 	if got != want {
 		t.Errorf("unexpected type name, got: %s want: %s", got, want)
@@ -314,7 +339,7 @@ func TestFieldType_Maps(t *testing.T) {
 	model := api.NewTestAPI([]*api.Message{map1}, []*api.Enum{}, []*api.Service{})
 	annotateModel(model, map[string]string{})
 
-	got := fieldType(field, model.State, map[string]*dartImport{})
+	got := fieldType(field, model.State, map[string]string{}, map[string]string{})
 	want := "Map<String, int>"
 	if got != want {
 		t.Errorf("unexpected type name, got: %s want: %s", got, want)
@@ -335,9 +360,9 @@ func TestFieldType_Bytes(t *testing.T) {
 	}
 	model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
 	annotateModel(model, map[string]string{})
-	imports := map[string]*dartImport{}
+	imports := map[string]string{}
 
-	got := fieldType(field, model.State, imports)
+	got := fieldType(field, model.State, map[string]string{}, imports)
 	want := "Uint8List"
 	if got != want {
 		t.Errorf("unexpected type name, got: %s want: %s", got, want)
@@ -348,8 +373,7 @@ func TestFieldType_Bytes(t *testing.T) {
 		t.Errorf("unexpected: no typed_data import added")
 	}
 
-	for _, imp := range imports {
-		got := imp.DartImport
+	for _, got := range imports {
 		want := "dart:typed_data"
 		if got != want {
 			t.Errorf("unexpected import, got: %s want: %s", got, want)
@@ -388,7 +412,7 @@ func TestFieldType_Repeated(t *testing.T) {
 		model := api.NewTestAPI([]*api.Message{message}, []*api.Enum{}, []*api.Service{})
 		annotateModel(model, map[string]string{})
 
-		got := fieldType(field, model.State, map[string]*dartImport{})
+		got := fieldType(field, model.State, map[string]string{}, map[string]string{})
 		if got != test.want {
 			t.Errorf("unexpected type name, got: %s want: %s", got, test.want)
 		}
@@ -426,13 +450,13 @@ func TestFieldType_Repeated(t *testing.T) {
 	)
 	annotateModel(model, map[string]string{})
 
-	got := fieldType(field1, model.State, map[string]*dartImport{})
+	got := fieldType(field1, model.State, map[string]string{}, map[string]string{})
 	want := "List<CreateSecretRequest>"
 	if got != want {
 		t.Errorf("unexpected type name, got: %s want: %s", got, want)
 	}
 
-	got = fieldType(field2, model.State, map[string]*dartImport{})
+	got = fieldType(field2, model.State, map[string]string{}, map[string]string{})
 	want = "List<State>"
 	if got != want {
 		t.Errorf("unexpected type name, got: %s want: %s", got, want)

--- a/generator/internal/dart/darttemplate_test.go
+++ b/generator/internal/dart/darttemplate_test.go
@@ -79,7 +79,7 @@ func TestAnnotateMethod(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	annotateMethod(method, model.State, map[string]*dartImport{})
+	annotateMethod(method, model.State, map[string]string{}, map[string]string{})
 	codec := method.Codec.(*methodAnnotation)
 
 	got := codec.Name
@@ -89,13 +89,13 @@ func TestAnnotateMethod(t *testing.T) {
 	}
 
 	got = codec.RequestType
-	want = "ListSecretVersionRequest"
+	want = "ListSecretVersionRequest" // todo:
 	if got != want {
 		t.Errorf("mismatched type, got=%q, want=%q", got, want)
 	}
 
 	got = codec.ResponseType
-	want = "ListSecretVersionsResponse"
+	want = "ListSecretVersionsResponse" // todo:
 	if got != want {
 		t.Errorf("mismatched type, got=%q, want=%q", got, want)
 	}
@@ -104,25 +104,22 @@ func TestAnnotateMethod(t *testing.T) {
 func TestCalculateDependencies(t *testing.T) {
 	for _, test := range []struct {
 		name    string
-		imports []*dartImport
+		imports []string
 		want    []string
 	}{
-		{name: "empty", imports: []*dartImport{}, want: []string{}},
-		{name: "dart import", imports: []*dartImport{typedDataImport}, want: []string{}},
-		{name: "package import", imports: []*dartImport{httpImport}, want: []string{"http"}},
-		{name: "dart and package imports", imports: []*dartImport{typedDataImport, httpImport}, want: []string{"http"}},
-		{name: "package imports", imports: []*dartImport{
+		{name: "empty", imports: []string{}, want: []string{}},
+		{name: "dart import", imports: []string{typedDataImport}, want: []string{}},
+		{name: "package import", imports: []string{httpImport}, want: []string{"http"}},
+		{name: "dart and package imports", imports: []string{typedDataImport, httpImport}, want: []string{"http"}},
+		{name: "package imports", imports: []string{
 			httpImport,
-			{
-				Package:    "google_cloud_foo",
-				DartImport: "package:google_cloud_foo/foo.dart",
-			},
+			"package:google_cloud_foo/foo.dart",
 		}, want: []string{"google_cloud_foo", "http"}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			deps := map[string]*dartImport{}
+			deps := map[string]string{}
 			for _, imp := range test.imports {
-				deps[imp.Package] = imp
+				deps[imp] = imp
 			}
 			gotFull := calculateDependencies(deps)
 
@@ -141,35 +138,32 @@ func TestCalculateDependencies(t *testing.T) {
 func TestCalculateImports(t *testing.T) {
 	for _, test := range []struct {
 		name    string
-		imports []*dartImport
+		imports []string
 		want    []string
 	}{
-		{name: "dart import", imports: []*dartImport{typedDataImport}, want: []string{
+		{name: "dart import", imports: []string{typedDataImport}, want: []string{
 			"import 'dart:typed_data';",
 		}},
-		{name: "package import", imports: []*dartImport{httpImport}, want: []string{
+		{name: "package import", imports: []string{httpImport}, want: []string{
 			"import 'package:http/http.dart';",
 		}},
-		{name: "dart and package imports", imports: []*dartImport{typedDataImport, httpImport}, want: []string{
+		{name: "dart and package imports", imports: []string{typedDataImport, httpImport}, want: []string{
 			"import 'dart:typed_data';",
 			"",
 			"import 'package:http/http.dart';",
 		}},
-		{name: "package imports", imports: []*dartImport{
+		{name: "package imports", imports: []string{
 			httpImport,
-			{
-				Package:    "google_cloud_foo",
-				DartImport: "package:google_cloud_foo/foo.dart",
-			},
+			"package:google_cloud_foo/foo.dart",
 		}, want: []string{
 			"import 'package:google_cloud_foo/foo.dart';",
 			"import 'package:http/http.dart';",
 		}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			deps := map[string]*dartImport{}
+			deps := map[string]string{}
 			for _, imp := range test.imports {
-				deps[imp.Package] = imp
+				deps[imp] = imp
 			}
 			got := calculateImports(deps)
 

--- a/generator/internal/dart/darttemplate_test.go
+++ b/generator/internal/dart/darttemplate_test.go
@@ -79,7 +79,7 @@ func TestAnnotateMethod(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	annotateMethod(method, model.State)
+	annotateMethod(method, model.State, map[string]*dartImport{})
 	codec := method.Codec.(*methodAnnotation)
 
 	got := codec.Name

--- a/generator/internal/dart/templates/lib/main.dart.mustache
+++ b/generator/internal/dart/templates/lib/main.dart.mustache
@@ -25,12 +25,13 @@ limitations under the License.
 {{/Codec.DocLines}}
 library;
 
-{{#Codec.PartFileReference}}
-part '{{Codec.PartFileReference}}';
-{{/Codec.PartFileReference}}
 {{#Codec.Imports}}
 {{{.}}}
 {{/Codec.Imports}}
+{{#Codec.PartFileReference}}
+
+part '{{Codec.PartFileReference}}';
+{{/Codec.PartFileReference}}
 {{#Services}}
 {{> service}}
 {{/Services}}

--- a/generator/internal/rust/rust.go
+++ b/generator/internal/rust/rust.go
@@ -1017,8 +1017,8 @@ func protobufLinkMapping(doc ast.Node, source []byte) []string {
 //
 // The Google API documentation (typically in protos) include links to code
 // elements in the form `[Thing][google.package.blah.v1.Thing.SubThing]`.
-// This regular expression captures the `][...]` part. There is a lot of
-// escaping because the brackets are metacharacters in regex.
+// This regular expression captures the `][...]` part. There is a lot of scaping
+// because the brackets are metacharacters in regex.
 var commentCrossReferenceLink = regexp.MustCompile(
 	`` + // `go fmt` is annoying
 		`\]` + // The closing bracket for the `[Thing]`
@@ -1075,6 +1075,7 @@ func escapeHTMLTags(node ast.Node, line text.Segment, documentationBytes []byte)
 					escapedHTML := strings.Replace(segmentContent, "<", "\\<", 1)
 					escapedHTML = strings.Replace(escapedHTML, ">", "\\>", 1)
 					escapedString = strings.ReplaceAll(escapedString, string(lineContent[start:end]), escapedHTML)
+
 				}
 			}
 		}

--- a/generator/internal/rust/rust.go
+++ b/generator/internal/rust/rust.go
@@ -1017,8 +1017,8 @@ func protobufLinkMapping(doc ast.Node, source []byte) []string {
 //
 // The Google API documentation (typically in protos) include links to code
 // elements in the form `[Thing][google.package.blah.v1.Thing.SubThing]`.
-// This regular expression captures the `][...]` part. There is a lot of scaping
-// because the brackets are metacharacters in regex.
+// This regular expression captures the `][...]` part. There is a lot of
+// escaping because the brackets are metacharacters in regex.
 var commentCrossReferenceLink = regexp.MustCompile(
 	`` + // `go fmt` is annoying
 		`\]` + // The closing bracket for the `[Thing]`
@@ -1075,7 +1075,6 @@ func escapeHTMLTags(node ast.Node, line text.Segment, documentationBytes []byte)
 					escapedHTML := strings.Replace(segmentContent, "<", "\\<", 1)
 					escapedHTML = strings.Replace(escapedHTML, ">", "\\>", 1)
 					escapedString = strings.ReplaceAll(escapedString, string(lineContent[start:end]), escapedHTML)
-
 				}
 			}
 		}

--- a/generator/internal/sidekick/sidekick_dart_test.go
+++ b/generator/internal/sidekick/sidekick_dart_test.go
@@ -38,9 +38,10 @@ func TestDartFromProtobuf(t *testing.T) {
 		Language:      "dart",
 		Output:        outDir,
 		Codec: map[string]string{
-			"copyright-year":      "2025",
-			"not-for-publication": "true",
-			"version":             "0.1.0",
+			"copyright-year":        "2025",
+			"not-for-publication":   "true",
+			"version":               "0.1.0",
+			"proto:google.protobuf": "package:google_cloud_protobuf/protobuf.dart",
 		},
 	}
 	cmdGenerate, _, _ := cmdSidekick.lookup([]string{"generate"})

--- a/generator/testdata/dart/protobuf/golden/secretmanager/.sidekick.toml
+++ b/generator/testdata/dart/protobuf/golden/secretmanager/.sidekick.toml
@@ -25,4 +25,5 @@ name-override = 'secretmanager'
 [codec]
 copyright-year = '2025'
 not-for-publication = 'true'
+'proto:google.protobuf' = 'package:google_cloud_protobuf/protobuf.dart'
 version = '0.1.0'

--- a/generator/testdata/dart/protobuf/golden/secretmanager/lib/secretmanager.dart
+++ b/generator/testdata/dart/protobuf/golden/secretmanager/lib/secretmanager.dart
@@ -22,6 +22,8 @@ library;
 
 import 'dart:typed_data';
 
+import 'package:google_cloud_location/location.dart';
+import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:http/http.dart';
 
 /// Secret Manager Service
@@ -180,7 +182,7 @@ class Secret {
 
   /// Output only. The time at which the
   /// [Secret][google.cloud.secretmanager.v1.Secret] was created.
-  final DateTime? createTime;
+  final Timestamp? createTime;
 
   /// The labels assigned to this Secret.
   /// 
@@ -202,11 +204,11 @@ class Secret {
   /// Optional. Timestamp in UTC when the
   /// [Secret][google.cloud.secretmanager.v1.Secret] is scheduled to expire.
   /// This is always provided on output, regardless of what was sent on input.
-  final DateTime? expireTime;
+  final Timestamp? expireTime;
 
   /// Input only. The TTL for the
   /// [Secret][google.cloud.secretmanager.v1.Secret].
-  final Duration? ttl;
+  final PbDuration? ttl;
 
   /// Optional. Etag of the currently stored
   /// [Secret][google.cloud.secretmanager.v1.Secret].
@@ -250,7 +252,7 @@ class Secret {
   /// For secret with TTL>0, version destruction doesn't happen immediately
   /// on calling destroy instead the version goes to a disabled state and
   /// destruction happens after the TTL expires.
-  final Duration? versionDestroyTtl;
+  final PbDuration? versionDestroyTtl;
 
   /// Optional. The customer-managed encryption configuration of the Regionalised
   /// Secrets. If no configuration is provided, Google-managed default encryption
@@ -294,14 +296,14 @@ class SecretVersion {
 
   /// Output only. The time at which the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] was created.
-  final DateTime? createTime;
+  final Timestamp? createTime;
 
   /// Output only. The time this
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] was destroyed.
   /// Only present if [state][google.cloud.secretmanager.v1.SecretVersion.state]
   /// is
   /// [DESTROYED][google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED].
-  final DateTime? destroyTime;
+  final Timestamp? destroyTime;
 
   /// Output only. The current state of the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -329,7 +331,7 @@ class SecretVersion {
   /// destroyed, the version is moved to disabled state and it is scheduled for
   /// destruction. The version is destroyed only after the
   /// `scheduled_destroy_time`.
-  final DateTime? scheduledDestroyTime;
+  final Timestamp? scheduledDestroyTime;
 
   /// Output only. The customer-managed encryption status of the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]. Only
@@ -608,7 +610,7 @@ class Rotation {
   /// MUST  be set if
   /// [rotation_period][google.cloud.secretmanager.v1.Rotation.rotation_period]
   /// is set.
-  final DateTime? nextRotationTime;
+  final Timestamp? nextRotationTime;
 
   /// Input only. The Duration between rotation notifications. Must be in seconds
   /// and at least 3600s (1h) and at most 3153600000s (100 years).
@@ -621,7 +623,7 @@ class Rotation {
   /// [next_rotation_time][google.cloud.secretmanager.v1.Rotation.next_rotation_time]
   /// will be advanced by this period when the service automatically sends
   /// rotation notifications.
-  final Duration? rotationPeriod;
+  final PbDuration? rotationPeriod;
 
   Rotation({
     this.nextRotationTime,

--- a/generator/testdata/dart/protobuf/golden/secretmanager/lib/secretmanager.dart
+++ b/generator/testdata/dart/protobuf/golden/secretmanager/lib/secretmanager.dart
@@ -22,7 +22,6 @@ library;
 
 import 'dart:typed_data';
 
-import 'package:google_cloud_location/location.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:http/http.dart';
 

--- a/generator/testdata/dart/protobuf/golden/secretmanager/pubspec.yaml
+++ b/generator/testdata/dart/protobuf/golden/secretmanager/pubspec.yaml
@@ -24,4 +24,6 @@ environment:
 resolution: workspace
 
 dependencies:
+  google_cloud_location: any
+  google_cloud_protobuf: any
   http: any

--- a/generator/testdata/dart/protobuf/golden/secretmanager/pubspec.yaml
+++ b/generator/testdata/dart/protobuf/golden/secretmanager/pubspec.yaml
@@ -24,6 +24,5 @@ environment:
 resolution: workspace
 
 dependencies:
-  google_cloud_location: any
   google_cloud_protobuf: any
   http: any


### PR DESCRIPTION
- create a mapping from several well-known type proto packages to Dart package and library imports
- use that info when annotating the model objects to update the dart imports info
-  prep for generating the `google.protobuf.Duration` type by renaming references to it to `PbDuration` (`Duration` is a core Dart type)

Note that this PR collects import information as part of generally annotating the model tree. In order to not over-collect import info (avoid calculating import info based on messages that won't be emitted in the current library) we now only annotate model objects that will be emitted in the current library. Having annotated and non-annotated messages in the api model works for the Dart generator currently but could cause issues down the road. I'm open to instead annotating everything and having a 2nd pass to collect + calculate import info.
