### PR TITLE
feat(auth): API Key credentials

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod api_key_credential;
 pub(crate) mod mds_credential;
 mod service_account_credential;
 pub(crate) mod user_credential;
@@ -268,6 +269,10 @@ pub async fn create_access_token_credential() -> Result<Credential> {
         ))),
     }
 }
+
+/// Export API Key factory function and options
+pub use api_key_credential::create_api_key_credential;
+pub use api_key_credential::ApiKeyOptions;
 
 #[derive(Debug, PartialEq)]
 enum AdcPath {

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 use google_cloud_auth::credentials::testing::test_credentials;
-use google_cloud_auth::credentials::{create_access_token_credential, Credential, CredentialTrait};
+use google_cloud_auth::credentials::{
+    create_access_token_credential, create_api_key_credential, ApiKeyOptions, Credential,
+    CredentialTrait,
+};
 use google_cloud_auth::errors::CredentialError;
 use google_cloud_auth::token::Token;
 
@@ -123,6 +126,15 @@ mod test {
         let sac = create_access_token_credential().await.unwrap();
         let fmt = format!("{:?}", sac);
         assert!(fmt.contains("ServiceAccountCredential"));
+    }
+
+    #[tokio::test]
+    async fn create_api_key_credential_success() {
+        let creds = create_api_key_credential("test-api-key", ApiKeyOptions::default())
+            .await
+            .unwrap();
+        let fmt = format!("{:?}", creds);
+        assert!(fmt.contains("ApiKeyCredential"));
     }
 
     mockall::mock! {


### PR DESCRIPTION
Part of the work for #1371 and #652

Implement API Key credentials. This gets a different top level factory function.

Take this opportunity to introduce `*Options` classes for this top level factory functions. Maybe it belongs in a `mod options`? Not sure. I like it being defined next to the only place it is used, the factory function.

Integration tests will come in a follow up PR.