### PR TITLE
refactor(auth): common test code for headers

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -394,6 +394,32 @@ mod test {
     use scoped_env::ScopedEnv;
     use std::error::Error;
 
+    // Convenience struct for verifying (HeaderName, HeaderValue) pairs.
+    #[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
+    pub struct HV {
+        pub header: String,
+        pub value: String,
+        pub is_sensitive: bool,
+    }
+
+    impl HV {
+        pub fn from(headers: Vec<(HeaderName, HeaderValue)>) -> Vec<HV> {
+            let mut hvs: Vec<HV> = headers
+                .into_iter()
+                .map(|(h, v)| HV {
+                    header: h.to_string(),
+                    value: v.to_str().unwrap().to_string(),
+                    is_sensitive: v.is_sensitive(),
+                })
+                .collect();
+
+            // We want to verify the contents of the headers. We do not care
+            // what order they are in.
+            hvs.sort();
+            hvs
+        }
+    }
+
     #[cfg(target_os = "windows")]
     #[test]
     #[serial_test::serial]

--- a/src/auth/src/credentials/api_key_credential.rs
+++ b/src/auth/src/credentials/api_key_credential.rs
@@ -136,6 +136,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::credentials::test::HV;
     use scoped_env::ScopedEnv;
 
     #[test]
@@ -145,14 +146,6 @@ mod test {
         };
         let fmt = format!("{expected:?}");
         assert!(!fmt.contains("super-secret-api-key"), "{fmt}");
-    }
-
-    // Convenience struct for verifying (HeaderName, HeaderValue) pairs.
-    #[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
-    struct HV {
-        header: String,
-        value: String,
-        is_sensitive: bool,
     }
 
     #[tokio::test]
@@ -173,17 +166,7 @@ mod test {
                 metadata: None,
             }
         );
-        let headers: Vec<HV> = creds
-            .get_headers()
-            .await
-            .unwrap()
-            .into_iter()
-            .map(|(h, v)| HV {
-                header: h.to_string(),
-                value: v.to_str().unwrap().to_string(),
-                is_sensitive: v.is_sensitive(),
-            })
-            .collect();
+        let headers: Vec<HV> = HV::from(creds.get_headers().await.unwrap());
 
         assert_eq!(
             headers,
@@ -204,17 +187,7 @@ mod test {
         let creds = create_api_key_credential("test-api-key", options)
             .await
             .unwrap();
-        let headers: Vec<HV> = creds
-            .get_headers()
-            .await
-            .unwrap()
-            .into_iter()
-            .map(|(h, v)| HV {
-                header: h.to_string(),
-                value: v.to_str().unwrap().to_string(),
-                is_sensitive: v.is_sensitive(),
-            })
-            .collect();
+        let headers: Vec<HV> = HV::from(creds.get_headers().await.unwrap());
 
         assert_eq!(
             headers,
@@ -241,17 +214,7 @@ mod test {
         let creds = create_api_key_credential("test-api-key", options)
             .await
             .unwrap();
-        let headers: Vec<HV> = creds
-            .get_headers()
-            .await
-            .unwrap()
-            .into_iter()
-            .map(|(h, v)| HV {
-                header: h.to_string(),
-                value: v.to_str().unwrap().to_string(),
-                is_sensitive: v.is_sensitive(),
-            })
-            .collect();
+        let headers: Vec<HV> = HV::from(creds.get_headers().await.unwrap());
 
         assert_eq!(
             headers,

--- a/src/auth/src/credentials/mds_credential.rs
+++ b/src/auth/src/credentials/mds_credential.rs
@@ -166,6 +166,7 @@ impl TokenProvider for MDSAccessTokenProvider {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::credentials::test::HV;
     use crate::token::test::MockTokenProvider;
     use axum::response::IntoResponse;
     use reqwest::StatusCode;
@@ -212,13 +213,6 @@ mod test {
 
     #[tokio::test]
     async fn get_headers_success() {
-        #[derive(Debug, PartialEq)]
-        struct HV {
-            header: String,
-            value: String,
-            is_sensitive: bool,
-        }
-
         let token = Token {
             token: "test-token".to_string(),
             token_type: "Bearer".to_string(),
@@ -232,17 +226,7 @@ mod test {
         let mdsc = MDSCredential {
             token_provider: mock,
         };
-        let headers: Vec<HV> = mdsc
-            .get_headers()
-            .await
-            .unwrap()
-            .into_iter()
-            .map(|(h, v)| HV {
-                header: h.to_string(),
-                value: v.to_str().unwrap().to_string(),
-                is_sensitive: v.is_sensitive(),
-            })
-            .collect();
+        let headers: Vec<HV> = HV::from(mdsc.get_headers().await.unwrap());
 
         assert_eq!(
             headers,

--- a/src/auth/src/credentials/service_account_credential.rs
+++ b/src/auth/src/credentials/service_account_credential.rs
@@ -182,6 +182,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::credentials::test::HV;
     use crate::token::test::MockTokenProvider;
     use base64::Engine;
     use rsa::pkcs1::EncodeRsaPrivateKey;
@@ -246,13 +247,6 @@ mod test {
 
     #[tokio::test]
     async fn get_headers_success() {
-        #[derive(Debug, PartialEq)]
-        struct HV {
-            header: String,
-            value: String,
-            is_sensitive: bool,
-        }
-
         let token = Token {
             token: "test-token".to_string(),
             token_type: "Bearer".to_string(),
@@ -266,17 +260,7 @@ mod test {
         let sac = ServiceAccountCredential {
             token_provider: mock,
         };
-        let headers: Vec<HV> = sac
-            .get_headers()
-            .await
-            .unwrap()
-            .into_iter()
-            .map(|(h, v)| HV {
-                header: h.to_string(),
-                value: v.to_str().unwrap().to_string(),
-                is_sensitive: v.is_sensitive(),
-            })
-            .collect();
+        let headers: Vec<HV> = HV::from(sac.get_headers().await.unwrap());
 
         assert_eq!(
             headers,

--- a/src/auth/src/credentials/user_credential.rs
+++ b/src/auth/src/credentials/user_credential.rs
@@ -184,6 +184,7 @@ struct Oauth2RefreshResponse {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::credentials::test::HV;
     use crate::token::test::MockTokenProvider;
     use axum::extract::Json;
     use http::StatusCode;
@@ -309,14 +310,6 @@ mod test {
         assert!(uc.get_token().await.is_err());
     }
 
-    // Convenience struct for verifying (HeaderName, HeaderValue) pairs.
-    #[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
-    struct HV {
-        header: String,
-        value: String,
-        is_sensitive: bool,
-    }
-
     #[tokio::test]
     async fn get_headers_success() {
         let token = Token {
@@ -333,17 +326,7 @@ mod test {
             token_provider: mock,
             quota_project_id: None,
         };
-        let headers: Vec<HV> = uc
-            .get_headers()
-            .await
-            .unwrap()
-            .into_iter()
-            .map(|(h, v)| HV {
-                header: h.to_string(),
-                value: v.to_str().unwrap().to_string(),
-                is_sensitive: v.is_sensitive(),
-            })
-            .collect();
+        let headers: Vec<HV> = HV::from(uc.get_headers().await.unwrap());
 
         assert_eq!(
             headers,
@@ -385,20 +368,7 @@ mod test {
             token_provider: mock,
             quota_project_id: Some("test-project".to_string()),
         };
-        let mut headers: Vec<HV> = uc
-            .get_headers()
-            .await
-            .unwrap()
-            .into_iter()
-            .map(|(h, v)| HV {
-                header: h.to_string(),
-                value: v.to_str().unwrap().to_string(),
-                is_sensitive: v.is_sensitive(),
-            })
-            .collect();
-
-        // The ordering of the headers does not matter.
-        headers.sort();
+        let headers: Vec<HV> = HV::from(uc.get_headers().await.unwrap());
         assert_eq!(
             headers,
             vec![


### PR DESCRIPTION
Save some lines in our tests.

Reminder that things gated by `[cfg(test)]` do not get exported to other crates.