### PR TITLE
test(auth): api key integration  test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,7 @@ version = "0.0.0"
 dependencies = [
  "google-cloud-auth",
  "google-cloud-gax",
+ "google-cloud-language-v2",
  "google-cloud-secretmanager-v1",
  "scoped-env",
  "serial_test",

--- a/src/auth/integration-tests/Cargo.toml
+++ b/src/auth/integration-tests/Cargo.toml
@@ -27,6 +27,7 @@ run-integration-tests = []
 [dev-dependencies]
 auth          = { path = "../../../src/auth", package = "google-cloud-auth" }
 gax           = { path = "../../../src/gax", package = "google-cloud-gax" }
+language      = { path = "../../../src/generated/cloud/language/v2", package = "google-cloud-language-v2" }
 scoped-env    = "2.1.0"
 secretmanager = { path = "../../../src/generated/cloud/secretmanager/v1", package = "google-cloud-secretmanager-v1" }
 serial_test   = "3.2.0"


### PR DESCRIPTION
Fixes #1371 

Add an integration test for API  Keys.

The test uses a long lived API key, stored in secret manager. These keys can take on the order of minutes to be ready after being created by the `apikeys` service. So let's avoid that latency in our tests.

https://github.com/googleapis/google-cloud-cpp/blob/1f054ae244e473fe3911419ddec3358e4dbeeccf/examples/api_key.cc#L141-L160