### PR TITLE
feat(generator/dart): generate the Duration WKT

### DIFF
--- a/generator/dart/packages/generated/google_cloud_protobuf/.sidekick.toml
+++ b/generator/dart/packages/generated/google_cloud_protobuf/.sidekick.toml
@@ -19,7 +19,7 @@ specification-source = 'google/protobuf'
 name-override = 'protobuf'
 title-override = 'Core Protobuf Types'
 description-override = 'Core Protobuf types used by most services.'
-include-list = "field_mask.proto"
+include-list = "duration.proto,field_mask.proto"
 
 [codec]
 copyright-year = '2025'

--- a/generator/dart/packages/generated/google_cloud_protobuf/lib/protobuf.dart
+++ b/generator/dart/packages/generated/google_cloud_protobuf/lib/protobuf.dart
@@ -22,6 +22,86 @@ library;
 
 part 'src/protobuf.p.dart';
 
+/// A Duration represents a signed, fixed-length span of time represented
+/// as a count of seconds and fractions of seconds at nanosecond
+/// resolution. It is independent of any calendar and concepts like "day"
+/// or "month". It is related to Timestamp in that the difference between
+/// two Timestamp values is a Duration and it can be added or subtracted
+/// from a Timestamp. Range is approximately +-10,000 years.
+/// 
+/// # Examples
+/// 
+/// Example 1: Compute Duration from two Timestamps in pseudo code.
+/// 
+///     Timestamp start = ...;
+///     Timestamp end = ...;
+///     Duration duration = ...;
+/// 
+///     duration.seconds = end.seconds - start.seconds;
+///     duration.nanos = end.nanos - start.nanos;
+/// 
+///     if (duration.seconds < 0 && duration.nanos > 0) {
+///       duration.seconds += 1;
+///       duration.nanos -= 1000000000;
+///     } else if (duration.seconds > 0 && duration.nanos < 0) {
+///       duration.seconds -= 1;
+///       duration.nanos += 1000000000;
+///     }
+/// 
+/// Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
+/// 
+///     Timestamp start = ...;
+///     Duration duration = ...;
+///     Timestamp end = ...;
+/// 
+///     end.seconds = start.seconds + duration.seconds;
+///     end.nanos = start.nanos + duration.nanos;
+/// 
+///     if (end.nanos < 0) {
+///       end.seconds -= 1;
+///       end.nanos += 1000000000;
+///     } else if (end.nanos >= 1000000000) {
+///       end.seconds += 1;
+///       end.nanos -= 1000000000;
+///     }
+/// 
+/// Example 3: Compute Duration from datetime.timedelta in Python.
+/// 
+///     td = datetime.timedelta(days=3, minutes=10)
+///     duration = Duration()
+///     duration.FromTimedelta(td)
+/// 
+/// # JSON Mapping
+/// 
+/// In JSON format, the Duration type is encoded as a string rather than an
+/// object, where the string ends in the suffix "s" (indicating seconds) and
+/// is preceded by the number of seconds, with nanoseconds expressed as
+/// fractional seconds. For example, 3 seconds with 0 nanoseconds should be
+/// encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
+/// be expressed in JSON format as "3.000000001s", and 3 seconds and 1
+/// microsecond should be expressed in JSON format as "3.000001s".
+/// 
+class Duration {
+
+  /// Signed seconds of the span of time. Must be from -315,576,000,000
+  /// to +315,576,000,000 inclusive. Note: these bounds are computed from:
+  /// 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+  final int? seconds;
+
+  /// Signed fractions of a second at nanosecond resolution of the span
+  /// of time. Durations less than one second are represented with a 0
+  /// `seconds` field and a positive or negative `nanos` field. For durations
+  /// of one second or more, a non-zero value for the `nanos` field must be
+  /// of the same sign as the `seconds` field. Must be from -999,999,999
+  /// to +999,999,999 inclusive.
+  final int? nanos;
+
+  Duration({
+    this.seconds,
+    this.nanos,
+  });
+}
+
 /// `FieldMask` represents a set of symbolic field paths, for example:
 /// 
 ///     paths: "f.a"

--- a/generator/dart/packages/generated/google_cloud_protobuf/lib/protobuf.dart
+++ b/generator/dart/packages/generated/google_cloud_protobuf/lib/protobuf.dart
@@ -99,7 +99,9 @@ class Duration {
   Duration({
     this.seconds,
     this.nanos,
-  });
+  }) {
+    _validate();
+  }
 }
 
 /// `FieldMask` represents a set of symbolic field paths, for example:

--- a/generator/dart/packages/generated/google_cloud_protobuf/lib/src/protobuf.p.dart
+++ b/generator/dart/packages/generated/google_cloud_protobuf/lib/src/protobuf.p.dart
@@ -25,3 +25,37 @@ extension FieldMaskExtension on FieldMask {
     return FieldMask(paths: format.split(','));
   }
 }
+
+extension DurationExtension on Duration {
+  /// Encode into a decimal representation of the seconds and nanos, suffixed
+  /// with 's'.
+  ///
+  /// E.g., 3 seconds with 0 nanoseconds would be '3s'; 3 seconds with 70
+  /// nanosecond would be '3.00000007s'.
+  String encode() {
+    if (nanos == 0) return '${seconds}s';
+
+    var duration = '${seconds}.${nanos.toString().padLeft(9, '0')}';
+    while (duration.endsWith('0')) {
+      duration = duration.substring(0, duration.length - 1);
+    }
+
+    return '${duration}s';
+  }
+
+  /// Decode a string representation of the duration.
+  ///
+  /// This is a decimal value suffixed with 's'. 3 seconds with 0 nanoseconds
+  /// would be '3s'; 3 seconds with 70 nanosecond would be '3.00000007s'.
+  static Duration decode(String format) {
+    if (!format.endsWith('s')) {
+      throw FormatException("duration value should end in 's'");
+    }
+
+    final value = double.parse(format.substring(0, format.length - 1));
+    final seconds = value.truncate();
+    final nanos = ((value - seconds) * 1_000_000_000).round();
+
+    return Duration(seconds: seconds, nanos: nanos);
+  }
+}

--- a/generator/dart/packages/generated/google_cloud_protobuf/lib/src/protobuf.p.dart
+++ b/generator/dart/packages/generated/google_cloud_protobuf/lib/src/protobuf.p.dart
@@ -27,20 +27,40 @@ extension FieldMaskExtension on FieldMask {
 }
 
 extension DurationExtension on Duration {
+  // Called from the Duration constructor to validate the construction
+  // parameters.
+  void _validate() {
+    // For durations of one second or more, a non-zero value for the `nanos`
+    // field must be of the same sign as the `seconds` field.
+    if ((seconds! < 0 && nanos! > 0) || (seconds! > 0 && nanos! < 0)) {
+      throw ArgumentError('seconds and nanos must have the same sign');
+    }
+
+    // Nanos must be from -999,999,999 to +999,999,999 inclusive.
+    if (nanos! < -999_999_999 || nanos! > 999_999_999) {
+      throw ArgumentError('nanos out of range');
+    }
+  }
+
   /// Encode into a decimal representation of the seconds and nanos, suffixed
   /// with 's'.
   ///
   /// E.g., 3 seconds with 0 nanoseconds would be '3s'; 3 seconds with 70
   /// nanosecond would be '3.00000007s'.
   String encode() {
-    if (nanos == 0) return '${seconds}s';
+    if (nanos == 0) {
+      return '${seconds}s';
+    } else {
+      final rhs = nanos!.abs().toString().padLeft(9, '0');
 
-    var duration = '${seconds}.${nanos.toString().padLeft(9, '0')}';
-    while (duration.endsWith('0')) {
-      duration = duration.substring(0, duration.length - 1);
+      var duration =
+          seconds == 0 ? '${nanos! < 0 ? '-' : ''}0.$rhs' : '${seconds}.$rhs';
+      while (duration.endsWith('0')) {
+        duration = duration.substring(0, duration.length - 1);
+      }
+
+      return '${duration}s';
     }
-
-    return '${duration}s';
   }
 
   /// Decode a string representation of the duration.
@@ -52,10 +72,21 @@ extension DurationExtension on Duration {
       throw FormatException("duration value should end in 's'");
     }
 
-    final value = double.parse(format.substring(0, format.length - 1));
-    final seconds = value.truncate();
-    final nanos = ((value - seconds) * 1_000_000_000).round();
+    // '-123.456s'
+    format = format.substring(0, format.length - 1);
+    final negative = format.startsWith('-');
 
-    return Duration(seconds: seconds, nanos: nanos);
+    final parts = format.split('.');
+    if (parts.length > 2) {
+      throw FormatException('too many periods');
+    }
+
+    final seconds = int.parse(parts[0]);
+    if (parts.length == 1) {
+      return Duration(seconds: seconds, nanos: 0);
+    }
+
+    final nanos = int.parse(parts[1].padRight(9, '0'));
+    return Duration(seconds: seconds, nanos: negative ? -nanos : nanos);
   }
 }

--- a/generator/dart/packages/generated/google_cloud_protobuf/test/types_test.dart
+++ b/generator/dart/packages/generated/google_cloud_protobuf/test/types_test.dart
@@ -52,31 +52,58 @@ void main() {
   });
 
   group('Duration', () {
-    final testCases = [
-      (Duration(seconds: 0, nanos: 0), '0s'),
-      (Duration(seconds: 1, nanos: 0), '1s'),
-      (Duration(seconds: 0, nanos: 1), '0.000000001s'),
-      (Duration(seconds: 1, nanos: 1), '1.000000001s'),
-      (Duration(seconds: 60, nanos: 1_000_000), '60.001s'),
-    ];
+    const secondsInDay = 24 * 60 * 60;
+    const secondsInYear = 365 * secondsInDay + secondsInDay ~/ 4;
 
-    // encode tests
-    for (final testCase in testCases) {
-      test('encode ${testCase.$2}', () {
-        expect(testCase.$1.encode(), testCase.$2);
+    void testCase(int seconds, int nanos, String encoding) {
+      test('test case $encoding', () {
+        // test DurationExtension.encode()
+        final duration = Duration(seconds: seconds, nanos: nanos);
+        expect(duration.encode(), encoding);
+
+        // test DurationExtension.decode()
+        final copy = DurationExtension.decode(encoding);
+        expect(copy.seconds, seconds);
+        expect(copy.nanos, nanos);
       });
     }
 
-    // decode tests
-    for (final testCase in testCases) {
-      test('decode ${testCase.$2}', () {
-        final expected = testCase.$1;
-        final actual = DurationExtension.decode(testCase.$2);
+    // encode and decode tests
+    testCase(0, 0, '0s');
+    testCase(1, 0, '1s');
+    testCase(0, 1, '0.000000001s');
+    testCase(1, 1, '1.000000001s');
+    testCase(60, 1_000_000, '60.001s');
+    testCase(10_000 * secondsInYear, 0, '315576000000s');
+    testCase(10_000 * secondsInYear, 999_999_999, '315576000000.999999999s');
+    testCase(-10_000 * secondsInYear, -999_999_999, '-315576000000.999999999s');
+    testCase(0, 999_999_999, '0.999999999s');
+    testCase(0, -999_999_999, '-0.999999999s');
 
-        expect(actual.seconds, expected.seconds);
-        expect(actual.nanos, expected.nanos);
+    // Verify durations can roundtrip from string -> Duration -> string.
+    void roundTrip(String name, String encoding) {
+      test('round trip $name ($encoding)', () {
+        final duration = DurationExtension.decode(encoding);
+        expect(duration.encode(), encoding);
       });
     }
+
+    roundTrip('zero', '0s');
+    roundTrip('2ns', '0.000000002s');
+    roundTrip('200ms', '0.2s');
+    roundTrip('round positive seconds', '12s');
+    roundTrip('positive seconds and nanos', '12.000000123s');
+    // TODO: double check rust impl
+    roundTrip('positive seconds and micros', '12.000123s');
+    roundTrip('positive seconds and millis', '12.123s');
+    roundTrip('positive seconds and full nanos', '12.123456789s');
+    roundTrip('round negative seconds', '-12s');
+    roundTrip('negative seconds and nanos', '-12.000000123s');
+    roundTrip('negative seconds and micros', '-12.000123s');
+    roundTrip('negative seconds and millis', '-12.123s');
+    roundTrip('negative seconds and full nanos', '-12.123456789s');
+    roundTrip('range edge start', '-315576000000.999999999s');
+    roundTrip('range edge end', '315576000000.999999999s');
 
     // bad format tests
     test('bad number', () {
@@ -85,6 +112,28 @@ void main() {
 
     test('bad format', () {
       expect(() => DurationExtension.decode('2.00001'), throwsFormatException);
+    });
+
+    test('bad format', () {
+      expect(() => DurationExtension.decode('1.2.3.4s'), throwsFormatException);
+    });
+
+    test('too many positive nanoseconds', () {
+      expect(() => Duration(seconds: 0, nanos: 1_000_000_000),
+          throwsArgumentError);
+    });
+
+    test('too many negative nanoseconds', () {
+      expect(() => Duration(seconds: 0, nanos: -1_000_000_000),
+          throwsArgumentError);
+    });
+
+    test('mismatched sign case 1', () {
+      expect(() => Duration(seconds: 1, nanos: -1), throwsArgumentError);
+    });
+
+    test('mismatched sign case 2', () {
+      expect(() => Duration(seconds: -1, nanos: 1), throwsArgumentError);
     });
   });
 }

--- a/generator/dart/packages/generated/google_cloud_protobuf/test/types_test.dart
+++ b/generator/dart/packages/generated/google_cloud_protobuf/test/types_test.dart
@@ -80,7 +80,7 @@ void main() {
     testCase(0, 999_999_999, '0.999999999s');
     testCase(0, -999_999_999, '-0.999999999s');
 
-    // Verify durations can roundtrip from string -> Duration -> string.
+    // Verify durations can roundtrip from String -> Duration -> String.
     void roundTrip(String name, String encoding) {
       test('round trip $name ($encoding)', () {
         final duration = DurationExtension.decode(encoding);
@@ -93,7 +93,6 @@ void main() {
     roundTrip('200ms', '0.2s');
     roundTrip('round positive seconds', '12s');
     roundTrip('positive seconds and nanos', '12.000000123s');
-    // TODO: double check rust impl
     roundTrip('positive seconds and micros', '12.000123s');
     roundTrip('positive seconds and millis', '12.123s');
     roundTrip('positive seconds and full nanos', '12.123456789s');

--- a/generator/dart/packages/generated/google_cloud_protobuf/test/types_test.dart
+++ b/generator/dart/packages/generated/google_cloud_protobuf/test/types_test.dart
@@ -50,4 +50,41 @@ void main() {
       expect(actual, 'one|two');
     });
   });
+
+  group('Duration', () {
+    final testCases = [
+      (Duration(seconds: 0, nanos: 0), '0s'),
+      (Duration(seconds: 1, nanos: 0), '1s'),
+      (Duration(seconds: 0, nanos: 1), '0.000000001s'),
+      (Duration(seconds: 1, nanos: 1), '1.000000001s'),
+      (Duration(seconds: 60, nanos: 1_000_000), '60.001s'),
+    ];
+
+    // encode tests
+    for (final testCase in testCases) {
+      test('encode ${testCase.$2}', () {
+        expect(testCase.$1.encode(), testCase.$2);
+      });
+    }
+
+    // decode tests
+    for (final testCase in testCases) {
+      test('decode ${testCase.$2}', () {
+        final expected = testCase.$1;
+        final actual = DurationExtension.decode(testCase.$2);
+
+        expect(actual.seconds, expected.seconds);
+        expect(actual.nanos, expected.nanos);
+      });
+    }
+
+    // bad format tests
+    test('bad number', () {
+      expect(() => DurationExtension.decode('20u10s'), throwsFormatException);
+    });
+
+    test('bad format', () {
+      expect(() => DurationExtension.decode('2.00001'), throwsFormatException);
+    });
+  });
 }

--- a/generator/dart/packages/generated/google_cloud_rpc/lib/rpc.dart
+++ b/generator/dart/packages/generated/google_cloud_rpc/lib/rpc.dart
@@ -98,7 +98,7 @@ class ErrorInfo {
 class RetryInfo {
 
   /// Clients should wait at least this long between retrying the same request.
-  final PbDuration? retryDelay;
+  final Duration? retryDelay;
 
   RetryInfo({
     this.retryDelay,

--- a/generator/internal/dart/dart.go
+++ b/generator/internal/dart/dart.go
@@ -32,6 +32,10 @@ var dartTemplates embed.FS
 var typedDataImport = "dart:typed_data"
 var httpImport = "package:http/http.dart"
 
+var needsCtorValidation = map[string]string{
+	".google.protobuf.Duration": ".google.protobuf.Duration",
+}
+
 func Generate(model *api.API, outdir string, options map[string]string) error {
 	_, err := annotateModel(model, options)
 	if err != nil {

--- a/generator/internal/dart/dart.go
+++ b/generator/internal/dart/dart.go
@@ -29,18 +29,6 @@ import (
 //go:embed templates
 var dartTemplates embed.FS
 
-// A map of message ID => name renames.
-//
-// `Duration` in particular is important to rename as this would conflict with
-// the `Duration` class in the 'dart:core' library (imported by default into
-// every library).
-// TODO(#1034): Renaming this class is practical but unlikely to be what we want
-// to do long term. We want a reliable, low-ceremony way of avoiding name
-// conflicts with dart:core types.
-var messageRenames = map[string]string{
-	".google.protobuf.Duration": "PbDuration",
-}
-
 var typedDataImport = "dart:typed_data"
 var httpImport = "package:http/http.dart"
 
@@ -159,11 +147,6 @@ func resolveTypeName(message *api.Message, packageMapping map[string]string, imp
 }
 
 func messageName(m *api.Message) string {
-	rename, ok := messageRenames[m.ID]
-	if ok {
-		return rename
-	}
-
 	if m.Parent != nil {
 		return messageName(m.Parent) + "$" + strcase.ToCamel(m.Name)
 	}

--- a/generator/internal/dart/dart_test.go
+++ b/generator/internal/dart/dart_test.go
@@ -184,7 +184,7 @@ func TestResolveTypeName(t *testing.T) {
 		{message.ID, "CreateSecretRequest"},
 		{".google.protobuf.Empty", "void"},
 		{".google.protobuf.Timestamp", "Timestamp"},
-		{".google.protobuf.Duration", "PbDuration"},
+		{".google.protobuf.Duration", "Duration"},
 	} {
 		got := resolveTypeName(state.MessageByID[test.typeId], map[string]string{}, map[string]string{})
 		if got != test.want {

--- a/generator/internal/dart/templates/lib/message.mustache
+++ b/generator/internal/dart/templates/lib/message.mustache
@@ -27,7 +27,7 @@ class {{Codec.Name}} {
   {{#Fields}}
     this.{{Codec.Name}},
   {{/Fields}}
-  });
+  }){{Codec.ConstructorBody}}
 }
 {{#Messages}}
 {{> message}}

--- a/generator/testdata/dart/protobuf/golden/secretmanager/lib/secretmanager.dart
+++ b/generator/testdata/dart/protobuf/golden/secretmanager/lib/secretmanager.dart
@@ -207,7 +207,7 @@ class Secret {
 
   /// Input only. The TTL for the
   /// [Secret][google.cloud.secretmanager.v1.Secret].
-  final PbDuration? ttl;
+  final Duration? ttl;
 
   /// Optional. Etag of the currently stored
   /// [Secret][google.cloud.secretmanager.v1.Secret].
@@ -251,7 +251,7 @@ class Secret {
   /// For secret with TTL>0, version destruction doesn't happen immediately
   /// on calling destroy instead the version goes to a disabled state and
   /// destruction happens after the TTL expires.
-  final PbDuration? versionDestroyTtl;
+  final Duration? versionDestroyTtl;
 
   /// Optional. The customer-managed encryption configuration of the Regionalised
   /// Secrets. If no configuration is provided, Google-managed default encryption
@@ -622,7 +622,7 @@ class Rotation {
   /// [next_rotation_time][google.cloud.secretmanager.v1.Rotation.next_rotation_time]
   /// will be advanced by this period when the service automatically sends
   /// rotation notifications.
-  final PbDuration? rotationPeriod;
+  final Duration? rotationPeriod;
 
   Rotation({
     this.nextRotationTime,


### PR DESCRIPTION
- generate the `Duration` WKT
- contribute hand-written json encode and decode methods
- remove the rename special-casing for `Duration` (we'll revisit this w/ some future mechanism)
