### PR TITLE
cleanup(generator/rust): remove unused option

### DIFF
--- a/generator/internal/rust/rust.go
+++ b/generator/internal/rust/rust.go
@@ -70,13 +70,12 @@ func Generate(model *api.API, outdir string, options map[string]string) error {
 func newCodec(options map[string]string) (*codec, error) {
 	year, _, _ := time.Now().Date()
 	codec := &codec{
-		generationYear:           fmt.Sprintf("%04d", year),
-		modulePath:               "crate::model",
-		deserializeWithdDefaults: true,
-		extraPackages:            []*packagez{},
-		packageMapping:           map[string]*packagez{},
-		version:                  "0.0.0",
-		releaseLevel:             "preview",
+		generationYear: fmt.Sprintf("%04d", year),
+		modulePath:     "crate::model",
+		extraPackages:  []*packagez{},
+		packageMapping: map[string]*packagez{},
+		version:        "0.0.0",
+		releaseLevel:   "preview",
 	}
 
 	for key, definition := range options {
@@ -91,12 +90,6 @@ func newCodec(options map[string]string) (*codec, error) {
 			codec.generateModule = value
 		case key == "module-path":
 			codec.modulePath = definition
-		case key == "deserialize-with-defaults":
-			value, err := strconv.ParseBool(definition)
-			if err != nil {
-				return nil, fmt.Errorf("cannot convert `deserialize-with-defaults` value %q to boolean: %w", definition, err)
-			}
-			codec.deserializeWithdDefaults = value
 		case key == "copyright-year":
 			codec.generationYear = definition
 		case key == "not-for-publication":
@@ -197,9 +190,6 @@ type codec struct {
 	// Note that using `self` does not work, as the generated code may contain
 	// nested modules for nested messages.
 	modulePath string
-	// If true, the deserialization functions will accept default values in
-	// messages. In almost all cases this should be `true`, but
-	deserializeWithdDefaults bool
 	// Additional Rust packages imported by this module. The Mustache template
 	// hardcodes a number of packages, but some are configured via the
 	// command-line.
@@ -690,15 +680,11 @@ func methodInOutTypeName(id string, state *api.APIState, modulePath, sourceSpeci
 	return fullyQualifiedMessageName(m, modulePath, sourceSpecificationPackageName, packageMapping)
 }
 
-func messageAttributes(deserializeWithdDefaults bool) []string {
-	serde := `#[serde(default, rename_all = "camelCase")]`
-	if !deserializeWithdDefaults {
-		serde = `#[serde(rename_all = "camelCase")]`
-	}
+func messageAttributes() []string {
 	return []string{
 		`#[serde_with::serde_as]`,
 		`#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]`,
-		serde,
+		`#[serde(default, rename_all = "camelCase")]`,
 		`#[non_exhaustive]`,
 	}
 }

--- a/generator/internal/rust/rust_test.go
+++ b/generator/internal/rust/rust_test.go
@@ -64,12 +64,11 @@ func TestParseOptions(t *testing.T) {
 		defaultFeatures: true,
 	}
 	want := &codec{
-		version:                  "1.2.3",
-		releaseLevel:             "preview",
-		packageNameOverride:      "test-only",
-		generationYear:           "2035",
-		modulePath:               "alternative::generated",
-		deserializeWithdDefaults: true,
+		version:             "1.2.3",
+		releaseLevel:        "preview",
+		packageNameOverride: "test-only",
+		generationYear:      "2035",
+		modulePath:          "alternative::generated",
 		extraPackages: []*packagez{
 			gp,
 			{

--- a/generator/internal/rust/rusttemplate.go
+++ b/generator/internal/rust/rusttemplate.go
@@ -202,7 +202,7 @@ func annotateModel(model *api.API, c *codec, outdir string) *modelAnnotations {
 		annotateEnum(e, model.State, c.modulePath, c.packageMapping)
 	}
 	for _, m := range model.Messages {
-		annotateMessage(m, model.State, c.deserializeWithdDefaults, c.modulePath, model.PackageName, c.packageMapping)
+		annotateMessage(m, model.State, c.modulePath, model.PackageName, c.packageMapping)
 	}
 	hasLROs := false
 	for _, s := range model.Services {
@@ -215,10 +215,10 @@ func annotateModel(model *api.API, c *codec, outdir string) *modelAnnotations {
 			}
 			annotateMethod(m, s, model.State, c.modulePath, model.PackageName, c.packageMapping, packageNamespace)
 			if m := m.InputType; m != nil {
-				annotateMessage(m, model.State, c.deserializeWithdDefaults, c.modulePath, model.PackageName, c.packageMapping)
+				annotateMessage(m, model.State, c.modulePath, model.PackageName, c.packageMapping)
 			}
 			if m := m.OutputType; m != nil {
-				annotateMessage(m, model.State, c.deserializeWithdDefaults, c.modulePath, model.PackageName, c.packageMapping)
+				annotateMessage(m, model.State, c.modulePath, model.PackageName, c.packageMapping)
 			}
 		}
 		annotateService(s, model, c.modulePath, c.packageMapping)
@@ -335,7 +335,7 @@ func partitionFields(fields []*api.Field, state *api.APIState) fieldPartition {
 
 // annotateMessage annotates the message, its fields, its nested
 // messages, and its nested enums.
-func annotateMessage(m *api.Message, state *api.APIState, deserializeWithDefaults bool, modulePath, sourceSpecificationPackageName string, packageMapping map[string]*packagez) {
+func annotateMessage(m *api.Message, state *api.APIState, modulePath, sourceSpecificationPackageName string, packageMapping map[string]*packagez) {
 	for _, f := range m.Fields {
 		annotateField(f, m, state, modulePath, sourceSpecificationPackageName, packageMapping)
 	}
@@ -346,7 +346,7 @@ func annotateMessage(m *api.Message, state *api.APIState, deserializeWithDefault
 		annotateEnum(e, state, modulePath, packageMapping)
 	}
 	for _, child := range m.Messages {
-		annotateMessage(child, state, deserializeWithDefaults, modulePath, sourceSpecificationPackageName, packageMapping)
+		annotateMessage(child, state, modulePath, sourceSpecificationPackageName, packageMapping)
 	}
 	hasSyntheticFields := false
 	for _, f := range m.Fields {
@@ -365,7 +365,7 @@ func annotateMessage(m *api.Message, state *api.APIState, deserializeWithDefault
 		QualifiedName:      fullyQualifiedMessageName(m, modulePath, sourceSpecificationPackageName, packageMapping),
 		SourceFQN:          strings.TrimPrefix(m.ID, "."),
 		DocLines:           formatDocComments(m.Documentation, m.ID, state, modulePath, m.Scopes(), packageMapping),
-		MessageAttributes:  messageAttributes(deserializeWithDefaults),
+		MessageAttributes:  messageAttributes(),
 		HasNestedTypes:     language.HasNestedTypes(m),
 		BasicFields:        basicFields,
 		SingularFields:     partition.singularFields,

--- a/generator/internal/sidekick/sidekick_test.go
+++ b/generator/internal/sidekick/sidekick_test.go
@@ -162,9 +162,8 @@ func TestRustModuleFromProtobuf(t *testing.T) {
 			ServiceConfig: "google/rpc/rpc_publish.yaml",
 			Name:          "rpc",
 			ExtraOptions: map[string]string{
-				"module-path":               "crate::error::rpc::generated",
-				"deserialize-with-defaults": "false",
-				"package:wkt":               "package=google-cloud-wkt,path=src/wkt,source=google.protobuf",
+				"module-path": "crate::error::rpc::generated",
+				"package:wkt": "package=google-cloud-wkt,path=src/wkt,source=google.protobuf",
 			},
 		},
 		{

--- a/generator/testdata/rust/protobuf/golden/module/rpc/.sidekick.toml
+++ b/generator/testdata/rust/protobuf/golden/module/rpc/.sidekick.toml
@@ -23,7 +23,6 @@ googleapis-root = 'testdata/googleapis'
 
 [codec]
 copyright-year = '2024'
-deserialize-with-defaults = 'false'
 generate-module = 'true'
 module-path = 'crate::error::rpc::generated'
 'package:wkt' = 'package=google-cloud-wkt,path=src/wkt,source=google.protobuf'

--- a/generator/testdata/rust/protobuf/golden/module/rpc/mod.rs
+++ b/generator/testdata/rust/protobuf/golden/module/rpc/mod.rs
@@ -47,7 +47,7 @@
 /// ```
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ErrorInfo {
 
@@ -131,7 +131,7 @@ impl wkt::message::Message for ErrorInfo {
 /// reached.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct RetryInfo {
 
@@ -161,7 +161,7 @@ impl wkt::message::Message for RetryInfo {
 /// Describes additional debugging info.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct DebugInfo {
 
@@ -216,7 +216,7 @@ impl wkt::message::Message for DebugInfo {
 /// quota failure.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct QuotaFailure {
 
@@ -258,7 +258,7 @@ pub mod quota_failure {
     /// daily quota or a custom quota that was exceeded.
     #[serde_with::serde_as]
     #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-    #[serde(rename_all = "camelCase")]
+    #[serde(default, rename_all = "camelCase")]
     #[non_exhaustive]
     pub struct Violation {
 
@@ -311,7 +311,7 @@ pub mod quota_failure {
 /// PreconditionFailure message.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct PreconditionFailure {
 
@@ -352,7 +352,7 @@ pub mod precondition_failure {
     /// A message type used to describe a single precondition failure.
     #[serde_with::serde_as]
     #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-    #[serde(rename_all = "camelCase")]
+    #[serde(default, rename_all = "camelCase")]
     #[non_exhaustive]
     pub struct Violation {
 
@@ -412,7 +412,7 @@ pub mod precondition_failure {
 /// syntactic aspects of the request.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct BadRequest {
 
@@ -453,7 +453,7 @@ pub mod bad_request {
     /// A message type used to describe a single bad request field.
     #[serde_with::serde_as]
     #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-    #[serde(rename_all = "camelCase")]
+    #[serde(default, rename_all = "camelCase")]
     #[non_exhaustive]
     pub struct FieldViolation {
 
@@ -533,7 +533,7 @@ pub mod bad_request {
 /// or providing other forms of feedback.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct RequestInfo {
 
@@ -575,7 +575,7 @@ impl wkt::message::Message for RequestInfo {
 /// Describes the resource that is being accessed.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ResourceInfo {
 
@@ -650,7 +650,7 @@ impl wkt::message::Message for ResourceInfo {
 /// directly to the right place in the developer console to flip the bit.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Help {
 
@@ -691,7 +691,7 @@ pub mod help {
     /// Describes a URL link.
     #[serde_with::serde_as]
     #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-    #[serde(rename_all = "camelCase")]
+    #[serde(default, rename_all = "camelCase")]
     #[non_exhaustive]
     pub struct Link {
 
@@ -733,7 +733,7 @@ pub mod help {
 /// which can be attached to an RPC error.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct LocalizedMessage {
 
@@ -781,7 +781,7 @@ impl wkt::message::Message for LocalizedMessage {
 /// [API Design Guide](https://cloud.google.com/apis/design/errors).
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Status {
 


### PR DESCRIPTION
To be pedantic, the option was only used in tests. It became obsolete
when we introduced message names for `Any`.