### PR TITLE
feat(wkt): implement  `NullValue`

### DIFF
--- a/src/wkt/src/rstruct.rs
+++ b/src/wkt/src/rstruct.rs
@@ -12,22 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Implement the well-known types for structured, yet dynamically typed
+//! messages. These types are a representation of JSON objects, lists, and
+//! values as Protobuf messages. We have taken some (allowed) liberty in their
+//! representation for Rust. We map them directly to the [serde_json] types,
+//! except for `NullValue` where there is no corresponding type in serde.
+//! 
+//! Services specified using Protobuf files may use `google.protobuf.Struct`,
+//! `google.protobuf.Value`, `google.protobuf.ListValue`, and/or 
+//! `google.protobuf.NullValue` as part of their interface specification.
+
 /// Protobuf (and consequently the Google Cloud APIs) use `Struct` to represent
-/// JSON objects. We need a type that might be referenced from the generated
-/// code.
+/// JSON objects. We need a type that can be referenced from the generated code.
 pub type Struct = serde_json::Map<String, serde_json::Value>;
 
 /// Protobuf (and consequently the Google Cloud APIs) use `Value` to represent
-/// JSON values. We need a type that might be referenced from the generated
-/// code.
+/// JSON values. We need a type that can be referenced from the generated code.
 pub type Value = serde_json::Value;
 
 /// Protobuf (and consequently the Google Cloud APIs) use `ListValue` to
-/// represent a list of JSON values. We need a type that might be referenced
+/// represent a list of JSON values. We need a type that can be referenced
 /// from the generated code.
 pub type ListValue = Vec<serde_json::Value>;
 
-/// A message representing the `null` value.
+/// A message representing the `null` value. We need a type that can be
+/// referenced from the generated code.
 #[derive(Clone, Debug, PartialEq)]
 pub struct NullValue;
 

--- a/src/wkt/src/rstruct.rs
+++ b/src/wkt/src/rstruct.rs
@@ -17,9 +17,9 @@
 //! values as Protobuf messages. We have taken some (allowed) liberty in their
 //! representation for Rust. We map them directly to the [serde_json] types,
 //! except for `NullValue` where there is no corresponding type in serde.
-//! 
+//!
 //! Services specified using Protobuf files may use `google.protobuf.Struct`,
-//! `google.protobuf.Value`, `google.protobuf.ListValue`, and/or 
+//! `google.protobuf.Value`, `google.protobuf.ListValue`, and/or
 //! `google.protobuf.NullValue` as part of their interface specification.
 
 /// Protobuf (and consequently the Google Cloud APIs) use `Struct` to represent

--- a/src/wkt/tests/null_value.rs
+++ b/src/wkt/tests/null_value.rs
@@ -91,7 +91,7 @@ mod test {
         Ok(())
     }
 
-    // A test message, inspired by `google.firestore.v1.ValueType`.
+    // A test message, inspired by `google.firestore.v1.Value`.
     #[serde_with::serde_as]
     #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
     #[serde(default, rename_all = "camelCase")]

--- a/src/wkt/tests/null_value.rs
+++ b/src/wkt/tests/null_value.rs
@@ -1,0 +1,149 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test serialization and deserialization of `NullValue`.
+//!
+//! `NullValue` is an well-known type that represents a null JSON value. We need
+//! to verify it works well as part of a larger message or in enums.
+
+#[cfg(test)]
+mod test {
+    use google_cloud_wkt as wkt;
+    use serde_json::json;
+    type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
+
+    #[test]
+    fn test_serialize() -> TestResult {
+        let input = Value::new()
+            .set_test_name("test_serialize")
+            .set_null_value(wkt::NullValue);
+        let got = serde_json::to_value(&input)?;
+        let want = json!({
+            "testName": "test_serialize",
+            "nullValue": null
+        });
+        assert_eq!(got, want);
+
+        let input = Value::new()
+            .set_test_name("test_serialize")
+            .set_duration(wkt::Duration::clamp(123, 456));
+        let got = serde_json::to_value(&input)?;
+        let want = json!({
+            "testName": "test_serialize",
+            "duration": "123.000000456s",
+        });
+        assert_eq!(got, want);
+
+        let input = Value::new()
+            .set_test_name("test_serialize")
+            .set_number(123.5);
+        let got = serde_json::to_value(&input)?;
+        let want = json!({
+            "testName": "test_serialize",
+            "number": 123.5,
+        });
+        assert_eq!(got, want);
+        Ok(())
+    }
+
+    #[test]
+    fn test_deserialize() -> TestResult {
+        let input = json!({
+            "testName": "test_serialize",
+            "nullValue": null
+        });
+        let got = serde_json::from_value::<Value>(input)?;
+        let want = Value::new()
+            .set_test_name("test_serialize")
+            .set_null_value(wkt::NullValue);
+        assert_eq!(got, want);
+
+        let input = json!({
+            "testName": "test_serialize",
+            "duration": "123.000000456s",
+        });
+        let got = serde_json::from_value::<Value>(input)?;
+        let want = Value::new()
+            .set_test_name("test_serialize")
+            .set_duration(wkt::Duration::clamp(123, 456));
+        assert_eq!(got, want);
+
+        let input = json!({
+            "testName": "test_serialize",
+            "number": 123.5,
+        });
+        let got = serde_json::from_value::<Value>(input)?;
+        let want = Value::new()
+            .set_test_name("test_serialize")
+            .set_number(123.5);
+        assert_eq!(got, want);
+        Ok(())
+    }
+
+    // A test message, inspired by `google.firestore.v1.ValueType`.
+    #[serde_with::serde_as]
+    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+    #[serde(default, rename_all = "camelCase")]
+    #[non_exhaustive]
+    pub struct Value {
+        #[serde(skip_serializing_if = "std::string::String::is_empty")]
+        pub test_name: String,
+
+        #[serde(flatten, skip_serializing_if = "Option::is_none")]
+        pub value: Option<value::ValueType>,
+    }
+
+    impl Value {
+        pub fn new() -> Self {
+            Self {
+                test_name: String::new(),
+                value: None,
+            }
+        }
+
+        pub fn set_test_name<T: Into<String>>(mut self, v: T) -> Self {
+            self.test_name = v.into();
+            self
+        }
+
+        pub fn set_null_value<T: Into<wkt::NullValue>>(mut self, v: T) -> Self {
+            self.value = Some(value::ValueType::NullValue(v.into()));
+            self
+        }
+
+        pub fn set_duration<T: Into<Box<wkt::Duration>>>(mut self, v: T) -> Self {
+            self.value = Some(value::ValueType::Duration(v.into()));
+            self
+        }
+
+        pub fn set_number<T: Into<f64>>(mut self, v: T) -> Self {
+            self.value = Some(value::ValueType::Number(v.into()));
+            self
+        }
+    }
+
+    mod value {
+        #[allow(unused_imports)]
+        use super::*;
+
+        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[serde(rename_all = "camelCase")]
+        #[non_exhaustive]
+        pub enum ValueType {
+            NullValue(wkt::NullValue),
+            Duration(Box<wkt::Duration>),
+            Number(f64),
+        }
+    }
+}


### PR DESCRIPTION
The `google.protobuf.NullValue` well-known type is represented as a
unit-like struct. It only has one value, and it is a distinct type.

It can be stored inside a `wkt::Any` and freely converts to and from
`serde_json::Value::NullValue`. Recall that `wkt::Value` is a type alias
for `serde_json::Value`, meaning it works well with the value type.

The type also works as a member of oneof fields, their only use (AFAICT)
in Google Cloud services.

Fixes #37
