### PR TITLE
feat(generator/rust): enums with bad defaults

### DIFF
--- a/generator/internal/rust/templates/common/enum.mustache
+++ b/generator/internal/rust/templates/common/enum.mustache
@@ -53,6 +53,11 @@ impl std::convert::From<std::string::String> for {{Codec.Name}} {
 
 impl std::default::Default for {{Codec.Name}} {
     fn default() -> Self {
+        {{#Codec.DefaultValueName}}
         {{Codec.ModuleName}}::{{Codec.DefaultValueName}}
+        {{/Codec.DefaultValueName}}
+        {{^Codec.DefaultValueName}}
+        Self::new("")
+        {{/Codec.DefaultValueName}}
     }
 }


### PR DESCRIPTION
Initialize enums with no obvious default to the empty string. None of
the Google Cloud enums need this, but we will use it to generate
`google.protobuf.ProtoDescriptor`.

Part of the work for #37