### PR TITLE
feat(auth): enhance retry logic for authentication errors

### DIFF
--- a/src/auth/src/errors.rs
+++ b/src/auth/src/errors.rs
@@ -63,7 +63,7 @@ impl CredentialError {
     /// # Arguments
     /// * `is_retryable` - A boolean indicating whether the error is retryable.
     /// * `message` - The underlying error that caused the auth failure.
-    pub(crate) fn from_str<T: Into<String>>(is_retryable: bool, message: T) -> Self {
+    pub fn from_str<T: Into<String>>(is_retryable: bool, message: T) -> Self {
         CredentialError::new(
             is_retryable,
             CredentialErrorImpl::SimpleMessage(message.into()),

--- a/src/gax/src/http_client/mod.rs
+++ b/src/gax/src/http_client/mod.rs
@@ -26,6 +26,8 @@ use crate::retry_policy::RetryPolicy;
 use crate::retry_throttler::RetryThrottlerWrapped;
 use crate::Result;
 use auth::credentials::{create_access_token_credential, Credential};
+use http::HeaderName;
+use http::HeaderValue;
 use std::sync::Arc;
 
 #[derive(Clone, Debug)]
@@ -76,11 +78,16 @@ impl ReqwestClient {
         body: Option<I>,
         options: crate::options::RequestOptions,
     ) -> Result<O> {
-        let auth_headers = self
-            .cred
-            .get_headers()
-            .await
-            .map_err(Error::authentication)?;
+        let retry_policy = self.get_retry_policy(&options);
+        let auth_headers = match &retry_policy {
+            None => self
+                .cred
+                .get_headers()
+                .await
+                .map_err(Error::authentication)?,
+            Some(policy) => self.auth_retry_loop(&options, &policy).await?,
+        };
+
         for header in auth_headers.into_iter() {
             builder = builder.header(header.0, header.1);
         }
@@ -93,9 +100,74 @@ impl ReqwestClient {
         if let Some(body) = body {
             builder = builder.json(&body);
         }
-        match self.get_retry_policy(&options) {
+        match &retry_policy {
             None => self.request_attempt::<O>(builder, &options, None).await,
-            Some(policy) => self.retry_loop::<O>(builder, &options, policy).await,
+            Some(policy) => {
+                self.retry_loop::<O>(builder, &options, Arc::clone(policy))
+                    .await
+            }
+        }
+    }
+
+    async fn auth_retry_loop(
+        &self,
+        options: &crate::options::RequestOptions,
+        retry_policy: &Arc<dyn RetryPolicy>,
+    ) -> Result<Vec<(HeaderName, HeaderValue)>> {
+        let loop_start = std::time::Instant::now();
+        let backoff = self.get_backoff_policy(options);
+        let throttler = self.get_retry_throttler(options);
+        let mut attempt_count = 0;
+
+        loop {
+            if attempt_count > 0 {
+                let do_throttle = {
+                    let t = throttler.lock().expect("retry_throttler lock poisoned");
+                    t.throttle_retry_attempt()
+                };
+                if do_throttle {
+                    if let Some(err) = retry_policy.on_throttle(loop_start, attempt_count) {
+                        return Err(err);
+                    }
+                    let delay = backoff.on_failure(loop_start, attempt_count);
+                    tokio::time::sleep(delay).await;
+                }
+            }
+
+            attempt_count += 1;
+            match self.cred.get_headers().await {
+                Ok(hdrs) => {
+                    {
+                        let mut t = throttler.lock().expect("retry_throttler lock poisoned");
+                        t.on_success();
+                    }
+                    return Ok(hdrs);
+                }
+                Err(cred_err) => {
+                    let gax_err = Error::authentication(cred_err);
+                    let flow = retry_policy.on_error(
+                        loop_start,
+                        attempt_count,
+                        options.idempotent.unwrap_or(false),
+                        gax_err,
+                    );
+                    let delay = backoff.on_failure(loop_start, attempt_count);
+
+                    {
+                        let mut t = throttler.lock().expect("retry_throttler lock poisoned");
+                        t.on_retry_failure(&flow);
+                    }
+
+                    match flow {
+                        LoopState::Permanent(e) | LoopState::Exhausted(e) => {
+                            return Err(e);
+                        }
+                        LoopState::Continue(_) => {
+                            tokio::time::sleep(delay).await;
+                        }
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Description
Issue: https://github.com/googleapis/google-cloud-rust/issues/1350

I implemented the following two unit tests for CredentialError:

auth_error_retryable() { ... }
auth_error_non_retryable() { ... }
I tried to extend the existing retry_loop to implement the authentication loop process, but I couldn't get it to work properly. So, I implemented auth_retry_loop instead.

If you think it should be unified, please suggest an implementation approach.

## Test
`cargo test -p google-cloud-gax --test auth`