### PR TITLE
feat(generator/dart): whitespace updates to the emitted dartdocs

### DIFF
--- a/generator/dart/packages/generated/google_cloud_protobuf/lib/protobuf.dart
+++ b/generator/dart/packages/generated/google_cloud_protobuf/lib/protobuf.dart
@@ -28,18 +28,18 @@ part 'src/protobuf.p.dart';
 /// or "month". It is related to Timestamp in that the difference between
 /// two Timestamp values is a Duration and it can be added or subtracted
 /// from a Timestamp. Range is approximately +-10,000 years.
-/// 
+///
 /// # Examples
-/// 
+///
 /// Example 1: Compute Duration from two Timestamps in pseudo code.
-/// 
+///
 ///     Timestamp start = ...;
 ///     Timestamp end = ...;
 ///     Duration duration = ...;
-/// 
+///
 ///     duration.seconds = end.seconds - start.seconds;
 ///     duration.nanos = end.nanos - start.nanos;
-/// 
+///
 ///     if (duration.seconds < 0 && duration.nanos > 0) {
 ///       duration.seconds += 1;
 ///       duration.nanos -= 1000000000;
@@ -47,16 +47,16 @@ part 'src/protobuf.p.dart';
 ///       duration.seconds -= 1;
 ///       duration.nanos += 1000000000;
 ///     }
-/// 
+///
 /// Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
-/// 
+///
 ///     Timestamp start = ...;
 ///     Duration duration = ...;
 ///     Timestamp end = ...;
-/// 
+///
 ///     end.seconds = start.seconds + duration.seconds;
 ///     end.nanos = start.nanos + duration.nanos;
-/// 
+///
 ///     if (end.nanos < 0) {
 ///       end.seconds -= 1;
 ///       end.nanos += 1000000000;
@@ -64,15 +64,15 @@ part 'src/protobuf.p.dart';
 ///       end.seconds += 1;
 ///       end.nanos -= 1000000000;
 ///     }
-/// 
+///
 /// Example 3: Compute Duration from datetime.timedelta in Python.
-/// 
+///
 ///     td = datetime.timedelta(days=3, minutes=10)
 ///     duration = Duration()
 ///     duration.FromTimedelta(td)
-/// 
+///
 /// # JSON Mapping
-/// 
+///
 /// In JSON format, the Duration type is encoded as a string rather than an
 /// object, where the string ends in the suffix "s" (indicating seconds) and
 /// is preceded by the number of seconds, with nanoseconds expressed as
@@ -80,7 +80,6 @@ part 'src/protobuf.p.dart';
 /// encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
 /// be expressed in JSON format as "3.000000001s", and 3 seconds and 1
 /// microsecond should be expressed in JSON format as "3.000001s".
-/// 
 class Duration {
 
   /// Signed seconds of the span of time. Must be from -315,576,000,000
@@ -105,25 +104,25 @@ class Duration {
 }
 
 /// `FieldMask` represents a set of symbolic field paths, for example:
-/// 
+///
 ///     paths: "f.a"
 ///     paths: "f.b.d"
-/// 
+///
 /// Here `f` represents a field in some root message, `a` and `b`
 /// fields in the message found in `f`, and `d` a field found in the
 /// message in `f.b`.
-/// 
+///
 /// Field masks are used to specify a subset of fields that should be
 /// returned by a get operation or modified by an update operation.
 /// Field masks also have a custom JSON encoding (see below).
-/// 
+///
 /// # Field Masks in Projections
-/// 
+///
 /// When used in the context of a projection, a response message or
 /// sub-message is filtered by the API to only contain those fields as
 /// specified in the mask. For example, if the mask in the previous
 /// example is applied to a response message as follows:
-/// 
+///
 ///     f {
 ///       a : 22
 ///       b {
@@ -133,26 +132,26 @@ class Duration {
 ///       y : 13
 ///     }
 ///     z: 8
-/// 
+///
 /// The result will not contain specific values for fields x,y and z
 /// (their value will be set to the default, and omitted in proto text
 /// output):
-/// 
-/// 
+///
+///
 ///     f {
 ///       a : 22
 ///       b {
 ///         d : 1
 ///       }
 ///     }
-/// 
+///
 /// A repeated field is not allowed except at the last position of a
 /// paths string.
-/// 
+///
 /// If a FieldMask object is not present in a get operation, the
 /// operation applies to all fields (as if a FieldMask of all fields
 /// had been specified).
-/// 
+///
 /// Note that a field mask does not necessarily apply to the
 /// top-level response message. In case of a REST get operation, the
 /// field mask applies directly to the response, but in case of a REST
@@ -162,26 +161,26 @@ class Duration {
 /// clearly documented together with its declaration in the API.  In
 /// any case, the effect on the returned resource/resources is required
 /// behavior for APIs.
-/// 
+///
 /// # Field Masks in Update Operations
-/// 
+///
 /// A field mask in update operations specifies which fields of the
 /// targeted resource are going to be updated. The API is required
 /// to only change the values of the fields as specified in the mask
 /// and leave the others untouched. If a resource is passed in to
 /// describe the updated values, the API ignores the values of all
 /// fields not covered by the mask.
-/// 
+///
 /// If a repeated field is specified for an update operation, new values will
 /// be appended to the existing repeated field in the target resource. Note that
 /// a repeated field is only allowed in the last position of a `paths` string.
-/// 
+///
 /// If a sub-message is specified in the last position of the field mask for an
 /// update operation, then new value will be merged into the existing sub-message
 /// in the target resource.
-/// 
+///
 /// For example, given the target message:
-/// 
+///
 ///     f {
 ///       b {
 ///         d: 1
@@ -189,22 +188,22 @@ class Duration {
 ///       }
 ///       c: [1]
 ///     }
-/// 
+///
 /// And an update message:
-/// 
+///
 ///     f {
 ///       b {
 ///         d: 10
 ///       }
 ///       c: [2]
 ///     }
-/// 
+///
 /// then if the field mask is:
-/// 
+///
 ///  paths: ["f.b", "f.c"]
-/// 
+///
 /// then the result will be:
-/// 
+///
 ///     f {
 ///       b {
 ///         d: 10
@@ -212,16 +211,16 @@ class Duration {
 ///       }
 ///       c: [1, 2]
 ///     }
-/// 
+///
 /// An implementation may provide options to override this default behavior for
 /// repeated and message fields.
-/// 
+///
 /// In order to reset a field's value to the default, the field must
 /// be in the mask and set to the default value in the provided resource.
 /// Hence, in order to reset all fields of a resource, provide a default
 /// instance of the resource and set all fields in the mask, or do
 /// not provide a mask as described below.
-/// 
+///
 /// If a field mask is not present on update, the operation applies to
 /// all fields (as if a field mask of all fields has been specified).
 /// Note that in the presence of schema evolution, this may mean that
@@ -229,26 +228,26 @@ class Duration {
 /// the request will be reset to their default. If this is unwanted
 /// behavior, a specific service may require a client to always specify
 /// a field mask, producing an error if not.
-/// 
+///
 /// As with get operations, the location of the resource which
 /// describes the updated values in the request message depends on the
 /// operation kind. In any case, the effect of the field mask is
 /// required to be honored by the API.
-/// 
+///
 /// ## Considerations for HTTP REST
-/// 
+///
 /// The HTTP kind of an update operation which uses a field mask must
 /// be set to PATCH instead of PUT in order to satisfy HTTP semantics
 /// (PUT must only be used for full updates).
-/// 
+///
 /// # JSON Encoding of Field Masks
-/// 
+///
 /// In JSON, a field mask is encoded as a single string where paths are
 /// separated by a comma. Fields name in each path are converted
 /// to/from lower-camel naming conventions.
-/// 
+///
 /// As an example, consider the following message declarations:
-/// 
+///
 ///     message Profile {
 ///       User user = 1;
 ///       Photo photo = 2;
@@ -257,49 +256,49 @@ class Duration {
 ///       string display_name = 1;
 ///       string address = 2;
 ///     }
-/// 
+///
 /// In proto a field mask for `Profile` may look as such:
-/// 
+///
 ///     mask {
 ///       paths: "user.display_name"
 ///       paths: "photo"
 ///     }
-/// 
+///
 /// In JSON, the same mask is represented as below:
-/// 
+///
 ///     {
 ///       mask: "user.displayName,photo"
 ///     }
-/// 
+///
 /// # Field Masks and Oneof Fields
-/// 
+///
 /// Field masks treat fields in oneofs just as regular fields. Consider the
 /// following message:
-/// 
+///
 ///     message SampleMessage {
 ///       oneof test_oneof {
 ///         string name = 4;
 ///         SubMessage sub_message = 9;
 ///       }
 ///     }
-/// 
+///
 /// The field mask can be:
-/// 
+///
 ///     mask {
 ///       paths: "name"
 ///     }
-/// 
+///
 /// Or:
-/// 
+///
 ///     mask {
 ///       paths: "sub_message"
 ///     }
-/// 
+///
 /// Note that oneof type names ("test_oneof" in this case) cannot be used in
 /// paths.
-/// 
+///
 /// ## Field Mask Verification
-/// 
+///
 /// The implementation of any API method which has a FieldMask type field in the
 /// request should verify the included field paths, and return an
 /// `INVALID_ARGUMENT` error if any path is unmappable.

--- a/generator/dart/packages/generated/google_cloud_protobuf/test/types_test.dart
+++ b/generator/dart/packages/generated/google_cloud_protobuf/test/types_test.dart
@@ -113,7 +113,7 @@ void main() {
       expect(() => DurationExtension.decode('2.00001'), throwsFormatException);
     });
 
-    test('bad format', () {
+    test('bad format - too many periods', () {
       expect(() => DurationExtension.decode('1.2.3.4s'), throwsFormatException);
     });
 

--- a/generator/dart/packages/generated/google_cloud_rpc/lib/rpc.dart
+++ b/generator/dart/packages/generated/google_cloud_rpc/lib/rpc.dart
@@ -24,10 +24,10 @@ import 'dart:typed_data';
 import 'package:google_cloud_protobuf/protobuf.dart';
 
 /// Describes the cause of the error with structured details.
-/// 
+///
 /// Example of an error when contacting the "pubsub.googleapis.com" API when it
 /// is not enabled:
-/// 
+///
 ///     { "reason": "API_DISABLED"
 ///       "domain": "googleapis.com"
 ///       "metadata": {
@@ -35,12 +35,12 @@ import 'package:google_cloud_protobuf/protobuf.dart';
 ///         "service": "pubsub.googleapis.com"
 ///       }
 ///     }
-/// 
+///
 /// This response indicates that the pubsub.googleapis.com API is not enabled.
-/// 
+///
 /// Example of an error that is returned when attempting to create a Spanner
 /// instance in a region that is out of stock:
-/// 
+///
 ///     { "reason": "STOCKOUT"
 ///       "domain": "spanner.googleapis.com",
 ///       "metadata": {
@@ -65,7 +65,7 @@ class ErrorInfo {
   final String? domain;
 
   /// Additional structured details about this error.
-  /// 
+  ///
   /// Keys must match a regular expression of `[a-z][a-zA-Z0-9-_]+` but should
   /// ideally be lowerCamelCase. Also, they must be limited to 64 characters in
   /// length. When identifying the current value of an exceeded limit, the units
@@ -85,10 +85,10 @@ class ErrorInfo {
 /// Describes when the clients can retry a failed request. Clients could ignore
 /// the recommendation here or retry when this information is missing from error
 /// responses.
-/// 
+///
 /// It's always recommended that clients should use exponential backoff when
 /// retrying.
-/// 
+///
 /// Clients should wait until `retry_delay` amount of time has passed since
 /// receiving the error response before retrying.  If retrying requests also
 /// fail, clients should use an exponential backoff scheme to gradually increase
@@ -121,14 +121,14 @@ class DebugInfo {
 }
 
 /// Describes how a quota check failed.
-/// 
+///
 /// For example if a daily limit was exceeded for the calling project,
 /// a service could respond with a QuotaFailure detail containing the project
 /// id and the description of the quota limit that was exceeded.  If the
 /// calling project hasn't enabled the service in the developer console, then
 /// a service could respond with the project id and set `service_disabled`
 /// to true.
-/// 
+///
 /// Also see RetryInfo and Help types for other details about handling a
 /// quota failure.
 class QuotaFailure {
@@ -154,7 +154,7 @@ class QuotaFailure$Violation {
   /// description to find more about the quota configuration in the service's
   /// public documentation, or find the relevant quota limit to adjust through
   /// developer console.
-  /// 
+  ///
   /// For example: "Service disabled" or "Daily Limit for read operations
   /// exceeded".
   final String? description;
@@ -166,7 +166,7 @@ class QuotaFailure$Violation {
 }
 
 /// Describes what preconditions have failed.
-/// 
+///
 /// For example, if an RPC failed because it required the Terms of Service to be
 /// acknowledged, it could list the terms of service violation in the
 /// PreconditionFailure message.
@@ -195,7 +195,7 @@ class PreconditionFailure$Violation {
 
   /// A description of how the precondition failed. Developers can use this
   /// description to understand how to fix the failure.
-  /// 
+  ///
   /// For example: "Terms of service not accepted".
   final String? description;
 
@@ -224,9 +224,9 @@ class BadRequest$FieldViolation {
   /// A path that leads to a field in the request body. The value will be a
   /// sequence of dot-separated identifiers that identify a protocol buffer
   /// field.
-  /// 
+  ///
   /// Consider the following:
-  /// 
+  ///
   ///     message CreateContactRequest {
   ///       message EmailAddress {
   ///         enum Type {
@@ -234,25 +234,25 @@ class BadRequest$FieldViolation {
   ///           HOME = 1;
   ///           WORK = 2;
   ///         }
-  /// 
+  ///
   ///         optional string email = 1;
   ///         repeated EmailType type = 2;
   ///       }
-  /// 
+  ///
   ///       string full_name = 1;
   ///       repeated EmailAddress email_addresses = 2;
   ///     }
-  /// 
+  ///
   /// In this example, in proto `field` could take one of the following values:
-  /// 
+  ///
   /// * `full_name` for a violation in the `full_name` value
   /// * `email_addresses[1].email` for a violation in the `email` field of the
   ///   first `email_addresses` message
   /// * `email_addresses[3].type[2]` for a violation in the second `type`
   ///   value in the third `email_addresses` message.
-  /// 
+  ///
   /// In JSON, the same values are represented as:
-  /// 
+  ///
   /// * `fullName` for a violation in the `fullName` value
   /// * `emailAddresses[1].email` for a violation in the `email` field of the
   ///   first `emailAddresses` message
@@ -334,7 +334,7 @@ class ResourceInfo {
 }
 
 /// Provides links to documentation or for performing an out of band action.
-/// 
+///
 /// For example, if a quota check failed with an error indicating the calling
 /// project hasn't enabled the accessed service, this can contain a URL pointing
 /// directly to the right place in the developer console to flip the bit.
@@ -448,7 +448,7 @@ class HttpHeader {
 /// different programming environments, including REST APIs and RPC APIs. It is
 /// used by [gRPC](https://github.com/grpc). Each `Status` message contains
 /// three pieces of data: error code, error message, and error details.
-/// 
+///
 /// You can find out more about this error model and how to work with it in the
 /// [API Design Guide](https://cloud.google.com/apis/design/errors).
 class Status {
@@ -475,20 +475,20 @@ class Status {
 }
 
 /// The canonical error codes for gRPC APIs.
-/// 
-/// 
+///
+///
 /// Sometimes multiple error codes may apply.  Services should return
 /// the most specific error code that applies.  For example, prefer
 /// `OUT_OF_RANGE` over `FAILED_PRECONDITION` if both codes apply.
 /// Similarly prefer `NOT_FOUND` or `ALREADY_EXISTS` over `FAILED_PRECONDITION`.
 class Code {
   /// Not an error; returned on success.
-  /// 
+  ///
   /// HTTP Mapping: 200 OK
   static const Code ok = Code('OK');
 
   /// The operation was cancelled, typically by the caller.
-  /// 
+  ///
   /// HTTP Mapping: 499 Client Closed Request
   static const Code cancelled = Code('CANCELLED');
 
@@ -497,7 +497,7 @@ class Code {
   /// an error space that is not known in this address space.  Also
   /// errors raised by APIs that do not return enough error information
   /// may be converted to this error.
-  /// 
+  ///
   /// HTTP Mapping: 500 Internal Server Error
   static const Code unknown = Code('UNKNOWN');
 
@@ -505,7 +505,7 @@ class Code {
   /// from `FAILED_PRECONDITION`.  `INVALID_ARGUMENT` indicates arguments
   /// that are problematic regardless of the state of the system
   /// (e.g., a malformed file name).
-  /// 
+  ///
   /// HTTP Mapping: 400 Bad Request
   static const Code invalidArgument = Code('INVALID_ARGUMENT');
 
@@ -514,24 +514,24 @@ class Code {
   /// even if the operation has completed successfully.  For example, a
   /// successful response from a server could have been delayed long
   /// enough for the deadline to expire.
-  /// 
+  ///
   /// HTTP Mapping: 504 Gateway Timeout
   static const Code deadlineExceeded = Code('DEADLINE_EXCEEDED');
 
   /// Some requested entity (e.g., file or directory) was not found.
-  /// 
+  ///
   /// Note to server developers: if a request is denied for an entire class
   /// of users, such as gradual feature rollout or undocumented allowlist,
   /// `NOT_FOUND` may be used. If a request is denied for some users within
   /// a class of users, such as user-based access control, `PERMISSION_DENIED`
   /// must be used.
-  /// 
+  ///
   /// HTTP Mapping: 404 Not Found
   static const Code notFound = Code('NOT_FOUND');
 
   /// The entity that a client attempted to create (e.g., file or directory)
   /// already exists.
-  /// 
+  ///
   /// HTTP Mapping: 409 Conflict
   static const Code alreadyExists = Code('ALREADY_EXISTS');
 
@@ -543,19 +543,19 @@ class Code {
   /// instead for those errors). This error code does not imply the
   /// request is valid or the requested entity exists or satisfies
   /// other pre-conditions.
-  /// 
+  ///
   /// HTTP Mapping: 403 Forbidden
   static const Code permissionDenied = Code('PERMISSION_DENIED');
 
   /// The request does not have valid authentication credentials for the
   /// operation.
-  /// 
+  ///
   /// HTTP Mapping: 401 Unauthorized
   static const Code unauthenticated = Code('UNAUTHENTICATED');
 
   /// Some resource has been exhausted, perhaps a per-user quota, or
   /// perhaps the entire file system is out of space.
-  /// 
+  ///
   /// HTTP Mapping: 429 Too Many Requests
   static const Code resourceExhausted = Code('RESOURCE_EXHAUSTED');
 
@@ -563,7 +563,7 @@ class Code {
   /// required for the operation's execution.  For example, the directory
   /// to be deleted is non-empty, an rmdir operation is applied to
   /// a non-directory, etc.
-  /// 
+  ///
   /// Service implementors can use the following guidelines to decide
   /// between `FAILED_PRECONDITION`, `ABORTED`, and `UNAVAILABLE`:
   ///  (a) Use `UNAVAILABLE` if the client can retry just the failing call.
@@ -575,48 +575,48 @@ class Code {
   ///      fails because the directory is non-empty, `FAILED_PRECONDITION`
   ///      should be returned since the client should not retry unless
   ///      the files are deleted from the directory.
-  /// 
+  ///
   /// HTTP Mapping: 400 Bad Request
   static const Code failedPrecondition = Code('FAILED_PRECONDITION');
 
   /// The operation was aborted, typically due to a concurrency issue such as
   /// a sequencer check failure or transaction abort.
-  /// 
+  ///
   /// See the guidelines above for deciding between `FAILED_PRECONDITION`,
   /// `ABORTED`, and `UNAVAILABLE`.
-  /// 
+  ///
   /// HTTP Mapping: 409 Conflict
   static const Code aborted = Code('ABORTED');
 
   /// The operation was attempted past the valid range.  E.g., seeking or
   /// reading past end-of-file.
-  /// 
+  ///
   /// Unlike `INVALID_ARGUMENT`, this error indicates a problem that may
   /// be fixed if the system state changes. For example, a 32-bit file
   /// system will generate `INVALID_ARGUMENT` if asked to read at an
   /// offset that is not in the range [0,2^32-1], but it will generate
   /// `OUT_OF_RANGE` if asked to read from an offset past the current
   /// file size.
-  /// 
+  ///
   /// There is a fair bit of overlap between `FAILED_PRECONDITION` and
   /// `OUT_OF_RANGE`.  We recommend using `OUT_OF_RANGE` (the more specific
   /// error) when it applies so that callers who are iterating through
   /// a space can easily look for an `OUT_OF_RANGE` error to detect when
   /// they are done.
-  /// 
+  ///
   /// HTTP Mapping: 400 Bad Request
   static const Code outOfRange = Code('OUT_OF_RANGE');
 
   /// The operation is not implemented or is not supported/enabled in this
   /// service.
-  /// 
+  ///
   /// HTTP Mapping: 501 Not Implemented
   static const Code unimplemented = Code('UNIMPLEMENTED');
 
   /// Internal errors.  This means that some invariants expected by the
   /// underlying system have been broken.  This error code is reserved
   /// for serious errors.
-  /// 
+  ///
   /// HTTP Mapping: 500 Internal Server Error
   static const Code internal = Code('INTERNAL');
 
@@ -624,15 +624,15 @@ class Code {
   /// transient condition, which can be corrected by retrying with
   /// a backoff. Note that it is not always safe to retry
   /// non-idempotent operations.
-  /// 
+  ///
   /// See the guidelines above for deciding between `FAILED_PRECONDITION`,
   /// `ABORTED`, and `UNAVAILABLE`.
-  /// 
+  ///
   /// HTTP Mapping: 503 Service Unavailable
   static const Code unavailable = Code('UNAVAILABLE');
 
   /// Unrecoverable data loss or corruption.
-  /// 
+  ///
   /// HTTP Mapping: 500 Internal Server Error
   static const Code dataLoss = Code('DATA_LOSS');
 

--- a/generator/dart/packages/generated/google_cloud_type/lib/type.dart
+++ b/generator/dart/packages/generated/google_cloud_type/lib/type.dart
@@ -23,31 +23,31 @@ library;
 /// Represents a textual expression in the Common Expression Language (CEL)
 /// syntax. CEL is a C-like expression language. The syntax and semantics of CEL
 /// are documented at https://github.com/google/cel-spec.
-/// 
+///
 /// Example (Comparison):
-/// 
+///
 ///     title: "Summary size limit"
 ///     description: "Determines if a summary is less than 100 chars"
 ///     expression: "document.summary.size() < 100"
-/// 
+///
 /// Example (Equality):
-/// 
+///
 ///     title: "Requestor is owner"
 ///     description: "Determines if requestor is the document owner"
 ///     expression: "document.owner == request.auth.claims.email"
-/// 
+///
 /// Example (Logic):
-/// 
+///
 ///     title: "Public documents"
 ///     description: "Determine whether the document should be publicly visible"
 ///     expression: "document.type != 'private' && document.type != 'internal'"
-/// 
+///
 /// Example (Data Manipulation):
-/// 
+///
 ///     title: "Notification string"
 ///     description: "Create a notification string with a timestamp."
 ///     expression: "'New message received at ' + string(document.create_time)"
-/// 
+///
 /// The exact variables and functions that may be referenced within an expression
 /// are determined by the service that evaluates it. See the service
 /// documentation for additional information.

--- a/generator/internal/dart/dart.go
+++ b/generator/internal/dart/dart.go
@@ -189,11 +189,25 @@ func httpPathArgs(_ *api.PathInfo) []string {
 }
 
 func formatDocComments(documentation string, _ *api.APIState) []string {
-	ss := strings.Split(documentation, "\n")
-	for i := range ss {
-		ss[i] = strings.TrimRightFunc(ss[i], unicode.IsSpace)
+	lines := strings.Split(documentation, "\n")
+
+	for i, line := range lines {
+		lines[i] = strings.TrimRightFunc(line, unicode.IsSpace)
 	}
-	return ss
+
+	for len(lines) > 0 && len(lines[len(lines)-1]) == 0 {
+		lines = lines[:len(lines)-1]
+	}
+
+	for i, line := range lines {
+		if len(line) == 0 {
+			lines[i] = "///"
+		} else {
+			lines[i] = "/// " + line
+		}
+	}
+
+	return lines
 }
 
 func modelPackageName(api *api.API, packageNameOverride string) string {

--- a/generator/internal/dart/templates/lib/enum.mustache
+++ b/generator/internal/dart/templates/lib/enum.mustache
@@ -15,12 +15,12 @@ limitations under the License.
 }}
 
 {{#Codec.DocLines}}
-/// {{{.}}}
+{{{.}}}
 {{/Codec.DocLines}}
 class {{Codec.Name}} {
   {{#Values}}
   {{#Codec.DocLines}}
-  /// {{{.}}}
+  {{{.}}}
   {{/Codec.DocLines}}
   static const {{Parent.Codec.Name}} {{Codec.Name}} = {{Parent.Codec.Name}}('{{Name}}');
 

--- a/generator/internal/dart/templates/lib/field.mustache
+++ b/generator/internal/dart/templates/lib/field.mustache
@@ -15,6 +15,6 @@ limitations under the License.
 }}
 
 {{#Codec.DocLines}}
-/// {{{.}}}
+{{{.}}}
 {{/Codec.DocLines}}
 final {{{Codec.Type}}}? {{Codec.Name}};

--- a/generator/internal/dart/templates/lib/main.dart.mustache
+++ b/generator/internal/dart/templates/lib/main.dart.mustache
@@ -21,7 +21,7 @@ limitations under the License.
 /// The Google Cloud client for the {{Title}}.
 ///
 {{#Codec.DocLines}}
-/// {{{.}}}
+{{{.}}}
 {{/Codec.DocLines}}
 library;
 

--- a/generator/internal/dart/templates/lib/message.mustache
+++ b/generator/internal/dart/templates/lib/message.mustache
@@ -16,7 +16,7 @@ limitations under the License.
 {{^IsMap}}
 
 {{#Codec.DocLines}}
-/// {{{.}}}
+{{{.}}}
 {{/Codec.DocLines}}
 class {{Codec.Name}} {
   {{#Fields}}

--- a/generator/internal/dart/templates/lib/method.mustache
+++ b/generator/internal/dart/templates/lib/method.mustache
@@ -15,7 +15,7 @@ limitations under the License.
 }}
 
 {{#Codec.DocLines}}
-/// {{{.}}}
+{{{.}}}
 {{/Codec.DocLines}}
 Future<{{Codec.ResponseType}}> {{Codec.Name}}({{Codec.RequestType}} request) {
   throw UnimplementedError('{{Codec.Name}}');

--- a/generator/internal/dart/templates/lib/service.mustache
+++ b/generator/internal/dart/templates/lib/service.mustache
@@ -15,7 +15,7 @@ limitations under the License.
 }}
 
 {{#Codec.DocLines}}
-/// {{{.}}}
+{{{.}}}
 {{/Codec.DocLines}}
 class {{Codec.Name}} {
   static const String defaultHost = 'https://{{DefaultHost}}';

--- a/generator/testdata/dart/protobuf/golden/secretmanager/lib/secretmanager.dart
+++ b/generator/testdata/dart/protobuf/golden/secretmanager/lib/secretmanager.dart
@@ -26,10 +26,10 @@ import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:http/http.dart';
 
 /// Secret Manager Service
-/// 
+///
 /// Manages secrets and operations using those secrets. Implements a REST
 /// model with the following objects:
-/// 
+///
 /// * [Secret][google.cloud.secretmanager.v1.Secret]
 /// * [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
 class SecretManagerService {
@@ -77,7 +77,7 @@ class SecretManagerService {
 
   /// Gets metadata for a
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-  /// 
+  ///
   /// `projects/*/secrets/*/versions/latest` is an alias to the most recently
   /// created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
   Future<SecretVersion> getSecretVersion(GetSecretVersionRequest request) {
@@ -86,7 +86,7 @@ class SecretManagerService {
 
   /// Accesses a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
   /// This call returns the secret data.
-  /// 
+  ///
   /// `projects/*/secrets/*/versions/latest` is an alias to the most recently
   /// created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
   Future<AccessSecretVersionResponse> accessSecretVersion(AccessSecretVersionRequest request) {
@@ -94,7 +94,7 @@ class SecretManagerService {
   }
 
   /// Disables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-  /// 
+  ///
   /// Sets the [state][google.cloud.secretmanager.v1.SecretVersion.state] of the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
   /// [DISABLED][google.cloud.secretmanager.v1.SecretVersion.State.DISABLED].
@@ -103,7 +103,7 @@ class SecretManagerService {
   }
 
   /// Enables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-  /// 
+  ///
   /// Sets the [state][google.cloud.secretmanager.v1.SecretVersion.state] of the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
   /// [ENABLED][google.cloud.secretmanager.v1.SecretVersion.State.ENABLED].
@@ -112,7 +112,7 @@ class SecretManagerService {
   }
 
   /// Destroys a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-  /// 
+  ///
   /// Sets the [state][google.cloud.secretmanager.v1.SecretVersion.state] of the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to
   /// [DESTROYED][google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED]
@@ -123,7 +123,7 @@ class SecretManagerService {
 
   /// Sets the access control policy on the specified secret. Replaces any
   /// existing policy.
-  /// 
+  ///
   /// Permissions on
   /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] are enforced
   /// according to the policy set on the associated
@@ -141,7 +141,7 @@ class SecretManagerService {
   /// Returns permissions that a caller has for the specified secret.
   /// If the secret does not exist, this call returns an empty set of
   /// permissions, not a NOT_FOUND error.
-  /// 
+  ///
   /// Note: This operation is designed to be used for building permission-aware
   /// UIs and command-line tools, not for authorization checking. This operation
   /// may "fail open" without warning.
@@ -162,7 +162,7 @@ class SecretManagerService {
 
 /// A [Secret][google.cloud.secretmanager.v1.Secret] is a logical secret whose
 /// value and versions can be accessed.
-/// 
+///
 /// A [Secret][google.cloud.secretmanager.v1.Secret] is made up of zero or more
 /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] that represent
 /// the secret data.
@@ -175,7 +175,7 @@ class Secret {
 
   /// Optional. Immutable. The replication policy of the secret data attached to
   /// the [Secret][google.cloud.secretmanager.v1.Secret].
-  /// 
+  ///
   /// The replication policy cannot be changed after the Secret has been created.
   final Replication? replication;
 
@@ -184,15 +184,15 @@ class Secret {
   final Timestamp? createTime;
 
   /// The labels assigned to this Secret.
-  /// 
+  ///
   /// Label keys must be between 1 and 63 characters long, have a UTF-8 encoding
   /// of maximum 128 bytes, and must conform to the following PCRE regular
   /// expression: `[\p{Ll}\p{Lo}][\p{Ll}\p{Lo}\p{N}_-]{0,62}`
-  /// 
+  ///
   /// Label values must be between 0 and 63 characters long, have a UTF-8
   /// encoding of maximum 128 bytes, and must conform to the following PCRE
   /// regular expression: `[\p{Ll}\p{Lo}\p{N}_-]{0,63}`
-  /// 
+  ///
   /// No more than 64 labels can be assigned to a given resource.
   final Map<String, String>? labels;
 
@@ -219,34 +219,34 @@ class Secret {
   final Rotation? rotation;
 
   /// Optional. Mapping from version alias to version name.
-  /// 
+  ///
   /// A version alias is a string with a maximum length of 63 characters and can
   /// contain uppercase and lowercase letters, numerals, and the hyphen (`-`)
   /// and underscore ('_') characters. An alias string must start with a
   /// letter and cannot be the string 'latest' or 'NEW'.
   /// No more than 50 aliases can be assigned to a given secret.
-  /// 
+  ///
   /// Version-Alias pairs will be viewable via GetSecret and modifiable via
   /// UpdateSecret. Access by alias is only be supported on
   /// GetSecretVersion and AccessSecretVersion.
   final Map<String, int>? versionAliases;
 
   /// Optional. Custom metadata about the secret.
-  /// 
+  ///
   /// Annotations are distinct from various forms of labels.
   /// Annotations exist to allow client tools to store their own state
   /// information without requiring a database.
-  /// 
+  ///
   /// Annotation keys must be between 1 and 63 characters long, have a UTF-8
   /// encoding of maximum 128 bytes, begin and end with an alphanumeric character
   /// ([a-z0-9A-Z]), and may have dashes (-), underscores (_), dots (.), and
   /// alphanumerics in between these symbols.
-  /// 
+  ///
   /// The total size of annotation keys and values must be less than 16KiB.
   final Map<String, String>? annotations;
 
   /// Optional. Secret Version TTL after destruction request
-  /// 
+  ///
   /// This is a part of the Delayed secret version destroy feature.
   /// For secret with TTL>0, version destruction doesn't happen immediately
   /// on calling destroy instead the version goes to a disabled state and
@@ -256,7 +256,7 @@ class Secret {
   /// Optional. The customer-managed encryption configuration of the Regionalised
   /// Secrets. If no configuration is provided, Google-managed default encryption
   /// is used.
-  /// 
+  ///
   /// Updates to the [Secret][google.cloud.secretmanager.v1.Secret] encryption
   /// configuration only apply to
   /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] added
@@ -287,7 +287,7 @@ class SecretVersion {
   /// Output only. The resource name of the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format
   /// `projects/*/secrets/*/versions/*`.
-  /// 
+  ///
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] IDs in a
   /// [Secret][google.cloud.secretmanager.v1.Secret] start at 1 and are
   /// incremented for each subsequent version of the secret.
@@ -404,7 +404,7 @@ class Replication$Automatic {
   /// Optional. The customer-managed encryption configuration of the
   /// [Secret][google.cloud.secretmanager.v1.Secret]. If no configuration is
   /// provided, Google-managed default encryption is used.
-  /// 
+  ///
   /// Updates to the [Secret][google.cloud.secretmanager.v1.Secret] encryption
   /// configuration only apply to
   /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] added
@@ -424,7 +424,7 @@ class Replication$UserManaged {
 
   /// Required. The list of Replicas for this
   /// [Secret][google.cloud.secretmanager.v1.Secret].
-  /// 
+  ///
   /// Cannot be empty.
   final List<Replication$UserManaged$Replica>? replicas;
 
@@ -444,7 +444,7 @@ class Replication$UserManaged$Replica {
   /// Optional. The customer-managed encryption configuration of the
   /// [User-Managed Replica][Replication.UserManaged.Replica]. If no
   /// configuration is provided, Google-managed default encryption is used.
-  /// 
+  ///
   /// Updates to the [Secret][google.cloud.secretmanager.v1.Secret]
   /// encryption configuration only apply to
   /// [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] added
@@ -464,16 +464,16 @@ class CustomerManagedEncryption {
 
   /// Required. The resource name of the Cloud KMS CryptoKey used to encrypt
   /// secret payloads.
-  /// 
+  ///
   /// For secrets using the
   /// [UserManaged][google.cloud.secretmanager.v1.Replication.UserManaged]
   /// replication policy type, Cloud KMS CryptoKeys must reside in the same
   /// location as the [replica location][Secret.UserManaged.Replica.location].
-  /// 
+  ///
   /// For secrets using the
   /// [Automatic][google.cloud.secretmanager.v1.Replication.Automatic]
   /// replication policy type, Cloud KMS CryptoKeys must reside in `global`.
-  /// 
+  ///
   /// The expected format is `projects/*/locations/*/keyRings/*/cryptoKeys/*`.
   final String? kmsKeyName;
 
@@ -489,7 +489,7 @@ class ReplicationStatus {
   /// Describes the replication status of a
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] with
   /// automatic replication.
-  /// 
+  ///
   /// Only populated if the parent
   /// [Secret][google.cloud.secretmanager.v1.Secret] has an automatic
   /// replication policy.
@@ -498,7 +498,7 @@ class ReplicationStatus {
   /// Describes the replication status of a
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] with
   /// user-managed replication.
-  /// 
+  ///
   /// Only populated if the parent
   /// [Secret][google.cloud.secretmanager.v1.Secret] has a user-managed
   /// replication policy.
@@ -513,7 +513,7 @@ class ReplicationStatus {
 /// The replication status of a
 /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] using
 /// automatic replication.
-/// 
+///
 /// Only populated if the parent [Secret][google.cloud.secretmanager.v1.Secret]
 /// has an automatic replication policy.
 class ReplicationStatus$AutomaticStatus {
@@ -531,7 +531,7 @@ class ReplicationStatus$AutomaticStatus {
 /// The replication status of a
 /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] using
 /// user-managed replication.
-/// 
+///
 /// Only populated if the parent [Secret][google.cloud.secretmanager.v1.Secret]
 /// has a user-managed replication policy.
 class ReplicationStatus$UserManagedStatus {
@@ -604,7 +604,7 @@ class Rotation {
   /// [Secret][google.cloud.secretmanager.v1.Secret] is scheduled to rotate.
   /// Cannot be set to less than 300s (5 min) in the future and at most
   /// 3153600000s (100 years).
-  /// 
+  ///
   /// [next_rotation_time][google.cloud.secretmanager.v1.Rotation.next_rotation_time]
   /// MUST  be set if
   /// [rotation_period][google.cloud.secretmanager.v1.Rotation.rotation_period]
@@ -613,7 +613,7 @@ class Rotation {
 
   /// Input only. The Duration between rotation notifications. Must be in seconds
   /// and at least 3600s (1h) and at most 3153600000s (100 years).
-  /// 
+  ///
   /// If
   /// [rotation_period][google.cloud.secretmanager.v1.Rotation.rotation_period]
   /// is set,
@@ -650,7 +650,7 @@ class SecretPayload {
   /// request, the
   /// [SecretManagerService][google.cloud.secretmanager.v1.SecretManagerService]
   /// will generate and store one for you.
-  /// 
+  ///
   /// The CRC32C value is encoded as a Int64 for compatibility, and can be
   /// safely downconverted to uint32 in languages that support this type.
   /// https://cloud.google.com/apis/design/design_patterns#integer_types
@@ -731,7 +731,7 @@ class CreateSecretRequest {
   final String? parent;
 
   /// Required. This must be unique within the project.
-  /// 
+  ///
   /// A secret ID is a string with a maximum length of 255 characters and can
   /// contain uppercase and lowercase letters, numerals, and the hyphen (`-`) and
   /// underscore (`_`) characters.
@@ -851,7 +851,7 @@ class GetSecretVersionRequest {
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format
   /// `projects/*/secrets/*/versions/*` or
   /// `projects/*/locations/*/secrets/*/versions/*`.
-  /// 
+  ///
   /// `projects/*/secrets/*/versions/latest` or
   /// `projects/*/locations/*/secrets/*/versions/latest` is an alias to the most
   /// recently created
@@ -888,7 +888,7 @@ class AccessSecretVersionRequest {
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] in the format
   /// `projects/*/secrets/*/versions/*` or
   /// `projects/*/locations/*/secrets/*/versions/*`.
-  /// 
+  ///
   /// `projects/*/secrets/*/versions/latest` or
   /// `projects/*/locations/*/secrets/*/versions/latest` is an alias to the most
   /// recently created


### PR DESCRIPTION
Whitespace updates to the emitted dartdocs:

- don't generate lines with trailing whitespace
- don't generate trailing blank dartdoc lines
- tests for the existing behavior

We will eventually want to move to running `dart format` over the source as part of the generation process.