### PR TITLE
ops(generator/dart): analyze and test the generated packages on CI

### DIFF
--- a/.github/workflows/generator_dart.yaml
+++ b/.github/workflows/generator_dart.yaml
@@ -14,15 +14,17 @@
 
 name: Client Generator - Dart
 permissions: read-all
+
 # Run on PRs and pushes to the default branch.
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+
 jobs:
   generator-build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: generator
@@ -45,3 +47,22 @@ jobs:
       - name: Detect changed goldens
         run: git diff --exit-code
         working-directory: generator/testdata/dart
+
+  validate-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+
+      - run: dart pub get
+        working-directory: generator/dart
+
+      # package:google_cloud_protobuf
+      - run: dart analyze
+        working-directory: generator/dart/packages/generated/google_cloud_protobuf
+      - run: dart test
+        working-directory: generator/dart/packages/generated/google_cloud_protobuf
+
+      # package:google_cloud_type
+      - run: dart analyze
+        working-directory: generator/dart/packages/generated/google_cloud_type

--- a/.github/workflows/generator_dart.yaml
+++ b/.github/workflows/generator_dart.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   generator-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: generator
@@ -49,7 +49,7 @@ jobs:
         working-directory: generator/testdata/dart
 
   validate-packages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1

--- a/.github/workflows/generator_dart.yaml
+++ b/.github/workflows/generator_dart.yaml
@@ -57,12 +57,13 @@ jobs:
       - run: dart pub get
         working-directory: generator/dart
 
-      # package:google_cloud_protobuf
-      - run: dart analyze
+      - name: "analyze package:google_cloud_protobuf"
+        run: dart analyze
         working-directory: generator/dart/packages/generated/google_cloud_protobuf
-      - run: dart test
+      - name: "test package:google_cloud_protobuf"
+        run: dart test
         working-directory: generator/dart/packages/generated/google_cloud_protobuf
 
-      # package:google_cloud_type
-      - run: dart analyze
+      - name: "analyze package:google_cloud_type"
+        run: dart analyze
         working-directory: generator/dart/packages/generated/google_cloud_type


### PR DESCRIPTION
Analyze and test the generated packages on CI:

- analyze and test `google_cloud_protobuf`
- analyze `google_cloud_type` (it doesn't have unit tests)
- don't do anything for `google_cloud_rpc` (we need `Any` to analyze it cleanly)
