### PR TITLE
chore: silence typos

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -119,6 +119,7 @@ asscociated = "asscociated"
 launguage   = "launguage"
 simliar     = "simliar"
 inputed     = "inputed"     # probably mean input-ed
+maxiumn     = "maxiumn"
 # src/generated/cloud/edgenetwork/v1 has a typo, it needs to be fixed upstream.
 diagnositcs = "diagnositcs"
 # src/generated/cloud/eventarc/v1 has a typo, it needs to be fixed upstream.
@@ -143,6 +144,9 @@ Insepction = "Insepction"
 # src/generated/cloud/networkconnectivity has a typo, it needs to be fixed
 # upstream.
 flexibile = "flexibile"
+# src/generated/cloud/networkservices/v1 has a typo, it needs to be fixed
+# upstream.
+forwareded = "forwareded"
 # src/generated/cloud/notebooks/v2 has a typo, it needs to be fixed upstream.
 maxmium = "maxmium"
 # src/generated/cloud/netapp/v1 has a typo, it needs to be fixed upstream.
@@ -218,6 +222,10 @@ combintation = "combintation"
 # true positives
 [type.rust]
 extend-ignore-re = [
+  # This is intentional, `typ` is the name of a field in OAuth2 claims:
+  "\"typ\"",
+  "\\Wtyp:",
+  "test_typ\"",
   # src/generated/cloud/aiplatform has a typo in the code. Won't be fixed.
   # Seems too risky to ignore the word, a RE seems cleaner
   "CheckTrialEarlyStoppingStateMetatdata",

--- a/generator/internal/parser/protobuf.go
+++ b/generator/internal/parser/protobuf.go
@@ -452,13 +452,13 @@ var descriptorpbToTypez = map[descriptorpb.FieldDescriptorProto_Type]api.Typez{
 }
 
 func normalizeTypes(state *api.APIState, in *descriptorpb.FieldDescriptorProto, field *api.Field) {
-	typ := in.GetType()
+	typez := in.GetType()
 	field.Typez = api.UNDEFINED_TYPE
-	if tz, ok := descriptorpbToTypez[typ]; ok {
+	if tz, ok := descriptorpbToTypez[typez]; ok {
 		field.Typez = tz
 	}
 
-	switch typ {
+	switch typez {
 	case descriptorpb.FieldDescriptorProto_TYPE_GROUP:
 		field.TypezID = in.GetTypeName()
 	case descriptorpb.FieldDescriptorProto_TYPE_MESSAGE:


### PR DESCRIPTION
It seems that something changed with `typos-cli` and now it flags a few more typos. It is not the version, that is pinned, maybe the source data for the dictionary?

Part of the work for #1405 