### PR TITLE
chore: unpin minor and patch versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.12.2"
+version = "1.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2b7ddaa2c56a367ad27a094ad8ef4faacf8a617c2575acb2ba88949df999ca"
+checksum = "5e4e8200b9a4a5801a769d50eeabc05670fec7e959a8cb7a63a93e4e519942ae"
 dependencies = [
  "aws-lc-sys",
  "paste",
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ac4f13dad353b209b34cbec082338202cbc01c8f00336b55c750c13ac91f8f"
+checksum = "0f9dd2e03ee80ca2822dd6ea431163d2ef259f2066a4d6ccaca6d9dcb386aa43"
 dependencies = [
  "bindgen",
  "cc",
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "built"
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.13"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -510,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 
 [[package]]
 name = "encoding_rs"
@@ -525,9 +525,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -4156,9 +4156,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4592,9 +4592,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libloading"
@@ -4620,9 +4620,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -4636,9 +4636,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "matchit"
@@ -4666,9 +4666,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -4712,9 +4712,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -4817,9 +4817,9 @@ checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -4849,9 +4849,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
@@ -4964,9 +4964,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "powerfmt"
@@ -5021,18 +5021,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
@@ -5055,8 +5055,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.0",
- "zerocopy 0.8.17",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.21",
 ]
 
 [[package]]
@@ -5076,7 +5076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -5090,19 +5090,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.1",
- "zerocopy 0.8.17",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
 dependencies = [
  "bitflags",
 ]
@@ -5182,15 +5181,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -5418,9 +5416,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
 dependencies = [
  "itoa",
  "serde",
@@ -5538,9 +5536,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
@@ -5588,9 +5586,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5803,9 +5801,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
  "tokio",
@@ -5942,15 +5940,15 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "untrusted"
@@ -6333,11 +6331,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.17"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
+checksum = "dcf01143b2dd5d134f11f545cf9f1431b13b749695cb33bcce051e7568f99478"
 dependencies = [
- "zerocopy-derive 0.8.17",
+ "zerocopy-derive 0.8.21",
 ]
 
 [[package]]
@@ -6353,9 +6351,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.17"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
+checksum = "712c8386f4f4299382c9abee219bee7084f78fb939d88b6840fcc1320d5f6da2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6364,18 +6362,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/guide/samples/Cargo.toml
+++ b/guide/samples/Cargo.toml
@@ -28,18 +28,18 @@ categories.workspace = true
 name = "getting_started"
 
 [dependencies]
-tokio = { version = "1.43", features = ["full", "macros"] }
+tokio = { version = "1", features = ["full", "macros"] }
 # ANCHOR: longrunning
-google-cloud-longrunning = { version = "0.22.0", path = "../../src/generated/longrunning" }
+google-cloud-longrunning = { version = "0.22", path = "../../src/generated/longrunning" }
 # ANCHOR_END: longrunning
 # ANCHOR: gax
-google-cloud-gax = { version = "0.20.0", path = "../../src/gax" }
+google-cloud-gax = { version = "0.20", path = "../../src/gax" }
 # ANCHOR_END: gax
 # ANCHOR: speech
-google-cloud-speech-v2 = { version = "0.1.0", path = "../../src/generated/cloud/speech/v2" }
+google-cloud-speech-v2 = { version = "0.1", path = "../../src/generated/cloud/speech/v2" }
 # ANCHOR_END: speech
 # ANCHOR: secretmanager
-google-cloud-secretmanager-v1 = { version = "0.1.0", features = [
+google-cloud-secretmanager-v1 = { version = "0.1", features = [
   "unstable-stream",
 ], path = "../../src/generated/cloud/secretmanager/v1" }
 # ANCHOR_END: secretmanager

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -25,29 +25,29 @@ keywords.workspace   = true
 categories.workspace = true
 
 [dependencies]
-async-trait    = "0.1.87"
-http           = "1.2.0"
-reqwest        = { version = "0.12.11", features = ["json"] }
-serde          = { version = "1.0.218", features = ["derive"] }
+async-trait    = "0.1"
+http           = "1"
+reqwest        = { version = "0.12", features = ["json"] }
+serde          = { version = "1", features = ["derive"] }
 serde_json     = "1"
 thiserror      = "2"
 time           = { version = "0.3.37", features = ["serde"] }
-rustls         = "0.23.23"
+rustls         = "0.23"
 rustls-pemfile = "2.2"
-tokio          = { version = "1.42", features = ["fs"] }
+tokio          = { version = "1", features = ["fs"] }
 base64         = "0.22"
-derive_builder = "0.20.2"
+derive_builder = "0.20"
 
 
 [dev-dependencies]
-axum        = "0.8.1"
-mockall     = "0.13.1"
-rand        = "0.8.5"
-regex       = "1.11.1"
-rsa         = { version = "0.9.7", features = ["pem"] }
-scoped-env  = "2.1.0"
-serial_test = "3.2.0"
-tempfile    = "3.17.1"
-test-case   = "3.3.1"
-tokio       = { version = "1.42", features = ["macros", "rt-multi-thread", "test-util"] }
-tokio-test  = "0.4.4"
+axum        = "0.8"
+mockall     = "0.13"
+rand        = "0.8"
+regex       = "1"
+rsa         = { version = "0.9", features = ["pem"] }
+scoped-env  = "2"
+serial_test = "3"
+tempfile    = "3"
+test-case   = "3"
+tokio       = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
+tokio-test  = "0.4"

--- a/src/auth/integration-tests/Cargo.toml
+++ b/src/auth/integration-tests/Cargo.toml
@@ -28,8 +28,8 @@ run-integration-tests = []
 auth          = { path = "../../../src/auth", package = "google-cloud-auth" }
 gax           = { path = "../../../src/gax", package = "google-cloud-gax" }
 language      = { path = "../../../src/generated/cloud/language/v2", package = "google-cloud-language-v2" }
-scoped-env    = "2.1.0"
+scoped-env    = "2"
 secretmanager = { path = "../../../src/generated/cloud/secretmanager/v1", package = "google-cloud-secretmanager-v1" }
-serial_test   = "3.2.0"
-tempfile      = "3.17.1"
-tokio         = { version = "1.42", features = ["full", "macros"] }
+serial_test   = "3"
+tempfile      = "3"
+tokio         = { version = "1", features = ["full", "macros"] }

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -27,33 +27,33 @@ repository.workspace = true
 
 [dependencies]
 auth        = { version = "0.18.0", path = "../auth", package = "google-cloud-auth" }
-base64      = "0.22.1"
-bytes       = "1.10.0"
-futures     = { version = "0.3.31", optional = true }
-http        = "1.1.0"
-pin-project = { version = "1.1.9", optional = true }
+base64      = "0.22"
+bytes       = "1"
+futures     = { version = "0.3", optional = true }
+http        = "1"
+pin-project = { version = "1", optional = true }
 rand        = "0.9"
-reqwest     = { version = "0.12.11", optional = true }
+reqwest     = { version = "0.12", optional = true }
 rpc         = { version = "0.1", path = "../generated/rpc/types", package = "google-cloud-rpc" }
-serde       = "1.0.218"
+serde       = "1"
 serde_json  = "1"
-serde_with  = { version = "3.12.0", default-features = false, features = ["base64", "macros"] }
-thiserror   = "2.0.12"
-tokio       = { version = "1.42", features = ["macros", "rt-multi-thread"] }
+serde_with  = { version = "3", default-features = false, features = ["base64", "macros"] }
+thiserror   = "2"
+tokio       = { version = "1", features = ["macros", "rt-multi-thread"] }
 wkt         = { version = "0.1", path = "../wkt", package = "google-cloud-wkt" }
 
 [dev-dependencies]
 echo-server = { path = "echo-server" }
 # This is a workaround to integration test features of this crate. Open issue
 # https://github.com/rust-lang/cargo/issues/2911.
-axum        = "0.8.1"
+axum        = "0.8"
 gax         = { path = ".", package = "google-cloud-gax", features = ["unstable-sdk-client", "unstable-stream"] }
-mockall     = "0.13.1"
-serde       = { version = "1.0.218", features = ["serde_derive"] }
-serial_test = "3.2.0"
-tempfile    = "3.17.1"
-test-case   = "3.3.1"
-tokio       = { version = "1.42", features = ["test-util"] }
+mockall     = "0.13"
+serde       = { version = "1", features = ["serde_derive"] }
+serial_test = "3"
+tempfile    = "3"
+test-case   = "3"
+tokio       = { version = "1", features = ["test-util"] }
 
 [build-dependencies]
 built = "0.7"

--- a/src/integration-tests/Cargo.toml
+++ b/src/integration-tests/Cargo.toml
@@ -24,9 +24,9 @@ log-integration-tests = []
 run-integration-tests = []
 
 [dependencies]
-bytes              = "1.10.0"
-crc32c             = "0.6.8"
-futures            = "0.3.31"
+bytes              = "1"
+crc32c             = "0.6"
+futures            = "0.3"
 gax                = { path = "../../src/gax", package = "google-cloud-gax" }
 iam_v1             = { path = "../../src/generated/iam/v1", package = "google-cloud-iam-v1" }
 loc                = { path = "../../src/generated/cloud/location", package = "google-cloud-location" }
@@ -34,8 +34,8 @@ longrunning        = { path = "../../src/generated/longrunning", package = "goog
 rand               = "0.9"
 serde_json         = "1"
 tokio              = { version = "1.42", features = ["full", "macros"] }
-tracing            = "0.1.41"
-tracing-subscriber = "0.3.19"
+tracing            = "0.1"
+tracing-subscriber = "0.3"
 wkt                = { path = "../../src/wkt", package = "google-cloud-wkt" }
 
 [dependencies.sm]
@@ -54,8 +54,8 @@ package  = "google-cloud-workflows-v1"
 path     = "../../src/generated/cloud/workflows/v1"
 
 [dev-dependencies]
-mockall    = "0.13.1"
-serde      = { version = "1.0.218", features = ["serde_derive"] }
-serde_with = { version = "3.12.0", features = ["base64"] }
-test-case  = "3.3.1"
-tokio      = { version = "1.42", features = ["full", "macros"] }
+mockall    = "0.13"
+serde      = { version = "1", features = ["serde_derive"] }
+serde_with = { version = "3", features = ["base64"] }
+test-case  = "3"
+tokio      = { version = "1", features = ["full", "macros"] }

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -25,13 +25,13 @@ license.workspace    = true
 repository.workspace = true
 
 [dependencies]
-futures     = { version = "0.3.31", optional = true }
+futures     = { version = "0.3", optional = true }
 gax         = { version = "0.20", path = "../gax", package = "google-cloud-gax" }
 longrunning = { version = "0.22", path = "../generated/longrunning", package = "google-cloud-longrunning" }
-pin-project = { version = "1.1.9", optional = true }
+pin-project = { version = "1", optional = true }
 rpc         = { version = "0.1", path = "../generated/rpc/types", package = "google-cloud-rpc" }
-serde       = "1.0.218"
-tokio       = { version = "1.42", features = ["time"] }
+serde       = "1"
+tokio       = { version = "1", features = ["time"] }
 wkt         = { version = "0.1", path = "../wkt", package = "google-cloud-wkt" }
 
 [features]
@@ -39,8 +39,8 @@ unstable-stream = ["dep:futures", "dep:pin-project"]
 
 [dev-dependencies]
 auth       = { path = "../auth", package = "google-cloud-auth" }
-axum       = "0.8.1"
+axum       = "0.8"
 lro        = { path = ".", package = "google-cloud-lro", features = ["unstable-stream"] }
-reqwest    = "0.12.11"
+reqwest    = "0.12"
 serde_json = "1"
-tokio      = { version = "1.42", features = ["test-util"] }
+tokio      = { version = "1", features = ["test-util"] }

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -29,15 +29,15 @@ chrono = ["dep:chrono"]
 time   = []
 
 [dependencies]
-bytes      = { version = "1.10.0", features = ["serde"] }
-chrono     = { version = "0.4.40", optional = true }
-serde      = { version = "1.0.218", features = ["serde_derive"] }
+bytes      = { version = "1", features = ["serde"] }
+chrono     = { version = "0.4", optional = true }
+serde      = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
-serde_with = { version = "3.12.0", default-features = false, features = ["base64", "macros", "std"] }
+serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
 thiserror  = "2"
-time       = { version = "0.3.36", features = ["formatting", "parsing"] }
+time       = { version = "0.3", features = ["formatting", "parsing"] }
 
 [dev-dependencies]
-bytes     = { version = "1.10.0", features = ["serde"] }
-test-case = "3.3.1"
+bytes     = { version = "1", features = ["serde"] }
+test-case = "3"
 wkt       = { path = ".", package = "google-cloud-wkt", features = ["chrono", "time"] }

--- a/tools/check-copyright/Cargo.toml
+++ b/tools/check-copyright/Cargo.toml
@@ -19,4 +19,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-regex = "1.11.1"
+regex = "1"


### PR DESCRIPTION
Unless we are explicitly using a feature only available in 1.x (or 0.y.z) we should not mention the minor version (nor patch) version in our Cargo.toml files.
