### PR TITLE
refactor(generator): move `SourceRoots()`

### DIFF
--- a/generator/internal/config/source_roots.go
+++ b/generator/internal/config/source_roots.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package parser
+package config
 
 import "strings"
 

--- a/generator/internal/parser/protobuf.go
+++ b/generator/internal/parser/protobuf.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/google-cloud-rust/generator/internal/api"
+	"github.com/googleapis/google-cloud-rust/generator/internal/config"
 	"google.golang.org/genproto/googleapis/api/serviceconfig"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/descriptorpb"
@@ -106,7 +107,7 @@ func protoc(tempFile string, files []string, options map[string]string) ([]byte,
 		"--retain_options",
 		"--descriptor_set_out", tempFile,
 	}
-	for _, name := range SourceRoots(options) {
+	for _, name := range config.SourceRoots(options) {
 		if path, ok := options[name]; ok {
 			args = append(args, "--proto_path")
 			args = append(args, path)
@@ -136,7 +137,7 @@ func determineInputFiles(source string, options map[string]string) ([]string, er
 	// `config.Source` is relative to the `googleapis-root`,
 	// or `extra-protos-root`, when that is set. It should always be a directory
 	// and by default all the the files in that directory are used.
-	for _, opt := range SourceRoots(options) {
+	for _, opt := range config.SourceRoots(options) {
 		location, ok := options[opt]
 		if !ok {
 			// Ignore options that are not set

--- a/generator/internal/parser/service_config.go
+++ b/generator/internal/parser/service_config.go
@@ -20,6 +20,7 @@ import (
 	"path"
 
 	"github.com/ghodss/yaml"
+	"github.com/googleapis/google-cloud-rust/generator/internal/config"
 	"google.golang.org/genproto/googleapis/api/serviceconfig"
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -54,7 +55,7 @@ func readServiceConfig(serviceConfigPath string) (*serviceconfig.Service, error)
 // path (or `extra-protos-root` when set). This finds the right path given a
 // configuration
 func findServiceConfigPath(serviceConfigFile string, options map[string]string) string {
-	for _, opt := range SourceRoots(options) {
+	for _, opt := range config.SourceRoots(options) {
 		dir, ok := options[opt]
 		if !ok {
 			// Ignore options that are not set

--- a/generator/internal/sidekick/refreshall.go
+++ b/generator/internal/sidekick/refreshall.go
@@ -26,7 +26,6 @@ import (
 	"sync"
 
 	"github.com/googleapis/google-cloud-rust/generator/internal/config"
-	"github.com/googleapis/google-cloud-rust/generator/internal/parser"
 )
 
 func init() {
@@ -47,7 +46,7 @@ func overrideSources(rootConfig *config.Config) (*config.Config, error) {
 	override := *rootConfig
 	override.Codec = maps.Clone(rootConfig.Codec)
 	override.Source = maps.Clone(rootConfig.Source)
-	for _, root := range parser.SourceRoots(rootConfig.Source) {
+	for _, root := range config.SourceRoots(rootConfig.Source) {
 		configPrefix := strings.TrimSuffix(root, "-root")
 		if _, ok := rootConfig.Source[root]; !ok {
 			continue


### PR DESCRIPTION
Move this function to the `config`, I am planning to use it outside of
the `parser` package for the Rust+Prost codec.

Part of the work for #1414
