### PR TITLE
feat(wkt): convert to Prost's version of the WKT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
+name = "anyhow"
+version = "1.0.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4089,6 +4095,7 @@ dependencies = [
  "bytes",
  "chrono",
  "google-cloud-wkt",
+ "prost-types",
  "serde",
  "serde_json",
  "serde_with",
@@ -5026,6 +5033,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
 ]
 
 [[package]]

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -26,18 +26,20 @@ repository.workspace = true
 
 [features]
 chrono = ["dep:chrono"]
+prost  = ["dep:prost-types"]
 time   = []
 
 [dependencies]
-bytes      = { version = "1", features = ["serde"] }
-chrono     = { version = "0.4", optional = true }
-serde      = { version = "1", features = ["serde_derive"] }
-serde_json = "1"
-serde_with = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-thiserror  = "2"
-time       = { version = "0.3", features = ["formatting", "parsing"] }
+bytes       = { version = "1", features = ["serde"] }
+chrono      = { version = "0.4", optional = true }
+prost-types = { version = "0.13", optional = true }
+serde       = { version = "1", features = ["serde_derive"] }
+serde_json  = "1"
+serde_with  = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
+thiserror   = "2"
+time        = { version = "0.3", features = ["formatting", "parsing"] }
 
 [dev-dependencies]
 bytes     = { version = "1", features = ["serde"] }
 test-case = "3"
-wkt       = { path = ".", package = "google-cloud-wkt", features = ["chrono", "time"] }
+wkt       = { path = ".", package = "google-cloud-wkt", features = ["chrono", "prost", "time"] }

--- a/src/wkt/src/lib.rs
+++ b/src/wkt/src/lib.rs
@@ -40,3 +40,6 @@ pub use crate::rstruct::*;
 mod wrappers;
 pub use crate::wrappers::*;
 pub mod message;
+
+#[cfg(feature = "prost")]
+pub mod prost;

--- a/src/wkt/src/prost.rs
+++ b/src/wkt/src/prost.rs
@@ -1,0 +1,300 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Helper functions to convert from the well-known types to and from their
+//! Prost versions.
+
+/// Converts from `Self` into `T`.
+pub trait Convert<T>: Sized {
+    fn cnv(self) -> T;
+}
+
+macro_rules! impl_primitive {
+    ($t: ty) => {
+        impl Convert<$t> for $t {
+            fn cnv(self) -> $t {
+                self
+            }
+        }
+    };
+}
+
+impl_primitive!(bool);
+impl_primitive!(f32);
+impl_primitive!(i32);
+impl_primitive!(u32);
+impl_primitive!(f64);
+impl_primitive!(i64);
+impl_primitive!(u64);
+impl_primitive!(String);
+impl_primitive!(bytes::Bytes);
+
+impl Convert<crate::Duration> for prost_types::Duration {
+    fn cnv(self) -> crate::Duration {
+        crate::Duration::clamp(self.seconds, self.nanos)
+    }
+}
+
+impl Convert<prost_types::Duration> for crate::Duration {
+    fn cnv(self) -> prost_types::Duration {
+        prost_types::Duration {
+            seconds: self.seconds(),
+            nanos: self.nanos(),
+        }
+    }
+}
+
+impl Convert<crate::FieldMask> for prost_types::FieldMask {
+    fn cnv(self) -> crate::FieldMask {
+        crate::FieldMask::default().set_paths(self.paths)
+    }
+}
+
+impl Convert<prost_types::FieldMask> for crate::FieldMask {
+    fn cnv(self) -> prost_types::FieldMask {
+        prost_types::FieldMask { paths: self.paths }
+    }
+}
+
+impl Convert<crate::Timestamp> for prost_types::Timestamp {
+    fn cnv(self) -> crate::Timestamp {
+        crate::Timestamp::clamp(self.seconds, self.nanos)
+    }
+}
+
+impl Convert<prost_types::Timestamp> for crate::Timestamp {
+    fn cnv(self) -> prost_types::Timestamp {
+        prost_types::Timestamp {
+            seconds: self.seconds(),
+            nanos: self.nanos(),
+        }
+    }
+}
+
+impl Convert<crate::Struct> for prost_types::Struct {
+    fn cnv(self) -> crate::Struct {
+        self.fields
+            .into_iter()
+            .map(|(k, v)| (k.cnv(), v.cnv()))
+            .collect()
+    }
+}
+
+impl Convert<prost_types::Struct> for crate::Struct {
+    fn cnv(self) -> prost_types::Struct {
+        prost_types::Struct {
+            fields: self.into_iter().map(|(k, v)| (k.cnv(), v.cnv())).collect(),
+        }
+    }
+}
+
+impl Convert<crate::Value> for prost_types::Value {
+    fn cnv(self) -> crate::Value {
+        use prost_types::value::Kind;
+        match self.kind {
+            None => crate::Value::Null,
+            Some(kind) => match kind {
+                Kind::NullValue(_) => crate::Value::Null,
+                Kind::NumberValue(v) => {
+                    let number =
+                        serde_json::Number::from_f64(v).expect("JSON numbers cannot be NaN");
+                    serde_json::Value::Number(number)
+                }
+                Kind::StringValue(v) => crate::Value::String(v),
+                Kind::BoolValue(v) => crate::Value::Bool(v),
+                Kind::StructValue(v) => crate::Value::Object(v.cnv()),
+                Kind::ListValue(v) => crate::Value::Array(v.cnv()),
+            },
+        }
+    }
+}
+
+impl Convert<prost_types::Value> for crate::Value {
+    fn cnv(self) -> prost_types::Value {
+        use prost_types::value::Kind;
+        let kind = match self {
+            serde_json::Value::Null => Kind::NullValue(0),
+            serde_json::Value::Number(v) => Kind::NumberValue(v.as_f64().unwrap_or_default()),
+            serde_json::Value::String(v) => Kind::StringValue(v),
+            serde_json::Value::Bool(v) => Kind::BoolValue(v),
+            serde_json::Value::Array(v) => Kind::ListValue(v.cnv()),
+            serde_json::Value::Object(v) => Kind::StructValue(v.cnv()),
+        };
+        prost_types::Value { kind: Some(kind) }
+    }
+}
+
+impl Convert<crate::ListValue> for prost_types::ListValue {
+    fn cnv(self) -> crate::ListValue {
+        self.values.into_iter().map(|v| v.cnv()).collect()
+    }
+}
+
+impl Convert<prost_types::ListValue> for crate::ListValue {
+    fn cnv(self) -> prost_types::ListValue {
+        prost_types::ListValue {
+            values: self.into_iter().map(|v| v.cnv()).collect(),
+        }
+    }
+}
+
+impl Convert<i32> for crate::NullValue {
+    fn cnv(self) -> i32 {
+        prost_types::NullValue::NullValue as i32
+    }
+}
+
+impl Convert<crate::NullValue> for prost_types::NullValue {
+    fn cnv(self) -> crate::NullValue {
+        crate::NullValue
+    }
+}
+
+impl Convert<prost_types::NullValue> for crate::NullValue {
+    fn cnv(self) -> prost_types::NullValue {
+        prost_types::NullValue::NullValue
+    }
+}
+
+impl std::convert::From<i32> for crate::NullValue {
+    fn from(_value: i32) -> Self {
+        Self
+    }
+}
+
+impl std::convert::From<crate::NullValue> for i32 {
+    fn from(_value: crate::NullValue) -> Self {
+        i32::default()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde_json::json;
+    use test_case::test_case;
+
+    #[test]
+    fn primitive_bool() {
+        let input: bool = true;
+        let got: bool = input.cnv();
+        assert_eq!(got, input);
+    }
+
+    #[test_case(0 as f32)]
+    #[test_case(0 as i32)]
+    #[test_case(0 as u32)]
+    #[test_case(0 as f64)]
+    #[test_case(0 as i64)]
+    #[test_case(0 as u64)]
+    fn primitive_numeric<T>(input: T)
+    where
+        T: std::fmt::Debug + Copy + PartialEq + Convert<T>,
+    {
+        let got: T = input.cnv();
+        assert_eq!(got, input);
+    }
+
+    #[test]
+    fn primitive_string() {
+        let input = "abc".to_string();
+        let got: String = input.cnv();
+        assert_eq!(&got, "abc");
+    }
+
+    #[test]
+    fn primitive_bytes() {
+        let input = bytes::Bytes::from_static(b"abc");
+        let got: bytes::Bytes = input.clone().cnv();
+        assert_eq!(got, input);
+    }
+
+    #[test]
+    fn from_prost_duration() {
+        let input = prost_types::Duration {
+            seconds: 123,
+            nanos: 456,
+        };
+        let got: crate::Duration = input.cnv();
+        assert_eq!(got, crate::Duration::clamp(123, 456));
+    }
+
+    #[test]
+    fn from_wkt_duration() {
+        let input = crate::Duration::clamp(123, 456);
+        let got: prost_types::Duration = input.cnv();
+        assert_eq!(
+            got,
+            prost_types::Duration {
+                seconds: 123,
+                nanos: 456
+            }
+        );
+    }
+
+    #[test]
+    fn from_prost_field_mask() {
+        let input = prost_types::FieldMask {
+            paths: ["a", "b", "c"].map(str::to_string).to_vec(),
+        };
+        let got: crate::FieldMask = input.cnv();
+        assert_eq!(got, crate::FieldMask::default().set_paths(["a", "b", "c"]));
+    }
+
+    #[test]
+    fn from_wkt_field_mask() {
+        let input = crate::FieldMask::default().set_paths(["p1", "p2", "p3"]);
+        let got: prost_types::FieldMask = input.cnv();
+        assert_eq!(
+            got,
+            prost_types::FieldMask {
+                paths: ["p1", "p2", "p3"].map(str::to_string).to_vec()
+            }
+        );
+    }
+
+    #[test]
+    fn from_prost_timestamp() {
+        let input = prost_types::Timestamp {
+            seconds: 123,
+            nanos: 456,
+        };
+        let got: crate::Timestamp = input.cnv();
+        assert_eq!(got, crate::Timestamp::clamp(123, 456));
+    }
+
+    #[test]
+    fn from_wkt_timestamp() {
+        let input = crate::Timestamp::clamp(123, 456);
+        let got: prost_types::Timestamp = input.cnv();
+        assert_eq!(
+            got,
+            prost_types::Timestamp {
+                seconds: 123,
+                nanos: 456
+            }
+        );
+    }
+
+    #[test_case(json!(null))]
+    #[test_case(json!(1234.5))]
+    #[test_case(json!("xyz"))]
+    #[test_case(json!([true, 1234.5, "xyz", null, {"a": "b"}]))]
+    #[test_case(json!({"a": true, "b": "xyz"}))]
+    fn wkt_value_roundtrip(input: crate::Value) {
+        let convert: prost_types::Value = input.clone().cnv();
+        let got: crate::Value = convert.cnv();
+        assert_eq!(got, input);
+    }
+}


### PR DESCRIPTION
We will need to convert to and from Prost's versions of the well-known
types. The same trait will be used to convert between our generated
types and the types that Prost generates.

Part of the work for #1414
