### PR TITLE
cleanup: faster local development

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -43,8 +43,8 @@ jobs:
       - name: Display rustc version
         run: rustc --version
       - name: Test gax with features disabled
-        run: cargo build -p google-cloud-gax
-      - run: cargo test
+        run: cargo test --package google-cloud-gax
+      - run: cargo test --workspace
   coverage:
     runs-on: ubuntu-24.04
     strategy:
@@ -98,10 +98,10 @@ jobs:
         run: cargo version
       - name: Display rustc version
         run: rustc --version
-      - run: cargo doc
+      - run: cargo doc --workspace
         env:
           RUSTDOCFLAGS: "-D warnings"
-      - run: cargo doc -p google-cloud-gax
+      - run: cargo doc --package google-cloud-gax
         env:
           RUSTDOCFLAGS: "-D warnings"
       - run: mdbook build guide
@@ -145,8 +145,8 @@ jobs:
         run: cargo version
       - name: Display rustc version
         run: rustc --version
-      - run: cargo clippy -- --deny warnings
-      - run: cargo fmt
+      - run: cargo clippy --workspace -- --deny warnings
+      - run: cargo fmt --workspace
       - run: git diff --exit-code
   regenerate:
     # Verifies the generated code has not been tampered with. Or maybe that the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,18 @@
 [workspace]
 resolver = "2"
 
+default-members = [
+  "guide/samples",
+  "src/auth",
+  "src/auth/integration-tests",
+  "src/base",
+  "src/gax",
+  "src/integration-tests",
+  "src/lro",
+  "src/root",
+  "src/wkt",
+  "tools/check-copyright",
+]
 members = [
   "guide/samples",
   "src/auth",

--- a/doc/contributor/howto-guide-set-up-development-environment.md
+++ b/doc/contributor/howto-guide-set-up-development-environment.md
@@ -19,6 +19,24 @@ The code generator is implemented in [Go](https://go.dev). Follow the
 Whatever works for you. Several team members use Visual Studio Code, but Rust
 can be used with many IDEs.
 
+### Recommended VS Code Configuration
+
+The default configuration for VS Code is to `cargo check` all the code when you
+save a file. As the project is rather large (almost 200 crates, over 1 million
+lines of code), this can be rather slow. We recommend you override these
+defaults in your `settings.json` file:
+
+```json
+    "rust-analyzer.cargo.buildScripts.overrideCommand": [
+        "cargo",
+        "check",
+        "--quiet",
+        "--message-format=json",
+        "--keep-going"
+    ],
+    "rust-analyzer.check.workspace": false,
+```
+
 ## Compile the Code
 
 Just use cargo:


### PR DESCRIPTION
Skip local development by skipping most of the generated crates. The CI
builds will still compile all the code, we just won't do it in our
local development environments.