### PR TITLE
refactor(generator): codecs consume full config

### DIFF
--- a/generator/internal/dart/dart.go
+++ b/generator/internal/dart/dart.go
@@ -22,6 +22,7 @@ import (
 	"unicode"
 
 	"github.com/googleapis/google-cloud-rust/generator/internal/api"
+	"github.com/googleapis/google-cloud-rust/generator/internal/config"
 	"github.com/googleapis/google-cloud-rust/generator/internal/language"
 	"github.com/iancoleman/strcase"
 )
@@ -36,8 +37,8 @@ var needsCtorValidation = map[string]string{
 	".google.protobuf.Duration": ".google.protobuf.Duration",
 }
 
-func Generate(model *api.API, outdir string, options map[string]string) error {
-	_, err := annotateModel(model, options)
+func Generate(model *api.API, outdir string, cfg *config.Config) error {
+	_, err := annotateModel(model, cfg.Codec)
 	if err != nil {
 		return err
 	}

--- a/generator/internal/golang/golang.go
+++ b/generator/internal/golang/golang.go
@@ -22,6 +22,7 @@ import (
 	"unicode"
 
 	"github.com/googleapis/google-cloud-rust/generator/internal/api"
+	"github.com/googleapis/google-cloud-rust/generator/internal/config"
 	"github.com/googleapis/google-cloud-rust/generator/internal/language"
 	"github.com/iancoleman/strcase"
 )
@@ -34,8 +35,8 @@ type goImport struct {
 	name string
 }
 
-func Generate(model *api.API, outdir string, options map[string]string) error {
-	_, err := annotateModel(model, options)
+func Generate(model *api.API, outdir string, cfg *config.Config) error {
+	_, err := annotateModel(model, cfg.Codec)
 	if err != nil {
 		return err
 	}

--- a/generator/internal/rust/rust.go
+++ b/generator/internal/rust/rust.go
@@ -28,6 +28,7 @@ import (
 	"unicode"
 
 	"github.com/googleapis/google-cloud-rust/generator/internal/api"
+	"github.com/googleapis/google-cloud-rust/generator/internal/config"
 	"github.com/googleapis/google-cloud-rust/generator/internal/language"
 	"github.com/iancoleman/strcase"
 	"github.com/yuin/goldmark"
@@ -56,8 +57,8 @@ var commentUrlRegex = regexp.MustCompile(
 		`[a-zA-Z]{2,63}` + // The root domain is far more strict
 		`(/[-a-zA-Z0-9@:%_\+.~#?&/={}\$]*)?`) // Accept just about anything on the query and URL fragments
 
-func Generate(model *api.API, outdir string, options map[string]string) error {
-	codec, err := newCodec(options)
+func Generate(model *api.API, outdir string, cfg *config.Config) error {
+	codec, err := newCodec(cfg.Codec)
 	if err != nil {
 		return err
 	}

--- a/generator/internal/sidekick/refresh.go
+++ b/generator/internal/sidekick/refresh.go
@@ -96,13 +96,13 @@ func refreshDir(rootConfig *config.Config, cmdLine *CommandLine, output string) 
 
 	switch config.General.Language {
 	case "rust":
-		return rust.Generate(model, output, config.Codec)
+		return rust.Generate(model, output, config)
 	case "rust+prost":
 		return rust_prost.Generate(model, output, config)
 	case "go":
-		return golang.Generate(model, output, config.Codec)
+		return golang.Generate(model, output, config)
 	case "dart":
-		return dart.Generate(model, output, config.Codec)
+		return dart.Generate(model, output, config)
 	default:
 		return fmt.Errorf("unknown language: %s", config.General.Language)
 	}


### PR DESCRIPTION
Eventually we will need to use more of the configuration in the codecs.
For example, we need to know if the specification was in Protobuf form
to decide if enums are integers over the wire.

Part of the work for #1379