### PR TITLE
feat(generator): separate unique enum values

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -261,6 +261,9 @@ type Enum struct {
 	ID string
 	// Values associated with the Enum.
 	Values []*EnumValue
+	// The unique integer values, some enums have multiple aliases for the
+	// same number (e.g. `enum X { a = 0, b = 0, c = 1 }`).
+	UniqueNumberValues []*EnumValue
 	// Parent returns the ancestor of this node, if any.
 	Parent *Message
 	// The Protobuf package this enum belongs to.

--- a/generator/internal/parser/parser_test.go
+++ b/generator/internal/parser/parser_test.go
@@ -40,7 +40,7 @@ func checkMessage(t *testing.T, got *api.Message, want *api.Message) {
 
 func checkEnum(t *testing.T, got api.Enum, want api.Enum) {
 	t.Helper()
-	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(api.Enum{}, "Values", "Parent")); diff != "" {
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(api.Enum{}, "Values", "UniqueNumberValues", "Parent")); diff != "" {
 		t.Errorf("mismatched service attributes (-want, +got):\n%s", diff)
 	}
 	less := func(a, b *api.EnumValue) bool { return a.Name < b.Name }

--- a/generator/internal/parser/protobuf_test.go
+++ b/generator/internal/parser/protobuf_test.go
@@ -455,6 +455,58 @@ func TestProtobuf_Comments(t *testing.T) {
 	})
 }
 
+func TestProtobuf_UniqueEnumValues(t *testing.T) {
+	test := makeAPIForProtobuf(nil, newTestCodeGeneratorRequest(t, "enum_values.proto"))
+	withAlias, ok := test.State.EnumByID[".test.WithAlias"]
+	if !ok {
+		t.Fatalf("Cannot find enum %s in API State", ".test.WithAlias")
+	}
+	fullList := []*api.EnumValue{
+		{
+			Name:   "X_UNSPECIFIED",
+			Number: 0,
+		},
+		{
+			Name:   "LONG_NAME_VALUE",
+			Number: 2,
+		},
+		{
+			Name:   "V2",
+			Number: 2,
+		},
+		{
+			Name:   "bad_style",
+			Number: 3,
+		},
+		{
+			Name:   "FOLLOWS_STYLE",
+			Number: 3,
+		},
+	}
+	uniqueList := []*api.EnumValue{
+		{
+			Name:   "X_UNSPECIFIED",
+			Number: 0,
+		},
+		{
+			Name:   "V2",
+			Number: 2,
+		},
+		{
+			Name:   "FOLLOWS_STYLE",
+			Number: 3,
+		},
+	}
+
+	less := func(a, b *api.EnumValue) bool { return a.Name < b.Name }
+	if diff := cmp.Diff(fullList, withAlias.Values, cmpopts.SortSlices(less), cmpopts.IgnoreFields(api.EnumValue{}, "Parent")); diff != "" {
+		t.Errorf("method mismatch (-want, +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(uniqueList, withAlias.UniqueNumberValues, cmpopts.SortSlices(less), cmpopts.IgnoreFields(api.EnumValue{}, "Parent")); diff != "" {
+		t.Errorf("method mismatch (-want, +got):\n%s", diff)
+	}
+}
+
 func TestProtobuf_OneOfs(t *testing.T) {
 	test := makeAPIForProtobuf(nil, newTestCodeGeneratorRequest(t, "oneofs.proto"))
 	message, ok := test.State.MessageByID[".test.Fake"]

--- a/generator/internal/parser/testdata/enum_values.proto
+++ b/generator/internal/parser/testdata/enum_values.proto
@@ -1,0 +1,26 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+syntax = "proto3";
+package test;
+
+enum WithAlias {
+    option allow_alias = true;
+    X_UNSPECIFIED = 0;
+    LONG_NAME_VALUE = 2;
+    V2 = 2;
+    bad_style = 3;
+    FOLLOWS_STYLE = 3;
+}


### PR DESCRIPTION
Some enums have aliases for the same value. Sometimes we need the list
of unique values to generate switch statements and similar constructs.

Part of the work for #1379
